### PR TITLE
外部譜面データ読み込み時の文字コード設定を追加

### DIFF
--- a/danoni/danoni2.html
+++ b/danoni/danoni2.html
@@ -1,19 +1,19 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html;charset=shift_jis">
+<meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
 <meta http-equiv="Content-Script-Type" content="text/javascript">
 <meta http-equiv="Content-Style-Type" content="text/css">
 <script src="../js/danoni_main.js" charset="UTF-8"></script>
 <link rel="stylesheet" type="text/css" href="../css/danoni_main.css">
-<title>Dancing★Onigiri Test2</title>
+<title>Dancing笘�Onigiri Test2</title>
 <style type="text/css">
 <!--//
 a:link   { color:#BAB7E0;}
 a:visited{ color:#BAB7E0;}
 a:active { color:#CCCCCC;}
 body{
-	font-family:"Arial","メイリオ","MS P ゴシック",sans-serif;
+	font-family:"Arial","繝｡繧､繝ｪ繧ｪ","MS P 繧ｴ繧ｷ繝�繧ｯ",sans-serif;
 	scrollbar-base-color:"black";
 	scrollbar-arrow-color:"white";
 	color:#cccccc;
@@ -38,6 +38,7 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 <body>
 <table><tr><td>
 <input type="hidden" name="externalDos" id="externalDos" value="danoni2.txt">
+<input type="hidden" name="externalDosCharset" id="externalDosCharset" value="Shift_JIS">
 <div id="canvas-frame" style="width:500px;margin:auto;">
 	<canvas id="layer0" width="500" height="500"></canvas>
 	<canvas id="layer1" width="500" height="500"></canvas>

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1374,20 +1374,21 @@ function clearWindow() {
 
 }
 
-function loadScript(url, callback) {
+function loadScript(_url, _callback, _charset = `UTF-8`) {
 	const script = document.createElement(`script`);
 	script.type = `text/javascript`;
-	script.src = url;
+	script.src = _url;
+	script.charset = _charset;
 
 	if (script.readyState) {
 		script.onreadystatechange = _ => {
 			if (script.readyState === `loaded` || script.readyState === `complete`) {
 				script.onreadystatechange = null;
-				callback();
+				_callback();
 			}
 		};
 	} else {
-		script.onload = _ => callback();
+		script.onload = _ => _callback();
 	}
 	document.querySelector(`head`).appendChild(script);
 }
@@ -1432,6 +1433,12 @@ function initialControl() {
 
 	// 外部dos読み込み
 	if (externalDosInput !== null) {
+		let charset = document.characterSet;
+		const charsetInput = document.querySelector(`#externalDosCharset`);
+		if (charsetInput !== null) {
+			charset = charsetInput.value;
+		}
+
 		const filename = externalDosInput.value.match(/.+\..*/)[0];
 		const randTime = new Date().getTime();
 		loadScript(`${filename}?${randTime}`, _ => {
@@ -1442,7 +1449,7 @@ function initialControl() {
 				makeWarningWindow(C_MSG_E_0022);
 			}
 			initAfterDosLoaded();
-		});
+		}, charset);
 	}
 }
 


### PR DESCRIPTION
## 変更内容
外部譜面データ読み込み時の文字コードを指定できます。
~~~
<input type="hidden" name="externalDosCharset" id="externalDosCharset" value="Shift_JIS">
~~~

## 変更理由
ダンおに譜面エディタはShift_JISで出力するものが多く、UTF-8等のページでは文字化けを起こすため。

## その他コメント
loadScriptの引数名が命名ルールに合っていなかったので修正しています。