### PR TITLE
[ver4.4.1] Volumeのカーソル位置をLocalStorageから読み込んだ値に合わせるように修正 他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/05/01
+ * Revised : 2019/05/02
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 4.4.0`;
-const g_revisedDate = `2019/05/01`;
+const g_version = `Ver 4.4.1`;
+const g_revisedDate = `2019/05/02`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4897,7 +4897,7 @@ function getFirstArrowFrame(_dataObj) {
 function getStartFrame(_lastFrame) {
 	let frameNum = 0;
 	if (g_headerObj.startFrame !== undefined) {
-		frameNum = parseInt(g_headerObj.startFrame[g_stateObj.scoreId] || g_headerObj.startFrame[0])
+		frameNum = parseInt(g_headerObj.startFrame[g_stateObj.scoreId] || g_headerObj.startFrame[0] || 0);
 	}
 	if (_lastFrame >= frameNum) {
 		frameNum = Math.round(g_stateObj.fadein / 100 * (_lastFrame - frameNum)) + frameNum;


### PR DESCRIPTION
## 変更内容
1. Volumeのカーソル位置をLocalStorageから読み込んだ値に合わせるように修正 ( #270 )
1. startFrameがundefined以外でかつ、未指定の場合にエラーとなる問題を修正

## 変更理由
1. Pull Request #270 を参照。
1. 譜面ヘッダーでstartFrameを複数指定した場合に、一方を無指定とする場合があり、
その際に曲開始できない問題がある。これを回避するため。

## その他コメント

