### PR TITLE
[ver1.6.0] ゲージ設定の名称変更（Borderless→Original）他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9,7 +9,7 @@
  * https://github.com/cwtickle/danoniplus
  */
 const g_version = "Ver 1.6.0";
-const g_version_gauge = "Ver 0.5.0.20181223";
+const g_version_gauge = "Ver 0.5.1.20181223";
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
 let g_localVersion = "";
@@ -2551,10 +2551,10 @@ function createOptionWindow(_sprite) {
 
 		if (_mode === C_LFE_BORDER) {
 			if (borderVal !== 0) {
-				return "[Init:" + initVal + ", Border:" + borderVal + ", <br>Rcv:" + _rcv + ", Dmg:" + _dmg + "]";
+				return "[Start:" + initVal + ", Border:" + borderVal + ", <br>Rcv:" + _rcv + ", Dmg:" + _dmg + "]";
 			}
 		}
-		return "[Init:" + initVal + ", Rcv:" + _rcv + ", Dmg:" + _dmg + "]";
+		return "[Start:" + initVal + ", Rcv:" + _rcv + ", Dmg:" + _dmg + "]";
 	}
 
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2510,10 +2510,10 @@ function createOptionWindow(_sprite) {
 				g_stateObj.lifeInit = g_headerObj.lifeInits[g_stateObj.scoreId];
 			}
 			if (setVal(g_headerObj.lifeRecoverys[g_stateObj.scoreId], "", "number") !== "") {
-				g_stateObj.lifeRcv = g_headerObj.lifeRecoverys[g_stateObj.scoreId] * 2;
+				g_stateObj.lifeRcv = g_headerObj.lifeRecoverys[g_stateObj.scoreId];
 			}
 			if (setVal(g_headerObj.lifeDamages[g_stateObj.scoreId], "", "number") !== "") {
-				g_stateObj.lifeDmg = g_headerObj.lifeDamages[g_stateObj.scoreId];
+				g_stateObj.lifeDmg = g_headerObj.lifeDamages[g_stateObj.scoreId] / 2;
 			}
 		}
 
@@ -2551,10 +2551,10 @@ function createOptionWindow(_sprite) {
 
 		if (_mode === C_LFE_BORDER) {
 			if (borderVal !== 0) {
-				return "[Start:" + initVal + ", Border:" + borderVal + ", <br>Rcv:" + _rcv + ", Dmg:" + _dmg + "]";
+				return "[Init:" + initVal + ", Border:" + borderVal + ", <br>Rcv:" + _rcv + ", Dmg:" + _dmg + "]";
 			}
 		}
-		return "[Start:" + initVal + ", Rcv:" + _rcv + ", Dmg:" + _dmg + "]";
+		return "[Init:" + initVal + ", Rcv:" + _rcv + ", Dmg:" + _dmg + "]";
 	}
 
 


### PR DESCRIPTION
## 変更内容
- ゲージ設定の名称変更（Borderless→Original）
- ゲージ設定「Light」の既定を見直し（ダメージ半減 → 回復量2倍）

## 変更理由
- ノルマのないゲージ設定がすでに存在するため
- ゲージの軽さという意味に反した設定になっていたため（ダメージ半減→回復量倍増）

## その他コメント

