### PR TITLE
[ver5.1.1] LocalStorageが設定されていないキーのときにReverseが初期化されない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/05/18
+ * Revised : 2019/05/19
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 5.1.0`;
-const g_revisedDate = `2019/05/18`;
+const g_version = `Ver 5.1.1`;
+const g_revisedDate = `2019/05/19`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
@@ -3834,6 +3834,8 @@ function createOptionWindow(_sprite) {
 						keyCtrl: [[]],
 						keyCtrlPtn: 0,
 					};
+					g_stateObj.reverse = C_FLG_OFF;
+					g_reverseNum = 0;
 				}
 			}
 		}


### PR DESCRIPTION
## 変更内容
- LocalStorageが設定されていないキーのときにReverseが初期化されない問題を修正

## 変更理由
- 譜面によってキーが変わる場合に、保存済みのキーがReverse:ONの場合で
保存されていないキーが後続にある場合、Reverse:ONが元に戻らずにONのままとなってしまう。
この問題を修正する。

## その他コメント

