### PR TITLE
[fix-gauge-custom:0.1.0] 独自キーが2譜面目以降にある場合に読み込みできない場合がある問題を修正　他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2583,7 +2583,7 @@ function headerConvert(_dosObj) {
 
 	// ノルマ制設定
 	for (let j = 0; j < g_gaugeOptionObj.border.length; j++) {
-		if (g_gaugeOptionObj.border[j] != `SuddenDeath`) {
+		if (g_gaugeOptionObj.border[j] !== `SuddenDeath`) {
 			getGaugeSetting(_dosObj, g_gaugeOptionObj.border[j], obj);
 		}
 	}
@@ -2591,7 +2591,7 @@ function headerConvert(_dosObj) {
 	g_gauges = JSON.parse(JSON.stringify(g_gaugeOptionObj[g_gaugeType.toLowerCase()]));
 	g_stateObj.gauge = g_gauges[g_gaugeNum];
 
-	if (g_gaugeOptionObj[`gauge${g_stateObj.gauge}s`] != undefined) {
+	if (g_gaugeOptionObj[`gauge${g_stateObj.gauge}s`] !== undefined) {
 		if (g_gaugeOptionObj[`gauge${g_stateObj.gauge}s`].lifeBorders[0] === `x`) {
 			g_stateObj.lifeBorder = 0;
 		} else {
@@ -3647,23 +3647,23 @@ function createOptionWindow(_sprite) {
 		// ゲージ設定別に個別設定した場合はここで設定を上書き
 		const tmpScoreId = g_stateObj.scoreId;
 
-		if (g_gaugeOptionObj[`gauge${g_stateObj.gauge}s`] != undefined) {
+		if (g_gaugeOptionObj[`gauge${g_stateObj.gauge}s`] !== undefined) {
 			const tmpGaugeObj = g_gaugeOptionObj[`gauge${g_stateObj.gauge}s`];
 
-			if (setVal(tmpGaugeObj.lifeBorders[tmpScoreId], `string`) != ``) {
+			if (setVal(tmpGaugeObj.lifeBorders[tmpScoreId], `string`) !== ``) {
 				if (tmpGaugeObj.lifeBorders[tmpScoreId] === `x`) {
 					g_stateObj.lifeBorder = 0;
 				} else {
 					g_stateObj.lifeBorder = tmpGaugeObj.lifeBorders[tmpScoreId];
 				}
 			}
-			if (setVal(tmpGaugeObj.lifeRecoverys[tmpScoreId], `float`) != ``) {
+			if (setVal(tmpGaugeObj.lifeRecoverys[tmpScoreId], `float`) !== ``) {
 				g_stateObj.lifeRcv = tmpGaugeObj.lifeRecoverys[tmpScoreId];
 			}
-			if (setVal(tmpGaugeObj.lifeDamages[tmpScoreId], `float`) != ``) {
+			if (setVal(tmpGaugeObj.lifeDamages[tmpScoreId], `float`) !== ``) {
 				g_stateObj.lifeDmg = tmpGaugeObj.lifeDamages[tmpScoreId];
 			}
-			if (setVal(tmpGaugeObj.lifeInits[tmpScoreId], `float`) != ``) {
+			if (setVal(tmpGaugeObj.lifeInits[tmpScoreId], `float`) !== ``) {
 				g_stateObj.lifeInit = tmpGaugeObj.lifeInits[tmpScoreId];
 			}
 		}
@@ -3943,6 +3943,10 @@ function createOptionWindow(_sprite) {
 					};
 					g_stateObj.reverse = C_FLG_OFF;
 					g_reverseNum = 0;
+				}
+			} else {
+				if (g_keyObj.currentPtn === -1) {
+					g_keyObj.currentPtn = 0;
 				}
 			}
 
@@ -5159,7 +5163,7 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame, _dummyNo = ``) {
 		} else if (_dosObj.word_data !== undefined) {
 			inputWordData = _dosObj.word_data;
 		}
-		if (inputWordData != ``) {
+		if (inputWordData !== ``) {
 			let tmpArrayData = inputWordData.split(`\r`).join(`\n`);
 			tmpArrayData = tmpArrayData.split(`\n`);
 


### PR DESCRIPTION
## 変更内容
1. 通常キー（キーコンフィグ保存済み）が1譜面目、独自キーが2譜面目の場合に
譜面の読み込みやキーコンフィグの設定ができない問題を修正しました。
2. `danoni_setting.js` の `g_presetGaugeCustom` において0が指定できない問題を修正しました。

## 変更理由
1. 通常キーでキーコンフィグ設定済みの場合、キーパターンは`-1`に設定されます。
独自キーの場合、譜面変更時にキーパターンを初期化する処理が抜けており、
独自キーにキーパターン`-1`が定義されていなかったため、エラーとなっていました。
2. `g_presetGaugeCustom` の存在条件に厳密等価演算子を使用していなかったため、
0と空白が同一と見做され、適用できない状態になっていました。

## その他コメント
- ver4, 5の両方に影響する不具合です。
