### PR TITLE
[ver4.10.1] fadeFrameとendFrameが同時指定された場合の条件を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,8 +8,8 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 4.10.0`;
-const g_revisedDate = `2019/05/15`;
+const g_version = `Ver 4.10.1`;
+const g_revisedDate = `2019/05/16`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
@@ -5948,16 +5948,19 @@ function MainInit() {
 	}
 
 	// 終了時間指定の場合、その値を適用する
+	let endFrameUseFlg = false;
 	if (g_headerObj.endFrame !== undefined) {
 		if (!isNaN(parseInt(g_headerObj.endFrame[g_stateObj.scoreId]))) {
 			duration = (parseInt(g_headerObj.endFrame[g_stateObj.scoreId]) - g_headerObj.blankFrame) / 60;
+			endFrameUseFlg = true;
 		} else if (!isNaN(parseInt(g_headerObj.endFrame[0]))) {
 			duration = (parseInt(g_headerObj.endFrame[0]) - g_headerObj.blankFrame) / 60;
+			endFrameUseFlg = true;
 		}
 	}
 
 	let fullSecond = Math.ceil(g_headerObj.blankFrame / 60 + duration / g_headerObj.playbackRate);
-	if (fadeOutFrame !== Infinity && g_headerObj.endFrame === undefined) {
+	if (fadeOutFrame !== Infinity && !endFrameUseFlg) {
 		fullSecond += Math.ceil(C_FRM_AFTERFADE / 60);
 	}
 


### PR DESCRIPTION
## 変更内容
- fadeFrameとendFrameが同時指定された場合の条件を修正

## 変更理由
- fadeFrameが指定ありで、かつendFrameが無指定のときにはendFrameを優先するよう
ver4.10.0 ( #289 )にて修正を行ったが、endFrameが配列長(で無指定)となっている場合に対処できていなかった。

## その他コメント

