### PR TITLE
フリーズ始点での通常判定の追加(dotさんソース方式)、演出用のactualFrame変数をmain.jsに格納

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2758,7 +2758,8 @@ function headerConvert(_dosObj) {
 	obj.titlelineheight = setVal(_dosObj.titlelineheight, ``, `number`);
 
 	// フリーズアローの始点で通常矢印の判定を行うか(dotさんソース方式)
-	obj.frzStartjdgUse = setVal(_dosObj.frzStartjdgUse, setVal(g_presetFrzStartjdgUse, `false`, `string`), `string`);
+	obj.frzStartjdgUse = setVal(_dosObj.frzStartjdgUse,
+		(typeof g_presetFrzStartjdgUse === `string` ? setVal(g_presetFrzStartjdgUse, `false`, `string`) : `false`), `string`);
 
 	// オプション利用可否設定
 	// Motion

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -56,3 +56,7 @@ const g_presetSettingUse = {
 	autoPlay: `true`,
 	gauge: `true`,
 };
+
+// フリーズアローの始点で通常矢印の判定を行うか(dotさんソース方式)
+// 判定させる場合は `true` を指定
+g_presetFrzStartjdgUse = `false`;


### PR DESCRIPTION
## 変更内容
・フリーズ始点での通常判定の追加(dotさんソース方式)

・演出用のactualFrame変数をmain.jsに格納

・通常矢印の移動処理にて、Autoの処理とウワァン判定の処理を分離

## 変更理由
・フリーズ始点での通常判定の追加(dotさんソース方式)
主に蒼宮あいすさんの作品用に。
Gitterで提案されたように譜面ヘッダー内にて
|frzStartjdgUse=true|
と追加することでフリーズ始点でも通常判定が行われます。

・演出用のactualFrame変数をmain.jsに格納
元々はティックルさんのdanoniplus-custom
( https://github.com/cwtickle/danoniplus-custom )
内の演出サンプル用custom.jsに書かれていたものです。
演出作品で個別のcustom.jsを作るたびに、actualFrameを毎回定義するのは
無駄が多いだろうという意見をいただいたので
本体のmain.jsに格納しました。
また、合わせて演出サンプル用custom.jsでは
「オプション画面でのAdjustment( g_stateObj.adjustment )」は計算されているが
「譜面ヘッダーで定義されるAdjustment( g_headerObj.adjustment )」が計算されておらず
演出のタイミングがズレる場合があったので移植と同時に計算を追加しています。

・通常矢印の移動処理にて、Autoのジャスト判定処理と見逃しウワァン判定の処理を分離
かなり特殊な事例ですが、演出作品で曲中にAuto処理をOnOffする作品の時に
( 例：WALL BATTLE / ルゼ http://mfv2.sakura.ne.jp/do/_cumulo/?id=wallbattle  )
「矢印を見逃す」「Auto処理がONになる」「見逃した矢印がウワァン処理になる前にAuto処理の矢印が来る」
という流れが同じレーンの矢印で連続した場合にフリーズするため、
else ifで繋げて書かれてあった部分をif文2つとして独立させました。
(おそらく処理する矢印番号が1→3→2 みたいに前後するため…？)

## その他コメント
フリーズ始点での通常判定の追加にあたり少し前のバージョンであった
customJudgeFrz関数を復活させようか少し迷ったのですが、
始点での通常矢印処理が本体で実装された以上は不要かな　と判断しました。
正直この事例以外で始点でカスタム処理が必要になりそうな場面ってありますかね…？