### PR TITLE
[lyrics-css] 歌詞フェードイン・アウトのCSS化対応、複数化対応

### DIFF
--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -280,8 +280,46 @@ input[type=range]:focus {
 	}
 }
 
+/* フェードイン */
+@keyframes fadeIn0 {
+	0% {
+		opacity: 0;
+	}
+	100% {
+		opacity: 1;
+	}
+}
+
+@keyframes fadeIn1 {
+	0% {
+		opacity: 0;
+	}
+	100% {
+		opacity: 1;
+	}
+}
+
+/* フェードアウト */
+@keyframes fadeOut0 {
+	0% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0;
+	}
+}
+
+@keyframes fadeOut1 {
+	0% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0;
+	}
+}
+
 /* タイトルデフォルトモーション（HTML側で上書き可能） */
-#lblmusicTitle{
+#lblmusicTitle {
 	animation-duration: 1.5s;
 	animation-name: leftToRight;
 }

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5903,8 +5903,10 @@ function MainInit() {
 	g_workObj.word0Data = ``;
 	g_workObj.word1Data = ``;
 	g_currentArrows = 0;
-	g_workObj.fadeInNo = 0;
-	g_workObj.fadeOutNo = 0;
+	g_workObj.fadeInNo = [0, 0, 0, 0];
+	g_workObj.fadeOutNo = [0, 0, 0, 0];
+	g_workObj.fadingFrame = [0, 0, 0, 0];
+	g_workObj.lastFadeFrame = [0, 0, 0, 0];
 
 	// 背景スプライトを作成
 	const backSprite = createSprite(`divRoot`, `backSprite`, 0, 0, g_sWidth, g_sHeight);
@@ -6668,20 +6670,24 @@ function MainInit() {
 			g_wordSprite = document.querySelector(`#lblword${g_wordObj.wordDir}`);
 
 			if (g_wordSprite !== null) {
+				const wordDepth = Number(g_wordObj.wordDir);
 				if (g_wordObj.wordDat === `[fadein]`) {
-					g_wordObj[`fadeInFlg${g_wordObj.wordDir}`] = true;
-					g_wordObj[`fadeOutFlg${g_wordObj.wordDir}`] = false;
-					g_wordSprite.style.opacity = 0;
+					g_wordObj[`fadeInFlg${wordDepth}`] = true;
+					g_wordObj[`fadeOutFlg${wordDepth}`] = false;
+					g_workObj.fadingFrame[wordDepth] = 0;
+					g_workObj.lastFadeFrame[wordDepth] = g_scoreObj.frameNum;
 
-					g_wordSprite.style.animationName = `fadeIn${(++g_workObj.fadeInNo % 2)}`;
+					g_wordSprite.style.animationName = `fadeIn${(++g_workObj.fadeInNo[wordDepth] % 2)}`;
 					g_wordSprite.style.animationDuration = `0.5s`;
 					g_wordSprite.style.animationFillMode = `forwards`;
 
 				} else if (g_wordObj.wordDat === `[fadeout]`) {
-					g_wordObj[`fadeInFlg${g_wordObj.wordDir}`] = false;
-					g_wordObj[`fadeOutFlg${g_wordObj.wordDir}`] = true;
+					g_wordObj[`fadeInFlg${wordDepth}`] = false;
+					g_wordObj[`fadeOutFlg${wordDepth}`] = true;
+					g_workObj.fadingFrame[wordDepth] = 0;
+					g_workObj.lastFadeFrame[wordDepth] = g_scoreObj.frameNum;
 
-					g_wordSprite.style.animationName = `fadeOut${(++g_workObj.fadeInNo % 2)}`;
+					g_wordSprite.style.animationName = `fadeOut${(++g_workObj.fadeOutNo[wordDepth] % 2)}`;
 					g_wordSprite.style.animationDuration = `0.5s`;
 					g_wordSprite.style.animationFillMode = `forwards`;
 
@@ -6689,10 +6695,16 @@ function MainInit() {
 					g_wordObj.wordDat === `[left]` || g_wordObj.wordDat === `[right]`) {
 
 				} else {
+					g_workObj.fadingFrame = (g_scoreObj.frameNum - g_workObj.lastFadeFrame[wordDepth]) / 60;
 					if (g_wordObj[`fadeOutFlg${g_wordObj.wordDir}`]
-						&& Number(g_wordSprite.style.opacity) === 0) {
-						g_wordSprite.style.opacity = 1;
+						&& g_workObj.fadingFrame >= 0.5) {
 						g_wordSprite.style.animationName = `none`;
+						g_wordObj[`fadeOutFlg${g_wordObj.wordDir}`] = false;
+					}
+					if (g_wordObj[`fadeInFlg${g_wordObj.wordDir}`]
+						&& g_workObj.fadingFrame >= 0.5) {
+						g_wordSprite.style.animationName = `none`;
+						g_wordObj[`fadeInFlg${g_wordObj.wordDir}`] = false;
 					}
 					g_workObj[`word${g_wordObj.wordDir}Data`] = g_wordObj.wordDat;
 					g_wordSprite.innerHTML = g_wordObj.wordDat;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -272,6 +272,7 @@ const g_wordObj = {
 	fadeOutFlg1: false
 };
 let g_wordSprite;
+let C_WOD_FRAME = 30;
 
 // 譜面データ持ち回り用
 let g_rootObj = {};
@@ -4988,6 +4989,7 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame) {
 	// 歌詞データの分解 (3つで1セット, セット毎の改行区切り可)
 	obj.wordData = [];
 	obj.wordData.length = 0;
+	obj.wordMaxDepth = -1;
 	if (g_stateObj.d_lyrics === C_FLG_ON) {
 
 		let inputWordData = ``;
@@ -5011,6 +5013,10 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame) {
 						}
 						tmpWordData[k] = calcFrame(tmpWordData[k]);
 						tmpWordData[k + 1] = parseFloat(tmpWordData[k + 1]);
+
+						if (tmpWordData[k + 1] > obj.wordMaxDepth) {
+							obj.wordMaxDepth = tmpWordData[k + 1];
+						}
 
 						let addFrame = 0;
 						if (obj.wordData[tmpWordData[k]] === undefined) {
@@ -5900,13 +5906,18 @@ function MainInit() {
 		l0ctx.fillRect(0, 0, g_sWidth, g_sHeight);
 	}
 
-	g_workObj.word0Data = ``;
-	g_workObj.word1Data = ``;
 	g_currentArrows = 0;
-	g_workObj.fadeInNo = [0, 0, 0, 0];
-	g_workObj.fadeOutNo = [0, 0, 0, 0];
-	g_workObj.fadingFrame = [0, 0, 0, 0];
-	g_workObj.lastFadeFrame = [0, 0, 0, 0];
+	g_workObj.fadeInNo = [];
+	g_workObj.fadeOutNo = [];
+	g_workObj.fadingFrame = [];
+	g_workObj.lastFadeFrame = [];
+
+	for (let j = 0; j <= g_scoreObj.wordMaxDepth; j++) {
+		g_workObj.fadeInNo[j] = 0;
+		g_workObj.fadeOutNo[j] = 0;
+		g_workObj.fadingFrame[j] = 0;
+		g_workObj.lastFadeFrame[j] = 0;
+	}
 
 	// 背景スプライトを作成
 	const backSprite = createSprite(`divRoot`, `backSprite`, 0, 0, g_sWidth, g_sHeight);
@@ -6080,29 +6091,21 @@ function MainInit() {
 	infoSprite.appendChild(makeCounterSymbol(`lblIknai`, g_sWidth - 110, C_CLR_IKNAI, 9, 0));
 	infoSprite.appendChild(makeCounterSymbol(`lblFCombo`, g_sWidth - 110, `#ffffff`, 10, 0));
 
-	// 歌詞表示1
-	const lblWord0 = createDivLabel(`lblword0`, 100, 10, g_sWidth - 200, 30, 14, `#ffffff`,
-		g_workObj.word0Data);
-	lblWord0.style.textAlign = C_ALIGN_LEFT;
-	judgeSprite.appendChild(lblWord0);
-
-	// 歌詞表示2
-	const lblWord1 = createDivLabel(`lblword1`, 100, g_sHeight - 60, g_sWidth - 200, 20, 14, `#ffffff`,
-		g_workObj.word1Data);
-	lblWord1.style.textAlign = C_ALIGN_LEFT;
-	judgeSprite.appendChild(lblWord1);
-
-	// 歌詞表示3
-	const lblWord2 = createDivLabel(`lblword2`, 100, 10, g_sWidth - 200, 30, 14, `#ffffff`,
-		g_workObj.word0Data);
-	lblWord2.style.textAlign = C_ALIGN_LEFT;
-	judgeSprite.appendChild(lblWord2);
-
-	// 歌詞表示4
-	const lblWord3 = createDivLabel(`lblword3`, 100, g_sHeight - 60, g_sWidth - 200, 20, 14, `#ffffff`,
-		g_workObj.word1Data);
-	lblWord3.style.textAlign = C_ALIGN_LEFT;
-	judgeSprite.appendChild(lblWord3);
+	// 歌詞表示
+	createSprite(`judgeSprite`, `wordSprite`, 0, 0, g_sWidth, g_sHeight);
+	for (let j = 0; j <= g_scoreObj.wordMaxDepth; j++) {
+		let lblWord;
+		if (j % 2 === 0) {
+			lblWord = createSprite(`wordSprite`, `lblword${j}`, 100, 10, g_sWidth - 200, 30);
+		} else {
+			lblWord = createSprite(`wordSprite`, `lblword${j}`, 100, g_sHeight - 60, g_sWidth - 200, 20);
+		}
+		lblWord.style.fontSize = `14px`;
+		lblWord.style.color = `#ffffff`;
+		lblWord.style.fontFamily = getBasicFont();
+		lblWord.style.textAlign = C_ALIGN_LEFT;
+		lblWord.innerHTML = ``;
+	}
 
 	// 曲名・アーティスト名表示
 	const musicTitle = g_headerObj.musicTitles[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.musicTitle;
@@ -6678,7 +6681,7 @@ function MainInit() {
 					g_workObj.lastFadeFrame[wordDepth] = g_scoreObj.frameNum;
 
 					g_wordSprite.style.animationName = `fadeIn${(++g_workObj.fadeInNo[wordDepth] % 2)}`;
-					g_wordSprite.style.animationDuration = `0.5s`;
+					g_wordSprite.style.animationDuration = `${C_WOD_FRAME / 60}s`;
 					g_wordSprite.style.animationFillMode = `forwards`;
 
 				} else if (g_wordObj.wordDat === `[fadeout]`) {
@@ -6688,21 +6691,21 @@ function MainInit() {
 					g_workObj.lastFadeFrame[wordDepth] = g_scoreObj.frameNum;
 
 					g_wordSprite.style.animationName = `fadeOut${(++g_workObj.fadeOutNo[wordDepth] % 2)}`;
-					g_wordSprite.style.animationDuration = `0.5s`;
+					g_wordSprite.style.animationDuration = `${C_WOD_FRAME / 60}s`;
 					g_wordSprite.style.animationFillMode = `forwards`;
 
 				} else if (g_wordObj.wordDat === `[center]` ||
 					g_wordObj.wordDat === `[left]` || g_wordObj.wordDat === `[right]`) {
 
 				} else {
-					g_workObj.fadingFrame = (g_scoreObj.frameNum - g_workObj.lastFadeFrame[wordDepth]) / 60;
+					g_workObj.fadingFrame = g_scoreObj.frameNum - g_workObj.lastFadeFrame[wordDepth];
 					if (g_wordObj[`fadeOutFlg${g_wordObj.wordDir}`]
-						&& g_workObj.fadingFrame >= 0.5) {
+						&& g_workObj.fadingFrame >= C_WOD_FRAME) {
 						g_wordSprite.style.animationName = `none`;
 						g_wordObj[`fadeOutFlg${g_wordObj.wordDir}`] = false;
 					}
 					if (g_wordObj[`fadeInFlg${g_wordObj.wordDir}`]
-						&& g_workObj.fadingFrame >= 0.5) {
+						&& g_workObj.fadingFrame >= C_WOD_FRAME) {
 						g_wordSprite.style.animationName = `none`;
 						g_wordObj[`fadeInFlg${g_wordObj.wordDir}`] = false;
 					}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5903,6 +5903,8 @@ function MainInit() {
 	g_workObj.word0Data = ``;
 	g_workObj.word1Data = ``;
 	g_currentArrows = 0;
+	g_workObj.fadeInNo = 0;
+	g_workObj.fadeOutNo = 0;
 
 	// 背景スプライトを作成
 	const backSprite = createSprite(`divRoot`, `backSprite`, 0, 0, g_sWidth, g_sHeight);
@@ -6671,18 +6673,26 @@ function MainInit() {
 					g_wordObj[`fadeOutFlg${g_wordObj.wordDir}`] = false;
 					g_wordSprite.style.opacity = 0;
 
+					g_wordSprite.style.animationName = `fadeIn${(++g_workObj.fadeInNo % 2)}`;
+					g_wordSprite.style.animationDuration = `0.5s`;
+					g_wordSprite.style.animationFillMode = `forwards`;
+
 				} else if (g_wordObj.wordDat === `[fadeout]`) {
 					g_wordObj[`fadeInFlg${g_wordObj.wordDir}`] = false;
 					g_wordObj[`fadeOutFlg${g_wordObj.wordDir}`] = true;
-					g_wordSprite.style.opacity = 1;
+
+					g_wordSprite.style.animationName = `fadeOut${(++g_workObj.fadeInNo % 2)}`;
+					g_wordSprite.style.animationDuration = `0.5s`;
+					g_wordSprite.style.animationFillMode = `forwards`;
 
 				} else if (g_wordObj.wordDat === `[center]` ||
 					g_wordObj.wordDat === `[left]` || g_wordObj.wordDat === `[right]`) {
 
 				} else {
-					if (!g_wordObj[`fadeOutFlg${g_wordObj.wordDir}`]
+					if (g_wordObj[`fadeOutFlg${g_wordObj.wordDir}`]
 						&& Number(g_wordSprite.style.opacity) === 0) {
 						g_wordSprite.style.opacity = 1;
+						g_wordSprite.style.animationName = `none`;
 					}
 					g_workObj[`word${g_wordObj.wordDir}Data`] = g_wordObj.wordDat;
 					g_wordSprite.innerHTML = g_wordObj.wordDat;
@@ -6703,12 +6713,6 @@ function MainInit() {
 				}
 			}
 		}
-
-		// 歌詞フェードイン・アウト
-		fadeWord(`0`);
-		fadeWord(`1`);
-		fadeWord(`2`);
-		fadeWord(`3`);
 
 		// マスク表示・マスクモーション
 		if (g_scoreObj.maskData[g_scoreObj.frameNum] !== undefined) {
@@ -6956,33 +6960,6 @@ function changeFrzColors(_mkColor, _mkColorCd, _colorPatterns, _keyNum, _allFlg)
 					}
 				}
 			}
-		}
-	}
-}
-
-/**
- * 歌詞のフェードイン・アウト
- * @param {string} _wordDir 
- */
-function fadeWord(_wordDir) {
-
-	if (g_wordObj[`fadeInFlg${_wordDir}`]) {
-		let wordAlpha = parseFloat(document.querySelector(`#lblword${_wordDir}`).style.opacity);
-		if (wordAlpha + 0.04 >= 0.99) {
-			g_wordObj[`fadeInFlg${_wordDir}`] = false;
-			document.querySelector(`#lblword${_wordDir}`).style.opacity = 1;
-		} else {
-			wordAlpha += 0.04;
-			document.querySelector(`#lblword${_wordDir}`).style.opacity = wordAlpha;
-		}
-	} else if (g_wordObj[`fadeOutFlg${_wordDir}`]) {
-		let wordAlpha = parseFloat(document.querySelector(`#lblword${_wordDir}`).style.opacity);
-		if (wordAlpha - 0.04 <= 0.01) {
-			g_wordObj[`fadeOutFlg${_wordDir}`] = false;
-			document.querySelector(`#lblword${_wordDir}`).style.opacity = 0;
-		} else {
-			wordAlpha -= 0.04;
-			document.querySelector(`#lblword${_wordDir}`).style.opacity = wordAlpha;
 		}
 	}
 }


### PR DESCRIPTION
## 変更内容
- 歌詞フェードイン・アウトのCSS化対応 ( Issue #307 )
- 歌詞の複数階層化に対応 ( Issue #307 )

## 変更理由
- 経緯は Issue #307 を参照。
CSS化することで歌詞表示系の構造を単純化し、多層構造に耐えられるようにする。

## その他コメント
