### PR TITLE
[fix-frzonly:0.1.0] フリーズアローのみの譜面がプレイできない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5502,7 +5502,10 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 	let arrowArrivalFrm;
 	let frmPrev;
 
-	for (let j = 0; j < _dataObj.arrowData.length; j++) {
+	const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
+	const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
+
+	for (let j = 0; j < keyNum; j++) {
 
 		// 矢印の出現フレーム数計算
 		if (_dataObj.arrowData[j] !== undefined) {


### PR DESCRIPTION
## 変更内容
- フリーズアローのみの譜面がプレイできない問題を修正

## 変更理由
- 矢印毎の譜面格納ループ条件が矢印のレーン数となっているため、
矢印が存在しない場合にはレーン数が０となっていた。
このためフリーズアローのみの譜面の場合、譜面格納が行われず、
譜面がプレイできない状況になっていた。

## その他コメント

