### PR TITLE
[ver1.5.0.pre] ゲージ設定の見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9,7 +9,7 @@
  * https://github.com/cwtickle/danoniplus
  */
 const g_version = "Ver 1.4.0";
-const g_version_gauge = "Ver 0.1.0.20181221";
+const g_version_gauge = "Ver 0.2.0.20181221";
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
 let g_localVersion = "";
@@ -1718,14 +1718,13 @@ function headerConvert(_dosObj) {
 	if (obj.lifeBorders[0] === "x") {
 		g_stateObj.lifeBorder = 0;
 		g_stateObj.lifeMode = C_LFE_SURVIVAL;
-		g_stateObj.lifeSetName = "Borderless";
 		g_gaugeType = C_LFE_SURVIVAL;
 	} else {
 		g_stateObj.lifeBorder = obj.lifeBorders[0];
 		g_stateObj.lifeMode = C_LFE_BORDER;
-		g_stateObj.lifeSetName = "Normal";
 		g_gaugeType = C_LFE_BORDER;
 	}
+	g_stateObj.lifeSetName = g_gaugeOptionObj[g_gaugeType.toLowerCase()][g_stateObj.lifeId];
 	g_stateObj.lifeRcv = obj.lifeRecoverys[0];
 	g_stateObj.lifeDmg = obj.lifeDamages[0];
 	g_stateObj.lifeInit = obj.lifeInits[0];
@@ -2443,6 +2442,19 @@ function createOptionWindow(_sprite) {
 			}
 			if (setVal(g_headerObj.lifeDamages[g_stateObj.scoreId], "", "number") !== "") {
 				g_stateObj.lifeDmg = g_headerObj.lifeDamages[g_stateObj.scoreId];
+			}
+
+		} else if (g_stateObj.lifeSetName == "Light" || g_stateObj.lifeSetName == "Easy") {
+			// ゲージ設定がLight/Easyのとき、Borderless/Normalに合わせて設定を見直す
+
+			if (setVal(g_headerObj.lifeInits[g_stateObj.scoreId], "", "number") !== "") {
+				g_stateObj.lifeInit = g_headerObj.lifeInits[g_stateObj.scoreId];
+			}
+			if (setVal(g_headerObj.lifeRecoverys[g_stateObj.scoreId], "", "number") !== "") {
+				g_stateObj.lifeRcv = g_headerObj.lifeRecoverys[g_stateObj.scoreId];
+			}
+			if (setVal(g_headerObj.lifeDamages[g_stateObj.scoreId], "", "number") !== "") {
+				g_stateObj.lifeDmg = g_headerObj.lifeDamages[g_stateObj.scoreId] / 2;
 			}
 		}
 	}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,11 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2018/12/11
+ * Revised : 2018/12/21
  * 
  * https://github.com/cwtickle/danoniplus
  */
 const g_version = "Ver 1.4.0";
+const g_version_gauge = "Ver 0.1.0.20181221";
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
 let g_localVersion = "";
@@ -167,20 +168,20 @@ const C_LFE_SURVIVAL = "Survival";
 const C_LFE_BORDER = "Border";
 
 const g_gaugeOptionObj = {
-	survival: ["Borderless", "No Recovery", "SuddenDeath", "Practice"],
-	border: ["Normal", "No Recovery", "SuddenDeath"],
+	survival: ["Borderless", "Light", "No Recovery", "SuddenDeath", "Practice"],
+	border: ["Normal", "Easy", "Hard", "SuddenDeath"],
 
-	initSurvival: [250, C_VAL_MAXLIFE, C_VAL_MAXLIFE, C_VAL_MAXLIFE / 2],
-	rcvSurvival: [6, 0, 0, 0],
-	dmgSurvival: [40, 50, C_VAL_MAXLIFE, 0],
-	typeSurvival: [C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL],
-	clearSurvival: [0, 0, 0, 0],
+	initSurvival: [250, 250, C_VAL_MAXLIFE, C_VAL_MAXLIFE, C_VAL_MAXLIFE / 2],
+	rcvSurvival: [6, 6, 0, 0, 0],
+	dmgSurvival: [40, 20, 50, C_VAL_MAXLIFE, 0],
+	typeSurvival: [C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL],
+	clearSurvival: [0, 0, 0, 0, 0],
 
-	initBorder: [250, C_VAL_MAXLIFE, C_VAL_MAXLIFE],
-	rcvBorder: [2, 0, 0],
-	dmgBorder: [7, 50, C_VAL_MAXLIFE],
-	typeBorder: [C_LFE_BORDER, C_LFE_SURVIVAL, C_LFE_SURVIVAL],
-	clearBorder: [70, 0, 0]
+	initBorder: [250, 250, C_VAL_MAXLIFE, C_VAL_MAXLIFE],
+	rcvBorder: [2, 2, 1, 0],
+	dmgBorder: [7, 4, 50, C_VAL_MAXLIFE],
+	typeBorder: [C_LFE_BORDER, C_LFE_BORDER, C_LFE_BORDER, C_LFE_BORDER],
+	clearBorder: [70, 70, 0, 0]
 };
 let g_gaugeType;
 const C_GAG_DEFAULT = 0;
@@ -5336,7 +5337,7 @@ function lifeDamage() {
 	g_workObj.lifeVal -= g_workObj.lifeDmg;
 	if (g_workObj.lifeVal <= 0) {
 		g_workObj.lifeVal = 0;
-		if (g_stateObj.lifeMode === C_LFE_SURVIVAL) {
+		if (g_workObj.lifeBorder === 0) {
 			g_audio.pause();
 			clearTimeout(g_timeoutEvtId);
 			setTimeout(function () {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9,7 +9,7 @@
  * https://github.com/cwtickle/danoniplus
  */
 const g_version = "Ver 1.4.0";
-const g_version_gauge = "Ver 0.2.0.20181221";
+const g_version_gauge = "Ver 0.2.1.20181221";
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
 let g_localVersion = "";
@@ -184,9 +184,6 @@ const g_gaugeOptionObj = {
 	clearBorder: [70, 70, 0, 0]
 };
 let g_gaugeType;
-const C_GAG_DEFAULT = 0;
-const C_GAG_NORECOVERY = 1;
-const C_GAG_SUDDENDEATH = 2;
 
 const g_volumes = [100, 75, 50, 25, 10, 5, 2, 1, 0.5, 0.25, 0];
 let g_volumeNum = 0;


### PR DESCRIPTION
## 変更内容
- ゲージ設定を2系統に分離
  - ライフ制：「Borderless」「Light」「No Recovery」「SuddenDeath」
  - ノルマ制：「Normal」「Easy」「Hard」「SuddenDeath」
- ゲームオーバー条件の変更
  - ライフ制/ノルマ制で区切らず、クリアボーダー(g_workObj.lifeBorder)が0かどうかで判定

## 変更理由
- 現状のFlash(ParaFla)版の実態に合わせた変更

## その他コメント
- ライフ制・ノルマ制を示す変数表記が実態と乖離しているため、様子を見て直す予定
