### PR TITLE
[ver4.6.1] ローカルストレージとキーコンフィグで設定の際、Shuffle配列がコピーされない可能性がある問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,7 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 4.6.0`;
+const g_version = `Ver 4.6.1`;
 const g_revisedDate = `2019/05/03`;
 const g_alphaVersion = ``;
 
@@ -3660,7 +3660,7 @@ function createOptionWindow(_sprite) {
 						g_keyObj[`div${copyPtn}`] = g_keyObj[`div${basePtn}`];
 						g_keyObj[`blank${copyPtn}`] = g_keyObj[`blank${basePtn}`];
 						if (g_keyObj[`shuffle${basePtn}`] !== undefined) {
-							g_keyObj[`shuffle${copyPtn}`] = g_keyObj[`shuffle${basePtn}`];
+							g_keyObj[`shuffle${copyPtn}`] = JSON.parse(JSON.stringify(g_keyObj[`shuffle${basePtn}`]));
 						}
 					}
 


### PR DESCRIPTION
## 変更内容
- ローカルストレージとキーコンフィグで設定の際、
Shuffle配列がコピーされない可能性がある問題を修正

## 変更理由
- 上述の通り

## その他コメント

