### PR TITLE
 [ver5.10.0] フリーズアロー許容フレーム数、タイトルバック・リトライキーの変更を譜面ヘッダーより制御する設定を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4468,10 +4468,10 @@ function keyConfigInit() {
 				const posj = g_keyObj[`pos${keyCtrlPtn}`][g_currentj];
 
 				leftCnt = (posj >= divideCnt ? posj - divideCnt : posj);
-				stdPos = (posj >= divideCnt ? leftCnt - (posMax - divideCnt) / 2 : leftCnt - divideCnt / 2);
+				stdPos = (posj >= divideCnt ? leftCnt + 1 - (posMax - (divideCnt - 1)) / 2 : leftCnt - (divideCnt - 1) / 2);
 				dividePos = (posj >= divideCnt ? 1 : 0);
 
-				cursor.style.left = `${kWidth / 2 + g_keyObj.blank * stdPos - 10}px`;
+				cursor.style.left = `${kWidth / 2 + g_keyObj.blank * stdPos - 10 - 25}px`;
 				cursor.style.top = `${50 + 150 * dividePos}px`;
 				if (g_kcType === `Replaced`) {
 					cursor.style.top = `${parseFloat(cursor.style.top) + 20}px`;
@@ -5815,8 +5815,8 @@ function getArrowSettings() {
 
 		const posj = g_keyObj[`pos${keyCtrlPtn}`][j];
 		const leftCnt = (posj >= divideCnt ? posj - divideCnt : posj);
-		const stdPos = (posj >= divideCnt ? leftCnt - (posMax - divideCnt) / 2 : leftCnt - divideCnt / 2);
-		g_workObj.stepX[j] = g_keyObj.blank * stdPos + g_sWidth / 2;
+		const stdPos = (posj >= divideCnt ? leftCnt + 1 - (posMax - (divideCnt - 1)) / 2 : leftCnt - (divideCnt - 1) / 2);
+		g_workObj.stepX[j] = g_keyObj.blank * stdPos + g_sWidth / 2 - 25;
 
 		if (g_stateObj.reverse === C_FLG_ON) {
 			g_workObj.dividePos[j] = (posj >= divideCnt ? 0 : 1);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/06/01
+ * Revised : 2019/06/08
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 5.8.0`;
-const g_revisedDate = `2019/06/01`;
+const g_version = `Ver 5.8.1`;
+const g_revisedDate = `2019/06/08`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/06/08
+ * Revised : 2019/06/09
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 5.8.1`;
-const g_revisedDate = `2019/06/08`;
+const g_version = `Ver 5.9.0`;
+const g_revisedDate = `2019/06/09`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,7 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 5.9.0`;
+const g_version = `Ver 5.10.0`;
 const g_revisedDate = `2019/06/09`;
 const g_alphaVersion = ``;
 


### PR DESCRIPTION
## 変更内容
1.  フリーズアローの許容フレームを譜面ヘッダーから指定できるように変更 ( #333 )
1.  プレイ中のショートカットキーを設定できるように変更 ( #334 )

## 変更理由
- Gitter要望より。詳細はPull Requestに記載しています。

## その他コメント

