### PR TITLE
[ver5.2.1] back_data, mask_dataのフレームが小さすぎる場合に画面が止まる問題を修正　他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4652,7 +4652,6 @@ function loadingScoreInit() {
 			g_headerObj.blankFrame += preblankFrame;
 		}
 	}
-	console.table(g_scoreObj.backData);
 
 	// シャッフルグループ未定義の場合
 	if (g_keyObj[`shuffle${keyCtrlPtn}`] === undefined) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/05/20
+ * Revised : 2019/05/21
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 5.2.0`;
-const g_revisedDate = `2019/05/20`;
+const g_version = `Ver 5.2.1`;
+const g_revisedDate = `2019/05/21`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
@@ -3782,6 +3782,9 @@ function createOptionWindow(_sprite) {
 			g_gaugeNum = 0;
 			if (!g_stateObj.extraKeyFlg) {
 				g_localKeyStorage.reverse = C_FLG_OFF;
+			} else {
+				g_stateObj.reverse = C_FLG_OFF;
+				g_reverseNum = 0;
 			}
 		}
 
@@ -4633,13 +4636,13 @@ function loadingScoreInit() {
 				g_scoreObj.acolorData = JSON.parse(JSON.stringify(tmpObj.acolorData));
 			}
 			if (tmpObj.wordData !== undefined && tmpObj.wordData.length >= 3) {
-				g_scoreObj.wordData = JSON.parse(JSON.stringify(tmpObj.wordData));
+				g_scoreObj.wordData = tmpObj.wordData.concat();
 			}
 			if (tmpObj.maskData !== undefined && tmpObj.maskData.length >= 1) {
-				g_scoreObj.maskData = JSON.parse(JSON.stringify(tmpObj.maskData));
+				g_scoreObj.maskData = tmpObj.maskData.concat();
 			}
 			if (tmpObj.backData !== undefined && tmpObj.backData.length >= 1) {
-				g_scoreObj.backData = JSON.parse(JSON.stringify(tmpObj.backData));
+				g_scoreObj.backData = tmpObj.backData.concat();
 			}
 
 			lastFrame += preblankFrame;
@@ -4649,6 +4652,7 @@ function loadingScoreInit() {
 			g_headerObj.blankFrame += preblankFrame;
 		}
 	}
+	console.table(g_scoreObj.backData);
 
 	// シャッフルグループ未定義の場合
 	if (g_keyObj[`shuffle${keyCtrlPtn}`] === undefined) {


### PR DESCRIPTION
## 変更内容
1. back_data, mask_dataのフレームが小さすぎる場合に画面が止まる問題を修正
1. 既存キーの譜面から特殊キーへ移るときにリバースの設定がリセットされない問題を修正

## 変更理由
1. 指定されたフレーム数が矢印到達フレームより小さい場合、
矢印到達フレームに合わせて自動調整処理を行うが、その際に配列を再生成している。
その配列を元の配列に再コピーする際、
`JSON.parse(JSON.stringfy(obj))`によるディープコピーを使用すると
未使用部分にもnullが入り、結果として処理が止まってしまう問題がある。
```javascirpt
g_scoreObj.maskData = JSON.parse(JSON.stringify(tmpObj.maskData)); // NG
g_scoreObj.maskData = tmpObj.maskData.concat(); // OK
```

2. 既存キーのリバース保存設定が「ON」の場合、
特殊キーのリバース設定が未設定であるために、リバース「ON」が引き継がれるようになっていた。
本来は「OFF」に戻すのが正しい。

## その他コメント
- back_dataを使用しているバージョン（v2, v3, v4）に影響する。
v1は`JSON.parse(JSON.stringfy(obj))`を使用していないため対象外。
