### PR TITLE
[ver4.6.0] localStorage保存有無ボタン追加、キー別のlocalStorage名を変更 他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/05/01
+ * Revised : 2019/05/02
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 4.4.0`;
-const g_revisedDate = `2019/05/01`;
+const g_version = `Ver 4.4.1`;
+const g_revisedDate = `2019/05/02`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4897,7 +4897,7 @@ function getFirstArrowFrame(_dataObj) {
 function getStartFrame(_lastFrame) {
 	let frameNum = 0;
 	if (g_headerObj.startFrame !== undefined) {
-		frameNum = parseInt(g_headerObj.startFrame[g_stateObj.scoreId] || g_headerObj.startFrame[0])
+		frameNum = parseInt(g_headerObj.startFrame[g_stateObj.scoreId] || g_headerObj.startFrame[0] || 0);
 	}
 	if (_lastFrame >= frameNum) {
 		frameNum = Math.round(g_stateObj.fadein / 100 * (_lastFrame - frameNum)) + frameNum;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,7 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 4.5.0`;
+const g_version = `Ver 4.6.0`;
 const g_revisedDate = `2019/05/03`;
 const g_alphaVersion = ``;
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/05/02
+ * Revised : 2019/05/03
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 4.4.1`;
-const g_revisedDate = `2019/05/02`;
+const g_version = `Ver 4.5.0`;
+const g_revisedDate = `2019/05/03`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)


### PR DESCRIPTION
## 変更内容
- ローカルストレージ保存有無ボタンの追加 ( #274 )
- キー別のローカルストレージ名を変更 ( #274 )
- キーコンフィグを変更した場合に、変更後のキーコンフィグが既存キーパターンに継承されてしまう問題を修正 ( #274, #275 )

## 変更理由
Pull Request #274, #275を参照。

## その他コメント

