### PR TITLE
[titleView] タイトル文字の複数行対応

### DIFF
--- a/danoni/danoni1.html
+++ b/danoni/danoni1.html
@@ -41,7 +41,7 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 <body>
 <table><tr><td>
 <input type="hidden" name="dos" id="dos" value='
-|musicTitle=Stormy wing,SHIKI,http://shiki2.sakura.ne.jp/|
+|musicTitle=Stormy wing<br>2,SHIKI,http://shiki2.sakura.ne.jp/|
 |difData=7,Normal,3.5,70,2,7$6,Extra,3.5,70,2,7$8|
 |setColor=0x99ffff,0xCCCC33,0xFFFFFF,0xff0066|
 |frzColor=0x66ffff,0x6666ff,0xffff66,0xffff66|
@@ -49,6 +49,8 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 |musicUrl=nosound.mp3|
 |blankFrame=200|
 |fadeFrame=10500$10500|
+|titlefont=Century|
+|titlelineheight=60|
 
 |customTitleUse=false|
 |customTitleArrowUse=false|

--- a/danoni/danoni1.html
+++ b/danoni/danoni1.html
@@ -41,7 +41,7 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 <body>
 <table><tr><td>
 <input type="hidden" name="dos" id="dos" value='
-|musicTitle=Stormy wing<br>2,SHIKI,http://shiki2.sakura.ne.jp/|
+|musicTitle=Stormy wing<br>2019.3.23,SHIKI,http://shiki2.sakura.ne.jp/|
 |difData=7,Normal,3.5,70,2,7$6,Extra,3.5,70,2,7$8|
 |setColor=0x99ffff,0xCCCC33,0xFFFFFF,0xff0066|
 |frzColor=0x66ffff,0x6666ff,0xffff66,0xffff66|
@@ -50,7 +50,8 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 |blankFrame=200|
 |fadeFrame=10500$10500|
 |titlefont=Century|
-|titlelineheight=60|
+|titlelineheight=40|
+|titlesize=60,40|
 
 |customTitleUse=false|
 |customTitleArrowUse=false|

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1796,36 +1796,42 @@ function titleInit() {
 			titlefontgrd += `,#ffffff`;
 		}
 
-		let titlefontsize = 64 * (12 / g_headerObj.musicTitle.length);
+		let titlefontsize = 64 * (12 / g_headerObj.musicTitleForView[0].length);
 		if (titlefontsize >= 64) {
 			titlefontsize = 64;
 		}
 
-		// カスタム変数 titlesize の定義 (使用例： |titlesize=40|)
+		// 変数 titlesize の定義 (使用例： |titlesize=40|)
 		if (g_headerObj.titlesize !== ``) {
 			titlefontsize = setVal(g_headerObj.titlesize, titlefontsize, `number`);
 		}
-		// カスタム変数 titlefont の定義 (使用例： |titlefont=Century,Meiryo UI|)
+		// 変数 titlefont の定義 (使用例： |titlefont=Century,Meiryo UI|)
 		let titlefontname = `メイリオ`;
 		if (g_headerObj.titlefont !== ``) {
 			titlefontname = setVal(g_headerObj.titlefont, titlefontname, `string`);
 		}
 		titlefontname = `'${(titlefontname.replace(/,/g, `','`))}'`;
 
-		// カスタム変数 titlepos の定義 (使用例： |titlepos=0,10| マイナス、小数点の指定もOK)
+		// 変数 titlepos の定義 (使用例： |titlepos=0,10| マイナス、小数点の指定もOK)
 		let titlefontpos = (
 			(setVal(g_headerObj.titlepos, ``, `string`) !== ``)
 				? g_headerObj.titlepos.split(`,`)
 				: [0, 0]
 		);
 
