### PR TITLE
[titlepos-relative] 曲名タイトルのline-heightの指定値が小さい場合に文字欠けする問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2047,7 +2047,7 @@ function titleInit() {
 		// 変数 titlelineheight の定義 (使用例： |titlelineheight=50|)
 		let titlelineheight = g_headerObj.titlelineheight;
 		if (g_headerObj.titlelineheight === ``) {
-			titlelineheight = setVal(g_headerObj.titlelineheight, titlefontsize1 + 10, `number`);
+			titlelineheight = setVal(g_headerObj.titlelineheight, titlefontsize2, `number`);
 		}
 
 		const lblmusicTitle = createDivLabel(`lblmusicTitle`,
@@ -2056,7 +2056,7 @@ function titleInit() {
 			titlefontsize, `#ffffff`,
 			`<span style="
 				align:${C_ALIGN_CENTER};
-				line-height:${titlelineheight}px;
+				position:relative;top:${titlefontsize1 - (titlefontsize1 + titlefontsize2) / 2}px;
 				font-family:${titlefontname};
 				font-size:${titlefontsize1}px;
 				background: linear-gradient(${titlefontgrd});
@@ -2068,6 +2068,7 @@ function titleInit() {
 				${g_headerObj.musicTitleForView[0]}<br>
 				<span style="
 					font-size:${titlefontsize2}px;
+					position:relative;top:${titlelineheight - (titlefontsize1 + titlefontsize2) / 2 - titlefontsize1 + titlefontsize2}px;
 					background: linear-gradient(${titlefontgrd2});
 					background-clip: text;
 					-webkit-background-clip: text;
@@ -2076,6 +2077,10 @@ function titleInit() {
 					${setVal(g_headerObj.musicTitleForView[1], ``, `string`)}
 				</span>
 			</span>`
+			//position:relative;top:${((titlefontsize1 + titlefontsize2) / 2 - titlefontsize1) * 3}px;
+			//position:relative;top:${titlefontsize1 - (titlefontsize1 + titlefontsize2) / 2 - (titlelineheight + titlefontsize1)}px;
+			//position:relative;top:${titlelineheight - (titlefontsize1 + titlefontsize2) / 2}px;
+			//position:relative;top:${titlefontsize1 - (titlefontsize1 + titlefontsize2) / 2 + (titlelineheight - titlefontsize1) - (titlefontsize1 - titlefontsize2)}px;
 		);
 		lblmusicTitle.style.display = `flex`;
 		lblmusicTitle.style.flexDirection = `column`;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2047,7 +2047,7 @@ function titleInit() {
 		// 変数 titlelineheight の定義 (使用例： |titlelineheight=50|)
 		let titlelineheight = g_headerObj.titlelineheight;
 		if (g_headerObj.titlelineheight === ``) {
-			titlelineheight = setVal(g_headerObj.titlelineheight, titlefontsize2, `number`);
+			titlelineheight = setVal(g_headerObj.titlelineheight, titlefontsize2 + 5, `number`);
 		}
 
 		const lblmusicTitle = createDivLabel(`lblmusicTitle`,
@@ -2077,10 +2077,6 @@ function titleInit() {
 					${setVal(g_headerObj.musicTitleForView[1], ``, `string`)}
 				</span>
 			</span>`
-			//position:relative;top:${((titlefontsize1 + titlefontsize2) / 2 - titlefontsize1) * 3}px;
-			//position:relative;top:${titlefontsize1 - (titlefontsize1 + titlefontsize2) / 2 - (titlelineheight + titlefontsize1)}px;
-			//position:relative;top:${titlelineheight - (titlefontsize1 + titlefontsize2) / 2}px;
-			//position:relative;top:${titlefontsize1 - (titlefontsize1 + titlefontsize2) / 2 + (titlelineheight - titlefontsize1) - (titlefontsize1 - titlefontsize2)}px;
 		);
 		lblmusicTitle.style.display = `flex`;
 		lblmusicTitle.style.flexDirection = `column`;


### PR DESCRIPTION
## 変更内容
- 曲名タイトル（デフォルト）のline-heightの指定値が小さい場合に
文字欠けする問題を修正しました。Pull Request #308 の派生対応です。
- CSSのline-heightで対応するのではなく、相対位置を計算して表示する仕様に変更しました。

### 変更前
曲名の1行目(2行目を包含)を表示しているspanに対して、
CSSのline-height属性に1行目のフォントサイズ+10pxを設定。

### 変更後
曲名の1行目、2行目が中央に来るように、
1行目・2行目のフォントサイズに合わせてY座標を修正。

## 変更理由
- CSSのline-heightを使用した場合、line-heightの小さい値に合わせて
フォントサイズの縦幅が決まってしまうため、文字欠けが発生してしまう。

## その他コメント
- この変更により、一部作品にて譜面ヘッダーの「titlelineheight」の値の変更が
必要になる場合がある。