### PR TITLE
[color-type:0.4.0] ColorTypeがDefault以外の場合、Display:ColorをOFFにするよう修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3698,14 +3698,15 @@ function keyConfigInit() {
 		switch (g_colorType) {
 			case `Default`:
 				g_colorType = `Type1`;
+				g_stateObj.d_color = `OFF`;
 				break;
-
 			case `Type1`:
 				g_colorType = `Type2`;
+				g_stateObj.d_color = `OFF`;
 				break;
-
 			case `Type2`:
 				g_colorType = `Default`;
+				g_stateObj.d_color = `ON`;
 				break;
 		}
 		g_headerObj.setColor = JSON.parse(JSON.stringify(g_headerObj[`setColor${g_colorType}`]));


### PR DESCRIPTION
## 変更内容
- ColorTypeがDefault以外の場合、Display:ColorをOFFに自動修正するよう変更
※Display:ColorをONに戻すこともできます。

## 変更理由
- ColorTypeだけを変えるとcolor_dataやacolor_dataにより色変更が発生することがあるため。

## その他コメント

