### PR TITLE
[ver1.7.0] オーディオエンコード実装（jsファイル指定）

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,7 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = "Ver 1.6.0";
+const g_version = "Ver 1.7.0";
 const g_version_gauge = "Ver 0.5.1.20181223";
 const g_version_musicEncoded = "Ver 0.1.0.20181224";
 


### PR DESCRIPTION
## 変更内容
- base64エンコードしたmp3への対応
  - 下記のようなjsファイルをmusicフォルダ(既定)に入れて、
musicUrlでjsファイルとして指定することで、
base64エンコードしたmp3が読み込まれるようになります。

```javascript
function musicInit(){
  g_musicdata='base64エンコードされた音楽データ';
}
```
## 変更理由
- mp3の利用条件によっては、直接mp3ファイルをファイルサーバへ
アップロードすることが禁止されている場合があるため、その対応

## その他コメント
- 互換性のため、既存の機能もそのまま生かしています。
mp3ファイルとして上げる場合は、
.htaccessでmp3にアクセス制御を掛けるなどの措置を取ることを強く推奨します。
