### PR TITLE
[ver3.13.1] startFrameが指定されないときにプレイ画面で止まる問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,7 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 3.12.0`;
+const g_version = `Ver 3.13.0`;
 const g_revisedDate = `2019/04/21`;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,7 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 3.13.0`;
+const g_version = `Ver 3.13.1`;
 const g_revisedDate = `2019/04/21`;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)


### PR DESCRIPTION
## 変更内容
- startFrameが指定されないときにプレイ画面で止まる問題を修正 ( #250 )

## 変更理由
- Pull Request #250 を参照。
Pull Request #242 以降、譜面ヘッダでstartFrameが指定されていないと
プレイ開始時に止まってしまうため。

## その他コメント

