### PR TITLE
[ver3.9.0] パターン付きのキー数自動修正＆cssモーションパターン拡張

### DIFF
--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -133,16 +133,8 @@ input[type=range]::-moz-range-thumb{
 input[type=range]:focus {
 	outline: 0;
 }
-@keyframes upToDown {
-	0% {
-		opacity: 0;/* 透明 */
-		transform: translateY(-50px);
-	}
-	100% {
-		opacity: 1;/* 不透明 */
-		transform: translateY(0);
-	}
-}
+
+/* 左から右へ */
 @keyframes leftToRight {
 	0% {
 		opacity: 0;/* 透明 */
@@ -153,6 +145,20 @@ input[type=range]:focus {
 		transform: translateX(0);
 	}
 }
+
+/* 上から下へ */
+@keyframes upToDown {
+	0% {
+		opacity: 0;/* 透明 */
+		transform: translateY(-50px);
+	}
+	100% {
+		opacity: 1;/* 不透明 */
+		transform: translateY(0);
+	}
+}
+
+/* 左から右へ移動し、フェードアウト（結果画面で使用） */
 @keyframes leftToRightFade {
 	0% {
 		opacity: 0;/* 透明 */
@@ -171,6 +177,8 @@ input[type=range]:focus {
 		transform: translateX(30px);
 	}
 }
+
+/* 上から下へ移動し、フェードアウト（結果画面で使用） */
 @keyframes upToDownFade {
 	0% {
 		opacity: 0;/* 透明 */
@@ -189,6 +197,8 @@ input[type=range]:focus {
 		transform: translateY(10px);
 	}
 }
+
+/* 徐々に表示（結果画面で使用） */
 @keyframes slowlyAppearing {
 	0% {
 		opacity: 0.5;/* 透明 */
@@ -199,4 +209,79 @@ input[type=range]:focus {
 	100% {
 		opacity: 1;/* 不透明 */
 	}
+}
+
+/* 文字拡大から元のサイズへ戻る */
+@keyframes fromBig {
+	0% {
+		opacity: 0;/* 透明 */
+		transform: scale(1.5, 1.5);
+		
+	}
+	100% {
+		opacity: 1;/* 不透明 */
+		transform: scale(1, 1);
+	}
+}
+
+/* X軸回転 */
+@keyframes spinX {
+	0% {
+		transform: rotateX(0deg);
+	}
+	100% {
+		transform: rotateX(360deg);
+	}
+}
+
+/* Y軸回転 */
+@keyframes spinY {
+	0% {
+		transform: rotateY(0deg);
+	}
+	100% {
+		transform: rotateY(360deg);
+	}
+}
+
+/* Z軸回転 */
+@keyframes spinZ {
+	0% {
+		transform: rotateZ(0deg);
+	}
+	100% {
+		transform: rotateZ(360deg);
+	}
+}
+
+/* ぼかし */
+@keyframes blur {
+	0% {
+		filter: blur(8px);
+	}
+	100% {
+		filter: blur(0);
+	}
+}
+
+/* 発光から暗くなり元に戻る */
+@keyframes brightToDark {
+	0% {
+		filter: brightness(0.0);
+	}
+	30% {
+		filter: brightness(2.0);
+	}
+	70% {
+		filter: brightness(0.0);
+	}
+	100% {
+		filter: brightness(1.0);
+	}
+}
+
+/* タイトルデフォルトモーション（HTML側で上書き可能） */
+#lblmusicTitle{
+	animation-duration: 1.5s;
+	animation-name: leftToRight;
 }

--- a/danoni/danoni1.html
+++ b/danoni/danoni1.html
@@ -34,6 +34,11 @@ th,td{padding:0;}
 
 a{ text-decoration: none; }
 a:hover  { color:#FF9900; text-decoration: underline; }
+
+#lblmusicTitle{
+	animation-duration: 2.0s;
+	animation-name: upToDown;
+}
 //-->
 </style>
 </head>

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/04/06
+ * Revised : 2019/04/14
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 3.8.0`;
-const g_revisedDate = `2019/04/13`;
+const g_version = `Ver 3.9.0`;
+const g_revisedDate = `2019/04/14`;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
 let g_localVersion = ``;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,8 +8,8 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 3.7.0`;
-const g_revisedDate = `2019/04/06`;
+const g_version = `Ver 3.8.0`;
+const g_revisedDate = `2019/04/13`;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
 let g_localVersion = ``;
@@ -1745,14 +1745,6 @@ function titleInit() {
 		l0ctx.fillRect(0, 0, g_sWidth, g_sHeight);
 	}
 
-	// ユーザカスタムイベント(初期)
-	if (typeof customTitleInit === `function`) {
-		customTitleInit();
-		if (typeof customTitleInit2 === `function`) {
-			customTitleInit2();
-		}
-	}
-
 	// 背景の矢印オブジェクトを表示
 	if (g_headerObj.customTitleArrowUse === `false`) {
 		const lblArrow = createArrowEffect(`lblArrow`, g_headerObj.setColor[0], (g_sWidth - 500) / 2, -15, 500, 180);
@@ -1865,6 +1857,14 @@ function titleInit() {
 		(g_userAgent.indexOf(`firefox`) !== -1 && location.href.match(`^file`))) {
 
 		makeWarningWindow(C_MSG_W_0001);
+	}
+
+	// ユーザカスタムイベント(初期)
+	if (typeof customTitleInit === `function`) {
+		customTitleInit();
+		if (typeof customTitleInit2 === `function`) {
+			customTitleInit2();
+		}
 	}
 
 	// ボタン描画

--- a/js/sample/danoni_custom-003.js
+++ b/js/sample/danoni_custom-003.js
@@ -22,45 +22,11 @@
  */
 function customTitleInit() {
 
-	// レイヤー情報取得
-	var layer0 = document.getElementById("layer0");
-	var l0ctx = layer0.getContext("2d");
-
-	// 画面背景を指定 (background-color)
-	var grd = l0ctx.createLinearGradient(0, 0, 0, g_sHeight);
-	grd.addColorStop(0, "#000000");
-	grd.addColorStop(1, "#000022");
-	l0ctx.fillStyle = grd;
-	l0ctx.fillRect(0, 0, g_sWidth, g_sHeight);
-
-
 	// 背景の矢印オブジェクトを表示
 	var lblC = createArrowEffect("lblC", "#ffffff", g_sWidth / 2 - 300, 0, 100, "onigiri");
 	lblC.style.opacity = 0.25;
 	divRoot.appendChild(lblC);
 
-	var lblArrow = createArrowEffect("lblArrow", g_headerObj["setColor"][0], (g_sWidth - 500) / 2, -15, 500, 180);
-	lblArrow.style.opacity = 0.25;
-	divRoot.appendChild(lblArrow);
-
-	// 曲名文字描画（曲名は譜面データから取得）
-	var grd = l0ctx.createLinearGradient(0, 0, g_sHeight, 0);
-	if (g_headerObj["setColor"][0] != undefined) {
-		grd.addColorStop(0, g_headerObj["setColor"][0]);
-	} else {
-		grd.addColorStop(0, "#ffffff");
-	}
-	if (g_headerObj["setColor"][2] != undefined) {
-		grd.addColorStop(1, g_headerObj["setColor"][2]);
-	} else {
-		grd.addColorStop(1, "#66ffff");
-	}
-	var titlefontsize = 64 * (12 / g_headerObj["musicTitle"].length);
-	if (titlefontsize >= 64) {
-		titlefontsize = 64;
-	}
-	createLabel(l0ctx, g_headerObj["musicTitle"], g_sWidth / 2, g_sHeight / 2,
-		titlefontsize, "Century Gothic", grd, "center");
 
 	// Tweetボタン描画
 	var btnTweet = createButton({
@@ -85,16 +51,6 @@ function customTitleInit() {
  * カスタム画面(コメントとか)
  */
 function customCommentInit() {
-	// レイヤー情報取得
-	var layer0 = document.getElementById("layer0");
-	var l0ctx = layer0.getContext("2d");
-
-	// 画面背景を指定 (background-color)
-	var grd = l0ctx.createLinearGradient(0, 0, 0, g_sHeight);
-	grd.addColorStop(0, "#000000");
-	grd.addColorStop(1, "#002222");
-	l0ctx.fillStyle = grd;
-	l0ctx.fillRect(0, 0, g_sWidth, g_sHeight);
 
 	// タイトル文字描画
 	var lblTitle = getTitleDivLabel("lblTitle",
@@ -137,16 +93,6 @@ function customCommentInit() {
  * オプション画面(初期表示)
  */
 function customOptionInit() {
-	// レイヤー情報取得
-	var layer0 = document.getElementById("layer0");
-	var l0ctx = layer0.getContext("2d");
-
-	// 画面背景を指定 (background-color)
-	var grd = l0ctx.createLinearGradient(0, 0, 0, g_sHeight);
-	grd.addColorStop(0, "#000000");
-	grd.addColorStop(1, "#171700");
-	l0ctx.fillStyle = grd;
-	l0ctx.fillRect(0, 0, g_sWidth, g_sHeight);
 
 }
 
@@ -154,16 +100,6 @@ function customOptionInit() {
  * キーコンフィグ画面(初期表示)
  */
 function customKeyConfigInit() {
-	// レイヤー情報取得
-	var layer0 = document.getElementById("layer0");
-	var l0ctx = layer0.getContext("2d");
-
-	// 画面背景を指定 (background-color)
-	var grd = l0ctx.createLinearGradient(0, 0, 0, g_sHeight);
-	grd.addColorStop(0, "#000000");
-	grd.addColorStop(1, "#171700");
-	l0ctx.fillStyle = grd;
-	l0ctx.fillRect(0, 0, g_sWidth, g_sHeight);
 
 }
 
@@ -203,15 +139,5 @@ function customMainEnterFrame() {
  * 結果画面(初期表示)
  */
 function customResultInit() {
-	// レイヤー情報取得
-	var layer0 = document.getElementById("layer0");
-	var l0ctx = layer0.getContext("2d");
-
-	// 画面背景を指定 (background-color)
-	var grd = l0ctx.createLinearGradient(0, 0, 0, g_sHeight);
-	grd.addColorStop(0, "#000000");
-	grd.addColorStop(1, "#001717");
-	l0ctx.fillStyle = grd;
-	l0ctx.fillRect(0, 0, g_sWidth, g_sHeight);
 
 }


### PR DESCRIPTION
## 変更内容
1. パターン付きのキー指定を自動修正 ( #238 )
1. CSSモーションパターンを追加し、デフォルトの曲名表示に対してモーションを指定

## 変更理由
1. ParaFlaソース時代に指定していた旧キー表記をそのまま移植すると、動作しない不具合があるため。
例）DPkey, 9key, TPkeyなど
2. CSSモーションをより使いやすくするため。

## その他コメント

