### PR TITLE
[storage-local] ハイスコアデータの初期化忘れを修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -878,6 +878,7 @@ if (g_checkStorage) {
 	g_localStorage = {
 		adjustment: 0,
 		volume: 100,
+		highscores: {},
 	};
 }
 


### PR DESCRIPTION
## 変更内容
- ハイスコアデータの初期化忘れを修正

## 変更理由
- localStorageが設定されていない作品の場合、結果画面に移行後画面が止まる問題がありました。

## その他コメント

