### PR TITLE
楽曲再生前に処理落ちすると譜面がずれる問題の修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4689,6 +4689,7 @@ function MainInit() {
 	// 曲時間制御変数
 	let thisTime;
 	let buffTime;
+	let musicStartTime;
 	let musicStartFlg = false;
 
 	g_inputKeyBuffer = [];
@@ -5064,6 +5065,7 @@ function MainInit() {
 			musicStartFlg = true;
 			g_audio.currentTime = firstFrame / 60;
 			g_audio.play();
+			musicStartTime = performance.now();
 			g_audio.dispatchEvent(new CustomEvent(`timeupdate`));
 		}
 
@@ -5496,7 +5498,10 @@ function MainInit() {
 
 		// 60fpsから遅延するため、その差分を取って次回のタイミングで遅れをリカバリする
 		thisTime = performance.now();
-		buffTime = (thisTime - mainStartTime - (g_scoreObj.frameNum - firstFrame) * 1000 / 60);
+		buffTime = 0;
+		if (g_scoreObj.frameNum >= musicStartFrame) {
+			buffTime = (thisTime - musicStartTime - (g_scoreObj.frameNum - musicStartFrame) * 1000 / 60);
+		}
 		g_scoreObj.frameNum++;
 		g_timeoutEvtId = setTimeout(_ => flowTimeline(), 1000 / 60 - buffTime);
 
@@ -5522,7 +5527,6 @@ function MainInit() {
 			}
 		}
 	}
-	const mainStartTime = performance.now();
 	g_timeoutEvtId = setTimeout(_ => flowTimeline(), 1000 / 60);
 }
 


### PR DESCRIPTION
## 変更内容
同期の基準時間をメイン画面開始時から曲再生開始時に変更しました。

## 変更理由
メイン画面開始後、曲再生開始前に処理落ちが発生すると譜面がずれる場合があります。
Playを押したあとウィンドウを最小化し、しばらくしてから復帰するとよく起こります。

## その他コメント
issue #176 のたまにずれる問題の原因が処理落ちなら直るかもしれません。