### PR TITLE
[ver5.7.0] フリーズ開始判定、見かけフレーム数の実装

### DIFF
--- a/js/danoni_custom.js
+++ b/js/danoni_custom.js
@@ -1,6 +1,7 @@
 ﻿`use strict`;
 /**
  * Dancing☆Onigiri カスタム用jsファイル
+ * その１：共通設定用
  * 
  * このファイルは、作品個別に設定できる項目となっています。
  * 譜面データ側で下記のように作品別の外部jsファイルを指定することで、
@@ -36,6 +37,11 @@ function customTitleInit() {
 
 }
 
+/**
+ * 譜面選択(Difficultyボタン)時カスタム処理
+ * @param {boolean} _initFlg 譜面変更フラグ (true:譜面変更選択時 / false:画面遷移による移動時)
+ * @param {boolean} _canLoadDifInfoFlg 譜面初期化フラグ (true:譜面設定を再読込 / false:譜面設定を引き継ぐ)
+ */
 function customSetDifficulty(_initFlg, _canLoadDifInfoFlg) {
 
 }
@@ -127,11 +133,6 @@ function customJudgeShobon(difFrame){
 
 // ウワァン
 function customJudgeUwan(difFrame){
-
-}
-
-// フリーズアロー開始矢印判定
-function customJudgeFrz(difFrame){
 
 }
 

--- a/js/danoni_custom2.js
+++ b/js/danoni_custom2.js
@@ -1,7 +1,7 @@
 ﻿`use strict`;
 /**
  * Dancing☆Onigiri カスタム用jsファイル
- * ver 2.9.0 以降向け (custom:Type2)
+ * その２：作品個別用
  * 
  * このファイルは、作品個別に設定できる項目となっています。
  * 譜面データ側で下記のように作品別の外部jsファイルを指定することで、
@@ -37,6 +37,11 @@ function customTitleInit2() {
     g_localVersion2 = ``;
 }
 
+/**
+ * 譜面選択(Difficultyボタン)時カスタム処理 
+ * @param {boolean} _initFlg 譜面変更フラグ (true:譜面変更選択時 / false:画面遷移による移動時)
+ * @param {boolean} _canLoadDifInfoFlg 譜面初期化フラグ (true:譜面設定を再読込 / false:譜面設定を引き継ぐ)
+ */
 function customSetDifficulty2(_initFlg, _canLoadDifInfoFlg) {
 
 }
@@ -126,11 +131,6 @@ function customJudgeShobon2(difFrame){
 
 // ウワァン
 function customJudgeUwan2(difFrame){
-
-}
-
-// フリーズアロー開始矢印判定
-function customJudgeFrz2(difFrame){
 
 }
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/05/27
+ * Revised : 2019/05/28
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 5.6.1`;
-const g_revisedDate = `2019/05/27`;
+const g_version = `Ver 5.6.2`;
+const g_revisedDate = `2019/05/28`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
@@ -6445,7 +6445,7 @@ function MainInit() {
 					g_workObj.stepX[targetj],
 					g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[targetj] + g_workObj.initY[g_scoreObj.frameNum] * boostSpdDir, 50,
 					g_workObj.stepRtn[targetj]);
-				step.setAttribute(`cnt`, g_workObj.arrivalFrame[g_scoreObj.frameNum]);
+				step.setAttribute(`cnt`, ++g_workObj.arrivalFrame[g_scoreObj.frameNum]);
 				step.setAttribute(`boostCnt`, g_workObj.motionFrame[g_scoreObj.frameNum]);
 				step.setAttribute(`judgEndFlg`, `false`);
 				step.setAttribute(`boostSpd`, boostSpdDir);
@@ -6520,7 +6520,7 @@ function MainInit() {
 					g_workObj.stepX[targetj],
 					g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[targetj] + g_workObj.initY[g_scoreObj.frameNum] * boostSpdDir,
 					50, 100 + frzLength);
-				frzRoot.setAttribute(`cnt`, g_workObj.arrivalFrame[g_scoreObj.frameNum]);
+				frzRoot.setAttribute(`cnt`, ++g_workObj.arrivalFrame[g_scoreObj.frameNum]);
 				frzRoot.setAttribute(`boostCnt`, g_workObj.motionFrame[g_scoreObj.frameNum]);
 				frzRoot.setAttribute(`judgEndFlg`, `false`);
 				frzRoot.setAttribute(`isMoving`, `true`);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/05/30
+ * Revised : 2019/06/01
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 5.6.6`;
-const g_revisedDate = `2019/05/30`;
+const g_version = `Ver 5.7.0`;
+const g_revisedDate = `2019/06/01`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
@@ -7114,7 +7114,7 @@ function judgeArrow(_j) {
 						} else {
 							judgeShobon(difCnt);
 						}
-						g_workObj.judgFrzHitCnt[_j] = fcurrentNo+1;
+						g_workObj.judgFrzHitCnt[_j] = fcurrentNo + 1;
 					}
 				}
 				changeHitFrz(_j, fcurrentNo);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,7 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 5.6.5`;
+const g_version = `Ver 5.6.6`;
 const g_revisedDate = `2019/05/30`;
 const g_alphaVersion = ``;
 
@@ -6445,7 +6445,7 @@ function MainInit() {
 					g_workObj.stepX[targetj],
 					g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[targetj] + g_workObj.initY[g_scoreObj.frameNum] * boostSpdDir, 50,
 					g_workObj.stepRtn[targetj]);
-				step.setAttribute(`cnt`, ++g_workObj.arrivalFrame[g_scoreObj.frameNum]);
+				step.setAttribute(`cnt`, g_workObj.arrivalFrame[g_scoreObj.frameNum] + 1);
 				step.setAttribute(`boostCnt`, g_workObj.motionFrame[g_scoreObj.frameNum]);
 				step.setAttribute(`judgEndFlg`, `false`);
 				step.setAttribute(`boostSpd`, boostSpdDir);
@@ -6520,7 +6520,7 @@ function MainInit() {
 					g_workObj.stepX[targetj],
 					g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[targetj] + g_workObj.initY[g_scoreObj.frameNum] * boostSpdDir,
 					50, 100 + frzLength);
-				frzRoot.setAttribute(`cnt`, ++g_workObj.arrivalFrame[g_scoreObj.frameNum]);
+				frzRoot.setAttribute(`cnt`, g_workObj.arrivalFrame[g_scoreObj.frameNum] + 1);
 				frzRoot.setAttribute(`boostCnt`, g_workObj.motionFrame[g_scoreObj.frameNum]);
 				frzRoot.setAttribute(`judgEndFlg`, `false`);
 				frzRoot.setAttribute(`isMoving`, `true`);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/05/26
+ * Revised : 2019/05/27
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 5.6.0`;
-const g_revisedDate = `2019/05/26`;
+const g_version = `Ver 5.6.1`;
+const g_revisedDate = `2019/05/27`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
@@ -3859,14 +3859,6 @@ function createOptionWindow(_sprite) {
 					g_reverseNum = 0;
 				}
 			}
