### PR TITLE
[ver2.7.1] 楽曲再生前に処理落ちすると譜面がずれる問題の修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,14 +4,11 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/02/12
+ * Revised : 2019/02/15
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 2.6.1`;
-const g_version_gauge = `Ver 0.5.1.20181223`;
-const g_version_musicEncoded = `Ver 0.1.1.20181224`;
-const g_version_lyrics = `Ver 0.2.0.20181230`;
+const g_version = `Ver 2.7.0`;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
 let g_localVersion = ``;
@@ -1406,8 +1403,8 @@ class AudioPlayer {
 		this._startTime = 0;
 		this._fadeinPosition = 0;
 		this._context.decodeAudioData(_arrayBuffer, _buffer => {
-		  this._duration = _buffer.duration;
-		  this._buffer = _buffer;
+			this._duration = _buffer.duration;
+			this._buffer = _buffer;
 		})
 	}
 
@@ -1441,9 +1438,9 @@ class AudioPlayer {
 		return this._duration;
 	}
 
-	load() {}
+	load() { }
 	get readyState() { return 4; }
-	dispatchEvent() {}
+	dispatchEvent() { }
 }
 
 /*-----------------------------------------------------------*/

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,11 +4,11 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/02/15
+ * Revised : 2019/02/16
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 2.7.0`;
+const g_version = `Ver 2.7.1`;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
 let g_localVersion = ``;
@@ -740,7 +740,6 @@ const g_rankObj = {
 
 let g_gameOverFlg = false;
 
-const g_hostName = location.hostname;
 const g_userAgent = window.navigator.userAgent.toLowerCase(); // msie, edge, chrome, safari, firefox, opera
 
 let g_audio = new Audio();
@@ -1720,10 +1719,12 @@ function titleInit() {
 			titlefontsize, titlefontname, grd2, `center`);
 	}
 
-	// ブラウザチェック
+	// 非推奨ブラウザに対して警告文を表示
+	// Firefoxはローカル環境時、Ver65以降矢印が表示されなくなるため非推奨表示
 	if (g_userAgent.indexOf(`msie`) !== -1 ||
 		g_userAgent.indexOf(`trident`) !== -1 ||
-		g_userAgent.indexOf(`edge`) !== -1) {
+		g_userAgent.indexOf(`edge`) !== -1 ||
+		(g_userAgent.indexOf(`firefox`) !== -1 && location.href.match(`^file`))) {
 
 		makeWarningWindow(C_MSG_W_0001);
 	}
@@ -4905,7 +4906,7 @@ function MainInit() {
 	}
 
 	// ローカル時のみフレーム数を残す
-	if (g_hostName === `localhost` || g_hostName === `127.0.0.1` || g_hostName === ``) {
+	if (location.href.match(`^file`)) {
 	} else {
 		document.querySelector(`#lblframe`).style.display = C_DIS_NONE;
 	}


### PR DESCRIPTION
## 変更内容
- Pull Request #197 を参照。
- ローカル環境かどうかの判定条件を統一（location.hrefを見るように）
- Firefoxかつローカル環境のとき、非推奨として表示するように変更。

## 変更理由
- issue #176 関連の修正。
- Firefox65以降、ローカル環境のみ矢印が非表示となる問題があるため。
（解消可能だが、configファイルの変更が必要で注意を要するため）

## その他コメント

