### PR TITLE
[frzstart-custom:0.1.0] フリーズ開始判定が取れるようにカスタム関数を追加

### DIFF
--- a/js/danoni_custom.js
+++ b/js/danoni_custom.js
@@ -1,7 +1,6 @@
 ﻿`use strict`;
 /**
  * Dancing☆Onigiri カスタム用jsファイル
- * ver 2.9.0 以降向け
  * 
  * このファイルは、作品個別に設定できる項目となっています。
  * 譜面データ側で下記のように作品別の外部jsファイルを指定することで、
@@ -124,6 +123,11 @@ function customJudgeShobon(difFrame){
 
 // ウワァン
 function customJudgeUwan(difFrame){
+
+}
+
+// フリーズアロー開始矢印判定
+function customJudgeFrz(difFrame){
 
 }
 

--- a/js/danoni_custom2.js
+++ b/js/danoni_custom2.js
@@ -125,6 +125,11 @@ function customJudgeUwan2(difFrame){
 
 }
 
+// フリーズアロー開始矢印判定
+function customJudgeFrz2(difFrame){
+
+}
+
 // キター
 function customJudgeKita2(difFrame){
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7101,8 +7101,16 @@ function judgeArrow(_j) {
 		const judgFrz = document.querySelector(`#frz${_j}_${fcurrentNo}`);
 
 		if (judgFrz !== null) {
+			const difFrame = Number(judgFrz.getAttribute(`cnt`));
 			const difCnt = Math.abs(judgFrz.getAttribute(`cnt`));
 			const judgEndFlg = judgFrz.getAttribute(`judgEndFlg`);
+
+			if (typeof customJudgeFrz === `function`) {
+				customJudgeFrz(difFrame);
+				if (typeof customJudgeFrz2 === `function`) {
+					customJudgeFrz2(difFrame);
+				}
+			}
 
 			if (difCnt <= g_judgObj.frzJ[C_JDG_SFSF] && judgEndFlg === `false`) {
 				changeHitFrz(_j, fcurrentNo);


### PR DESCRIPTION
## 変更内容
- フリーズ開始判定が取れるようにカスタム関数を追加

## 変更理由
- フレーム開始判定に対して、矢印同様の判定を行う作品が存在するため。

## その他コメント

