### PR TITLE
[fix-lyricsfade:0.1.0] 歌詞表示のフェードイン・アウトのモーションをlinearに変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -272,7 +272,7 @@ const g_wordObj = {
 	fadeOutFlg1: false
 };
 let g_wordSprite;
-let C_WOD_FRAME = 60;
+let C_WOD_FRAME = 30;
 
 // 譜面データ持ち回り用
 let g_rootObj = {};
@@ -6709,6 +6709,7 @@ function MainInit() {
 
 					g_wordSprite.style.animationName = `fadeIn${(++g_workObj.fadeInNo[wordDepth] % 2)}`;
 					g_wordSprite.style.animationDuration = `${g_workObj.wordFadeFrame[wordDepth] / 60}s`;
+					g_wordSprite.style.animationTimingFunction = `linear`;
 					g_wordSprite.style.animationFillMode = `forwards`;
 
 				} else if (g_wordObj.wordDat === `[fadeout]`) {
@@ -6725,6 +6726,7 @@ function MainInit() {
 
 					g_wordSprite.style.animationName = `fadeOut${(++g_workObj.fadeOutNo[wordDepth] % 2)}`;
 					g_wordSprite.style.animationDuration = `${g_workObj.wordFadeFrame[wordDepth] / 60}s`;
+					g_wordSprite.style.animationTimingFunction = `linear`;
 					g_wordSprite.style.animationFillMode = `forwards`;
 
 				} else if (g_wordObj.wordDat === `[center]` ||


### PR DESCRIPTION
## 変更内容
- 歌詞表示のフェードイン・アウトのモーション方法を変更しました。
CSSの`animation-timing-function`を`linear`に変更し、フェード時間を30Frameにしました。

## 変更理由
- CSSの`animation-timing-function`は未指定の場合`ease`となり、
想定より早くフェードされるように見える。
従来の歌詞表示フェードはopacityを単純減算させるように作っていたため、
挙動としては`animation-timing-function`を`linear`にした方が良い。

## その他コメント

