### PR TITLE
[0003-dummy-arrows] ダミー矢印・フリーズアローのS-Random実装、カスタム関数拡張

### DIFF
--- a/js/danoni_custom.js
+++ b/js/danoni_custom.js
@@ -146,8 +146,13 @@ function customJudgeIknai(difFrame){
 
 }
 
-// ダミー
-function customJudgeDummy(difFrame){
+// ダミー矢印
+function customJudgeDummyArrow(difFrame){
+
+}
+
+// ダミーフリーズアロー
+function customJudgeDummyFrz(difFrame){
 
 }
 */

--- a/js/danoni_custom2.js
+++ b/js/danoni_custom2.js
@@ -144,8 +144,13 @@ function customJudgeIknai2(difFrame){
 
 }
 
-// ダミー
-function customJudgeDummy2(difFrame){
+// ダミー矢印
+function customJudgeDummyArrow2(difFrame){
+
+}
+
+// ダミーフリーズアロー
+function customJudgeDummyFrz2(difFrame){
 
 }
 */

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4813,9 +4813,11 @@ function loadingScoreInit() {
 	} else if (g_stateObj.shuffle === `Random+`) {
 		applyRandom(keyNum, [[...Array(keyNum).keys()]]);
 	} else if (g_stateObj.shuffle === `S-Random`) {
-		applySRandom(keyNum, shuffleGroup);
+		applySRandom(keyNum, shuffleGroup, `arrow`, `frz`);
+		applySRandom(keyNum, shuffleGroup, `dummyArrow`, `dummyFrz`);
 	} else if (g_stateObj.shuffle === `S-Random+`) {
-		applySRandom(keyNum, [[...Array(keyNum).keys()]]);
+		applySRandom(keyNum, [[...Array(keyNum).keys()]], `arrow`, `frz`);
+		applySRandom(keyNum, [[...Array(keyNum).keys()]], `dummyArrow`, `dummyFrz`);
 	}
 
 	// 矢印・フリーズアロー・速度/色変化格納処理
@@ -4897,11 +4899,11 @@ function applyRandom(_keyNum, _shuffleGroup) {
 
 /**
  * S-Randomの適用
- * （ダミー矢印はシャッフル対象外）
  * @param {number} _keyNum
  * @param {array} _shuffleGroup
  */
-function applySRandom(_keyNum, _shuffleGroup) {
+function applySRandom(_keyNum, _shuffleGroup, _arrowHeader, _frzHeader) {
+
 	const tmpArrowData = [...Array(_keyNum)].map(_ => []);
 	const tmpFrzData = [...Array(_keyNum)].map(_ => []);
 
@@ -4910,7 +4912,7 @@ function applySRandom(_keyNum, _shuffleGroup) {
 		// 全フリーズを開始フレーム順に並べる
 		const allFreezeArrows = [];
 		_group.forEach(_key => {
-			const frzData = g_scoreObj.frzData[_key] || [];
+			const frzData = g_scoreObj[`${_frzHeader}Data`][_key] || [];
 			for (let i = 0; i < frzData.length; i += 2) {
 				allFreezeArrows.push({ begin: frzData[i], end: frzData[i + 1] });
 			}
@@ -4929,7 +4931,7 @@ function applySRandom(_keyNum, _shuffleGroup) {
 		});
 
 		// 通常矢印の配置
-		const allArrows = _group.map(_key => g_scoreObj.arrowData[_key]).flat();
+		const allArrows = _group.map(_key => g_scoreObj[`${_arrowHeader}Data`][_key]).flat();
 		allArrows.sort((_a, _b) => _a - _b);
 		allArrows.forEach(_arrow => {
 			// 置ける場所を検索
@@ -4945,8 +4947,8 @@ function applySRandom(_keyNum, _shuffleGroup) {
 		})
 	});
 
-	g_scoreObj.arrowData = tmpArrowData;
-	g_scoreObj.frzData = tmpFrzData.map(_freezes =>
+	g_scoreObj[`${_arrowHeader}Data`] = tmpArrowData;
+	g_scoreObj[`${_frzHeader}Data`] = tmpFrzData.map(_freezes =>
 		_freezes.map(_freeze => [_freeze.begin, _freeze.end]).flat()
 	);
 }


### PR DESCRIPTION
## 変更内容
1. ダミー矢印・フリーズアローに対してS-Random/S-Random+を実装
※ただし、通常矢印/フリーズアローとダミー矢印/フリーズアロー間の重なりは考慮されません。
2. ダミーフリーズアローの判定用カスタム関数を実装
3. コード整理

## 変更理由
1. ダミー矢印・フリーズアローに対するShaffle対応が不十分だったため。
2. ダミー矢印のみ判定用カスタム関数が存在していたため。
3. 矢印・フリーズアロー消去用関数をほぼ1か所に統一し、コードの散らばりを抑止する。

## その他コメント

