### PR TITLE
Develop

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,7 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = "Ver 1.5.1";
+const g_version = "Ver 1.6.0";
 const g_version_gauge = "Ver 0.5.0.20181223";
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)


### PR DESCRIPTION
## 変更内容
- ゲージ設定の名称変更（Borderless→Original）
- ゲージ設定「Light」の既定を見直し（ダメージ半減 → 回復量2倍）

## 変更理由
- ノルマのないゲージ設定がすでに存在するため
- ゲージの軽さという意味に反した設定になっていたため（ダメージ半減→回復量倍増）

## その他コメント

