### PR TITLE
[0001/music-reload] 曲の読込タイミングの変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1818,7 +1818,7 @@ function loadMusic() {
 	request.addEventListener(`load`, _ => {
 		if (request.status >= 200 && request.status < 300) {
 			const blobUrl = URL.createObjectURL(request.response);
-			const loader = document.querySelector(`#loader`);
+			const loader = createSprite(`divRoot`, `loader`, 0, g_sHeight - 10, g_sWidth, 10);
 			loader.style.backgroundColor = `#333333`;
 			lblLoading.innerText = `Please Wait...`;
 			setAudio(blobUrl);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1776,91 +1776,89 @@ function loadMusic() {
 	const musicUrl = g_headerObj.musicUrls[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.musicUrls[0];
 	const url = `../${g_headerObj.musicFolder}/${musicUrl}`;
 
-	if (musicUrl === g_headerObj.musicUrl) {
-		musicAfterLoaded();
+	g_headerObj.musicUrl = musicUrl;
+
+	if (musicUrl.slice(-3) === `.js` || musicUrl.slice(-4) === `.txt`) {
+		g_musicEncodedFlg = true;
 	} else {
-		g_headerObj.musicUrl = musicUrl;
-
-		if (musicUrl.slice(-3) === `.js` || musicUrl.slice(-4) === `.txt`) {
-			g_musicEncodedFlg = true;
-		} else {
-			g_musicEncodedFlg = false;
-		}
-
-		// レイヤー情報取得
-		const layer0 = document.querySelector(`#layer0`);
-		const l0ctx = layer0.getContext(`2d`);
-
-		// 画面背景を指定 (background-color)
-		const grd = l0ctx.createLinearGradient(0, 0, 0, g_sHeight);
-		if (g_headerObj.customBackUse === `false`) {
-			grd.addColorStop(0, `#000000`);
-			grd.addColorStop(1, `#222222`);
-			l0ctx.fillStyle = grd;
-			l0ctx.fillRect(0, 0, g_sWidth, g_sHeight);
-		}
-
-		// Now Loadingを表示
-		const lblLoading = createDivLabel(`lblLoading`, 0, g_sHeight - 40,
-			g_sWidth, C_LEN_SETLBL_HEIGHT, C_SIZ_SETLBL, C_CLR_TEXT, `Now Loading...`);
-		lblLoading.style.textAlign = C_ALIGN_RIGHT;
-		divRoot.appendChild(lblLoading);
-
-		// ローカル動作時
-		if (location.href.match(`^file`)) {
-			setAudio(url);
-			return;
-		}
-
-		// XHRで読み込み
-		const request = new XMLHttpRequest();
-		request.open(`GET`, url, true);
-		request.responseType = `blob`;
-
-		// 読み込み完了時
-		request.addEventListener(`load`, _ => {
-			if (request.status >= 200 && request.status < 300) {
-				const blobUrl = URL.createObjectURL(request.response);
-				setAudio(blobUrl);
-			} else {
-				makeWarningWindow(`${C_MSG_E_0032}<br>(${request.status} ${request.statusText})`);
-			}
-		});
-
-		// 進捗時
-		request.addEventListener(`progress`, _event => {
-			const lblLoading = document.querySelector(`#lblLoading`);
-
-			if (_event.lengthComputable) {
-				const rate = _event.loaded / _event.total;
-				const layer0 = document.querySelector(`#layer0`);
-				const l0ctx = layer0.getContext(`2d`);
-				l0ctx.fillStyle = C_CLR_LOADING_BAR;
-				l0ctx.fillRect(0, layer0.height - 10, layer0.width * rate, 10);
-				lblLoading.innerText = `Now Loading... ${Math.floor(rate * 100)}%`;
-			} else {
-				lblLoading.innerText = `Now Loading... ${_event.loaded}Bytes`;
-			}
-			// ユーザカスタムイベント
-			if (typeof customLoadingProgress === `function`) {
-				customLoadingProgress(_event);
-				if (typeof customLoadingProgress2 === `function`) {
-					customLoadingProgress2(_event);
-				}
-			}
-		});
-
-		// エラー処理
-		request.addEventListener(`timeout`, _ => {
-			makeWarningWindow(`${C_MSG_E_0033}`);
-		});
-
-		request.addEventListener(`error`, _ => {
-			makeWarningWindow(`${C_MSG_E_0034}`);
-		});
-
-		request.send();
+		g_musicEncodedFlg = false;
 	}
+
+	// レイヤー情報取得
+	const layer0 = document.querySelector(`#layer0`);
+	const l0ctx = layer0.getContext(`2d`);
+
+	// 画面背景を指定 (background-color)
+	const grd = l0ctx.createLinearGradient(0, 0, 0, g_sHeight);
+	if (g_headerObj.customBackUse === `false`) {
+		grd.addColorStop(0, `#000000`);
+		grd.addColorStop(1, `#222222`);
+		l0ctx.fillStyle = grd;
+		l0ctx.fillRect(0, 0, g_sWidth, g_sHeight);
+	}
+
+	// Now Loadingを表示
+	const lblLoading = createDivLabel(`lblLoading`, 0, g_sHeight - 40,
+		g_sWidth, C_LEN_SETLBL_HEIGHT, C_SIZ_SETLBL, C_CLR_TEXT, `Now Loading...`);
+	lblLoading.style.textAlign = C_ALIGN_RIGHT;
+	divRoot.appendChild(lblLoading);
+
+	// ローカル動作時
+	if (location.href.match(`^file`)) {
+		setAudio(url);
+		return;
+	}
+
+	// XHRで読み込み
+	const request = new XMLHttpRequest();
+	request.open(`GET`, url, true);
+	request.responseType = `blob`;
+
+	// 読み込み完了時
+	request.addEventListener(`load`, _ => {
+		if (request.status >= 200 && request.status < 300) {
+			const blobUrl = URL.createObjectURL(request.response);
+			const loader = document.querySelector(`#loader`);
+			loader.style.backgroundColor = `#333333`;
+			lblLoading.innerText = `Please Wait...`;
+			setAudio(blobUrl);
+		} else {
+			makeWarningWindow(`${C_MSG_E_0032}<br>(${request.status} ${request.statusText})`);
+		}
+	});
+
+	// 進捗時
+	request.addEventListener(`progress`, _event => {
+		const lblLoading = document.querySelector(`#lblLoading`);
+
+		if (_event.lengthComputable) {
+			const rate = _event.loaded / _event.total;
+			const loader = createSprite(`divRoot`, `loader`, 0, g_sHeight - 10, g_sWidth, 10);
+			loader.style.width = `${g_sWidth * rate}px`;
+			loader.style.backgroundColor = `#eeeeee`;
+			lblLoading.innerText = `Now Loading... ${Math.floor(rate * 100)}%`;
+		} else {
+			lblLoading.innerText = `Now Loading... ${_event.loaded}Bytes`;
+		}
+		// ユーザカスタムイベント
+		if (typeof customLoadingProgress === `function`) {
+			customLoadingProgress(_event);
+			if (typeof customLoadingProgress2 === `function`) {
+				customLoadingProgress2(_event);
+			}
+		}
+	});
+
+	// エラー処理
+	request.addEventListener(`timeout`, _ => {
+		makeWarningWindow(`${C_MSG_E_0033}`);
+	});
+
+	request.addEventListener(`error`, _ => {
+		makeWarningWindow(`${C_MSG_E_0034}`);
+	});
+
+	request.send();
 }
 
 // Data URIやBlob URIからArrayBufferに変換してWebAudioAPIで再生する準備
@@ -7790,7 +7788,7 @@ function resultInit() {
 	}, _ => {
 		g_audio.pause();
 		clearWindow();
-		musicAfterLoaded();
+		loadMusic();
 	});
 	divRoot.appendChild(btnRetry);
 


### PR DESCRIPTION
## 変更内容
1. 曲中リトライ以外のタイミングで曲の再読み込みを行う仕様に変更する。
また、曲の読込以外（ArrayBufferに変換する処理）を「Now Loading」から「Please Wait」表記に変更しています。
1. ローディングバーについて、Canvas描画からdiv要素へ変更する。
この変更により、ローディングバー自体を非表示にすることができるが、
`_event.lengthComputable`が`false`の場合はローディングバーそのものが存在しないため、
カスタム側でローディングバー`#loader`の存在チェックを入れる必要がある。

## 変更理由
1. 曲の読込タイミングについて、これまでは初回のみ読み込んでいたが、
プレイ完了後に時間を置いてからリトライを行うとタイミングがずれることがあるため。
1. ローディングバーがCanvas描画となっており、バー自体に変更を掛けることができないため。

## その他コメント
- 今回の変更で曲の再読み込みを行う回数が増えるが、
実際には曲の読込は初回で終わっており（キャッシュしているため）、
ArrayBufferに変換してWebAudioAPIで再生する準備を行っている。