### PR TITLE
[audio:0.1.1] base64エンコードデータをtxtファイルでも取り込み可能に変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10,7 +10,7 @@
  */
 const g_version = "Ver 1.7.0";
 const g_version_gauge = "Ver 0.5.1.20181223";
-const g_version_musicEncoded = "Ver 0.1.0.20181224";
+const g_version_musicEncoded = "Ver 0.1.1.20181224";
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
 let g_localVersion = "";
@@ -1892,7 +1892,7 @@ function headerConvert(_dosObj) {
 
 	// 楽曲URL
 	if (_dosObj.musicUrl !== undefined) {
-		if (_dosObj.musicUrl.slice(-3) === ".js") {
+		if (_dosObj.musicUrl.slice(-3) === ".js" || _dosObj.musicUrl.slice(-4) === ".txt") {
 			g_musicEncodedFlg = true;
 		}
 		obj.musicUrl = _dosObj.musicUrl;


### PR DESCRIPTION
## 変更内容
- base64エンコードデータをtxtファイルでも取り込み可能に変更

## 変更理由
- jsファイルの場合、簡易的なテキストエディタでは開けない場合があるため

## その他コメント

