### PR TITLE
[ver0.77.0]  リザルト画面のデザインを変更（曲名他を追加） 

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,8 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = "Ver 0.76.3";
-const g_version_result = "Ver 0.1.0.20181124";
+const g_version = "Ver 0.77.0";
 
 // ショートカット用文字列(↓の文字列を検索することで対象箇所へジャンプできます)
 //  タイトル:melon  設定・オプション:lime  キーコンフィグ:orange  譜面読込:strawberry  メイン:banana  結果:grape


### PR DESCRIPTION
## 変更内容
- リザルト画面に、曲名・譜面名・プレイスタイル・ディスプレイ設定の内容を追加

## 変更理由
- リザルト画面だけでは、プレイの詳細状況がわからないため
- 従来の表示は冗長で長くなりがちなため、できるだけ簡易な書き方に変更している

## その他コメント

