### PR TITLE
[music-branch] 複数曲の読込に対応、譜面別に曲名を複数表示できるように変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1633,16 +1633,22 @@ function initAfterDosLoaded() {
 	loadScript(`../js/${g_headerObj.customjs}?${randTime}`, _ => {
 		if (g_headerObj.customjs2 !== ``) {
 			loadScript(`../js/${g_headerObj.customjs2}?${randTime}`, _ => {
-				loadMusic();
+				titleInit();
 			});
 		} else {
-			loadMusic();
+			titleInit();
 		}
 	});
 }
 
 function loadMusic() {
 	const url = `../${g_headerObj.musicFolder}/${g_headerObj.musicUrl}`;
+
+	// Now Loadingを表示
+	const lblLoading = createDivLabel(`lblLoading`, 0, g_sHeight - 40,
+		g_sWidth, C_LEN_SETLBL_HEIGHT, C_SIZ_SETLBL, C_CLR_TEXT, `Now Loading...`);
+	lblLoading.style.textAlign = C_ALIGN_RIGHT;
+	divRoot.appendChild(lblLoading);
 
 	// ローカル動作時
 	if (location.href.match(`^file`)) {
@@ -1703,7 +1709,7 @@ function loadMusic() {
 // Data URIやBlob URIからArrayBufferに変換してWebAudioAPIで再生する準備
 async function initWebAudioAPI(_url) {
 	g_audio = new AudioPlayer();
-	titleInit();
+	musicAfterLoaded();
 	const promise = await fetch(_url);
 	const arrayBuffer = await promise.arrayBuffer();
 	await g_audio.init(arrayBuffer);
@@ -1717,12 +1723,12 @@ function setAudio(_url) {
 				initWebAudioAPI(`data:audio/mp3;base64,${g_musicdata}`);
 			} else {
 				makeWarningWindow(C_MSG_E_0031);
-				titleInit();
+				musicAfterLoaded();
 			}
 		});
 	} else if (location.href.match(`^file`)) {
 		g_audio.src = _url;
-		titleInit();
+		musicAfterLoaded();
 	} else {
 		initWebAudioAPI(_url);
 	}
@@ -2714,18 +2720,7 @@ function optionInit() {
 		align: C_ALIGN_CENTER
 	}, _ => {
 		clearWindow();
-		g_audio.load();
-
-		if (g_audio.readyState === 4) {
-			// audioの読み込みが終わった後の処理
-			loadingScoreInit();
-		} else {
-			// 読込中の状態
-			g_audio.addEventListener(`canplaythrough`, (_ => function f() {
-				g_audio.removeEventListener(`canplaythrough`, f, false);
-				loadingScoreInit();
-			})(), false);
-		}
+		loadMusic();
 	});
 	divRoot.appendChild(btnPlay);
 
@@ -2759,18 +2754,7 @@ function optionInit() {
 		}
 		if (setKey === 13) {
 			clearWindow();
-			g_audio.load();
-
-			if (g_audio.readyState === 4) {
-				// audioの読み込みが終わった後の処理
-				loadingScoreInit();
-			} else {
-				// 読込中の状態
-				g_audio.addEventListener(`canplaythrough`, (_ => function f() {
-					g_audio.removeEventListener(`canplaythrough`, f, false);
-					loadingScoreInit();
-				})(), false);
-			}
+			loadMusic();
 		}
 		for (let j = 0; j < C_BLOCK_KEYS.length; j++) {
 			if (setKey === C_BLOCK_KEYS[j]) {
@@ -2779,6 +2763,21 @@ function optionInit() {
 		}
 	}
 	document.onkeyup = evt => { }
+}
+
+function musicAfterLoaded() {
+	g_audio.load();
+
+	if (g_audio.readyState === 4) {
+		// audioの読み込みが終わった後の処理
+		loadingScoreInit();
+	} else {
+		// 読込中の状態
+		g_audio.addEventListener(`canplaythrough`, (_ => function f() {
+			g_audio.removeEventListener(`canplaythrough`, f, false);
+			loadingScoreInit();
+		})(), false);
+	}
 }
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10,7 +10,7 @@
  */
 const g_version = `Ver 3.13.1`;
 const g_revisedDate = `2019/04/21`;
