### PR TITLE
Volumeのカーソル位置をLocalStorageから読み込んだ値に合わせるように修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -866,6 +866,10 @@ if (g_checkStorage) {
 	// Volume初期値設定
 	if (g_localStorage.volume !== undefined) {
 		g_stateObj.volume = setVal(g_localStorage.volume, 100, `number`);
+		g_volumeNum = g_volumes.findIndex(volume => volume === g_stateObj.volume);
+		if (g_volumeNum < 0) {
+			g_volumeNum = 0;
+		}
 	} else {
 		g_localStorage.volume = 100;
 	}


### PR DESCRIPTION
## 変更内容
g_volumeNumをLocalStorageから読み込んだVolume値に合わせるようにしました。

## 変更理由
g_volumeNum=0(100%)で初期化されているため、保存されている値に関わらずボタンを押したときの挙動がVolume100%のときと同じになっています。

## その他コメント
