### PR TITLE
[ver3.7.0] カスタムデザイン（背景）の使用について、メインとそれ以外で設定を分離

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/04/03
+ * Revised : 2019/04/06
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 3.6.0`;
-const g_revisedDate = `2019/04/03`;
+const g_version = `Ver 3.7.0`;
+const g_revisedDate = `2019/04/06`;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
 let g_localVersion = ``;
@@ -5061,7 +5061,7 @@ function MainInit() {
 
 	// 画面背景を指定 (background-color)
 	const grd = l0ctx.createLinearGradient(0, 0, 0, g_sHeight);
-	if (g_headerObj.customBackUse === `false` && g_headerObj.customBackMainUse === `false`) {
+	if (g_headerObj.customBackMainUse === `false`) {
 		grd.addColorStop(0, `#000000`);
 		grd.addColorStop(1, `#222222`);
 		l0ctx.fillStyle = grd;


### PR DESCRIPTION
## 変更内容
- カスタムデザイン（背景）の使用について、メインとそれ以外で設定を分離
オリジナル背景を使用する場合、下記2か所の両方を`true`にする必要があります。
```javascript
	g_headerObj.customBackUse = `false`;            // メイン画面以外の背景設定
	g_headerObj.customBackMainUse = `false`;    // メイン画面の背景設定
```

## 変更理由
- これまでは g_headerObj.customBackUse のみでどの画面でも
背景をオリジナルにするかどうかを指定することができましたが、
g_headerObj.customBackMainUse の扱いが曖昧で、わかりにくいため明確に分離します。



## その他コメント

