### PR TITLE
[ver5.6.3] 判定位置の調整に伴うblankFrameの補正値追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/05/28
+ * Revised : 2019/05/29
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 5.6.2`;
-const g_revisedDate = `2019/05/28`;
+const g_version = `Ver 5.6.3`;
+const g_revisedDate = `2019/05/29`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
@@ -2628,6 +2628,9 @@ function headerConvert(_dosObj) {
 		obj.blankFrame = parseInt(_dosObj.blankFrame);
 		obj.blankFrameDef = parseInt(_dosObj.blankFrame);
 	}
+	// ver5.6.2で判定位置を1フレームずらしたことによる補正
+	obj.blankFrame--;
+	obj.blankFrameDef--;
 
 	// 開始フレーム数（0以外の場合はフェードインスタート）
 	if (_dosObj.startFrame !== undefined) {


### PR DESCRIPTION
## 変更内容
- ver5.6.2にて判定位置の調整を行ったが、それにより譜面データが全体的に-1される事象が発生する。
このための補正をblankFrameおよびblankFrameDefに対して適用する。

## 変更理由
- 上述の通り。
v1～v4に対しても同様の修正を行う。

## その他コメント

