### PR TITLE
[ver1.1.1] フリーズアローヒット時に後続矢印位置が補正されない問題を修正（ver1.0.2に対する修正）

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,7 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = "Ver 1.1.0";
+const g_version = "Ver 1.1.1";
 
 // ショートカット用文字列(↓の文字列を検索することで対象箇所へジャンプできます)
 //  タイトル:melon  設定・オプション:lime  キーコンフィグ:orange  譜面読込:strawberry  メイン:banana  結果:grape
@@ -5085,10 +5085,23 @@ function changeHitFrz(_j, _k) {
 	}
 
 	const frzBar = document.getElementById("frzBar" + _j + "_" + _k);
+	const frzRoot = document.getElementById("frz" + _j + "_" + _k);
+	const frzBtm = document.getElementById("frzBtm" + _j + "_" + _k);
+	const frzBtmShadow = document.getElementById("frzBtmShadow" + _j + "_" + _k);
+
 	frzBar.style.backgroundColor = g_workObj.frzHitBarColors[_j];
-	document.getElementById("frzBtm" + _j + "_" + _k).style.backgroundColor = g_workObj.frzHitColors[_j];
-	document.getElementById("frz" + _j + "_" + _k).style.top = document.getElementById("step" + _j).style.top;
-	document.getElementById("frz" + _j + "_" + _k).setAttribute("isMoving", "false");
+	frzBtm.style.backgroundColor = g_workObj.frzHitColors[_j];
+
+	// フリーズアロー位置の修正（ステップゾーン上に来るように）
+	const delFrzLength = parseFloat(document.getElementById("step" + _j).style.top) - parseFloat(frzRoot.style.top);
+
+	frzRoot.style.top = document.getElementById("step" + _j).style.top;
+	frzBtm.style.top = (parseFloat(frzBtm.style.top) - delFrzLength) + "px";
+	frzBtmShadow.style.top = (parseFloat(frzBtmShadow.style.top) - delFrzLength) + "px";
+	frzBar.style.top = (parseFloat(frzBar.style.top) - delFrzLength * g_workObj.dividePos[_j]) + "px";
+	frzBar.style.height = (parseFloat(frzBar.style.height) - delFrzLength * g_workObj.scrollDir[_j]) + "px";
+
+	frzRoot.setAttribute("isMoving", "false");
 }
 
 /**


### PR DESCRIPTION
## 変更内容
- フリーズアローヒット時に後続矢印位置が補正されない問題を修正

## 変更理由
- フリーズアローヒット時、先頭矢印は位置がステップゾーン上に来るが、  
それに伴って後続矢印の位置がずれてしまっていた
（フリーズアローの長さが補正されておらず、ずれた分だけ長く or 短くなっていた）。

## その他コメント

