### PR TITLE
[clear-condition:0.1.0] クリア条件を見直し、startFrameの機能拡張（譜面毎設定）

### DIFF
--- a/danoni/danoni1.html
+++ b/danoni/danoni1.html
@@ -50,7 +50,7 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 |difData=7,Normal,3.5,70,2,7$6,Extra,3.5,70,2,7$8|
 |setColor=0x99ffff,0xCCCC33,0xFFFFFF,0xff0066|
 |frzColor=0x66ffff,0x6666ff,0xffff66,0xffff66|
-|startFrame=0|debug=true|blankFrame=157|
+|startFrame=0|blankFrame=157|
 |musicUrl=nosound.mp3|
 |blankFrame=200|
 |fadeFrame=10500$10500|

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2230,11 +2230,9 @@ function headerConvert(_dosObj) {
 		obj.blankFrameDef = parseInt(_dosObj.blankFrame);
 	}
 
-	// フェードインフレーム数
+	// 開始フレーム数（0以外の場合はフェードインスタート）
 	if (_dosObj.startFrame !== undefined) {
-		obj.startFrame = parseInt(_dosObj.startFrame);
-	} else {
-		obj.startFrame = 0;
+		obj.startFrame = _dosObj.startFrame.split(`$`);
 	}
 
 	// フェードアウトフレーム数(譜面別)
@@ -4540,8 +4538,8 @@ function getFirstArrowFrame(_dataObj) {
  */
 function getStartFrame(_lastFrame) {
 	let frameNum = 0;
-	frameNum = g_headerObj.startFrame;
-	if (_lastFrame >= g_headerObj.startFrame) {
+	frameNum = parseInt(g_headerObj.startFrame[g_stateObj.scoreId]) || parseInt(g_headerObj.startFrame[0]) || 0;
+	if (_lastFrame >= frameNum) {
 		frameNum = Math.round(g_stateObj.fadein / 100 * (_lastFrame - frameNum)) + frameNum;
 	}
 	return frameNum;
@@ -6607,6 +6605,11 @@ function resultInit() {
 		l0ctx.fillRect(0, 0, g_sWidth, g_sHeight);
 	}
 
+	const playingArrows = g_resultObj.ii + g_resultObj.shakin +
+		g_resultObj.matari + g_resultObj.shobon + g_resultObj.uwan +
+		g_resultObj.kita + g_resultObj.iknai;
+	const fullArrows = g_allArrow + g_allFrz / 2;
+
 	// スコア計算(一括)
 	const scoreTmp = g_resultObj.ii * 8 +
 		g_resultObj.shakin * 4 +
@@ -6626,7 +6629,7 @@ function resultInit() {
 	if (g_gameOverFlg) {
 		rankMark = g_rankObj.rankMarkF;
 		rankColor = g_rankObj.rankColorF;
-	} else if (g_headerObj.startFrame === 0 && g_stateObj.auto === C_FLG_OFF) {
+	} else if (playingArrows === fullArrows && g_stateObj.auto === C_FLG_OFF) {
 		if (g_resultObj.matari + g_resultObj.shobon + g_resultObj.uwan + g_resultObj.sfsf + g_resultObj.iknai === 0) {
 			rankMark = g_rankObj.rankMarkPF;
 			rankColor = g_rankObj.rankColorPF;
@@ -6819,16 +6822,20 @@ function resultInit() {
 	divRoot.appendChild(lblResultPre);
 	lblResultPre.style.opacity = 0;
 
-	const fullArrows = g_allArrow + g_allFrz / 2;
 	let resultFlgTmp = ``;
-	if (g_resultObj.ii + g_resultObj.kita === fullArrows) {
-		resultFlgTmp = `<span style=color:#ffffff>All Perfect!!</span>`;
-	} else if (g_resultObj.ii + g_resultObj.shakin + g_resultObj.kita === fullArrows) {
-		resultFlgTmp = `<span style=color:#ffffcc>Perfect!!</span>`;
-	} else if (g_resultObj.uwan === 0 && g_resultObj.shobon === 0 && g_resultObj.iknai === 0) {
-		resultFlgTmp = `<span style=color:#66ffff>FullCombo!</span>`;
+
+	if (playingArrows === fullArrows) {
+		if (g_resultObj.ii + g_resultObj.kita === fullArrows) {
+			resultFlgTmp = `<span style=color:#ffffff>All Perfect!!</span>`;
+		} else if (g_resultObj.ii + g_resultObj.shakin + g_resultObj.kita === fullArrows) {
+			resultFlgTmp = `<span style=color:#ffffcc>Perfect!!</span>`;
+		} else if (g_resultObj.uwan === 0 && g_resultObj.shobon === 0 && g_resultObj.iknai === 0) {
+			resultFlgTmp = `<span style=color:#66ffff>FullCombo!</span>`;
+		} else {
+			resultFlgTmp = `CLEARED!`;
+		}
 	} else {
-		resultFlgTmp = `CLEARED!`;
+		resultFlgTmp = ``;
 	}
 
 	const lblResultPre2 = createDivLabel(`lblResultPre`, g_sWidth / 2 + 50, 40,


### PR DESCRIPTION
## 変更内容
1. 全ての矢印を判定させていれば、フェードイン位置によらずクリアと見做すように変更
2. 譜面ヘッダー「startFrame」について、譜面毎に設定できるように変更
※fadeFrame, endFrame同様に、譜面毎の設定が可能になります。
　startFrameを1つだけ指定した場合で複数譜面の場合は、
　これまで通り全譜面同じ値が適用されます。
```
|startFrame=0$2000|
```

## 変更理由
1. 曲の事情でフェードイン開始する作品があるが、
これまでは曲の最初の部分を切り取るしか方法が無かったため。
2. fadeFrame, endFrameが譜面毎に設定できるのに対して、startFrameだけ全譜面共通だったため。
譜面により曲の開始位置が変わることもありうると考えたため。

## その他コメント

