### PR TITLE
[ver1.5.1.pre] SuddenDeathで1ミスFailedにならない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9,7 +9,7 @@
  * https://github.com/cwtickle/danoniplus
  */
 const g_version = "Ver 1.5.0";
-const g_version_gauge = "Ver 0.4.1.20181223";
+const g_version_gauge = "Ver 0.4.2.20181223";
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
 let g_localVersion = "";
@@ -2543,7 +2543,7 @@ function createOptionWindow(_sprite) {
 	}
 
 	/**
-	 * ゲージ設定の詳細表示を整形 C_VAL_MAXLIFE * g_stateObj.lifeBorder / 100
+	 * ゲージ設定の詳細表示を整形
 	 */
 	function gaugeFormat(_mode, _border, _rcv, _dmg, _init) {
 		const initVal = C_VAL_MAXLIFE * _init / 1000;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9,7 +9,7 @@
  * https://github.com/cwtickle/danoniplus
  */
 const g_version = "Ver 1.5.0";
-const g_version_gauge = "Ver 0.4.2.20181223";
+const g_version_gauge = "Ver 0.4.3.20181223";
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
 let g_localVersion = "";
@@ -180,7 +180,7 @@ const g_gaugeOptionObj = {
 	initBorder: [250, 250, C_VAL_MAXLIFE, C_VAL_MAXLIFE],
 	rcvBorder: [2, 2, 1, 0],
 	dmgBorder: [7, 4, 50, C_VAL_MAXLIFE],
-	typeBorder: [C_LFE_BORDER, C_LFE_BORDER, C_LFE_BORDER, C_LFE_BORDER],
+	typeBorder: [C_LFE_BORDER, C_LFE_BORDER, C_LFE_BORDER, C_LFE_SURVIVAL],
 	clearBorder: [70, 70, 0, 0]
 };
 let g_gaugeType;


### PR DESCRIPTION
## 変更内容
- SuddenDeathで1ミスFailedにならない問題を修正

## 変更理由
- ノルマ制のSuddenDeathで、矢印数が1000を超える場合、1ミスFailedとならない。
- ノルマ制の場合、矢印数が1000を超えるとライフ減少量の変動で、減少量が1000未満となるため。

## その他コメント

