### PR TITLE
[ver1.1.4] 曲時間表示位置の修正、独自キーの変数の数値変換不具合の修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,7 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = "Ver 1.1.3";
+const g_version = "Ver 1.1.4";
 
 // ショートカット用文字列(↓の文字列を検索することで対象箇所へジャンプできます)
 //  タイトル:melon  設定・オプション:lime  キーコンフィグ:orange  譜面読込:strawberry  メイン:banana  結果:grape
@@ -1845,6 +1845,9 @@ function keysConvert(_dosObj) {
 				if (checkArrayVal(tmpColors, "string", 1)) {
 					for (var k = 0, len = tmpColors.length; k < len; k++) {
 						g_keyObj["color" + newKey + "_" + k] = tmpColors[k].split(",");
+						for (var m = 0, len2 = g_keyObj["color" + newKey + "_" + k].length; m < len2; m++) {
+							g_keyObj["color" + newKey + "_" + k][m] = Number(g_keyObj["color" + newKey + "_" + k][m]);
+						}
 					}
 					tmpMinPatterns = tmpColors.length;
 				}
@@ -1899,8 +1902,11 @@ function keysConvert(_dosObj) {
 			if (_dosObj["pos" + newKey] != undefined) {
 				const tmpPoss = _dosObj["pos" + newKey].split("$");
 				if (checkArrayVal(tmpPoss, "string", 1)) {
-					for (var k = 0, len = tmpPoss.length; k < len; k++) {
-						g_keyObj["pos" + newKey + "_" + k] = tmpPoss[k].split(",");
+					for (var j = 0, len = tmpPoss.length; j < len; j++) {
+						g_keyObj["pos" + newKey + "_" + j] = tmpPoss[j].split(",");
+						for (var k = 0, len2 = g_keyObj["pos" + newKey + "_" + j].length; k < len2; k++) {
+							g_keyObj["pos" + newKey + "_" + j][k] = Number(g_keyObj["pos" + newKey + "_" + j][k]);
+						}
 					}
 				}
 
@@ -1931,8 +1937,8 @@ function keysConvert(_dosObj) {
 							g_keyObj["keyCtrl" + newKey + "_" + p + "d"][k] = new Array();
 
 							for (var m = 0; m < tmpKeyPtn.length; m++) {
-								g_keyObj["keyCtrl" + newKey + "_" + p][k][m] = tmpKeyPtn[m];
-								g_keyObj["keyCtrl" + newKey + "_" + p + "d"][k][m] = tmpKeyPtn[m];
+								g_keyObj["keyCtrl" + newKey + "_" + p][k][m] = Number(tmpKeyPtn[m]);
+								g_keyObj["keyCtrl" + newKey + "_" + p + "d"][k][m] = Number(tmpKeyPtn[m]);
 							}
 						}
 					}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,7 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = "Ver 1.1.2";
+const g_version = "Ver 1.1.3";
 
 // ショートカット用文字列(↓の文字列を検索することで対象箇所へジャンプできます)
 //  タイトル:melon  設定・オプション:lime  キーコンフィグ:orange  譜面読込:strawberry  メイン:banana  結果:grape
@@ -1438,8 +1438,7 @@ function titleInit() {
 	// ブラウザチェック
 	if (g_userAgent.indexOf('msie') != -1 ||
 		g_userAgent.indexOf('trident') != -1 ||
-		g_userAgent.indexOf('edge') != -1 ||
-		g_userAgent.indexOf('firefox') != -1) {
+		g_userAgent.indexOf('edge') != -1) {
 
 		makeWarningWindow(C_MSG_W_0001);
 	}
@@ -2097,7 +2096,6 @@ function optionInit() {
 	document.onkeyup = function (evt) {
 	}
 }
-
 
 /**
  * 設定・オプション画面のラベル・ボタン処理の描画
@@ -3088,6 +3086,9 @@ function loadingScoreInit() {
 	const keyNum = g_keyObj["chara" + keyCtrlPtn].length;
 	g_headerObj.blankFrame = g_headerObj.blankFrameDef;
 
+	// 楽曲データのバックグラウンド再生 (Firefoxのみ)
+	startPreloadingAudio();
+
 	// 譜面データの読み込み
 	let scoreIdHeader = "";
 	if (g_stateObj.scoreId > 0) {
@@ -3180,6 +3181,24 @@ function loadingScoreInit() {
 
 	clearWindow();
 	MainInit();
+}
+
+/**
+ * 楽曲データのバックグラウンド再生 (Firefoxのみ)
+ * - Firefoxのみ楽曲の読み込みが遅れることがあるため、先にミュートで再生させておく。
+ * - @see {@link prepareAudio} とセット。
+ */
+function startPreloadingAudio() {
+	if (g_userAgent.indexOf("msie") != -1 ||
+		g_userAgent.indexOf("trident") != -1 ||
+		g_userAgent.indexOf('edge') != -1 ||
+		g_userAgent.indexOf("chrome") != -1 ||
+		g_userAgent.indexOf("safari") != -1) {
+	} else if (g_userAgent.indexOf("firefox") != -1) {
+		g_audio.play();
+		g_audio.muted = true;
+	} else if (g_userAgent.indexOf("opera") != -1) {
+	}
 }
 
 /**
@@ -4486,6 +4505,25 @@ function MainInit() {
 	}
 
 	/**
+	 * 楽曲の再生処理
+	 * - Firefoxはすでに @see {@link startPreloadingAudio} で楽曲再生しているためミュートのみ外す。
+	 */
+	function prepareAudio() {
+		if (g_userAgent.indexOf("msie") != -1 ||
+			g_userAgent.indexOf("trident") != -1 ||
+			g_userAgent.indexOf('edge') != -1 ||
+			g_userAgent.indexOf("chrome") != -1 ||
+			g_userAgent.indexOf("safari") != -1) {
+
+			g_audio.play();
+		} else if (g_userAgent.indexOf("firefox") != -1) {
+			g_audio.muted = false;
+		} else if (g_userAgent.indexOf("opera") != -1) {
+			g_audio.play();
+		}
+	}
+
+	/**
 	 * フレーム処理(譜面台)
 	 */
 	function flowTimeline() {
@@ -4499,7 +4537,7 @@ function MainInit() {
 		}
 
 		if (g_scoreObj.frameNum == musicStartFrame) {
-			g_audio.play();
+			prepareAudio();
 			musicStartFlg = true;
 			g_audio.currentTime = firstFrame / 60;
 			g_audio.dispatchEvent(g_timeupdate);


### PR DESCRIPTION
## 変更内容
1. 曲時間表示の位置を修正
1. 独自キーの変数の数値変換不具合の修正

## 変更理由
1. 再生時間が10分以上の場合、表示が崩れるため
1. 独自キーの取り込み変数で、本来数値の部分が文字列に変換されていたため。
具体的には、posXを設定したときに下段の表示が出ない不具合がある。

## その他コメント

