### PR TITLE
[ver4.0.1] back_dataでopacityが機能していない問題を修正、X/Y座標の整数値制限を緩和

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,8 +8,8 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 4.0.0`;
-const g_revisedDate = `2019/04/25`;
+const g_version = `Ver 4.0.1`;
+const g_revisedDate = `2019/04/27`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
@@ -4504,11 +4504,11 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame) {
 				const tmpDepth = setVal(tmpBackData[1], 0, `number`);
 				const tmpPath = escapeHtml(setVal(tmpBackData[2], ``, `string`));
 				const tmpClass = escapeHtml(setVal(tmpBackData[3], ``, `string`));
-				const tmpX = setVal(tmpBackData[4], 0, `number`);
-				const tmpY = setVal(tmpBackData[5], 0, `number`);
+				const tmpX = setVal(tmpBackData[4], 0, `float`);
+				const tmpY = setVal(tmpBackData[5], 0, `float`);
 				const tmpWidth = setVal(tmpBackData[6], 0, `number`);					// spanタグの場合は font-size
 				const tmpHeight = escapeHtml(setVal(tmpBackData[7], ``, `string`));	// spanタグの場合は color(文字列可)
-				const tmpOpacity = setVal(tmpBackData[8], 1, `number`);
+				const tmpOpacity = setVal(tmpBackData[8], 1, `float`);
 				const tmpAnimationName = escapeHtml(setVal(tmpBackData[9], C_DIS_NONE, `string`));
 				const tmpAnimationDuration = setVal(tmpBackData[10], 0, `number`) / 60;
 


### PR DESCRIPTION
## 変更内容
- back_dataでOpacityが機能していない問題を修正
- back_dataでX/Y座標の整数値制限を緩和（小数が使えるように）

## 変更理由
- back_dataのOpacity項目にて小数値が許可されていなかったため、実質使用できていませんでした。

## その他コメント
同様の修正を、過去バージョンにも適用します。（⇒ v1.15.3, v2.9.5, v3.13.2）
https://twitter.com/sssyouta/status/1121988665889050624
