### PR TITLE
[ver1.7.1] base64エンコードしたデータについてtxtファイルでも取り込み可能に変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,7 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = "Ver 1.7.0";
+const g_version = "Ver 1.7.1";
 const g_version_gauge = "Ver 0.5.1.20181223";
 const g_version_musicEncoded = "Ver 0.1.1.20181224";
 


### PR DESCRIPTION
## 変更内容
- base64エンコードしたデータについてtxtファイルでも取り込み可能に変更

## 変更理由
- txtファイルの方がメモ帳などで開くことができ、手軽であるため

## その他コメント

