### PR TITLE
[ver2.9.1] back_data利用時、フレーム計算が失敗しエラーとなる問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/02/17
+ * Revised : 2019/02/21
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 2.9.0`;
-const g_revisedDate = `2019/02/17`;
+const g_version = `Ver 2.9.1`;
+const g_revisedDate = `2019/02/21`;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
 let g_localVersion = ``;
@@ -3881,7 +3881,7 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame) {
 				const tmpBackData = tmpData.split(`,`);
 
 				// 値チェックとエスケープ処理
-				const tmpFrame = calcFranme(setVal(tmpBackData[0], 200, `number`));
+				const tmpFrame = calcFrame(setVal(tmpBackData[0], 200, `number`));
 				const tmpDepth = setVal(tmpBackData[1], 0, `number`);
 				const tmpPath = escapeHtml(setVal(tmpBackData[2], ``, `string`));
 				const tmpClass = escapeHtml(setVal(tmpBackData[3], ``, `string`));


### PR DESCRIPTION
## 変更内容
- back_data利用時、フレーム計算が失敗しエラーとなる問題を修正

## 変更理由
- 変数のスペルミスにより、エラーが発生している状態だったため。

## その他コメント

