### PR TITLE
総ノート数が0のときスコアがNaNになる不具合の修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6514,7 +6514,7 @@ function resultInit() {
 		g_resultObj.fmaxCombo * 2;
 
 	const allScore = (g_allArrow + g_allFrz / 2) * 10;
-	const resultScore = Math.round(scoreTmp / allScore * 1000000);
+	const resultScore = Math.round(scoreTmp / allScore * 1000000) || 0;
 	g_resultObj.score = resultScore;
 
 	// ランク計算


### PR DESCRIPTION
## 変更内容
スコアがNaNになったときは0にするように変更しました。

## 変更理由
総ノート数が0のときスコアが0/0でNaNになります。

## その他コメント