### PR TITLE
[ver5.6.2] 判定位置の調整

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/05/27
+ * Revised : 2019/05/28
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 5.6.1`;
-const g_revisedDate = `2019/05/27`;
+const g_version = `Ver 5.6.2`;
+const g_revisedDate = `2019/05/28`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
@@ -6445,7 +6445,7 @@ function MainInit() {
 					g_workObj.stepX[targetj],
 					g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[targetj] + g_workObj.initY[g_scoreObj.frameNum] * boostSpdDir, 50,
 					g_workObj.stepRtn[targetj]);
-				step.setAttribute(`cnt`, g_workObj.arrivalFrame[g_scoreObj.frameNum]);
+				step.setAttribute(`cnt`, ++g_workObj.arrivalFrame[g_scoreObj.frameNum]);
 				step.setAttribute(`boostCnt`, g_workObj.motionFrame[g_scoreObj.frameNum]);
 				step.setAttribute(`judgEndFlg`, `false`);
 				step.setAttribute(`boostSpd`, boostSpdDir);
@@ -6520,7 +6520,7 @@ function MainInit() {
 					g_workObj.stepX[targetj],
 					g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[targetj] + g_workObj.initY[g_scoreObj.frameNum] * boostSpdDir,
 					50, 100 + frzLength);
-				frzRoot.setAttribute(`cnt`, g_workObj.arrivalFrame[g_scoreObj.frameNum]);
+				frzRoot.setAttribute(`cnt`, ++g_workObj.arrivalFrame[g_scoreObj.frameNum]);
 				frzRoot.setAttribute(`boostCnt`, g_workObj.motionFrame[g_scoreObj.frameNum]);
 				frzRoot.setAttribute(`judgEndFlg`, `false`);
 				frzRoot.setAttribute(`isMoving`, `true`);


### PR DESCRIPTION
## 変更内容
- 判定基準位置が1フレーム手前になっている問題を修正。
矢印・フリーズアロー生成時の矢印保持時間を1フレーム増やすように修正しました。

## 変更理由
- 上述の通り。

## その他コメント
- v1～v4の過去バージョンについても同様の修正を行っています。
