### PR TITLE
追加キー定義でシャッフルグループが正しく読み込めない問題の修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2495,7 +2495,7 @@ function keysConvert(_dosObj) {
 			if (_dosObj[`shuffle${newKey}`] !== undefined) {
 				const tmpshuffles = _dosObj[`shuffle${newKey}`].split(`$`);
 				for (let k = 0; k < tmpshuffles.length; k++) {
-					g_keyObj[`shuffle${newKey}_${k}`] = tmpshuffles[k].split(`,`).map(parseInt);
+					g_keyObj[`shuffle${newKey}_${k}`] = tmpshuffles[k].split(`,`).map(n => parseInt(n, 10));
 				}
 			}
 		}


### PR DESCRIPTION
## 変更内容
シャッフルグループの読み込み部分を修正しました。

## 変更理由
2番目のキーのシャッフルグループがNaNになっています。

## その他コメント
parseIntに引数が2つあることを知りませんでした…。