### PR TITLE
[wordfade-duration] 歌詞フェードイン・アウトの時間を可変対応、デフォルトの時間を60Frameに変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -272,7 +272,7 @@ const g_wordObj = {
 	fadeOutFlg1: false
 };
 let g_wordSprite;
-let C_WOD_FRAME = 30;
+let C_WOD_FRAME = 60;
 
 // 譜面データ持ち回り用
 let g_rootObj = {};
@@ -5034,7 +5034,14 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame) {
 								}
 							}
 						}
-						obj.wordData[tmpWordData[k] + addFrame].push(tmpWordData[k + 1], tmpWordData[k + 2]);
+
+						if (tmpWordData.length > 3 && tmpWordData.length < 6) {
+							tmpWordData[3] = setVal(tmpWordData[3], C_WOD_FRAME, `number`);
+							obj.wordData[tmpWordData[0] + addFrame].push(tmpWordData[1], tmpWordData[2], tmpWordData[3]);
+							break;
+						} else {
+							obj.wordData[tmpWordData[k] + addFrame].push(tmpWordData[k + 1], tmpWordData[k + 2]);
+						}
 					}
 				}
 			}
@@ -5915,12 +5922,14 @@ function MainInit() {
 	g_workObj.fadeOutNo = [];
 	g_workObj.fadingFrame = [];
 	g_workObj.lastFadeFrame = [];
+	g_workObj.wordFadeFrame = [];
 
 	for (let j = 0; j <= g_scoreObj.wordMaxDepth; j++) {
 		g_workObj.fadeInNo[j] = 0;
 		g_workObj.fadeOutNo[j] = 0;
 		g_workObj.fadingFrame[j] = 0;
 		g_workObj.lastFadeFrame[j] = 0;
+		g_workObj.wordFadeFrame[j] = 0;
 	}
 
 	// 背景スプライトを作成
@@ -6684,8 +6693,14 @@ function MainInit() {
 					g_workObj.fadingFrame[wordDepth] = 0;
 					g_workObj.lastFadeFrame[wordDepth] = g_scoreObj.frameNum;
 
+					if (g_scoreObj.wordData[g_scoreObj.frameNum].length > 2) {
+						g_workObj.wordFadeFrame[wordDepth] = setVal(g_scoreObj.wordData[g_scoreObj.frameNum][2], C_WOD_FRAME, `number`);
+					} else {
+						g_workObj.wordFadeFrame[wordDepth] = C_WOD_FRAME;
+					}
+
 					g_wordSprite.style.animationName = `fadeIn${(++g_workObj.fadeInNo[wordDepth] % 2)}`;
-					g_wordSprite.style.animationDuration = `${C_WOD_FRAME / 60}s`;
+					g_wordSprite.style.animationDuration = `${g_workObj.wordFadeFrame[wordDepth] / 60}s`;
 					g_wordSprite.style.animationFillMode = `forwards`;
 
 				} else if (g_wordObj.wordDat === `[fadeout]`) {
@@ -6694,8 +6709,14 @@ function MainInit() {
 					g_workObj.fadingFrame[wordDepth] = 0;
 					g_workObj.lastFadeFrame[wordDepth] = g_scoreObj.frameNum;
 
+					if (g_scoreObj.wordData[g_scoreObj.frameNum].length > 2) {
+						g_workObj.wordFadeFrame[wordDepth] = setVal(g_scoreObj.wordData[g_scoreObj.frameNum][2], C_WOD_FRAME, `number`);
+					} else {
+						g_workObj.wordFadeFrame[wordDepth] = C_WOD_FRAME;
+					}
+
 					g_wordSprite.style.animationName = `fadeOut${(++g_workObj.fadeOutNo[wordDepth] % 2)}`;
-					g_wordSprite.style.animationDuration = `${C_WOD_FRAME / 60}s`;
+					g_wordSprite.style.animationDuration = `${g_workObj.wordFadeFrame[wordDepth] / 60}s`;
 					g_wordSprite.style.animationFillMode = `forwards`;
 
 				} else if (g_wordObj.wordDat === `[center]` ||
@@ -6704,12 +6725,12 @@ function MainInit() {
 				} else {
 					g_workObj.fadingFrame = g_scoreObj.frameNum - g_workObj.lastFadeFrame[wordDepth];
 					if (g_wordObj[`fadeOutFlg${g_wordObj.wordDir}`]
-						&& g_workObj.fadingFrame >= C_WOD_FRAME) {
+						&& g_workObj.fadingFrame >= g_workObj.wordFadeFrame[wordDepth]) {
 						g_wordSprite.style.animationName = `none`;
 						g_wordObj[`fadeOutFlg${g_wordObj.wordDir}`] = false;
 					}
 					if (g_wordObj[`fadeInFlg${g_wordObj.wordDir}`]
-						&& g_workObj.fadingFrame >= C_WOD_FRAME) {
+						&& g_workObj.fadingFrame >= g_workObj.wordFadeFrame[wordDepth]) {
 						g_wordSprite.style.animationName = `none`;
 						g_wordObj[`fadeInFlg${g_wordObj.wordDir}`] = false;
 					}


### PR DESCRIPTION
## 変更内容
1. 歌詞フェードイン・アウトの時間を可変にできるようにしました。
word_dataの4番目の項目にて、フレーム数で指定します。
（word_dataを行毎の改行区切りにしないと対応しません）
```
|word_data=
3000,0,[fadein],45
3000,0,歌詞テスト
|
```
2. 歌詞データのフェードイン・アウトのデフォルト時間を30→60Frameに変更しました。

## 変更理由
1.  歌詞フェードイン・アウトで状況によりフェード時間を変える場合に対応するため。
2.  CSSアニメーションに変わったことにより、
従来のフェード時間から感覚的に早まったため、60Frame(1秒)に変更する。

## その他コメント

