### PR TITLE
ゲーム中の経過時刻の取得にperformance.now()を使うように変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4461,8 +4461,8 @@ function MainInit() {
 		}
 
 		// 60fpsから遅延するため、その差分を取って次回のタイミングで遅れをリカバリする
-		thisTime = new Date();
-		buffTime = (thisTime.getTime() - mainStartTime.getTime() - (g_scoreObj.frameNum - firstFrame) * 1000 / 60);
+		thisTime = performance.now();
+		buffTime = (thisTime - mainStartTime - (g_scoreObj.frameNum - firstFrame) * 1000 / 60);
 		g_scoreObj.frameNum++;
 		g_timeoutEvtId = setTimeout(function () { flowTimeline() }, 1000 / 60 - buffTime);
 
@@ -4486,7 +4486,7 @@ function MainInit() {
 		}
 
 	}
-	const mainStartTime = new Date();
+	const mainStartTime = performance.now();
 	g_timeoutEvtId = setTimeout(flowTimeline(), 1000 / 60);
 }
 


### PR DESCRIPTION
## 変更方針
- ゲーム中の経過時刻の取得にはperformance.now()を使う
- new Date()はカレンダー的な意味での現在日時取得に使う

## 変更理由
new Date()は毎フレーム呼び出すには重い処理なので、代替メソッドを使います。
performance.now()は経過時刻の取得のために最適化されたメソッドです。
https://developer.mozilla.org/ja/docs/Web/API/Performance/now