### PR TITLE
[storage-local] ローカルストレージ設定のクリアボタンを追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2042,6 +2042,31 @@ function titleInit() {
 	});
 	divRoot.appendChild(btnStart);
 
+	// ローカルストレージ設定をクリア
+	const btnReset = createButton({
+		id: `btnReset`,
+		name: `Data Reset`,
+		x: 0,
+		y: g_sHeight - 20,
+		width: g_sWidth / 5,
+		height: 16,
+		fontsize: 12,
+		normalColor: C_CLR_DEFAULT,
+		hoverColor: C_CLR_RESET,
+		align: C_ALIGN_CENTER
+	}, _ => {
+		if (window.confirm(`この作品のローカル設定をクリアします。よろしいですか？\n(ハイスコアやAdjustment等のデータがクリアされます)`)) {
+			g_localStorage = {
+				adjustment: 0,
+				volume: 100,
+				highscores: {},
+			};
+			localStorage.setItem(location.href, JSON.stringify(g_localStorage));
+			location.reload(true);
+		}
+	});
+	divRoot.appendChild(btnReset);
+
 	// リロードボタン
 	const btnReload = createButton({
 		id: `btnReload`,


### PR DESCRIPTION
## 変更内容
- ローカルストレージ設定のクリアボタンを追加
厳密にはローカルストレージの削除ではなく、初期化処理を行います。

## 変更理由
- 何らかの理由でローカルストレージの整理が必要な場合に、対処するボタンが無いため。

## その他コメント

