### PR TITLE
譜面データのURIデコード対応 ほか

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -119,6 +119,9 @@ let g_musicdata = ``;
 // 外部dosデータ
 let g_externalDos = ``;
 
+// 譜面データの&区切りを有効にするか
+let g_enableAmpersandSplit = true;
+
 // Motionオプション配列の基準位置
 const C_MOTION_STD_POS = 15;
 
@@ -1714,6 +1717,12 @@ function initialControl() {
 	// 譜面初期情報ロード許可フラグ
 	g_canLoadDifInfoFlg = true;
 
+	// 譜面データの読み込みオプション
+	const ampSplitInput = document.querySelector(`#enableAmpersandSplit`);
+	if (ampSplitInput !== null) {
+		g_enableAmpersandSplit = setVal(ampSplitInput.value, true, `boolean`);
+	}
+
 	// 譜面データの読み込み
 	const dosInput = document.querySelector(`#dos`);
 	const externalDosInput = document.querySelector(`#externalDos`);
@@ -2378,7 +2387,7 @@ function makeWarningWindow(_text) {
 function dosConvert(_dos) {
 
 	const obj = {};
-	const paramsTmp = _dos.split(`&`).join(`|`);
+	const paramsTmp = g_enableAmpersandSplit ? _dos.split(`&`).join(`|`) : _dos;
 	const params = paramsTmp.split(`|`);
 	for (let j = 0; j < params.length; j++) {
 		const pos = params[j].indexOf(`=`);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1739,7 +1739,7 @@ function initialControl() {
 		loadScript(`${filename}?${randTime}`, _ => {
 			if (typeof externalDosInit === `function`) {
 				externalDosInit();
-				Object.assign(g_rootObj, dosConvert(g_externalDos.replace(`&`, `|`)));
+				Object.assign(g_rootObj, dosConvert(g_externalDos));
 			} else {
 				makeWarningWindow(C_MSG_E_0022);
 			}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -122,6 +122,9 @@ let g_externalDos = ``;
 // 譜面データの&区切りを有効にするか
 let g_enableAmpersandSplit = true;
 
+// 譜面データをdecodeURIするか
+let g_enableDecodeURI = false;
+
 // Motionオプション配列の基準位置
 const C_MOTION_STD_POS = 15;
 
@@ -1723,6 +1726,11 @@ function initialControl() {
 		g_enableAmpersandSplit = setVal(ampSplitInput.value, true, `boolean`);
 	}
 
+	const decodeUriInput = document.querySelector(`#enableDecodeURI`);
+	if (decodeUriInput !== null) {
+		g_enableDecodeURI = setVal(decodeUriInput.value, false, `boolean`);
+	}
+
 	// 譜面データの読み込み
 	const dosInput = document.querySelector(`#dos`);
 	const externalDosInput = document.querySelector(`#externalDos`);
@@ -2395,7 +2403,7 @@ function dosConvert(_dos) {
 			const pKey = params[j].substring(0, pos);
 			const pValue = params[j].substring(pos + 1);
 			if (pKey !== undefined) {
-				obj[pKey] = pValue;
+				obj[pKey] = g_enableDecodeURI ? decodeURIComponent(pValue) : pValue;
 			}
 		}
 	}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1029,30 +1029,38 @@ const g_handler = (_ => {
 
 /**
  * 文字列を想定された型に変換
- * - _type は `float`(小数)、`number`(整数)、`string`(文字列)から選択
- * - 型に合わない場合は _defaultStr を返却するが、_defaultStr自体の型チェック・変換は行わない
+ * - _type は `float`(小数)、`number`(整数)、`boolean`(真偽値)、`string`(文字列)から選択
+ * - 型に合わない場合は _default を返却するが、_default自体の型チェック・変換は行わない
  * @param {string} _checkStr 
- * @param {string} _defaultStr 
+ * @param {string} _default 
  * @param {string} _type 
  */
-function setVal(_checkStr, _defaultStr, _type) {
+function setVal(_checkStr, _default, _type) {
 
 	// 値がundefined相当の場合は無条件でデフォルト値を返却
-	if (_checkStr === undefined || _checkStr === ``) {
-		return _defaultStr;
+	if (_checkStr === undefined || _checkStr === null || _checkStr === ``) {
+		return _default;
 	}
 
 	let isNaNflg;
 	if (_type === `float`) {
 		// 数値型(小数可)の場合
 		isNaNflg = isNaN(parseFloat(_checkStr));
-		return (isNaNflg ? _defaultStr : parseFloat(_checkStr));
+		return (isNaNflg ? _default : parseFloat(_checkStr));
 
 	} else if (_type === `number`) {
 		// 数値型(整数のみ)の場合
 		isNaNflg = isNaN(parseInt(_checkStr));
-		return (isNaNflg ? _defaultStr : parseInt(_checkStr));
+		return (isNaNflg ? _default : parseInt(_checkStr));
 
+	} else if (_type === `boolean`) {
+		const lowerCase = _checkStr.toString().toLowerCase();
+		if (lowerCase === `true`) {
+			return true;
+		} else if (lowerCase === `false`) {
+			return false;
+		}
+		return _default
 	}
 
 	// 文字列型の場合 (最初でチェック済みのためそのまま値を返却)


### PR DESCRIPTION
## 変更内容
- 譜面データのURIデコードに対応しました
たとえば「%26」が「&」に変換されます。
HTML側に以下を追加することで有効になります。
```
<input type="hidden" name="enableDecodeURI" id="enableDecodeURI" value="true">
```

- 譜面データの&区切り可否を切り替え可能にしました
単に「&」が使えるほか、「&amp;comma;」などの文字参照が使えるようになります。
(URIデコードを使って「%26comma;」でも出来ますが)
HTML側に以下を追加することで無効化できます。
```
<input type="hidden" name="enableAmpersandSplit" id="enableAmpersandSplit" value="false">
```

- 外部dos読み込み処理中の&を|に置き換えるreplaceを削除しました
記述が間違っていて1個しか置き換えないのと、dosConvert側に正しい処理があります

- setValをbooleanに対応しました
上記設定のtrue/false読み込みのためです

## 変更理由
gitterでの要望より。

## その他コメント
