### PR TITLE
IE11でゲームが開始直後に止まる問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -701,6 +701,14 @@ let g_gameOverFlg = false;
 const g_userAgent = window.navigator.userAgent.toLowerCase(); // msie, edge, chrome, safari, firefox, opera
 
 const g_audio = new Audio();
+const g_timeupdate = (function() {
+	if (g_userAgent.indexOf("trident") == -1) {
+		return new CustomEvent("timeupdate");
+	}
+	const event = document.createEvent("CustomEvent");
+	event.initCustomEvent("timeupdate", false, false, {});
+	return event;
+})();
 let g_timeoutEvtId = 0;
 let g_inputKeyBuffer = new Array();
 
@@ -4350,7 +4358,7 @@ function MainInit() {
 			g_audio.play();
 			musicStartFlg = true;
 			g_audio.currentTime = firstFrame / 60;
-			g_audio.dispatchEvent(new CustomEvent("timeupdate"));
+			g_audio.dispatchEvent(g_timeupdate);
 		}
 
 		// フェードイン・アウト


### PR DESCRIPTION
## 変更内容
- IE11向けに、動作しないnew CustomEvent()の代替処理を追加

## 変更理由
これは 557a064 の変更以降、IE11だけで起きる問題です。
IE11でも、ひとまず譜面が見れる程度の動作を望むならば、修正が必要だと思います。

## その他コメント
IE11を完全にサポートしない、それこそ画面に何も表示されなくてもいいならば、
このコミットは取り込まなくて大丈夫です。
IE11をサポートするかどうかで、今後のコードの書き方が変わってきます。