### PR TITLE
[ver2.1.0] createLabelの複数フォント対応

### DIFF
--- a/js/danoni_custom.js
+++ b/js/danoni_custom.js
@@ -45,29 +45,34 @@ function customTitleInit() {
 
 	// 曲名文字描画（曲名は譜面データから取得）
 	// TEST:試験的に矢印色の1番目と3番目を使ってタイトルをグラデーション
-	var grd = l0ctx.createLinearGradient(0, 0, g_sHeight, 0);
+	var grd2 = l0ctx.createLinearGradient(0, 0, g_sHeight, 0);
 	if (g_headerObj[`setColor`][0] != undefined) {
-		grd.addColorStop(0, g_headerObj[`setColor`][0]);
+		grd2.addColorStop(0, g_headerObj[`setColor`][0]);
 	} else {
-		grd.addColorStop(0, `#ffffff`);
+		grd2.addColorStop(0, `#ffffff`);
 	}
 	if (g_headerObj[`setColor`][2] != undefined) {
-		grd.addColorStop(1, g_headerObj[`setColor`][2]);
+		grd2.addColorStop(1, g_headerObj[`setColor`][2]);
 	} else {
-		grd.addColorStop(1, `#66ffff`);
+		grd2.addColorStop(1, `#66ffff`);
 	}
 	var titlefontsize = 64 * (12 / g_headerObj[`musicTitle`].length);
 	if (titlefontsize >= 64) {
 		titlefontsize = 64;
 	}
 
-	// カスタム変数 titlesize の定義
+	// カスタム変数 titlesize の定義 (使用例： |titlesize=40|)
 	if (g_rootObj.titlesize != undefined && g_rootObj.titlesize != ``) {
 		titlefontsize = setVal(g_rootObj.titlesize, titlefontsize, `number`);
 	}
+	// カスタム変数 titlefont の定義 (使用例： |titlefont=Century,Meiryo UI|)
+	let titlefontname = `メイリオ`;
+	if (g_rootObj.titlefont !== undefined && g_rootObj.titlefont !== ``) {
+		titlefontname = setVal(g_rootObj.titlefont, titlefontname, `string`);
+	}
 
 	createLabel(l0ctx, g_headerObj[`musicTitle`], g_sWidth / 2, g_sHeight / 2,
-		titlefontsize, `メイリオ`, grd, `center`);
+		titlefontsize, titlefontname, grd2, `center`);
 }
 
 /**
@@ -146,13 +151,15 @@ function customMainInit() {
 	l0ctx.fillRect(0, 0, g_sWidth, g_sHeight);
 
 	// Ready?表示
-	var lblReady = createDivLabel(`lblReady`, g_sWidth / 2 - 100, g_sHeight / 2 - 100,
-		200, 50, 40, C_CLR_TITLE,
-		`<span style='color:#9999ff;font-size:60px;'>R</span>EADY?`);
-	divRoot.appendChild(lblReady);
-	lblReady.style.animationDuration = `2.5s`;
-	lblReady.style.animationName = `leftToRightFade`;
-	lblReady.style.opacity = 0;
+	if (g_rootObj.customReady === undefined || g_rootObj.customReady !== `true`) {
+		var lblReady = createDivLabel(`lblReady`, g_sWidth / 2 - 100, g_sHeight / 2 - 75,
+			200, 50, 40, C_CLR_TITLE,
+			`<span style='color:#9999ff;font-size:60px;'>R</span>EADY?`);
+		divRoot.appendChild(lblReady);
+		lblReady.style.animationDuration = `2.5s`;
+		lblReady.style.animationName = `leftToRightFade`;
+		lblReady.style.opacity = 0;
+	}
 
 	// ここにカスタム処理を記述する
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,7 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 2.0.2`;
+const g_version = `Ver 2.1.0`;
 const g_version_gauge = `Ver 0.5.1.20181223`;
 const g_version_musicEncoded = `Ver 0.1.1.20181224`;
 const g_version_lyrics = `Ver 0.2.0.20181230`;
@@ -1286,7 +1286,14 @@ function createButton(_obj, _func) {
  * @param {string} _align テキストの表示位置 (left, center, right)
  */
 function createLabel(_ctx, _text, _x, _y, _fontsize, _fontname, _color, _align) {
-	_ctx.font = `${_fontsize}px "${_fontname}"`;
+	const fontFamilys = _fontname.split(`,`);
+	let fontView = ``;
+	for (var j = 0; j < fontFamilys.length; j++) {
+		fontView += `"${fontFamilys[j]}",`;
+	}
+	fontView += `sans-serif`;
+
+	_ctx.font = `${_fontsize}px ${fontView}`;
 	_ctx.textAlign = _align;
 	_ctx.fillStyle = _color;
 	_ctx.fillText(_text, _x, _y);
@@ -1581,9 +1588,13 @@ function titleInit() {
 	if (setVal(g_localVersion2, ``, `string`) !== ``) {
 		customVersion += ` / ${g_localVersion2}`;
 	}
+	let releaseDate = ``;
+	if (setVal(g_headerObj.releaseDate, ``, `string`) !== ``) {
+		releaseDate += ` @${g_headerObj.releaseDate}`;
+	}
 	const lnkVersion = createButton({
 		id: `lnkVersion`,
-		name: `&copy; 2018 ティックル, CW ${g_version}${customVersion}`,
+		name: `&copy; 2018 ティックル, CW ${g_version}${customVersion}${releaseDate}`,
 		x: g_sWidth / 3,
 		y: g_sHeight - 20,
 		width: g_sWidth * 2 / 3 - 10,
@@ -1906,7 +1917,7 @@ function headerConvert(_dosObj) {
 		makeWarningWindow(C_MSG_E_0031);
 	}
 
-	// hashTag
+	// ハッシュタグ
 	if (_dosObj.hashTag !== undefined) {
 		obj.hashTag = _dosObj.hashTag;
 	}
@@ -1928,6 +1939,9 @@ function headerConvert(_dosObj) {
 
 	// 最終演出表示有無（noneで無効化）
 	obj.finishView = setVal(_dosObj.finishView, ``, `string`);
+
+	// 更新日
+	obj.releaseDate = setVal(_dosObj.releaseDate, ``, `string`);
 
 	return obj;
 }


### PR DESCRIPTION
## 変更内容
1. createLabelの複数フォント対応
1. (danoni_custom.js) タイトルフォントを譜面側から変更できるように対応

## 変更理由
1. 後述の2.にも関係するが、canvasのfontで複数フォントが指定できない問題を解消するため
1. 個人用customのためあくまで参考だが、そのまま利用するケースがあるため

## その他コメント
2. で、Webフォントを指定した場合は反映遅延が起こり、
初回はデフォルトのフォントが表示される。
これはcanvasの仕様のため、現状は回避できない。
