### PR TITLE
[custom 0.2.0] カスタム変数：titlesizeを追加

### DIFF
--- a/js/danoni_custom.js
+++ b/js/danoni_custom.js
@@ -58,6 +58,12 @@ function customTitleInit() {
 	if (titlefontsize >= 64) {
 		titlefontsize = 64;
 	}
+
+	// カスタム変数 titlesize の定義
+	if (g_rootObj.titlesize != undefined && g_rootObj.titlesize != "") {
+		titlefontsize = setVal(g_rootObj.titlesize, titlefontsize, "number");
+	}
+
 	createLabel(l0ctx, g_headerObj["musicTitle"], g_sWidth / 2, g_sHeight / 2,
 		titlefontsize, "メイリオ", grd, "center");
 }
@@ -120,7 +126,7 @@ function customMainInit() {
 	l0ctx.fillStyle = grd;
 	l0ctx.fillRect(0, 0, g_sWidth, g_sHeight);
 
-	// ここにカスタム処理を記述する
+	// Ready?表示
 	var lblReady = createDivLabel("lblReady", g_sWidth / 2 - 100, g_sHeight / 2 - 100,
 		200, 50, 40, C_CLR_TITLE,
 		"<span style='color:#9999ff;font-size:60px;'>R</span>EADY?");
@@ -128,6 +134,8 @@ function customMainInit() {
 	lblReady.style.animationDuration = "2.5s";
 	lblReady.style.animationName = "leftToRightFade";
 	lblReady.style.opacity = 0;
+
+	// ここにカスタム処理を記述する
 
 }
 


### PR DESCRIPTION
## 変更理由
タイトル文字はdanoni_custom.jsの領域であり、  
利用者で自由に変えることのできる領域のため、特に縛りをつける必要はないが、  
実装の簡易さから利用される可能性が大きい。  

ただ、そのまま利用するとフォントの関係で横にはみ出る問題が発生する。  
このため、標準テンプレートの一部として、titlesize変数を追加する。

## 使い方
譜面データ内に下記を記載することで、  
自動で指定したサイズではなく記載したサイズに変更される。  
ただし、danoni_custom.jsを書き換え、フォントサイズを自分で書き直した場合はこの限りではない。  
```
|titlesize=40|
```
