### PR TITLE
[ver1.9.0] 歌詞機能強化

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,7 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = "Ver 1.7.0";
+const g_version = "Ver 1.7.1";
 const g_version_gauge = "Ver 0.5.1.20181223";
 const g_version_musicEncoded = "Ver 0.1.1.20181224";
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,11 +4,11 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2018/12/24
+ * Revised : 2018/12/25
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = "Ver 1.7.1";
+const g_version = "Ver 1.8.0";
 const g_version_gauge = "Ver 0.5.1.20181223";
 const g_version_musicEncoded = "Ver 0.1.1.20181224";
 
@@ -5675,25 +5675,6 @@ function resultInit() {
 		rankColor = g_rankObj.rankColorX;
 	}
 
-
-	// Twitter用リザルト
-	let hashTag;
-	if (g_headerObj.hashTag !== undefined) {
-		hashTag = " " + g_headerObj.hashTag;
-	} else {
-		hashTag = "";
-	}
-	const tweetResultTmp = "【#danoni" + hashTag + "】" + g_headerObj.musicTitle + "(" +
-		g_headerObj.keyLabels[g_stateObj.scoreId] + "k-" + g_headerObj.difLabels[g_stateObj.scoreId] + ")/" +
-		g_headerObj.tuning + "/" +
-		"Rank:" + rankMark + "/" +
-		"Score:" + resultScore + "/" +
-		g_resultObj.ii + "-" + g_resultObj.shakin + "-" + g_resultObj.matari + "-" + g_resultObj.shobon + "-" + g_resultObj.uwan + "/" +
-		g_resultObj.kita + "-" + g_resultObj.iknai + "/" +
-		g_resultObj.maxCombo + "-" + g_resultObj.fmaxCombo + " " +
-		location.href;
-	const tweetResult = "https://twitter.com/intent/tweet?text=" + encodeURIComponent(tweetResultTmp);
-
 	// 曲名・オプション描画
 	playDataWindow.appendChild(makeResultPlayData("lblMusic", 20, "#999999", 0,
 		"Music", C_ALIGN_LEFT));
@@ -5708,7 +5689,7 @@ function resultInit() {
 		"Playstyle", C_ALIGN_LEFT));
 
 	let playStyleData = "";
-	playStyleData = g_stateObj.speed + " x";
+	playStyleData = g_stateObj.speed + "x";
 	if (g_stateObj.motion !== C_FLG_OFF) {
 		playStyleData += ", " + g_stateObj.motion;
 	}
@@ -5819,6 +5800,26 @@ function resultInit() {
 		"<span style='color:" + rankColor + ";'>" + rankMark + "</span>", "'Bookman Old Style', 'Meiryo UI', sans-serif");
 	lblRank.style.textAlign = C_ALIGN_CENTER;
 	resultWindow.appendChild(lblRank);
+
+	// Twitter用リザルト
+	let hashTag;
+	if (g_headerObj.hashTag !== undefined) {
+		hashTag = " " + g_headerObj.hashTag;
+	} else {
+		hashTag = "";
+	}
+	const tweetResultTmp = "【#danoni" + hashTag + "】" + g_headerObj.musicTitle + "(" +
+		g_headerObj.keyLabels[g_stateObj.scoreId] + "k-" + g_headerObj.difLabels[g_stateObj.scoreId] + ")/" +
+		g_headerObj.tuning + "/" +
+		"Rank:" + rankMark + "/" +
+		"Score:" + resultScore + "/" +
+		"Playstyle:" + playStyleData + "/" +
+		g_resultObj.ii + "-" + g_resultObj.shakin + "-" + g_resultObj.matari + "-" + g_resultObj.shobon + "-" + g_resultObj.uwan + "/" +
+		g_resultObj.kita + "-" + g_resultObj.iknai + "/" +
+		g_resultObj.maxCombo + "-" + g_resultObj.fmaxCombo + " " +
+		location.href;
+	const tweetResult = "https://twitter.com/intent/tweet?text=" + encodeURIComponent(tweetResultTmp);
+
 
 	// ユーザカスタムイベント(初期)
 	if (typeof customResultInit === "function") {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,11 +4,11 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2018/12/25
+ * Revised : 2018/12/30
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = "Ver 1.8.0";
+const g_version = "Ver 1.9.0";
 const g_version_gauge = "Ver 0.5.1.20181223";
 const g_version_musicEncoded = "Ver 0.1.1.20181224";
 const g_version_lyrics = "Ver 0.2.0.20181230";


### PR DESCRIPTION
## 変更内容
1. 歌詞表示の中央寄せ・右寄せ設定実装 (left, center, right)
1. 歌詞表示を2箇所→4箇所に拡大 (歌詞表示範囲：0～3)
1. 歌詞表示サイズ変更（横サイズにより自動変更）

## 変更理由
1. 場面により、一時的に歌詞を中央寄せ・右寄せする需要があるため
1. 上記に伴い、左右寄せ同時に表示するケースが考えられるため
1. 中央寄せ時、そもそも歌詞表示が真ん中になっていなかったため

## その他コメント
- 歌詞表示の拡張は互換性保持のため、0/2が上側、1/3が下側となる。
- そのまま表示すると表示が重なるため、
どちらか片方はあらかじめ[right]を指定して右寄せするなどの工夫が必要。
- キーワード[left][center][right]は、[fadein][fadeout]と同じ使い方。
