### PR TITLE
Revert #319

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/05/29
+ * Revised : 2019/05/28
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 5.6.3`;
-const g_revisedDate = `2019/05/29`;
+const g_version = `Ver 5.6.2`;
+const g_revisedDate = `2019/05/28`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
@@ -2628,9 +2628,6 @@ function headerConvert(_dosObj) {
 		obj.blankFrame = parseInt(_dosObj.blankFrame);
 		obj.blankFrameDef = parseInt(_dosObj.blankFrame);
 	}
-	// ver5.6.2で判定位置を1フレームずらしたことによる補正
-	obj.blankFrame--;
-	obj.blankFrameDef--;
 
 	// 開始フレーム数（0以外の場合はフェードインスタート）
 	if (_dosObj.startFrame !== undefined) {


### PR DESCRIPTION
## 変更内容
- #319 の変更を取り消します。

## 変更理由
- Adjustment方向が逆だったことと、
v4以降はAdjustmentが保存されるため、ソースの煩雑性を避けて取り止めとしました。

## その他コメント

