### PR TITLE
[ver5.6.0] 歌詞フェードイン・アウトの時間の可変対応 他

### DIFF
--- a/js/danoni_custom.js
+++ b/js/danoni_custom.js
@@ -36,6 +36,10 @@ function customTitleInit() {
 
 }
 
+function customSetDifficulty(_initFlg, _canLoadDifInfoFlg) {
+
+}
+
 /**
  * メイン画面(フレーム毎表示) [Scene: Title / Melon]
  */

--- a/js/danoni_custom2.js
+++ b/js/danoni_custom2.js
@@ -37,6 +37,10 @@ function customTitleInit2() {
     g_localVersion2 = ``;
 }
 
+function customSetDifficulty2(_initFlg, _canLoadDifInfoFlg) {
+
+}
+
 /**
  * タイトル画面(フレーム毎表示) [Scene: Title / Melon]
  */

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,7 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 5.4.0`;
+const g_version = `Ver 5.5.0`;
 const g_revisedDate = `2019/05/26`;
 const g_alphaVersion = ``;
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,7 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 5.5.0`;
+const g_version = `Ver 5.6.0`;
 const g_revisedDate = `2019/05/26`;
 const g_alphaVersion = ``;
 
@@ -3857,6 +3857,14 @@ function createOptionWindow(_sprite) {
 					};
 					g_stateObj.reverse = C_FLG_OFF;
 					g_reverseNum = 0;
+				}
+			}
+
+			// ユーザカスタムイベント(初期)
+			if (typeof customSetDifficulty === `function`) {
+				customSetDifficulty(_initFlg, g_canLoadDifInfoFlg);
+				if (typeof customSetDifficulty2 === `function`) {
+					customSetDifficulty2(_initFlg, g_canLoadDifInfoFlg);
 				}
 			}
 		}


### PR DESCRIPTION
## 変更内容
1. 歌詞フェードイン・アウトの時間の可変対応 ( #315 )
2. 歌詞データのフェードイン・アウトのデフォルト時間を30→60Frameに変更 ( #315 )
3. 譜面変更ボタン(setDifficulty)に対してカスタム関数を追加
  - customSetDifficulty(_initFlg, _canLoadDifInfoFlg),  customSetDifficulty2(_initFlg, _canLoadDifInfoFlg)にて定義することで対応できます。

## 変更理由
1, 2 Pull Request #315 を参照。
3 譜面変更に関して特殊設定が必要なパターンに対応するため。

## その他コメント