-
-			// ユーザカスタムイベント(初期)
-			if (typeof customSetDifficulty === `function`) {
-				customSetDifficulty(_initFlg, g_canLoadDifInfoFlg);
-				if (typeof customSetDifficulty2 === `function`) {
-					customSetDifficulty2(_initFlg, g_canLoadDifInfoFlg);
-				}
-			}
 		}
 
 		// ---------------------------------------------------
@@ -3888,6 +3880,14 @@ function createOptionWindow(_sprite) {
 
 		// ゲージ設定 (Gauge)
 		setGauge(0);
+
+		// ユーザカスタムイベント(初期)
+		if (typeof customSetDifficulty === `function`) {
+			customSetDifficulty(_initFlg, g_canLoadDifInfoFlg);
+			if (typeof customSetDifficulty2 === `function`) {
+				customSetDifficulty2(_initFlg, g_canLoadDifInfoFlg);
+			}
+		}
 
 		// ---------------------------------------------------
 		// 4. 譜面初期情報ロード許可フラグの設定
@@ -7130,16 +7130,8 @@ function judgeArrow(_j) {
 		const judgFrz = document.querySelector(`#frz${_j}_${fcurrentNo}`);
 
 		if (judgFrz !== null) {
-			const difFrame = Number(judgFrz.getAttribute(`cnt`));
 			const difCnt = Math.abs(judgFrz.getAttribute(`cnt`));
 			const judgEndFlg = judgFrz.getAttribute(`judgEndFlg`);
-
-			if (typeof customJudgeFrz === `function`) {
-				customJudgeFrz(difFrame);
-				if (typeof customJudgeFrz2 === `function`) {
-					customJudgeFrz2(difFrame);
-				}
-			}
 
 			if (difCnt <= g_judgObj.frzJ[C_JDG_SFSF] && judgEndFlg === `false`) {
 				changeHitFrz(_j, fcurrentNo);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/05/29
+ * Revised : 2019/05/28
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 5.6.3`;
-const g_revisedDate = `2019/05/29`;
+const g_version = `Ver 5.6.2`;
+const g_revisedDate = `2019/05/28`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
@@ -2628,9 +2628,6 @@ function headerConvert(_dosObj) {
 		obj.blankFrame = parseInt(_dosObj.blankFrame);
 		obj.blankFrameDef = parseInt(_dosObj.blankFrame);
 	}
-	// ver5.6.2で判定位置を1フレームずらしたことによる補正
-	obj.blankFrame--;
-	obj.blankFrameDef--;
 
 	// 開始フレーム数（0以外の場合はフェードインスタート）
 	if (_dosObj.startFrame !== undefined) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/05/28
+ * Revised : 2019/05/30
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 5.6.2`;
-const g_revisedDate = `2019/05/28`;
+const g_version = `Ver 5.6.5`;
+const g_revisedDate = `2019/05/30`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/05/28
+ * Revised : 2019/05/29
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 5.6.2`;
-const g_revisedDate = `2019/05/28`;
+const g_version = `Ver 5.6.3`;
+const g_revisedDate = `2019/05/29`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
@@ -2628,6 +2628,9 @@ function headerConvert(_dosObj) {
 		obj.blankFrame = parseInt(_dosObj.blankFrame);
 		obj.blankFrameDef = parseInt(_dosObj.blankFrame);
 	}
+	// ver5.6.2で判定位置を1フレームずらしたことによる補正
+	obj.blankFrame--;
+	obj.blankFrameDef--;
 
 	// 開始フレーム数（0以外の場合はフェードインスタート）
 	if (_dosObj.startFrame !== undefined) {


### PR DESCRIPTION
## 変更内容
1. フリーズ開始判定の実装 ( #324 )
1. 見かけフレーム数(g_workObj.baseFrame)の実装 ( #324 )
1. デフォルト背景画像描画部分のコード整理 ( #325 )

## 変更理由
1. フリーズ開始判定する作品に対応するため。
1. 演出用作品で、見かけのフレーム数をベースにアクションを起こる処理が必要なため。
これまでcustom側で実装していた部分を、main側に寄せる。
1. 繰り返しコード除去のため。

## その他コメント

