### PR TITLE
[ver3.1.4] 追加キー定義でシャッフルグループが正しく読み込めない問題の修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/02/27
+ * Revised : 2019/03/01
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 3.1.3`;
-const g_revisedDate = `2019/02/27`;
+const g_version = `Ver 3.1.4`;
+const g_revisedDate = `2019/03/01`;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
 let g_localVersion = ``;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/02/26
+ * Revised : 2019/02/27
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 3.1.2`;
-const g_revisedDate = `2019/02/26`;
+const g_version = `Ver 3.1.3`;
+const g_revisedDate = `2019/02/27`;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
 let g_localVersion = ``;


### PR DESCRIPTION
## 変更内容
- Pull Request #221 を参照。

## 変更理由
- 2番目のキーのシャッフルグループがNaNになるため。

## その他コメント

