### PR TITLE
[key-div2nd] 独自キーの2段目のpos最終番号を指定できるように変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -112,6 +112,8 @@ const C_IMG_CFRZBAR = `../img/frzbar.png`;
 const C_IMG_MORARAFRZBAR = `../img/frzbar.png`;
 const C_IMG_MONARFRZBAR = `../img/frzbar.png`;
 
+const C_ARW_WIDTH = 50;
+
 // 音楽ファイル エンコードフラグ
 let g_musicEncodedFlg = false;
 let g_musicdata = ``;
@@ -4222,13 +4224,13 @@ function keyConfigInit() {
 
 		// キーコンフィグ表示用の矢印・おにぎりを表示
 		keyconSprite.appendChild(createArrowEffect(`arrow${j}`, g_headerObj.setColor[g_keyObj[`color${keyCtrlPtn}`][j]],
-			g_keyObj.blank * stdPos + kWidth / 2 - 25,
+			g_keyObj.blank * stdPos + (kWidth - C_ARW_WIDTH) / 2,
 			150 * dividePos, 50,
 			g_keyObj[`stepRtn${keyCtrlPtn}`][j]));
 
 		for (let k = 0; k < g_keyObj[`keyCtrl${keyCtrlPtn}`][j].length; k++) {
 			keyconSprite.appendChild(createDivLabel(`keycon${j}_${k}`,
-				g_keyObj.blank * stdPos + kWidth / 2 - 25,
+				g_keyObj.blank * stdPos + (kWidth - C_ARW_WIDTH) / 2,
 				50 + 20 * k + 150 * dividePos,
 				50, 20, 16, `#cccccc`, g_kCd[g_keyObj[`keyCtrl${keyCtrlPtn}`][j][k]]));
 			if (g_keyObj[`keyCtrl${keyCtrlPtn}d`][j][k] !== g_keyObj[`keyCtrl${keyCtrlPtn}`][j][k]) {
@@ -4242,7 +4244,7 @@ function keyConfigInit() {
 
 	// カーソルの作成
 	const cursor = keyconSprite.appendChild(createImg(`cursor`, C_IMG_CURSOR,
-		kWidth / 2 + g_keyObj.blank * (posj - divideCnt / 2) - 10 - 25, 45, 15, 30));
+		(kWidth - C_ARW_WIDTH) / 2 + g_keyObj.blank * (posj - divideCnt / 2) - 10, 45, 15, 30));
 	cursor.style.transitionDuration = `0.125s`;
 
 	// キーコンフィグタイプ切替ボタン
@@ -4494,7 +4496,7 @@ function keyConfigInit() {
 					dividePos = 0;
 				}
 
-				cursor.style.left = `${kWidth / 2 + g_keyObj.blank * stdPos - 10 - 25}px`;
+				cursor.style.left = `${(kWidth - C_ARW_WIDTH) / 2 + g_keyObj.blank * stdPos - 10}px`;
 				cursor.style.top = `${50 + 150 * dividePos}px`;
 				if (g_kcType === `Replaced`) {
 					cursor.style.top = `${parseFloat(cursor.style.top) + 20}px`;
@@ -4527,7 +4529,7 @@ function resetCursorMain(_width, _divideCnt, _keyCtrlPtn) {
 	const posj = g_keyObj[`pos${_keyCtrlPtn}`][0];
 
 	const cursor = document.querySelector(`#cursor`);
-	cursor.style.left = `${_width / 2 + g_keyObj.blank * (posj - _divideCnt / 2) - 10 - 25}px`;
+	cursor.style.left = `${(_width - C_ARW_WIDTH) / 2 + g_keyObj.blank * (posj - _divideCnt / 2) - 10}px`;
 	cursor.style.top = `45px`;
 }
 
@@ -4564,7 +4566,7 @@ function resetCursorReplaced(_width, _divideCnt, _keyCtrlPtn) {
 	}
 
 	const cursor = document.querySelector(`#cursor`);
-	cursor.style.left = `${_width / 2 + g_keyObj.blank * stdPos - 10 - 25}px`;
+	cursor.style.left = `${(_width - C_ARW_WIDTH) / 2 + g_keyObj.blank * stdPos - 10}px`;
 	if (g_currentk === 1) {
 		cursor.style.top = `${65 + 150 * dividePos}px`;
 	} else {
@@ -4587,7 +4589,7 @@ function resetCursorALL(_width, _divideCnt, _keyCtrlPtn) {
 	const posj = g_keyObj[`pos${_keyCtrlPtn}`][0];
 
 	const cursor = document.querySelector(`#cursor`);
-	cursor.style.left = `${_width / 2 + g_keyObj.blank * (posj - _divideCnt / 2) - 10 - 25}px`;
+	cursor.style.left = `${(_width - C_ARW_WIDTH) / 2 + g_keyObj.blank * (posj - _divideCnt / 2) - 10}px`;
 	cursor.style.top = `45px`;
 }
 
@@ -5854,7 +5856,7 @@ function getArrowSettings() {
 		} else {
 			stdPos = posj - divideCnt / 2;
 		}
-		g_workObj.stepX[j] = g_keyObj.blank * stdPos + g_sWidth / 2 - 25;
+		g_workObj.stepX[j] = g_keyObj.blank * stdPos + (g_sWidth - C_ARW_WIDTH) / 2;
 
 		if (g_stateObj.reverse === C_FLG_ON) {
 			g_workObj.dividePos[j] = (posj > divideCnt ? 0 : 1);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -168,6 +168,8 @@ const C_MIN_SPEED = 1;
 /** キーコンフィグ設定 */
 let g_kcType = `Main`;
 let g_colorType = `Default`;
+const C_KYC_HEIGHT = 150;
+const C_KYC_REPHEIGHT = 20;
 
 /** メイン画面用共通オブジェクト */
 const g_workObj = {};
@@ -4223,14 +4225,14 @@ function keyConfigInit() {
 		// キーコンフィグ表示用の矢印・おにぎりを表示
 		keyconSprite.appendChild(createArrowEffect(`arrow${j}`, g_headerObj.setColor[g_keyObj[`color${keyCtrlPtn}`][j]],
 			g_keyObj.blank * stdPos + (kWidth - C_ARW_WIDTH) / 2,
-			150 * dividePos, 50,
+			C_KYC_HEIGHT * dividePos, 50,
 			g_keyObj[`stepRtn${keyCtrlPtn}`][j]));
 
 		for (let k = 0; k < g_keyObj[`keyCtrl${keyCtrlPtn}`][j].length; k++) {
 			keyconSprite.appendChild(createDivLabel(`keycon${j}_${k}`,
 				g_keyObj.blank * stdPos + (kWidth - C_ARW_WIDTH) / 2,
-				50 + 20 * k + 150 * dividePos,
-				50, 20, 16, `#cccccc`, g_kCd[g_keyObj[`keyCtrl${keyCtrlPtn}`][j][k]]));
+				50 + C_KYC_REPHEIGHT * k + C_KYC_HEIGHT * dividePos,
+				C_ARW_WIDTH, C_ARW_WIDTH, 16, `#cccccc`, g_kCd[g_keyObj[`keyCtrl${keyCtrlPtn}`][j][k]]));
 			if (g_keyObj[`keyCtrl${keyCtrlPtn}d`][j][k] !== g_keyObj[`keyCtrl${keyCtrlPtn}`][j][k]) {
 				document.querySelector(`#keycon${j}_${k}`).style.color = `#ffff00`;
 			} else if (g_keyObj.currentPtn === -1) {
@@ -4459,7 +4461,7 @@ function keyConfigInit() {
 			if (g_currentk < g_keyObj[`keyCtrl${keyCtrlPtn}`][g_currentj].length - 1 &&
 				g_kcType !== `Main`) {
 				g_currentk++;
-				cursor.style.top = `${parseInt(cursor.style.top) + 20}px`;
+				cursor.style.top = `${parseInt(cursor.style.top) + C_KYC_REPHEIGHT}px`;
 
 			} else if (g_currentj < g_keyObj[`keyCtrl${keyCtrlPtn}`].length - 1) {
 				// 他の代替キーが存在せず、次の矢印がある場合
@@ -4495,9 +4497,9 @@ function keyConfigInit() {
 				}
 
 				cursor.style.left = `${(kWidth - C_ARW_WIDTH) / 2 + g_keyObj.blank * stdPos - 10}px`;
-				cursor.style.top = `${50 + 150 * dividePos}px`;
+				cursor.style.top = `${50 + C_KYC_HEIGHT * dividePos}px`;
 				if (g_kcType === `Replaced`) {
-					cursor.style.top = `${parseFloat(cursor.style.top) + 20}px`;
+					cursor.style.top = `${parseFloat(cursor.style.top) + C_KYC_REPHEIGHT}px`;
 				}
 
 			} else {
@@ -4566,11 +4568,11 @@ function resetCursorReplaced(_width, _divideCnt, _keyCtrlPtn) {
 	const cursor = document.querySelector(`#cursor`);
 	cursor.style.left = `${(_width - C_ARW_WIDTH) / 2 + g_keyObj.blank * stdPos - 10}px`;
 	if (g_currentk === 1) {
-		cursor.style.top = `${65 + 150 * dividePos}px`;
+		cursor.style.top = `${45 + C_KYC_REPHEIGHT + C_KYC_HEIGHT * dividePos}px`;
 	} else {
 		g_kcType = `ALL`;
 		document.querySelector(`#lnkKcType`).innerHTML = g_kcType;
-		cursor.style.top = `${45 + 150 * dividePos}px`;
+		cursor.style.top = `${45 + C_KYC_HEIGHT * dividePos}px`;
 	}
 }
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3822,11 +3822,12 @@ function createOptionWindow(_sprite) {
 
 		if (g_canLoadDifInfoFlg || _initFlg) {
 
-			// キーパターン初期化
-			g_keyObj.currentPtn = 0;
-
 			// キー別のローカルストレージの初期設定　※特殊キーは除く
 			if (!g_stateObj.extraKeyFlg) {
+
+				// キーパターン初期化
+				g_keyObj.currentPtn = 0;
+
 				g_checkKeyStorage = localStorage.getItem(`danonicw-${g_keyObj.currentKey}k`);
 				if (g_checkKeyStorage) {
 					g_localKeyStorage = JSON.parse(g_checkKeyStorage);
@@ -4211,9 +4212,13 @@ function keyConfigInit() {
 	for (let j = 0; j < keyNum; j++) {
 
 		posj = g_keyObj[`pos${keyCtrlPtn}`][j];
-		leftCnt = (posj > divideCnt ? posj - divideCnt : posj);
-		stdPos = leftCnt - (posj > divideCnt ? (posMax - divideCnt) : divideCnt) / 2;
-		dividePos = (posj > divideCnt ? 1 : 0);
+		if (posj > divideCnt) {
+			stdPos = posj - (posMax + divideCnt) / 2;
+			dividePos = 1;
+		} else {
+			stdPos = posj - divideCnt / 2;
+			dividePos = 0;
+		}
 
 		// キーコンフィグ表示用の矢印・おにぎりを表示
 		keyconSprite.appendChild(createArrowEffect(`arrow${j}`, g_headerObj.setColor[g_keyObj[`color${keyCtrlPtn}`][j]],
@@ -4481,10 +4486,13 @@ function keyConfigInit() {
 					}
 				}
 				const posj = g_keyObj[`pos${keyCtrlPtn}`][g_currentj];
-
-				leftCnt = (posj > divideCnt ? posj - divideCnt : posj);
-				stdPos = leftCnt - (posj > divideCnt ? (posMax - divideCnt) : divideCnt) / 2;
-				dividePos = (posj > divideCnt ? 1 : 0);
+				if (posj > divideCnt) {
+					stdPos = posj - (posMax + divideCnt) / 2;
+					dividePos = 1;
+				} else {
+					stdPos = posj - divideCnt / 2;
+					dividePos = 0;
+				}
 
 				cursor.style.left = `${kWidth / 2 + g_keyObj.blank * stdPos - 10 - 25}px`;
 				cursor.style.top = `${50 + 150 * dividePos}px`;
@@ -4543,16 +4551,20 @@ function resetCursorReplaced(_width, _divideCnt, _keyCtrlPtn) {
 		}
 	}
 	const posj = g_keyObj[`pos${_keyCtrlPtn}`][g_currentj];
-
-	const cursor = document.querySelector(`#cursor`);
-
-	const leftCnt = (posj > _divideCnt ? posj - _divideCnt : posj);
 	const posMax = (g_keyObj[`divMax${_keyCtrlPtn}`] !== undefined ?
 		g_keyObj[`divMax${_keyCtrlPtn}`] : g_keyObj[`pos${_keyCtrlPtn}`][keyNum - 1] + 1);
-	const stdPos = leftCnt - (posj > _divideCnt ? (posMax - _divideCnt) : _divideCnt) / 2;
+	let stdPos;
+	let dividePos;
+	if (posj > _divideCnt) {
+		stdPos = posj - (posMax + _divideCnt) / 2;
+		dividePos = 1;
+	} else {
+		stdPos = posj - _divideCnt / 2;
+		dividePos = 0;
+	}
 
+	const cursor = document.querySelector(`#cursor`);
 	cursor.style.left = `${_width / 2 + g_keyObj.blank * stdPos - 10 - 25}px`;
-	const dividePos = (posj > _divideCnt ? 1 : 0);
 	if (g_currentk === 1) {
 		cursor.style.top = `${65 + 150 * dividePos}px`;
 	} else {
@@ -5836,8 +5848,12 @@ function getArrowSettings() {
 	for (let j = 0; j < keyNum; j++) {
 
 		const posj = g_keyObj[`pos${keyCtrlPtn}`][j];
-		const leftCnt = (posj > divideCnt ? posj - divideCnt : posj);
-		const stdPos = (posj > divideCnt ? leftCnt - (posMax - divideCnt) / 2 : leftCnt - divideCnt / 2);
+		let stdPos;
+		if (posj > divideCnt) {
+			stdPos = posj - (posMax + divideCnt) / 2;
+		} else {
+			stdPos = posj - divideCnt / 2;
+		}
 		g_workObj.stepX[j] = g_keyObj.blank * stdPos + g_sWidth / 2 - 25;
 
 		if (g_stateObj.reverse === C_FLG_ON) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4182,7 +4182,7 @@ function keyConfigInit() {
 	const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
 	const posMax = (g_keyObj[`divMax${keyCtrlPtn}`] !== undefined ?
 		g_keyObj[`divMax${keyCtrlPtn}`] : g_keyObj[`pos${keyCtrlPtn}`][keyNum - 1] + 1);
-	const divideCnt = g_keyObj[`div${keyCtrlPtn}`];
+	const divideCnt = g_keyObj[`div${keyCtrlPtn}`] - 1;
 	if (g_keyObj[`blank${keyCtrlPtn}`] !== undefined) {
 		g_keyObj.blank = g_keyObj[`blank${keyCtrlPtn}`];
 	} else {
@@ -4211,9 +4211,9 @@ function keyConfigInit() {
 	for (let j = 0; j < keyNum; j++) {
 
 		posj = g_keyObj[`pos${keyCtrlPtn}`][j];
-		leftCnt = (posj >= divideCnt ? posj - divideCnt : posj);
-		stdPos = (posj >= divideCnt ? leftCnt + 1 - (posMax - (divideCnt - 1)) / 2 : leftCnt - (divideCnt - 1) / 2);
-		dividePos = (posj >= divideCnt ? 1 : 0);
+		leftCnt = (posj > divideCnt ? posj - divideCnt : posj);
+		stdPos = leftCnt - (posj > divideCnt ? (posMax - divideCnt) : divideCnt) / 2;
+		dividePos = (posj > divideCnt ? 1 : 0);
 
 		// キーコンフィグ表示用の矢印・おにぎりを表示
 		keyconSprite.appendChild(createArrowEffect(`arrow${j}`, g_headerObj.setColor[g_keyObj[`color${keyCtrlPtn}`][j]],
@@ -4237,7 +4237,7 @@ function keyConfigInit() {
 
 	// カーソルの作成
 	const cursor = keyconSprite.appendChild(createImg(`cursor`, C_IMG_CURSOR,
-		kWidth / 2 + g_keyObj.blank * (posj - (divideCnt - 1) / 2) - 10 - 25, 45, 15, 30));
+		kWidth / 2 + g_keyObj.blank * (posj - divideCnt / 2) - 10 - 25, 45, 15, 30));
 	cursor.style.transitionDuration = `0.125s`;
 
 	// キーコンフィグタイプ切替ボタン
@@ -4376,7 +4376,8 @@ function keyConfigInit() {
 		clearWindow();
 		keyConfigInit();
 		const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
-		eval(`resetCursor${g_kcType}`)(kWidth, g_keyObj[`div${keyCtrlPtn}`], keyCtrlPtn);
+		const divideCnt = g_keyObj[`div${keyCtrlPtn}`] - 1;
+		eval(`resetCursor${g_kcType}`)(kWidth, divideCnt, keyCtrlPtn);
 	});
 	divRoot.appendChild(btnPtnChange);
 
@@ -4397,7 +4398,7 @@ function keyConfigInit() {
 			g_keyObj.currentKey = g_headerObj.keyLabels[g_stateObj.scoreId];
 			const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
 			const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
-			const divideCnt = g_keyObj[`div${keyCtrlPtn}`];
+			const divideCnt = g_keyObj[`div${keyCtrlPtn}`] - 1;
 
 			for (let j = 0; j < keyNum; j++) {
 				for (let k = 0; k < g_keyObj[`keyCtrl${keyCtrlPtn}`][j].length; k++) {
@@ -4481,9 +4482,9 @@ function keyConfigInit() {
 				}
 				const posj = g_keyObj[`pos${keyCtrlPtn}`][g_currentj];
 
-				leftCnt = (posj >= divideCnt ? posj - divideCnt : posj);
-				stdPos = (posj >= divideCnt ? leftCnt + 1 - (posMax - (divideCnt - 1)) / 2 : leftCnt - (divideCnt - 1) / 2);
-				dividePos = (posj >= divideCnt ? 1 : 0);
+				leftCnt = (posj > divideCnt ? posj - divideCnt : posj);
+				stdPos = leftCnt - (posj > divideCnt ? (posMax - divideCnt) : divideCnt) / 2;
+				dividePos = (posj > divideCnt ? 1 : 0);
 
 				cursor.style.left = `${kWidth / 2 + g_keyObj.blank * stdPos - 10 - 25}px`;
 				cursor.style.top = `${50 + 150 * dividePos}px`;
@@ -4518,7 +4519,7 @@ function resetCursorMain(_width, _divideCnt, _keyCtrlPtn) {
 	const posj = g_keyObj[`pos${_keyCtrlPtn}`][0];
 
 	const cursor = document.querySelector(`#cursor`);
-	cursor.style.left = `${_width / 2 + g_keyObj.blank * (posj - (_divideCnt - 1) / 2) - 10 - 25}px`;
+	cursor.style.left = `${_width / 2 + g_keyObj.blank * (posj - _divideCnt / 2) - 10 - 25}px`;
 	cursor.style.top = `45px`;
 }
 
@@ -4544,13 +4545,14 @@ function resetCursorReplaced(_width, _divideCnt, _keyCtrlPtn) {
 	const posj = g_keyObj[`pos${_keyCtrlPtn}`][g_currentj];
 
 	const cursor = document.querySelector(`#cursor`);
-	const leftCnt = (posj >= _divideCnt ? posj - _divideCnt : posj);
+
+	const leftCnt = (posj > _divideCnt ? posj - _divideCnt : posj);
 	const posMax = (g_keyObj[`divMax${_keyCtrlPtn}`] !== undefined ?
 		g_keyObj[`divMax${_keyCtrlPtn}`] : g_keyObj[`pos${_keyCtrlPtn}`][keyNum - 1] + 1);
-	const stdPos = (posj >= _divideCnt ? leftCnt + 1 - (posMax - (_divideCnt - 1)) / 2 : leftCnt - (_divideCnt - 1) / 2);
-	cursor.style.left = `${_width / 2 + g_keyObj.blank * stdPos - 10 - 25}px`;
+	const stdPos = leftCnt - (posj > _divideCnt ? (posMax - _divideCnt) : _divideCnt) / 2;
 
-	const dividePos = (posj >= _divideCnt ? 1 : 0);
+	cursor.style.left = `${_width / 2 + g_keyObj.blank * stdPos - 10 - 25}px`;
+	const dividePos = (posj > _divideCnt ? 1 : 0);
 	if (g_currentk === 1) {
 		cursor.style.top = `${65 + 150 * dividePos}px`;
 	} else {
@@ -4573,7 +4575,7 @@ function resetCursorALL(_width, _divideCnt, _keyCtrlPtn) {
 	const posj = g_keyObj[`pos${_keyCtrlPtn}`][0];
 
 	const cursor = document.querySelector(`#cursor`);
-	cursor.style.left = `${_width / 2 + g_keyObj.blank * (posj - (_divideCnt - 1) / 2) - 10 - 25}px`;
+	cursor.style.left = `${_width / 2 + g_keyObj.blank * (posj - _divideCnt / 2) - 10 - 25}px`;
 	cursor.style.top = `45px`;
 }
 
@@ -5792,7 +5794,7 @@ function getArrowSettings() {
 	const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
 	const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
 	const posMax = (g_keyObj[`divMax${keyCtrlPtn}`] !== undefined ? g_keyObj[`divMax${keyCtrlPtn}`] : g_keyObj[`pos${keyCtrlPtn}`][keyNum - 1] + 1);
-	const divideCnt = g_keyObj[`div${keyCtrlPtn}`];
+	const divideCnt = g_keyObj[`div${keyCtrlPtn}`] - 1;
 	if (g_keyObj[`blank${keyCtrlPtn}`] !== undefined) {
 		g_keyObj.blank = g_keyObj[`blank${keyCtrlPtn}`];
 	} else {
@@ -5834,16 +5836,16 @@ function getArrowSettings() {
 	for (let j = 0; j < keyNum; j++) {
 
 		const posj = g_keyObj[`pos${keyCtrlPtn}`][j];
-		const leftCnt = (posj >= divideCnt ? posj - divideCnt : posj);
-		const stdPos = (posj >= divideCnt ? leftCnt + 1 - (posMax - (divideCnt - 1)) / 2 : leftCnt - (divideCnt - 1) / 2);
+		const leftCnt = (posj > divideCnt ? posj - divideCnt : posj);
+		const stdPos = (posj > divideCnt ? leftCnt - (posMax - divideCnt) / 2 : leftCnt - divideCnt / 2);
 		g_workObj.stepX[j] = g_keyObj.blank * stdPos + g_sWidth / 2 - 25;
 
 		if (g_stateObj.reverse === C_FLG_ON) {
-			g_workObj.dividePos[j] = (posj >= divideCnt ? 0 : 1);
-			g_workObj.scrollDir[j] = (posj >= divideCnt ? 1 : -1);
+			g_workObj.dividePos[j] = (posj > divideCnt ? 0 : 1);
+			g_workObj.scrollDir[j] = (posj > divideCnt ? 1 : -1);
 		} else {
-			g_workObj.dividePos[j] = (posj >= divideCnt ? 1 : 0);
-			g_workObj.scrollDir[j] = (posj >= divideCnt ? -1 : 1);
+			g_workObj.dividePos[j] = (posj > divideCnt ? 1 : 0);
+			g_workObj.scrollDir[j] = (posj > divideCnt ? -1 : 1);
 		}
 
 		g_workObj.judgArrowCnt[j] = 1;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4203,8 +4203,6 @@ function keyConfigInit() {
 		document.querySelector(`#kcMsg`).innerHTML = ``;
 	}
 
-	/** 同行の左から数えた場合の位置(x座標) */
-	let leftCnt = 0;
 	/** 同行の中心から見た場合の位置(x座標) */
 	let stdPos = 0;
 	/** 行位置 */
@@ -4571,6 +4569,7 @@ function resetCursorReplaced(_width, _divideCnt, _keyCtrlPtn) {
 		cursor.style.top = `${65 + 150 * dividePos}px`;
 	} else {
 		g_kcType = `ALL`;
+		document.querySelector(`#lnkKcType`).innerHTML = g_kcType;
 		cursor.style.top = `${45 + 150 * dividePos}px`;
 	}
 }


### PR DESCRIPTION
## 変更内容
1. 独自キーの2段目のpos最終番号を指定できるように変更しました。
下記のように、divXの2番目要素を指定します。(Xはキー名)
```
|divX=7,14|
```
2. KeyConfigがReplacedの場合で、代替キーが2段目にしかない場合に
カーソルがおかしくなる問題を修正しました。
3. コードの整理

## 変更理由
1. 独自キーで下段右側にスペースのあるキーが作成できなかったため。
2. 上述の通り。
3. ver5.8.1が暫定修正のため、一部オンコードになっていた箇所を修正しました。

## その他コメント