+		// 変数 titlelineheight の定義 (使用例： |titlelineheight=50|)
+		let titlelineheight = g_headerObj.titlelineheight;
+		if (g_headerObj.titlelineheight === ``) {
+			titlelineheight = setVal(g_headerObj.titlelineheight, titlefontsize + 10, `number`);
+		}
+
 		const lblmusicTitle = createDivLabel(`lblmusicTitle`,
 			g_sWidth * -1 + Number(titlefontpos[0]), 0 + Number(titlefontpos[1]),
-			g_sWidth * 3, g_sHeight,
+			g_sWidth * 3, g_sHeight - 40,
 			titlefontsize, `#ffffff`,
 			`<span style="
 				align:${C_ALIGN_CENTER};
-				line-height:${(g_sHeight - 40)}px;
+				line-height:${titlelineheight}px;
 				font-family:${titlefontname};
 				font-size:${titlefontsize}px;
 				background: linear-gradient(${titlefontgrd});
@@ -1834,10 +1840,14 @@ function titleInit() {
 				-webkit-text-fill-color: rgba(255,255,255,0.0);
 				color: #ffffff;
 			">
-				${g_headerObj.musicTitle}
-			</span>
-			</div>`
+				${g_headerObj.musicTitleForView[0]}<br>
+				${setVal(g_headerObj.musicTitleForView[1], ``, `string`)}
+			</span>`
 		);
+		lblmusicTitle.style.display = `flex`;
+		lblmusicTitle.style.flexDirection = `column`;
+		lblmusicTitle.style.justifyContent = `center`;
+		lblmusicTitle.style.alignItems = `center`;
 		divRoot.appendChild(lblmusicTitle);
 	}
 
@@ -2026,7 +2036,8 @@ function headerConvert(_dosObj) {
 	// 曲名
 	if (_dosObj.musicTitle !== undefined && _dosObj.musicTitle !== ``) {
 		const musics = _dosObj.musicTitle.split(`,`);
-		obj.musicTitle = musics[0];
+		obj.musicTitle = musics[0].split(`<br>`).join(` `);
+		obj.musicTitleForView = musics[0].split("<br>");
 		if (musics.length > 1) {
 			obj.artistName = musics[1];
 		} else {
@@ -2305,6 +2316,9 @@ function headerConvert(_dosObj) {
 
 	// デフォルト曲名表示の表示位置調整
 	obj.titlepos = setVal(_dosObj.titlepos, ``, `string`);
+
+	// デフォルト曲名表示の複数行時の縦間隔
+	obj.titlelineheight = setVal(_dosObj.titlelineheight, ``, `number`);
 
 	// オプション利用可否設定
 	// Motion
@@ -6531,7 +6545,9 @@ function resultInit() {
 	playDataWindow.appendChild(makeResultPlayData(`lblMusic`, 20, `#999999`, 0,
 		`Music`, C_ALIGN_LEFT));
 	playDataWindow.appendChild(makeResultPlayData(`lblMusicData`, 60, `#cccccc`, 0,
-		g_headerObj.musicTitle, C_ALIGN_CENTER));
+		g_headerObj.musicTitleForView[0], C_ALIGN_CENTER));
+	playDataWindow.appendChild(makeResultPlayData(`lblMusicData`, 60, `#cccccc`, 1,
+		setVal(g_headerObj.musicTitleForView[1], ``, `string`), C_ALIGN_CENTER));
 	playDataWindow.appendChild(makeResultPlayData(`lblDifficulty`, 20, `#999999`, 2,
 		`Difficulty`, C_ALIGN_LEFT));
 	let difData = `${g_headerObj.keyLabels[g_stateObj.scoreId]} key / ${g_headerObj.difLabels[g_stateObj.scoreId]}`;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1801,9 +1801,13 @@ function titleInit() {
 			titlefontsize = 64;
 		}
 
-		// 変数 titlesize の定義 (使用例： |titlesize=40|)
+		// 変数 titlesize の定義 (使用例： |titlesize=40,20|)
+		let titlefontsize1;
+		let titlefontsize2;
 		if (g_headerObj.titlesize !== ``) {
-			titlefontsize = setVal(g_headerObj.titlesize, titlefontsize, `number`);
+			let titlefontsizes = g_headerObj.titlesize.split(`,`);
+			titlefontsize1 = setVal(titlefontsizes[0], titlefontsize, `number`);
+			titlefontsize2 = setVal(titlefontsizes[1], titlefontsize1, `number`);
 		}
 		// 変数 titlefont の定義 (使用例： |titlefont=Century,Meiryo UI|)
 		let titlefontname = `メイリオ`;
@@ -1833,7 +1837,7 @@ function titleInit() {
 				align:${C_ALIGN_CENTER};
 				line-height:${titlelineheight}px;
 				font-family:${titlefontname};
-				font-size:${titlefontsize}px;
+				font-size:${titlefontsize1}px;
 				background: linear-gradient(${titlefontgrd});
 				background-clip: text;
 				-webkit-background-clip: text;
@@ -1841,7 +1845,9 @@ function titleInit() {
 				color: #ffffff;
 			">
 				${g_headerObj.musicTitleForView[0]}<br>
-				${setVal(g_headerObj.musicTitleForView[1], ``, `string`)}
+				<span style="font-size:${titlefontsize2}px;">
+					${setVal(g_headerObj.musicTitleForView[1], ``, `string`)}
+				</span>
 			</span>`
 		);
 		lblmusicTitle.style.display = `flex`;
@@ -2306,7 +2312,7 @@ function headerConvert(_dosObj) {
 	obj.customReadyUse = setVal(_dosObj.customReadyUse, ``, `string`);
 
 	// デフォルト曲名表示のフォントサイズ
-	obj.titlesize = setVal(_dosObj.titlesize, ``, `number`);
+	obj.titlesize = setVal(_dosObj.titlesize, ``, `string`);
 
 	// デフォルト曲名表示のフォント名
 	obj.titlefont = setVal(_dosObj.titlefont, ``, `string`);


### PR DESCRIPTION
## 変更内容
1. タイトル文字（デフォルト）について、2行目を指定できるようにしました。
musicTitleの1つ目の変数について、&lt;br&gt;を指定することで2行目へ折り返しできます。

```
|musicTitle=Over the Rave<br>Original Mix,takoyaki_o,http://...|
```

2.  1行目、2行目の文字サイズを変更できるようにしました。
カンマ区切りで2行目のフォントサイズを指定します。
指定しない場合は1行目のフォントサイズに調整します。

```
|titlesize=40,20|
```

3. 1行目と2行目の間の数値を変更できるように、変数を設定しました。
指定しない場合は1行目のフォントサイズ＋10pxが指定されます。

```
|titlelineheight=50|
```

## 変更理由
- 曲名が長い曲に対して、表示位置を調整しやすくするため。
結果画面も2行対応させています。

## その他コメント
- これまでの line-heightの方法ではなく、display:flex （flexbox）を使用することで
中央寄せを実現しています。
この方法により、複数行の中央寄せが容易になります。
