### PR TITLE
曲名のフォントを初回から反映するように・グラデーション設定の追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1762,20 +1762,40 @@ function titleInit() {
 	}
 
 	// 曲名文字描画（曲名は譜面データから取得）
-	// 矢印色の1番目と3番目を使ってタイトルをグラデーション
-	const grd2 = l0ctx.createLinearGradient(0, 0, g_sHeight, 0);
+	let titlefontgrd = ``;
 	if (g_headerObj.customTitleUse === `false`) {
 
-		if (g_headerObj.setColor[0] != undefined) {
-			grd2.addColorStop(0, g_headerObj[`setColor`][0]);
-		} else {
-			grd2.addColorStop(0, `#ffffff`);
+		// グラデーションの指定がない場合、
+		// 矢印色の1番目と3番目を使ってタイトルをグラデーション
+		if (g_headerObj.titlegrd != undefined) {
+			titlefontgrd = g_headerObj.titlegrd;
+		}else{
+			if (g_headerObj.setColor[0] != undefined) {
+				titlefontgrd += g_headerObj[`setColor`][0];
+			} else {
+				titlefontgrd += `#ffffff`;
+			}
+
+			titlefontgrd += `,`;
+
+			if (g_headerObj.setColor[2] != undefined) {
+				titlefontgrd += g_headerObj[`setColor`][2];
+			} else {
+				titlefontgrd += `#66ffff`;
+			}
 		}
-		if (g_headerObj.setColor[2] != undefined) {
-			grd2.addColorStop(1, g_headerObj[`setColor`][2]);
-		} else {
-			grd2.addColorStop(1, `#66ffff`);
+
+		// グラデーションの方向の指定がない場合、左から右へグラデーションさせる
+		// 先頭1文字目が#かどうかで判断するので、redやwhiteのような色コードの指定はNG
+		if (titlefontgrd[0] == `#`) {
+			titlefontgrd = `to right,` + titlefontgrd;
 		}
+
+		// グラデーションが1色しか指定されていない場合、自動的に補完する
+		if (titlefontgrd.split(`#`).length <= 2) {
+			titlefontgrd += `,#ffffff`;
+		}
+
 		let titlefontsize = 64 * (12 / g_headerObj.musicTitle.length);
 		if (titlefontsize >= 64) {
 			titlefontsize = 64;
@@ -1790,8 +1810,28 @@ function titleInit() {
 		if (g_headerObj.titlefont !== ``) {
 			titlefontname = setVal(g_headerObj.titlefont, titlefontname, `string`);
 		}
-		createLabel(l0ctx, g_headerObj.musicTitle, g_sWidth / 2, g_sHeight / 2,
-			titlefontsize, titlefontname, grd2, `center`);
+		titlefontname = `'` + titlefontname.replace( /,/g , `','` ) + `'`;
+
+		const lblmusicTitle = createDivLabel(`lblmusicTitle`, 
+			g_sWidth * -1, 0, 
+			g_sWidth * 3, g_sHeight - 50, 
+			titlefontsize, `#ffffff`,
+			`<span style="
+				align:` + C_ALIGN_CENTER + `;
+				line-height:` + (g_sHeight - 50) + `px;
+				font-family:` + titlefontname + `;
+				font-size:` + titlefontsize + `px;
+				background: linear-gradient(` + titlefontgrd + `);
+				background-clip: text;
+				-webkit-background-clip: text;
+				-webkit-text-fill-color: rgba(255,255,255,0.0);
+				color: #ffffff;
+			">
+			` + g_headerObj.musicTitle + `
+			</span>
+			</div>`
+		);
+		divRoot.appendChild(lblmusicTitle);
 	}
 
 	// 非推奨ブラウザに対して警告文を表示
@@ -2252,6 +2292,9 @@ function headerConvert(_dosObj) {
 
 	// デフォルト曲名表示のフォント名
 	obj.titlefont = setVal(_dosObj.titlefont, ``, `string`);
+
+	// デフォルト曲名表示のグラデーション指定css
+	obj.titlegrd = setVal(_dosObj.titlegrd, ``, `string`);
 
 	// オプション利用可否設定
 	// Motion

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1767,10 +1767,10 @@ function titleInit() {
 
 		// グラデーションの指定がない場合、
 		// 矢印色の1番目と3番目を使ってタイトルをグラデーション
-		if (g_headerObj.titlegrd != undefined) {
+		if (setVal(g_headerObj.titlegrd, ``, `string`) !== ``) {
 			titlefontgrd = g_headerObj.titlegrd;
 		}else{
-			if (g_headerObj.setColor[0] != undefined) {
+			if (g_headerObj.setColor[0] !== undefined) {
 				titlefontgrd += g_headerObj[`setColor`][0];
 			} else {
 				titlefontgrd += `#ffffff`;
@@ -1778,7 +1778,7 @@ function titleInit() {
 
 			titlefontgrd += `,`;
 
-			if (g_headerObj.setColor[2] != undefined) {
+			if (g_headerObj.setColor[2] !== undefined) {
 				titlefontgrd += g_headerObj[`setColor`][2];
 			} else {
 				titlefontgrd += `#66ffff`;
@@ -1787,22 +1787,22 @@ function titleInit() {
 
 		// グラデーションの方向の指定がない場合、左から右へグラデーションさせる
 		// 先頭1文字目が#かどうかで判断するので、redやwhiteのような色コードの指定はNG
-		if (titlefontgrd[0] == `#`) {
+		if (titlefontgrd[0] === `#`) {
 			titlefontgrd = `to right,` + titlefontgrd;
 		}
-
+		
 		// グラデーションが1色しか指定されていない場合、自動的に補完する
 		if (titlefontgrd.split(`#`).length <= 2) {
 			titlefontgrd += `,#ffffff`;
 		}
-
+		
 		let titlefontsize = 64 * (12 / g_headerObj.musicTitle.length);
 		if (titlefontsize >= 64) {
 			titlefontsize = 64;
 		}
 
 		// カスタム変数 titlesize の定義 (使用例： |titlesize=40|)
-		if (g_headerObj.titlesize != ``) {
+		if (g_headerObj.titlesize !== ``) {
 			titlefontsize = setVal(g_headerObj.titlesize, titlefontsize, `number`);
 		}
 		// カスタム変数 titlefont の定義 (使用例： |titlefont=Century,Meiryo UI|)
@@ -1811,17 +1811,17 @@ function titleInit() {
 			titlefontname = setVal(g_headerObj.titlefont, titlefontname, `string`);
 		}
 		titlefontname = `'` + titlefontname.replace( /,/g , `','` ) + `'`;
-
+		
 		const lblmusicTitle = createDivLabel(`lblmusicTitle`, 
 			g_sWidth * -1, 0, 
-			g_sWidth * 3, g_sHeight - 50, 
+			g_sWidth *  3, g_sHeight, 
 			titlefontsize, `#ffffff`,
 			`<span style="
-				align:` + C_ALIGN_CENTER + `;
-				line-height:` + (g_sHeight - 50) + `px;
-				font-family:` + titlefontname + `;
-				font-size:` + titlefontsize + `px;
-				background: linear-gradient(` + titlefontgrd + `);
+				align:${C_ALIGN_CENTER};
+				line-height:${(g_sHeight - 20)}px;
+				font-family:${titlefontname};
+				font-size:${titlefontsize}px;
+				background: linear-gradient(${titlefontgrd});
 				background-clip: text;
 				-webkit-background-clip: text;
 				-webkit-text-fill-color: rgba(255,255,255,0.0);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1790,12 +1790,12 @@ function titleInit() {
 		if (titlefontgrd[0] === `#`) {
 			titlefontgrd = `to right,` + titlefontgrd;
 		}
-		
+
 		// グラデーションが1色しか指定されていない場合、自動的に補完する
 		if (titlefontgrd.split(`#`).length <= 2) {
 			titlefontgrd += `,#ffffff`;
 		}
-		
+
 		let titlefontsize = 64 * (12 / g_headerObj.musicTitle.length);
 		if (titlefontsize >= 64) {
 			titlefontsize = 64;
@@ -1811,14 +1811,22 @@ function titleInit() {
 			titlefontname = setVal(g_headerObj.titlefont, titlefontname, `string`);
 		}
 		titlefontname = `'` + titlefontname.replace( /,/g , `','` ) + `'`;
-		
+
+		// カスタム変数 titlepos の定義 (使用例： |titlepos=0,10| マイナス、小数点の指定もOK)
+		let titlefontpos = (
+			(setVal(g_headerObj.titlepos, ``, `string`) !== ``)
+			? g_headerObj.titlepos.split(`,`)
+			: [0,0]
+		);
+		console.log(titlefontpos);
+
 		const lblmusicTitle = createDivLabel(`lblmusicTitle`, 
-			g_sWidth * -1, 0, 
+			g_sWidth * -1 + Number(titlefontpos[0]), 0 + Number(titlefontpos[1]), 
 			g_sWidth *  3, g_sHeight, 
 			titlefontsize, `#ffffff`,
 			`<span style="
 				align:${C_ALIGN_CENTER};
-				line-height:${(g_sHeight - 20)}px;
+				line-height:${(g_sHeight - 40)}px;
 				font-family:${titlefontname};
 				font-size:${titlefontsize}px;
 				background: linear-gradient(${titlefontgrd});
@@ -2295,6 +2303,9 @@ function headerConvert(_dosObj) {
 
 	// デフォルト曲名表示のグラデーション指定css
 	obj.titlegrd = setVal(_dosObj.titlegrd, ``, `string`);
+
+	// デフォルト曲名表示の表示位置調整
+	obj.titlepos = setVal(_dosObj.titlepos, ``, `string`);
 
 	// オプション利用可否設定
 	// Motion

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1755,7 +1755,7 @@ function titleInit() {
 
 	// 背景の矢印オブジェクトを表示
 	if (g_headerObj.customTitleArrowUse === `false`) {
-		const lblArrow = createArrowEffect(`lblArrow`, g_headerObj[`setColor`][0], (g_sWidth - 500) / 2, -15, 500, 180);
+		const lblArrow = createArrowEffect(`lblArrow`, g_headerObj.setColor[0], (g_sWidth - 500) / 2, -15, 500, 180);
 		lblArrow.style.opacity = 0.25;
 		lblArrow.style.zIndex = 0;
 		divRoot.appendChild(lblArrow);
@@ -1771,7 +1771,7 @@ function titleInit() {
 			titlefontgrd = g_headerObj.titlegrd;
 		}else{
 			if (g_headerObj.setColor[0] !== undefined) {
-				titlefontgrd += g_headerObj[`setColor`][0];
+				titlefontgrd += g_headerObj.setColor[0];
 			} else {
 				titlefontgrd += `#ffffff`;
 			}
@@ -1779,7 +1779,7 @@ function titleInit() {
 			titlefontgrd += `,`;
 
 			if (g_headerObj.setColor[2] !== undefined) {
-				titlefontgrd += g_headerObj[`setColor`][2];
+				titlefontgrd += g_headerObj.setColor[2];
 			} else {
 				titlefontgrd += `#66ffff`;
 			}
@@ -1788,7 +1788,7 @@ function titleInit() {
 		// グラデーションの方向の指定がない場合、左から右へグラデーションさせる
 		// 先頭1文字目が#かどうかで判断するので、redやwhiteのような色コードの指定はNG
 		if (titlefontgrd[0] === `#`) {
-			titlefontgrd = `to right,` + titlefontgrd;
+			titlefontgrd = `to right,${titlefontgrd}`;
 		}
 
 		// グラデーションが1色しか指定されていない場合、自動的に補完する
@@ -1810,7 +1810,7 @@ function titleInit() {
 		if (g_headerObj.titlefont !== ``) {
 			titlefontname = setVal(g_headerObj.titlefont, titlefontname, `string`);
 		}
-		titlefontname = `'` + titlefontname.replace( /,/g , `','` ) + `'`;
+		titlefontname = `'${(titlefontname.replace( /,/g , `','` ))}'`;
 
 		// カスタム変数 titlepos の定義 (使用例： |titlepos=0,10| マイナス、小数点の指定もOK)
 		let titlefontpos = (
@@ -1818,7 +1818,6 @@ function titleInit() {
 			? g_headerObj.titlepos.split(`,`)
 			: [0,0]
 		);
-		console.log(titlefontpos);
 
 		const lblmusicTitle = createDivLabel(`lblmusicTitle`, 
 			g_sWidth * -1 + Number(titlefontpos[0]), 0 + Number(titlefontpos[1]), 
@@ -1835,7 +1834,7 @@ function titleInit() {
 				-webkit-text-fill-color: rgba(255,255,255,0.0);
 				color: #ffffff;
 			">
-			` + g_headerObj.musicTitle + `
+				${g_headerObj.musicTitle}
 			</span>
 			</div>`
 		);


### PR DESCRIPTION
## 変更内容
・タイトル画面の曲名にフォントを指定した場合に、読み込みのラグの関係で初回に指定したフォントが適用されない問題を修正しました。
・また、タイトル画面の曲名にかかるグラデーションを、譜面ヘッダで指定できるようにしました。

## 変更理由
タイトル画面が一番見られるのは初回時、結果画面から2回目以降を見られることは少ないため。
曲名表示で出来る表現の幅を広げるため。

## その他コメント
曲名フォントを初回から適用させるにあたり、従来の
「グラデーションを作成→createLabel関数内でfillTextメドットを用いて塗りつぶし」
ではなく、「createDivLabel関数でdiv要素を作成 → 変数を用いてcssを指定」
という形にして初回から反映させるようにしています。



また、cssによるグラデーション指定の実装にあたり、利便性のためいくつか例外処理を仕込んでいます。

まず基本の使用方法ですが、譜面ヘッダでは
|titlegrd=#DDDD99,#ffff00|
という表記で指定します。
3色以上のグラデーションも可能で
|titlegrd=#ff0000,#ff4500,#ffff00,#008000,#00ffff,#0000ff,#800080|
と指定すればタイトル文字が虹色になります。



今回cssグラデーションの実装にあたり使用したlinear-gradient()関数では
角度を省略した場合は上から下へとグラデーションがかかるため、
角度を指定せず色コードの書いた場合≒1文字目が 「#」 の場合は
先頭に「to right , 」を追加して、従来どおり左から右へグラデーションするようにしています。

グラデーションの方向を変えたい場合は
|titlegrd=to top right,#DDDD99,#ffff00|
|titlegrd=45deg,#DDDD99,#ffff00|
というように指定することが出来ます。

この処理にあたり「white」や「red」といった色コードではなく色の名前を指定した場合は
1文字目が 「#」 ではないためグラデの方向が上から下になるため注意してください。

次の例外処理ですが、グラデーションの指定にあたり色コードが1色だけではエラーになる、
しかし毎回律儀に2色指定するのも煩わしさを増やす、ということで
|titlegrd=#DDDD99|
のように1色だけ指定した場合、末尾に「,#ffffff」を追加して補完するようにしています。
この処理の条件も文字列内に「#」 が2個未満の場合としてあるため
色コードではなく色の名前を指定した場合はおかしくなります。

長くなりましたがよろしくお願い致します。