### PR TITLE
通常矢印の内側を塗りつぶす機能

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2610,7 +2610,7 @@ function headerConvert(_dosObj) {
 	}
 	obj.setColorDefault = JSON.parse(JSON.stringify(obj.setColor));
 	// 矢印の内側塗りつぶし色の設定
-	obj.setShadowColor = setVal(_dosObj.ShadowColor, ``, `string`);
+	obj.setShadowColor = setVal(_dosObj.ShadowColor.replace(`0x`, `#`), ``, `string`);
 
 
 	// フリーズアロー初期色情報

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2610,7 +2610,7 @@ function headerConvert(_dosObj) {
 	}
 	obj.setColorDefault = JSON.parse(JSON.stringify(obj.setColor));
 	// 矢印の内側塗りつぶし色の設定
-	obj.setshadowColor = setVal(_dosObj.shadowColor.replace(`0x`, `#`), ``, `string`);
+	obj.setShadowColor = setVal(_dosObj.shadowColor, ``, `string`).replace(`0x`, `#`);
 
 
 	// フリーズアロー初期色情報
@@ -6048,7 +6048,7 @@ function MainInit() {
 	// ステップゾーンを表示
 	for (let j = 0; j < keyNum; j++) {
 		// 矢印の内側を塗りつぶすか否か
-		if(g_headerObj.setshadowColor !== ``) {
+		if(g_headerObj.setShadowColor !== ``) {
 			// 矢印の塗り部分
 			const stepShadow = createColorObject(`stepShadow${j}`, `#000000`,
 			g_workObj.stepX[j],
@@ -6535,46 +6535,33 @@ function MainInit() {
 				const targetj = g_workObj.mkArrow[g_scoreObj.frameNum][j];
 				const boostSpdDir = g_workObj.boostSpd * g_workObj.scrollDir[targetj];
 
+				const stepRoot = createSprite(`mainSprite`, `arrow${targetj}_${++arrowCnts[targetj]}`,
+					g_workObj.stepX[targetj],
+					g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[targetj] + g_workObj.initY[g_scoreObj.frameNum] * boostSpdDir,
+					50, 100);
+				stepRoot.setAttribute(`cnt`, g_workObj.arrivalFrame[g_scoreObj.frameNum] + 1);
+				stepRoot.setAttribute(`boostCnt`, g_workObj.motionFrame[g_scoreObj.frameNum]);
+				stepRoot.setAttribute(`judgEndFlg`, `false`);
+				stepRoot.setAttribute(`boostSpd`, boostSpdDir);
+				mainSprite.appendChild(stepRoot);
+
+				// 内側塗りつぶし矢印は、下記の順で作成する。
+				// 後に作成するほど前面に表示される。
+
 				// 矢印の内側を塗りつぶすか否か
-				if(g_headerObj.setshadowColor === ``) {
-
-					const step = createArrowEffect(`arrow${targetj}_${++arrowCnts[targetj]}`, g_workObj.arrowColors[targetj],
-						g_workObj.stepX[targetj],
-						g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[targetj] + g_workObj.initY[g_scoreObj.frameNum] * boostSpdDir, 50,
-						g_workObj.stepRtn[targetj]);
-					step.setAttribute(`cnt`, g_workObj.arrivalFrame[g_scoreObj.frameNum] + 1);
-					step.setAttribute(`boostCnt`, g_workObj.motionFrame[g_scoreObj.frameNum]);
-					step.setAttribute(`judgEndFlg`, `false`);
-					step.setAttribute(`boostSpd`, boostSpdDir);
-
-					mainSprite.appendChild(step);
-
-				} else {
-					const stepRoot = createSprite(`mainSprite`, `arrow${targetj}_${++arrowCnts[targetj]}`,
-						g_workObj.stepX[targetj],
-						g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[targetj] + g_workObj.initY[g_scoreObj.frameNum] * boostSpdDir,
-						50, 100);
-					stepRoot.setAttribute(`cnt`, g_workObj.arrivalFrame[g_scoreObj.frameNum] + 1);
-					stepRoot.setAttribute(`boostCnt`, g_workObj.motionFrame[g_scoreObj.frameNum]);
-					stepRoot.setAttribute(`judgEndFlg`, `false`);
-					stepRoot.setAttribute(`boostSpd`, boostSpdDir);
-					mainSprite.appendChild(stepRoot);
-
-					// 内側塗りつぶし矢印は、下記の順で作成する。
-					// 後に作成するほど前面に表示される。
-					
+				if(g_headerObj.setShadowColor !== ``) {
 					// 矢印の塗り部分
-					const shadowColor = (g_headerObj.setshadowColor === `Default` ? g_workObj.arrowColors[targetj] : g_headerObj.setshadowColor);
-					const stepShadow = createColorObject(`stepShadow${targetj}_${arrowCnts[targetj]}`, shadowColor,
+					const shadowColor = (g_headerObj.setShadowColor === `Default` ? g_workObj.arrowColors[targetj] : g_headerObj.setShadowColor);
+					const arrShadow = createColorObject(`arrShadow${targetj}_${arrowCnts[targetj]}`, shadowColor,
 						0, 0, 50, 50, g_workObj.stepRtn[targetj], `arrowShadow`);
-					stepRoot.appendChild(stepShadow);
-					stepShadow.style.opacity = 0.5;
-
-					// 矢印
-					const step = createArrowEffect(`arrow${targetj}_${arrowCnts[targetj]}`, g_workObj.arrowColors[targetj],
-						0, 0, 50, g_workObj.stepRtn[targetj]);
-					stepRoot.appendChild(step);
+					arrShadow.style.opacity = 0.5;
+					stepRoot.appendChild(arrShadow);
 				}
+
+				// 矢印
+				const step = createArrowEffect(`arrTop${targetj}_${arrowCnts[targetj]}`, g_workObj.arrowColors[targetj],
+					0, 0, 50, g_workObj.stepRtn[targetj]);
+				stepRoot.appendChild(step);
 			}
 		}
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6047,6 +6047,17 @@ function MainInit() {
 
 	// ステップゾーンを表示
 	for (let j = 0; j < keyNum; j++) {
+		// 矢印の内側を塗りつぶすか否か
+		if(g_headerObj.setShadowColor !== ``) {
+			// 矢印の塗り部分
+			const stepShadow = createColorObject(`stepShadow${j}`, `#000000`,
+			g_workObj.stepX[j],
+			g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j],
+			50, 50, g_workObj.stepRtn[j], `arrowShadow`);
+			mainSprite.appendChild(stepShadow);
+			stepShadow.style.opacity = 0.7;
+		}
+
 		const step = createArrowEffect(`step${j}`, `#999999`,
 			g_workObj.stepX[j],
 			g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j], 50,

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2610,7 +2610,7 @@ function headerConvert(_dosObj) {
 	}
 	obj.setColorDefault = JSON.parse(JSON.stringify(obj.setColor));
 	// 矢印の内側塗りつぶし色の設定
-	obj.setShadowColor = setVal(_dosObj.shadowColor, ``, `string`).replace(`0x`, `#`);
+	obj.setShadowColor = setVal(_dosObj.setShadowColor, ``, `string`).replace(`0x`, `#`);
 
 
 	// フリーズアロー初期色情報

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2610,7 +2610,7 @@ function headerConvert(_dosObj) {
 	}
 	obj.setColorDefault = JSON.parse(JSON.stringify(obj.setColor));
 	// 矢印の内側塗りつぶし色の設定
-	obj.setShadowColor = setVal(_dosObj.ShadowColor.replace(`0x`, `#`), ``, `string`);
+	obj.setshadowColor = setVal(_dosObj.shadowColor.replace(`0x`, `#`), ``, `string`);
 
 
 	// フリーズアロー初期色情報
@@ -6048,7 +6048,7 @@ function MainInit() {
 	// ステップゾーンを表示
 	for (let j = 0; j < keyNum; j++) {
 		// 矢印の内側を塗りつぶすか否か
-		if(g_headerObj.setShadowColor !== ``) {
+		if(g_headerObj.setshadowColor !== ``) {
 			// 矢印の塗り部分
 			const stepShadow = createColorObject(`stepShadow${j}`, `#000000`,
 			g_workObj.stepX[j],
@@ -6536,7 +6536,7 @@ function MainInit() {
 				const boostSpdDir = g_workObj.boostSpd * g_workObj.scrollDir[targetj];
 
 				// 矢印の内側を塗りつぶすか否か
-				if(g_headerObj.setShadowColor === ``) {
+				if(g_headerObj.setshadowColor === ``) {
 
 					const step = createArrowEffect(`arrow${targetj}_${++arrowCnts[targetj]}`, g_workObj.arrowColors[targetj],
 						g_workObj.stepX[targetj],
@@ -6564,7 +6564,7 @@ function MainInit() {
 					// 後に作成するほど前面に表示される。
 					
 					// 矢印の塗り部分
-					const shadowColor = (g_headerObj.setShadowColor === `Default` ? g_workObj.arrowColors[targetj] : g_headerObj.setShadowColor);
+					const shadowColor = (g_headerObj.setshadowColor === `Default` ? g_workObj.arrowColors[targetj] : g_headerObj.setshadowColor);
 					const stepShadow = createColorObject(`stepShadow${targetj}_${arrowCnts[targetj]}`, shadowColor,
 						0, 0, 50, 50, g_workObj.stepRtn[targetj], `arrowShadow`);
 					stepRoot.appendChild(stepShadow);


### PR DESCRIPTION
## 変更内容
・通常矢印の内側を塗りつぶす機能

## 変更理由
背景や演出付きの作品で、背景で矢印が見えづらくなる場合があったため

## その他コメント
譜面ヘッダーにて
|ShadowColor=#000000|
という感じでカラーコードで指定できます。(0xから始まるカラーコードにも対応済み)
また、例外処理を1つだけ仕込んであり
|ShadowColor=Default|
と指定することでベースの矢印色と同色にすることも出来ます。

あと、矢印の縦連やおにぎり等AAの視認性の観点から
塗りつぶし部分の透明度を0.5で指定してあります。