### PR TITLE
[ver5.6.1] 譜面変更ボタン(setDifficulty)のカスタム関数で条件により通過できない不具合を修正　他

### DIFF
--- a/js/danoni_custom.js
+++ b/js/danoni_custom.js
@@ -1,6 +1,7 @@
 ﻿`use strict`;
 /**
  * Dancing☆Onigiri カスタム用jsファイル
+ * その１：共通設定用
  * 
  * このファイルは、作品個別に設定できる項目となっています。
  * 譜面データ側で下記のように作品別の外部jsファイルを指定することで、
@@ -36,6 +37,11 @@ function customTitleInit() {
 
 }
 
+/**
+ * 譜面選択(Difficultyボタン)時カスタム処理
+ * @param {boolean} _initFlg 譜面変更フラグ (true:譜面変更選択時 / false:画面遷移による移動時)
+ * @param {boolean} _canLoadDifInfoFlg 譜面初期化フラグ (true:譜面設定を再読込 / false:譜面設定を引き継ぐ)
+ */
 function customSetDifficulty(_initFlg, _canLoadDifInfoFlg) {
 
 }
@@ -127,11 +133,6 @@ function customJudgeShobon(difFrame){
 
 // ウワァン
 function customJudgeUwan(difFrame){
-
-}
-
-// フリーズアロー開始矢印判定
-function customJudgeFrz(difFrame){
 
 }
 

--- a/js/danoni_custom2.js
+++ b/js/danoni_custom2.js
@@ -1,7 +1,7 @@
 ﻿`use strict`;
 /**
  * Dancing☆Onigiri カスタム用jsファイル
- * ver 2.9.0 以降向け (custom:Type2)
+ * その２：作品個別用
  * 
  * このファイルは、作品個別に設定できる項目となっています。
  * 譜面データ側で下記のように作品別の外部jsファイルを指定することで、
@@ -37,6 +37,11 @@ function customTitleInit2() {
     g_localVersion2 = ``;
 }
 
+/**
+ * 譜面選択(Difficultyボタン)時カスタム処理 
+ * @param {boolean} _initFlg 譜面変更フラグ (true:譜面変更選択時 / false:画面遷移による移動時)
+ * @param {boolean} _canLoadDifInfoFlg 譜面初期化フラグ (true:譜面設定を再読込 / false:譜面設定を引き継ぐ)
+ */
 function customSetDifficulty2(_initFlg, _canLoadDifInfoFlg) {
 
 }
@@ -126,11 +131,6 @@ function customJudgeShobon2(difFrame){
 
 // ウワァン
 function customJudgeUwan2(difFrame){
-
-}
-
-// フリーズアロー開始矢印判定
-function customJudgeFrz2(difFrame){
 
 }
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/05/26
+ * Revised : 2019/05/27
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 5.6.0`;
-const g_revisedDate = `2019/05/26`;
+const g_version = `Ver 5.6.1`;
+const g_revisedDate = `2019/05/27`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
@@ -3859,14 +3859,6 @@ function createOptionWindow(_sprite) {
 					g_reverseNum = 0;
 				}
 			}
-
-			// ユーザカスタムイベント(初期)
-			if (typeof customSetDifficulty === `function`) {
-				customSetDifficulty(_initFlg, g_canLoadDifInfoFlg);
-				if (typeof customSetDifficulty2 === `function`) {
-					customSetDifficulty2(_initFlg, g_canLoadDifInfoFlg);
-				}
-			}
 		}
 
 		// ---------------------------------------------------
@@ -3888,6 +3880,14 @@ function createOptionWindow(_sprite) {
 
 		// ゲージ設定 (Gauge)
 		setGauge(0);
+
+		// ユーザカスタムイベント(初期)
+		if (typeof customSetDifficulty === `function`) {
+			customSetDifficulty(_initFlg, g_canLoadDifInfoFlg);
+			if (typeof customSetDifficulty2 === `function`) {
+				customSetDifficulty2(_initFlg, g_canLoadDifInfoFlg);
+			}
+		}
 
 		// ---------------------------------------------------
 		// 4. 譜面初期情報ロード許可フラグの設定
@@ -7130,16 +7130,8 @@ function judgeArrow(_j) {
 		const judgFrz = document.querySelector(`#frz${_j}_${fcurrentNo}`);
 
 		if (judgFrz !== null) {
-			const difFrame = Number(judgFrz.getAttribute(`cnt`));
 			const difCnt = Math.abs(judgFrz.getAttribute(`cnt`));
 			const judgEndFlg = judgFrz.getAttribute(`judgEndFlg`);
-
-			if (typeof customJudgeFrz === `function`) {
-				customJudgeFrz(difFrame);
-				if (typeof customJudgeFrz2 === `function`) {
-					customJudgeFrz2(difFrame);
-				}
-			}
 
 			if (difCnt <= g_judgObj.frzJ[C_JDG_SFSF] && judgEndFlg === `false`) {
 				changeHitFrz(_j, fcurrentNo);


### PR DESCRIPTION
## 変更内容
1. 譜面変更ボタン(setDifficulty)のカスタム関数で条件により通過できない不具合を修正
2. フリーズ開始判定用カスタム処理の見直しのため、一時的にカスタム処理を削除

## 変更理由
1. 上述の通り。
2. 関数内容の見直し（パラメータ不足）のため、一時削除します。

## その他コメント

