### PR TITLE
[ver4.10.0] 曲の読込タイミング変更　他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,7 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 4.8.1`;
+const g_version = `Ver 4.9.0`;
 const g_revisedDate = `2019/05/11`;
 const g_alphaVersion = ``;
 
@@ -2216,7 +2216,11 @@ function titleInit() {
 		normalColor: C_CLR_LNK,
 		hoverColor: C_CLR_DEFAULT,
 		align: C_ALIGN_LEFT
-	}, _ => window.open(g_headerObj.creatorUrl, `_blank`));
+	}, _ => {
+		if (setVal(g_headerObj.creatorUrl, ``, `string`) !== ``) {
+			window.open(g_headerObj.creatorUrl, `_blank`);
+		}
+	});
 	divRoot.appendChild(lnkMaker);
 
 	// 作曲者リンク表示
@@ -2231,7 +2235,11 @@ function titleInit() {
 		normalColor: C_CLR_LNK,
 		hoverColor: C_CLR_DEFAULT,
 		align: C_ALIGN_LEFT
-	}, _ => window.open(g_headerObj.artistUrl, `_blank`));
+	}, _ => {
+		if (setVal(g_headerObj.artistUrl, ``, `string`) !== ``) {
+			window.open(g_headerObj.artistUrl, `_blank`);
+		}
+	});
 	divRoot.appendChild(lnkArtist);
 
 	// バージョン描画
@@ -4127,6 +4135,17 @@ function keyConfigInit() {
 		g_keyObj.blank = g_keyObj[`blank${keyCtrlPtn}`];
 	} else {
 		g_keyObj.blank = g_keyObj.blank_def;
+	}
+
+	// 別キーモード警告メッセージ
+	const kcMsg = createDivLabel(`kcMsg`, 0, g_sHeight - 35, g_sWidth, 20, 14, `#ffff99`,
+		``);
+	kcMsg.style.align = C_ALIGN_CENTER;
+	divRoot.appendChild(kcMsg);
+	if (setVal(g_keyObj[`transKey${keyCtrlPtn}`], ``, `string`) !== ``) {
+		document.querySelector(`#kcMsg`).innerHTML = `別キーモードではハイスコア、キーコンフィグ等は保存されません`;
+	} else {
+		document.querySelector(`#kcMsg`).innerHTML = ``;
 	}
 
 	/** 同行の左から数えた場合の位置(x座標) */

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/05/11
+ * Revised : 2019/05/12
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 4.9.0`;
-const g_revisedDate = `2019/05/11`;
+const g_version = `Ver 4.9.1`;
+const g_revisedDate = `2019/05/12`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
@@ -4016,18 +4016,7 @@ function settingsDisplayInit() {
 		}
 		if (setKey === 13) {
 			clearWindow();
-			g_audio.load();
-
-			if (g_audio.readyState === 4) {
-				// audioの読み込みが終わった後の処理
-				loadingScoreInit();
-			} else {
-				// 読込中の状態
-				g_audio.addEventListener(`canplaythrough`, (_ => function f() {
-					g_audio.removeEventListener(`canplaythrough`, f, false);
-					loadingScoreInit();
-				})(), false);
-			}
+			loadMusic();
 		}
 		for (let j = 0; j < C_BLOCK_KEYS.length; j++) {
 			if (setKey === C_BLOCK_KEYS[j]) {
@@ -6195,18 +6184,8 @@ function MainInit() {
 			g_audio.pause();
 			clearTimeout(g_timeoutEvtId);
 			clearWindow();
-			g_audio.load();
+			musicAfterLoaded();
 
-			if (g_audio.readyState === 4) {
-				// audioの読み込みが終わった後の処理
-				loadingScoreInit();
-			} else {
-				// 読込中の状態
-				g_audio.addEventListener(`canplaythrough`, (_ => function f() {
-					g_audio.removeEventListener(`canplaythrough`, f, false);
-					loadingScoreInit();
-				})(), false);
-			}
 		} else if (setKey === 46) {
 			g_audio.pause();
 			clearTimeout(g_timeoutEvtId);
@@ -7811,19 +7790,7 @@ function resultInit() {
 	}, _ => {
 		g_audio.pause();
 		clearWindow();
-		g_audio.load();
-
-		if (g_audio.readyState === 4) {
-			// audioの読み込みが終わった後の処理
-			g_gameOverFlg = false;
-			loadingScoreInit();
-		} else {
-			// 読込中の状態
-			g_audio.addEventListener(`canplaythrough`, (_ => function f() {
-				g_audio.removeEventListener(`canplaythrough`, f, false);
-				loadingScoreInit();
-			})(), false);
-		}
+		musicAfterLoaded();
 	});
 	divRoot.appendChild(btnRetry);
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/05/12
+ * Revised : 2019/05/15
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 4.9.1`;
-const g_revisedDate = `2019/05/12`;
+const g_version = `Ver 4.10.0`;
+const g_revisedDate = `2019/05/15`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
@@ -5957,7 +5957,7 @@ function MainInit() {
 	}
 
 	let fullSecond = Math.ceil(g_headerObj.blankFrame / 60 + duration / g_headerObj.playbackRate);
-	if (fadeOutFrame !== Infinity) {
+	if (fadeOutFrame !== Infinity && g_headerObj.endFrame === undefined) {
 		fullSecond += Math.ceil(C_FRM_AFTERFADE / 60);
 	}
 


### PR DESCRIPTION
## 変更内容
1. 曲中リトライ以外のタイミングで曲の再読み込みを行う仕様に変更 ( #288 )
1. ローディングバーについて、Canvas描画からdiv要素へ変更 ( #288 )
1. fadeFrameとendFrameが同時指定された場合、endFrameの時間を優先するように変更

## 変更理由
1, 2 については Pull Request #288 を参照。
3. fadeFrameとendFrameが同時指定された場合、endFrameに420フレーム(7秒)が加算されるようになっており、直感的な指定で無かったため。

## その他コメント

