### PR TITLE
[setting-default:0.1.0] 設定ファイルのデフォルト値を指定　他

### DIFF
--- a/danoni/danoni1.html
+++ b/danoni/danoni1.html
@@ -55,7 +55,7 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 
 |customTitleUse=false|
 |customTitleArrowUse=false|
-|customBackUse=false|
+|customBackMainUse=true|
 
 |shuffleUse=false|
 

--- a/js/danoni_custom.js
+++ b/js/danoni_custom.js
@@ -35,14 +35,6 @@ function customTitleInit() {
 	// バージョン表記
 	g_localVersion = ``;
 
-	// デフォルトの曲名表示を利用しない場合は、下記をコメント化してください。
-	// もう一方のcustomファイルを使って再上書きも可能です。
-
-	g_headerObj.customTitleUse = `false`;
-	g_headerObj.customTitleArrowUse = `false`;
-	g_headerObj.customBackUse = `false`;
-	g_headerObj.customBackMainUse = `false`;
-	g_headerObj.customReadyUse = `false`;
 }
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2074,10 +2074,18 @@ function headerConvert(_dosObj) {
 		obj.lifeInits = [];
 		for (let j = 0; j < difs.length; j++) {
 			const difDetails = difs[j].split(`,`);
-			const border = (difDetails[3]) ? difDetails[3] : g_presetGauge.Border;
-			const recovery = (difDetails[4]) ? difDetails[4] : g_presetGauge.Recovery;
-			const damage = (difDetails[5]) ? difDetails[5] : g_presetGauge.Damage;
-			const init = (difDetails[6]) ? difDetails[6] : g_presetGauge.Init;
+			const border = (difDetails[3]) ? difDetails[3] :
+				(g_presetGauge !== undefined && (`Border` in g_presetGauge) ?
+					g_presetGauge.Border : `x`);
+			const recovery = (difDetails[4]) ? difDetails[4] :
+				(g_presetGauge !== undefined && (`Recovery` in g_presetGauge) ?
+					g_presetGauge.Recovery : 6);
+			const damage = (difDetails[5]) ? difDetails[5] :
+				(g_presetGauge !== undefined && (`Damage` in g_presetGauge) ?
+					g_presetGauge.Damage : 40);
+			const init = (difDetails[6]) ? difDetails[6] :
+				(g_presetGauge !== undefined && (`Init` in g_presetGauge) ?
+					g_presetGauge.Init : 25);
 			obj.keyLabels.push(setVal(difDetails[0], `7`, `string`));
 			obj.difLabels.push(setVal(difDetails[1], `Normal`, `string`));
 			obj.initSpeeds.push(setVal(difDetails[2], 3.5, `float`));
@@ -2297,19 +2305,29 @@ function headerConvert(_dosObj) {
 	obj.releaseDate = setVal(_dosObj.releaseDate, ``, `string`);
 
 	// タイトル画面のデフォルト曲名表示の利用有無
-	obj.customTitleUse = setVal(_dosObj.customTitleUse, ``, `string`);
+	obj.customTitleUse = setVal(_dosObj.customTitleUse,
+		(g_presetCustomDesignUse !== undefined && (`title` in g_presetCustomDesignUse) ?
+			g_presetCustomDesignUse.title : `false`), `string`);
 
 	// タイトル画面のデフォルト背景矢印の利用有無
-	obj.customTitleArrowUse = setVal(_dosObj.customTitleArrowUse, ``, `string`);
+	obj.customTitleArrowUse = setVal(_dosObj.customTitleArrowUse,
+		(g_presetCustomDesignUse !== undefined && (`titleArrow` in g_presetCustomDesignUse) ?
+			g_presetCustomDesignUse.titleArrow : `false`), `string`);
 
 	// デフォルト背景の利用有無
-	obj.customBackUse = setVal(_dosObj.customBackUse, ``, `string`);
+	obj.customBackUse = setVal(_dosObj.customBackUse,
+		(g_presetCustomDesignUse !== undefined && (`back` in g_presetCustomDesignUse) ?
+			g_presetCustomDesignUse.back : `false`), `string`);
 
 	// デフォルト背景の利用有無（メイン画面のみ適用）
-	obj.customBackMainUse = setVal(_dosObj.customBackMainUse, ``, `string`);
+	obj.customBackMainUse = setVal(_dosObj.customBackMainUse,
+		(g_presetCustomDesignUse !== undefined && (`backMain` in g_presetCustomDesignUse) ?
+			g_presetCustomDesignUse.backMain : `false`), `string`);
 
 	// デフォルトReady表示の利用有無
-	obj.customReadyUse = setVal(_dosObj.customReadyUse, ``, `string`);
+	obj.customReadyUse = setVal(_dosObj.customReadyUse,
+		(g_presetCustomDesignUse !== undefined && (`ready` in g_presetCustomDesignUse) ?
+			g_presetCustomDesignUse.ready : `false`), `string`);
 
 	// デフォルト曲名表示のフォントサイズ
 	obj.titlesize = setVal(_dosObj.titlesize, ``, `string`);
@@ -5043,7 +5061,7 @@ function MainInit() {
 
 	// 画面背景を指定 (background-color)
 	const grd = l0ctx.createLinearGradient(0, 0, 0, g_sHeight);
-	if (g_headerObj.customBackUse === `false` || g_headerObj.customBackMainUse === `false`) {
+	if (g_headerObj.customBackUse === `false` && g_headerObj.customBackMainUse === `false`) {
 		grd.addColorStop(0, `#000000`);
 		grd.addColorStop(1, `#222222`);
 		l0ctx.fillStyle = grd;

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -16,10 +16,10 @@ const g_presetTuningUrl = `https://www.google.co.jp/`;
 
 // ゲージ設定（デフォルト）
 const g_presetGauge = {
-	Border: 70,  // ノルマ制でのボーダーライン、ライフ制にしたい場合は `x` を指定
-	Recovery: 2, // 回復量
-	Damage: 7,   // ダメージ量
-	Init: 25,    // 初期値
+	//	Border: 70,  // ノルマ制でのボーダーライン、ライフ制にしたい場合は `x` を指定
+	//	Recovery: 2, // 回復量
+	//	Damage: 7,   // ダメージ量
+	//	Init: 25,    // 初期値
 };
 
 // ゲージ設定（デフォルト以外）
@@ -38,11 +38,21 @@ const g_presetGaugeCustom = {
 	},
 };
 
+// デフォルトのデザインを使用せず、独自のデザインを使用するかを指定
+// カスタムデザインにする場合は `true` を指定
+const g_presetCustomDesignUse = {
+	title: `false`,
+	titleArrow: `false`,
+	back: `false`,
+	backMain: `false`,
+	ready: `false`,
+}
+
 // オプション利用設定（デフォルト）
 // 一律使用させたくない場合は `false` を指定（デフォルトは `true`）
 const g_presetSettingUse = {
 	motion: `true`,
 	shuffle: `true`,
 	autoPlay: `true`,
-	gauge: `true`
+	gauge: `true`,
 };


### PR DESCRIPTION
## 変更内容
1.  設定ファイル(danoni_setting.js) のデフォルト値を指定
2.  カスタムデザインの設定をdanoni_setting.js へ移動
3.  カスタムデザインの設定の既定値を一律「false」に設定

## 変更理由
1. danoni_setting.js をそのまま利用するとノルマ制ゲージになるため、
デフォルト値を指定しない場合、ライフ制になるように修正。  
2. danoni_custom.js で設定する内容ではないため。
3. ver1の互換設定として残していたが、デフォルトのまま使用する状況が増えてきたため。

## その他コメント

