### PR TITLE
startFrameが指定されないとき0にする

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4594,7 +4594,9 @@ function getFirstArrowFrame(_dataObj) {
  */
 function getStartFrame(_lastFrame) {
 	let frameNum = 0;
-	frameNum = parseInt(g_headerObj.startFrame[g_stateObj.scoreId]) || parseInt(g_headerObj.startFrame[0]) || 0;
+	if (g_headerObj.startFrame !== undefined) {
+		frameNum = parseInt(g_headerObj.startFrame[g_stateObj.scoreId] || g_headerObj.startFrame[0])
+	}
 	if (_lastFrame >= frameNum) {
 		frameNum = Math.round(g_stateObj.fadein / 100 * (_lastFrame - frameNum)) + frameNum;
 	}


### PR DESCRIPTION
## 変更内容
譜面ヘッダでstartFrameが指定されなかったとき0にします

## 変更理由
PR #242 以降、譜面ヘッダでstartFrameが指定されていないとプレイ開始時に止まってしまいます

## その他コメント
