### PR TITLE
[ver2.0.2] フェードアウト中にリザルト画面へ移行させた場合の音量不具合を修正　他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,11 +4,11 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/01/19
+ * Revised : 2019/01/24
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 2.0.1`;
+const g_version = `Ver 2.0.2`;
 const g_version_gauge = `Ver 0.5.1.20181223`;
 const g_version_musicEncoded = `Ver 0.1.1.20181224`;
 const g_version_lyrics = `Ver 0.2.0.20181230`;
@@ -4341,7 +4341,7 @@ function getArrowSettings() {
 	g_resultObj.fCombo = 0;
 	g_resultObj.fmaxCombo = 0;
 
-	g_workObj.lifeVal = g_workObj.lifeInit;
+	g_workObj.lifeVal = Math.round(g_workObj.lifeInit);
 	g_gameOverFlg = false;
 }
 
@@ -6136,7 +6136,7 @@ function resultInit() {
 }
 
 function resultFadeOut() {
-	const tmpVolume = (g_audio.volume - 5 / 1000);
+	const tmpVolume = (g_audio.volume - (3 * g_stateObj.volume / 100) / 1000);
 	if (tmpVolume < 0) {
 		g_audio.volume = 0;
 		clearInterval(g_timeoutEvtId);


### PR DESCRIPTION
## 変更内容
1. フェードアウト中にリザルト画面へ移行させた場合の音量不具合を修正
1. 初期ライフ量が整数値になるように修正

## 変更理由
1. fadeFrameとendFrameを両方指定して、Volumeを100%より小さい値でプレイすると、
リザルト画面突入時のフェードアウトが通常より早く終了してしまう。
1. 改造の仕方により、初期ライフ量が無限小数表示されるケースがあるため。

## その他コメント