-const g_alphaVersion = `+ mb 0.4.0`;
+const g_alphaVersion = `+ mb 0.4.1`;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
 let g_localVersion = ``;
@@ -2093,7 +2093,7 @@ function headerConvert(_dosObj) {
 	obj.musicNos = [];
 
 	if (_dosObj.musicTitle !== undefined && _dosObj.musicTitle !== ``) {
-		const musicData = _dosObj.musicTitle.split(`;`);
+		const musicData = _dosObj.musicTitle.split(`$`);
 
 		if (_dosObj.musicNo !== undefined && _dosObj.musicNo !== ``) {
 			obj.musicNos = _dosObj.musicNo.split(`$`);
@@ -2355,7 +2355,7 @@ function headerConvert(_dosObj) {
 
 	// 楽曲URL
 	if (_dosObj.musicUrl !== undefined) {
-		obj.musicUrls = _dosObj.musicUrl.split(`;`);
+		obj.musicUrls = _dosObj.musicUrl.split(`$`);
 	} else {
 		makeWarningWindow(C_MSG_E_0031);
 	}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10,7 +10,7 @@
  */
 const g_version = `Ver 3.13.1`;
 const g_revisedDate = `2019/04/21`;
-const g_alphaVersion = `+ md 0.2.0`;
+const g_alphaVersion = `+ md 0.3.0`;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
 let g_localVersion = ``;
@@ -1646,72 +1646,78 @@ function loadMusic() {
 	const musicUrl = g_headerObj.musicUrls[g_stateObj.scoreId] || g_headerObj.musicUrls[0];
 	const url = `../${g_headerObj.musicFolder}/${musicUrl}`;
 
-	if (musicUrl.slice(-3) === `.js` || musicUrl.slice(-4) === `.txt`) {
-		g_musicEncodedFlg = true;
+	if (musicUrl === g_headerObj.musicUrl) {
+		musicAfterLoaded();
 	} else {
-		g_musicEncodedFlg = false;
-	}
+		g_headerObj.musicUrl = musicUrl;
 
-	// Now Loadingを表示
-	const lblLoading = createDivLabel(`lblLoading`, 0, g_sHeight - 40,
-		g_sWidth, C_LEN_SETLBL_HEIGHT, C_SIZ_SETLBL, C_CLR_TEXT, `Now Loading...`);
-	lblLoading.style.textAlign = C_ALIGN_RIGHT;
-	divRoot.appendChild(lblLoading);
-
-	// ローカル動作時
-	if (location.href.match(`^file`)) {
-		setAudio(url);
-		return;
-	}
-
-	// XHRで読み込み
-	const request = new XMLHttpRequest();
-	request.open(`GET`, url, true);
-	request.responseType = `blob`;
-
-	// 読み込み完了時
-	request.addEventListener(`load`, _ => {
-		if (request.status >= 200 && request.status < 300) {
-			const blobUrl = URL.createObjectURL(request.response);
-			setAudio(blobUrl);
+		if (musicUrl.slice(-3) === `.js` || musicUrl.slice(-4) === `.txt`) {
+			g_musicEncodedFlg = true;
 		} else {
-			makeWarningWindow(`${C_MSG_E_0032}<br>(${request.status} ${request.statusText})`);
+			g_musicEncodedFlg = false;
 		}
-	});
 
-	// 進捗時
-	request.addEventListener(`progress`, _event => {
-		const lblLoading = document.querySelector(`#lblLoading`);
+		// Now Loadingを表示
+		const lblLoading = createDivLabel(`lblLoading`, 0, g_sHeight - 40,
+			g_sWidth, C_LEN_SETLBL_HEIGHT, C_SIZ_SETLBL, C_CLR_TEXT, `Now Loading...`);
+		lblLoading.style.textAlign = C_ALIGN_RIGHT;
+		divRoot.appendChild(lblLoading);
 
-		if (_event.lengthComputable) {
-			const rate = _event.loaded / _event.total;
-			const layer0 = document.querySelector(`#layer0`);
-			const l0ctx = layer0.getContext(`2d`);
-			l0ctx.fillStyle = C_CLR_LOADING_BAR;
-			l0ctx.fillRect(0, layer0.height - 10, layer0.width * rate, 10);
-			lblLoading.innerText = `Now Loading... ${Math.floor(rate * 100)}%`;
-		} else {
-			lblLoading.innerText = `Now Loading... ${_event.loaded}Bytes`;
+		// ローカル動作時
+		if (location.href.match(`^file`)) {
+			setAudio(url);
+			return;
 		}
-		// ユーザカスタムイベント
-		if (typeof customLoadingProgress === `function`) {
-			customLoadingProgress(_event);
-			if (typeof customLoadingProgress2 === `function`) {
-				customLoadingProgress2(_event);
+
+		// XHRで読み込み
+		const request = new XMLHttpRequest();
+		request.open(`GET`, url, true);
+		request.responseType = `blob`;
+
+		// 読み込み完了時
+		request.addEventListener(`load`, _ => {
+			if (request.status >= 200 && request.status < 300) {
+				const blobUrl = URL.createObjectURL(request.response);
+				setAudio(blobUrl);
+			} else {
+				makeWarningWindow(`${C_MSG_E_0032}<br>(${request.status} ${request.statusText})`);
 			}
-		}
-	});
+		});
 
-	// エラー処理
-	request.addEventListener(`timeout`, _ => {
-		makeWarningWindow(`${C_MSG_E_0033}`);
-	});
+		// 進捗時
+		request.addEventListener(`progress`, _event => {
+			const lblLoading = document.querySelector(`#lblLoading`);
 
-	request.addEventListener(`error`, _ => {
-		makeWarningWindow(`${C_MSG_E_0034}`);
-	});
+			if (_event.lengthComputable) {
+				const rate = _event.loaded / _event.total;
+				const layer0 = document.querySelector(`#layer0`);
+				const l0ctx = layer0.getContext(`2d`);
+				l0ctx.fillStyle = C_CLR_LOADING_BAR;
+				l0ctx.fillRect(0, layer0.height - 10, layer0.width * rate, 10);
+				lblLoading.innerText = `Now Loading... ${Math.floor(rate * 100)}%`;
+			} else {
+				lblLoading.innerText = `Now Loading... ${_event.loaded}Bytes`;
+			}
+			// ユーザカスタムイベント
+			if (typeof customLoadingProgress === `function`) {
+				customLoadingProgress(_event);
+				if (typeof customLoadingProgress2 === `function`) {
+					customLoadingProgress2(_event);
+				}
+			}
+		});
 
-	request.send();
+		// エラー処理
+		request.addEventListener(`timeout`, _ => {
+			makeWarningWindow(`${C_MSG_E_0033}`);
+		});
+
+		request.addEventListener(`error`, _ => {
+			makeWarningWindow(`${C_MSG_E_0034}`);
+		});
+
+		request.send();
+	}
 }
 
 // Data URIやBlob URIからArrayBufferに変換してWebAudioAPIで再生する準備


### PR DESCRIPTION
## 変更内容
- 譜面別の複数曲読込に対応しました。
譜面ヘッダーを拡張し、複数曲の読込に対応しています。

- musicTitle, musicUrlは曲毎に"$"区切り。
musicNoは譜面毎に"$"区切りで、どの曲を読み込むか指定します。
1つ目の曲＝0, 2つ目の曲＝1のように指定します。
下記の例では、1・2譜面目は1つ目の曲、3譜面目は2つ目の曲を読み込みます。
```
|musicTitle=曲名タイトル,アーティスト1,URL1,曲名1$曲名2,アーティスト2,URL2|
|musicUrl=music1.mp3$music2.mp3|
|musicNo=0$0$1|
```

## 変更理由
- 1作品に複数曲（関連曲）を入れるケースがあるため。
将来的に選曲できるようにすることを見据え、曲切り替えできるようにします。

## その他コメント
- この変更により、プリロード位置がタイトル前からプレイ前に変更となります。
