### PR TITLE
[ver5.2.2] titlesizeを64以上に指定すると文字欠けが起こる問題を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Dancing☆Onigiri (CW Edition)
 
+[![Join the chat at https://gitter.im/danonicw/community](https://badges.gitter.im/danonicw/community.svg)](https://gitter.im/danonicw/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
 リズムゲームDancing☆Onigiri (CW Edition)のソース作成・配布場所です。  
 Flash版の同ゲームのHTML5版を制作しています。 
 (旧名:Dancing☆Onigiri for HTML5)  

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4652,7 +4652,6 @@ function loadingScoreInit() {
 			g_headerObj.blankFrame += preblankFrame;
 		}
 	}
-	console.table(g_scoreObj.backData);
 
 	// シャッフルグループ未定義の場合
 	if (g_keyObj[`shuffle${keyCtrlPtn}`] === undefined) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/05/21
+ * Revised : 2019/05/26
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 5.2.1`;
-const g_revisedDate = `2019/05/21`;
+const g_version = `Ver 5.2.2`;
+const g_revisedDate = `2019/05/26`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2026,7 +2026,10 @@ function titleInit() {
 			let titlefontsizes = g_headerObj.titlesize.split(`,`);
 			titlefontsize1 = setVal(titlefontsizes[0], titlefontsize, `number`);
 			titlefontsize2 = setVal(titlefontsizes[1], titlefontsize1, `number`);
+		} else {
+			titlefontsize1 = titlefontsize;
 		}
+
 		// 変数 titlefont の定義 (使用例： |titlefont=Century,Meiryo UI|)
 		let titlefontname = `メイリオ`;
 		if (g_headerObj.titlefont !== ``) {
@@ -2044,7 +2047,7 @@ function titleInit() {
 		// 変数 titlelineheight の定義 (使用例： |titlelineheight=50|)
 		let titlelineheight = g_headerObj.titlelineheight;
 		if (g_headerObj.titlelineheight === ``) {
-			titlelineheight = setVal(g_headerObj.titlelineheight, titlefontsize + 10, `number`);
+			titlelineheight = setVal(g_headerObj.titlelineheight, titlefontsize1 + 10, `number`);
 		}
 
 		const lblmusicTitle = createDivLabel(`lblmusicTitle`,


### PR DESCRIPTION
## 変更内容
- titlesizeを64以上に指定すると文字欠けが起こる問題を修正

## 変更理由
- titlesize未指定時に自動でMAX64pxになるように調整していたが、
titlesizeの指定・未指定によらず、titlelineheightに影響する仕様になっていた。

- izkdicさんgitterコメントより
>|titlesize=80|
のようにタイトルフォントサイズを大きな値にすると、spanの描画枠からはみ出て見切れてしまう現象が発生します。
>コードを見る限り、titlesizeの指定によってline-heightがtitlesize + 10に自動調整されてそうに見えるのですが、実際は|titlesize=80|と定義してもline-heightは74（デフォルトの最大サイズ64に10を加えたもの）のままになっています。)

## その他コメント
- line-heightの仕様で、titlelineheightを極端に小さい値を指定した場合、
文字欠けが起こる可能性がある。
こちらについては、line-heightを使用しない方法を取ることで別途対応中（ver5.3.x以降予定）。