### PR TITLE
不要なreplaceの削除

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1739,7 +1739,7 @@ function initialControl() {
 		loadScript(`${filename}?${randTime}`, _ => {
 			if (typeof externalDosInit === `function`) {
 				externalDosInit();
-				Object.assign(g_rootObj, dosConvert(g_externalDos.replace(`&`, `|`)));
+				Object.assign(g_rootObj, dosConvert(g_externalDos));
 			} else {
 				makeWarningWindow(C_MSG_E_0022);
 			}


### PR DESCRIPTION
## 変更内容
外部dos読み込み処理中の&を|に置き換えるreplaceを削除しました

## 変更理由
記述が間違っていて1個しか置き換えないのと、dosConvert側に正しい処理があります

## その他コメント