### PR TITLE
[0024-sprite-data] リバース用背景・マスクモーション、リザルトモーションの実装

### DIFF
--- a/js/danoni_custom.js
+++ b/js/danoni_custom.js
@@ -47,7 +47,7 @@ function customSetDifficulty(_initFlg, _canLoadDifInfoFlg) {
 }
 
 /**
- * メイン画面(フレーム毎表示) [Scene: Title / Melon]
+ * タイトル画面(フレーム毎表示) [Scene: Title / Melon]
  */
 function customTitleEnterFrame() {
 
@@ -103,6 +103,13 @@ function customMainEnterFrame() {
  * 結果画面(初期表示) [Scene: Result / Grape]
  */
 function customResultInit() {
+
+}
+
+/**
+ * 結果画面(フレーム毎表示) [Scene: Result / Grape]
+ */
+function customResultEnterFrame() {
 
 }
 

--- a/js/danoni_custom2.js
+++ b/js/danoni_custom2.js
@@ -105,6 +105,13 @@ function customResultInit2() {
 }
 
 /**
+ * 結果画面(フレーム毎表示) [Scene: Result / Grape]
+ */
+function customResultEnterFrame2() {
+
+}
+
+/**
  * 判定カスタム処理 (引数は共通で1つ保持)
  * @param {number} difFrame タイミング誤差(フレーム数)
  */

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1712,6 +1712,70 @@ class AudioPlayer {
 	dispatchEvent() { }
 }
 
+/**
+ * 多層スプライトデータの作成処理
+ * @param {array} _data 
+ * @param {function} _calcFrame 
+ */
+function makeSpriteData(_data, _calcFrame = _frame => _frame) {
+
+	const spriteData = [];
+	let maxDepth = -1;
+
+	let tmpArrayData = _data.split(`\r`).join(`\n`);
+	tmpArrayData = tmpArrayData.split(`\n`);
+
+	tmpArrayData.forEach(tmpData => {
+		if (tmpData !== undefined && tmpData !== ``) {
+			const tmpSpriteData = tmpData.split(`,`);
+
+			// 値チェックとエスケープ処理
+			const tmpFrame = _calcFrame(setVal(tmpSpriteData[0], 200, `number`));
+			const tmpDepth = setVal(tmpSpriteData[1], 0, `number`);
+			const tmpPath = escapeHtml(setVal(tmpSpriteData[2], ``, `string`));
+			const tmpClass = escapeHtml(setVal(tmpSpriteData[3], ``, `string`));
+			const tmpX = setVal(tmpSpriteData[4], 0, `float`);
+			const tmpY = setVal(tmpSpriteData[5], 0, `float`);
+			const tmpWidth = setVal(tmpSpriteData[6], 0, `number`);					// spanタグの場合は font-size
+			const tmpHeight = escapeHtml(setVal(tmpSpriteData[7], ``, `string`));	// spanタグの場合は color(文字列可)
+			const tmpOpacity = setVal(tmpSpriteData[8], 1, `float`);
+			const tmpAnimationName = escapeHtml(setVal(tmpSpriteData[9], C_DIS_NONE, `string`));
+			const tmpAnimationDuration = setVal(tmpSpriteData[10], 0, `number`) / 60;
+
+			if (tmpDepth > maxDepth) {
+				maxDepth = tmpDepth;
+			}
+
+			let addFrame = 0;
+			if (spriteData[tmpFrame] === undefined) {
+				spriteData[tmpFrame] = {};
+			} else {
+				for (let m = 1; ; m++) {
+					if (spriteData[tmpFrame + m] === undefined) {
+						spriteData[tmpFrame + m] = {};
+						addFrame = m;
+						break;
+					}
+				}
+			}
+			spriteData[tmpFrame + addFrame] = {
+				depth: tmpDepth,
+				path: tmpPath,
+				class: tmpClass,
+				left: tmpX,
+				top: tmpY,
+				width: tmpWidth,
+				height: tmpHeight,
+				opacity: tmpOpacity,
+				animationName: tmpAnimationName,
+				animationDuration: tmpAnimationDuration
+			};
+		}
+	});
+
+	return [spriteData, maxDepth];
+}
+
 /*-----------------------------------------------------------*/
 /* Scene : TITLE [melon] */
 /*-----------------------------------------------------------*/
@@ -2851,59 +2915,7 @@ function headerConvert(_dosObj) {
 	obj.backTitleData.length = 0;
 	obj.backTitleMaxDepth = -1;
 	if (_dosObj.backtitle_data !== undefined) {
-
-		let tmpArrayData = _dosObj.backtitle_data.split(`\r`).join(`\n`);
-		tmpArrayData = tmpArrayData.split(`\n`);
-
-		for (let j = 0, len = tmpArrayData.length; j < len; j++) {
-			const tmpData = tmpArrayData[j];
-
-			if (tmpData !== undefined && tmpData !== ``) {
-				const tmpBackTitleData = tmpData.split(`,`);
-
-				// 値チェックとエスケープ処理
-				const tmpFrame = setVal(tmpBackTitleData[0], 200, `number`);
-				const tmpDepth = setVal(tmpBackTitleData[1], 0, `number`);
-				const tmpPath = escapeHtml(setVal(tmpBackTitleData[2], ``, `string`));
-				const tmpClass = escapeHtml(setVal(tmpBackTitleData[3], ``, `string`));
-				const tmpX = setVal(tmpBackTitleData[4], 0, `float`);
-				const tmpY = setVal(tmpBackTitleData[5], 0, `float`);
-				const tmpWidth = setVal(tmpBackTitleData[6], 0, `number`);					// spanタグの場合は font-size
-				const tmpHeight = escapeHtml(setVal(tmpBackTitleData[7], ``, `string`));	// spanタグの場合は color(文字列可)
-				const tmpOpacity = setVal(tmpBackTitleData[8], 1, `float`);
-				const tmpAnimationName = escapeHtml(setVal(tmpBackTitleData[9], C_DIS_NONE, `string`));
-				const tmpAnimationDuration = setVal(tmpBackTitleData[10], 0, `number`) / 60;
-
-				if (tmpDepth > obj.backTitleMaxDepth) {
-					obj.backTitleMaxDepth = tmpDepth;
-				}
-
-				let addFrame = 0;
-				if (obj.backTitleData[tmpFrame] === undefined) {
-					obj.backTitleData[tmpFrame] = {};
-				} else {
-					for (let m = 1; ; m++) {
-						if (obj.backTitleData[tmpFrame + m] === undefined) {
-							obj.backTitleData[tmpFrame + m] = {};
-							addFrame = m;
-							break;
-						}
-					}
-				}
-				obj.backTitleData[tmpFrame + addFrame] = {
-					depth: tmpDepth,
-					path: tmpPath,
-					class: tmpClass,
-					left: tmpX,
-					top: tmpY,
-					width: tmpWidth,
-					height: tmpHeight,
-					opacity: tmpOpacity,
-					animationName: tmpAnimationName,
-					animationDuration: tmpAnimationDuration
-				};
-			}
-		}
+		[obj.backTitleData, obj.backTitleMaxDepth] = makeSpriteData(_dosObj.backtitle_data);
 	}
 
 	return obj;
@@ -5207,118 +5219,32 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame, _dummyNo = ``) {
 	// [フレーム数,階層,背景パス,class(CSSで別定義),X,Y,width,height,opacity,animationName,animationDuration]
 	obj.maskData = [];
 	obj.maskData.length = 0;
-	obj.maskMaxDepth = -1;
-	if (_dosObj[`mask${_scoreNo}_data`] !== undefined && g_stateObj.d_background === C_FLG_ON) {
-
-		let tmpArrayData = _dosObj[`mask${_scoreNo}_data`].split(`\r`).join(`\n`);
-		tmpArrayData = tmpArrayData.split(`\n`);
-
-		tmpArrayData.forEach(tmpData => {
-			if (tmpData !== undefined && tmpData !== ``) {
-				const tmpMaskData = tmpData.split(`,`);
-
-				// 値チェックとエスケープ処理
-				const tmpFrame = calcFrame(setVal(tmpMaskData[0], 200, `number`));
-				const tmpDepth = setVal(tmpMaskData[1], 0, `number`);
-				const tmpPath = escapeHtml(setVal(tmpMaskData[2], ``, `string`));
-				const tmpClass = escapeHtml(setVal(tmpMaskData[3], ``, `string`));
-				const tmpX = setVal(tmpMaskData[4], 0, `float`);
-				const tmpY = setVal(tmpMaskData[5], 0, `float`);
-				const tmpWidth = setVal(tmpMaskData[6], 0, `number`);				// spanタグの場合は font-size
-				const tmpHeight = escapeHtml(setVal(tmpMaskData[7], ``, `string`));	// spanタグの場合は color(文字列可)
-				const tmpOpacity = setVal(tmpMaskData[8], 1, `float`);
-				const tmpAnimationName = escapeHtml(setVal(tmpMaskData[9], C_DIS_NONE, `string`));
-				const tmpAnimationDuration = setVal(tmpMaskData[10], 0, `number`) / 60;
-
-				if (tmpDepth > obj.maskMaxDepth) {
-					obj.maskMaxDepth = tmpDepth;
-				}
-
-				let addFrame = 0;
-				if (obj.maskData[tmpFrame] === undefined) {
-					obj.maskData[tmpFrame] = {};
-				} else {
-					for (let m = 1; ; m++) {
-						if (obj.maskData[tmpFrame + m] === undefined) {
-							obj.maskData[tmpFrame + m] = {};
-							addFrame = m;
-							break;
-						}
-					}
-				}
-				obj.maskData[tmpFrame + addFrame] = {
-					depth: tmpDepth,
-					path: tmpPath,
-					class: tmpClass,
-					left: tmpX,
-					top: tmpY,
-					width: tmpWidth,
-					height: tmpHeight,
-					opacity: tmpOpacity,
-					animationName: tmpAnimationName,
-					animationDuration: tmpAnimationDuration
-				};
+	if (g_stateObj.d_background === C_FLG_ON) {
+		if (g_stateObj.reverse === C_FLG_ON) {
+			if (_dosObj[`maskRev${_scoreNo}_data`] !== undefined) {
+				[obj.maskData, obj.maskMaxDepth] = makeSpriteData(_dosObj[`maskRev${_scoreNo}_data`], calcFrame);
+			} else if (_dosObj[`mask${_scoreNo}_data`] !== undefined) {
+				[obj.maskData, obj.maskMaxDepth] = makeSpriteData(_dosObj[`mask${_scoreNo}_data`], calcFrame);
 			}
-		});
+		} else if (_dosObj[`mask${_scoreNo}_data`] !== undefined) {
+			[obj.maskData, obj.maskMaxDepth] = makeSpriteData(_dosObj[`mask${_scoreNo}_data`], calcFrame);
+		}
 	}
 
 	// 背景データの分解 (下記すべてで1セット、改行区切り)
 	// [フレーム数,階層,背景パス,class(CSSで別定義),X,Y,width,height,opacity,animationName,animationDuration]
 	obj.backData = [];
 	obj.backData.length = 0;
-	obj.backMaxDepth = -1;
-	if (_dosObj[`back${_scoreNo}_data`] !== undefined && g_stateObj.d_background === C_FLG_ON) {
-
-		let tmpArrayData = _dosObj[`back${_scoreNo}_data`].split(`\r`).join(`\n`);
-		tmpArrayData = tmpArrayData.split(`\n`);
-
-		tmpArrayData.forEach(tmpData => {
-			if (tmpData !== undefined && tmpData !== ``) {
-				const tmpBackData = tmpData.split(`,`);
-
-				// 値チェックとエスケープ処理
-				const tmpFrame = calcFrame(setVal(tmpBackData[0], 200, `number`));
-				const tmpDepth = setVal(tmpBackData[1], 0, `number`);
-				const tmpPath = escapeHtml(setVal(tmpBackData[2], ``, `string`));
-				const tmpClass = escapeHtml(setVal(tmpBackData[3], ``, `string`));
-				const tmpX = setVal(tmpBackData[4], 0, `float`);
-				const tmpY = setVal(tmpBackData[5], 0, `float`);
-				const tmpWidth = setVal(tmpBackData[6], 0, `number`);				// spanタグの場合は font-size
-				const tmpHeight = escapeHtml(setVal(tmpBackData[7], ``, `string`));	// spanタグの場合は color(文字列可)
-				const tmpOpacity = setVal(tmpBackData[8], 1, `float`);
-				const tmpAnimationName = escapeHtml(setVal(tmpBackData[9], C_DIS_NONE, `string`));
-				const tmpAnimationDuration = setVal(tmpBackData[10], 0, `number`) / 60;
-
-				if (tmpDepth > obj.backMaxDepth) {
-					obj.backMaxDepth = tmpDepth;
-				}
-
-				let addFrame = 0;
-				if (obj.backData[tmpFrame] === undefined) {
-					obj.backData[tmpFrame] = {};
-				} else {
-					for (let m = 1; ; m++) {
-						if (obj.backData[tmpFrame + m] === undefined) {
-							obj.backData[tmpFrame + m] = {};
-							addFrame = m;
-							break;
-						}
-					}
-				}
-				obj.backData[tmpFrame + addFrame] = {
-					depth: tmpDepth,
-					path: tmpPath,
-					class: tmpClass,
-					left: tmpX,
-					top: tmpY,
-					width: tmpWidth,
-					height: tmpHeight,
-					opacity: tmpOpacity,
-					animationName: tmpAnimationName,
-					animationDuration: tmpAnimationDuration
-				};
+	if (g_stateObj.d_background === C_FLG_ON) {
+		if (g_stateObj.reverse === C_FLG_ON) {
+			if (_dosObj[`backRev${_scoreNo}_data`] !== undefined) {
+				[obj.backData, obj.backMaxDepth] = makeSpriteData(_dosObj[`backRev${_scoreNo}_data`], calcFrame);
+			} else if (_dosObj[`back${_scoreNo}_data`] !== undefined) {
+				[obj.backData, obj.backMaxDepth] = makeSpriteData(_dosObj[`back${_scoreNo}_data`], calcFrame);
 			}
-		});
+		} else if (_dosObj[`back${_scoreNo}_data`] !== undefined) {
+			[obj.backData, obj.backMaxDepth] = makeSpriteData(_dosObj[`back${_scoreNo}_data`], calcFrame);
+		}
 	}
 
 	return obj;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -289,6 +289,7 @@ const g_userAgent = window.navigator.userAgent.toLowerCase(); // msie, edge, chr
 let g_audio = new Audio();
 let g_timeoutEvtId = 0;
 let g_timeoutEvtTitleId = 0;
+let g_timeoutEvtResultId = 0;
 let g_inputKeyBuffer = [];
 
 // 歌詞制御
@@ -2115,12 +2116,10 @@ function titleInit() {
 	drawDefaultBackImage(``);
 
 	// タイトル用フレーム初期化
-	g_scoreObj.backTitleFrameNum = 0;
-	g_scoreObj.maskTitleFrameNum = 0;
+	g_scoreObj.titleFrameNum = 0;
 
 	// タイトル用ループカウンター
-	g_scoreObj.backTitleLoopCount = 0;
-	g_scoreObj.maskTitleLoopCount = 0;
+	g_scoreObj.titleLoopCount = 0;
 
 	const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
 
@@ -2418,12 +2417,6 @@ function titleInit() {
 	}, _ => window.open(`https://github.com/cwtickle/danoniplus`, `_blank`));
 	divRoot.appendChild(lnkVersion);
 
-	// マスクスプライトを作成
-	createSprite(`divRoot`, `maskTitleSprite`, 0, 0, g_sWidth, g_sHeight);
-	for (let j = 0; j <= g_headerObj.maskTitleMaxDepth; j++) {
-		createSprite(`maskTitleSprite`, `maskTitleSprite${j}`, 0, 0, g_sWidth, g_sHeight);
-	}
-
 	/**
 	 * タイトルのモーション設定
 	 */
@@ -2438,17 +2431,10 @@ function titleInit() {
 		}
 
 		// 背景表示・背景モーション
-		if (g_headerObj.backTitleData[g_scoreObj.backTitleFrameNum] !== undefined) {
-			g_scoreObj.backTitleFrameNum = drawSpriteData(g_scoreObj.backTitleFrameNum, `title`, `back`);
+		if (g_headerObj.backTitleData[g_scoreObj.titleFrameNum] !== undefined) {
+			g_scoreObj.titleFrameNum = drawSpriteData(g_scoreObj.titleFrameNum, `title`, `back`);
 		}
-
-		// マスク表示・マスクモーション
-		if (g_headerObj.maskTitleData[g_scoreObj.maskTitleFrameNum] !== undefined) {
-			g_scoreObj.maskTitleFrameNum = drawSpriteData(g_scoreObj.maskTitleFrameNum, `title`, `mask`);
-		}
-
-		g_scoreObj.backTitleFrameNum++;
-		g_scoreObj.maskTitleFrameNum++;
+		g_scoreObj.titleFrameNum++;
 		g_timeoutEvtTitleId = setTimeout(_ => flowTitleTimeline(), 1000 / 60);
 	}
 
@@ -2934,7 +2920,7 @@ function headerConvert(_dosObj) {
 	// 別キーパターンの使用有無
 	obj.transKeyUse = setVal(_dosObj.transKeyUse, `true`, `string`);
 
-	// 背景データの分解 (下記すべてで1セット、改行区切り)
+	// タイトル画面用・背景データの分解 (下記すべてで1セット、改行区切り)
 	// [フレーム数,階層,背景パス,class(CSSで別定義),X,Y,width,height,opacity,animationName,animationDuration]
 	obj.backTitleData = [];
 	obj.backTitleData.length = 0;
@@ -2943,13 +2929,21 @@ function headerConvert(_dosObj) {
 		[obj.backTitleData, obj.backTitleMaxDepth] = makeSpriteData(_dosObj.backtitle_data);
 	}
 
-	// マスクデータの分解 (下記すべてで1セット、改行区切り)
+	// 結果画面用・背景データの分解 (下記すべてで1セット、改行区切り)
 	// [フレーム数,階層,背景パス,class(CSSで別定義),X,Y,width,height,opacity,animationName,animationDuration]
-	obj.maskTitleData = [];
-	obj.maskTitleData.length = 0;
-	obj.maskTitleMaxDepth = -1;
-	if (_dosObj.masktitle_data !== undefined) {
-		[obj.maskTitleData, obj.maskTitleMaxDepth] = makeSpriteData(_dosObj.masktitle_data);
+	obj.backResultData = [];
+	obj.backResultData.length = 0;
+	obj.backResultMaxDepth = -1;
+	if (_dosObj.backresult_data !== undefined) {
+		[obj.backResultData, obj.backResultMaxDepth] = makeSpriteData(_dosObj.backresult_data);
+	}
+
+	// 結果画面用・マスクデータの分解 (下記すべてで1セット、改行区切り)
+	obj.maskResultData = [];
+	obj.maskResultData.length = 0;
+	obj.maskResultMaxDepth = -1;
+	if (_dosObj.maskresult_data !== undefined) {
+		[obj.maskResultData, obj.maskResultMaxDepth] = makeSpriteData(_dosObj.maskresult_data);
 	}
 
 	return obj;
@@ -7904,7 +7898,22 @@ function finishViewing() {
 function resultInit() {
 
 	drawDefaultBackImage(``);
+
+	// 結果画面用フレーム初期化
+	g_scoreObj.backResultFrameNum = 0;
+	g_scoreObj.maskResultFrameNum = 0;
+
+	// 結果画面用ループカウンター
+	g_scoreObj.backResultLoopCount = 0;
+	g_scoreObj.maskResultLoopCount = 0;
+
 	const divRoot = document.querySelector(`#divRoot`);
+
+	// 背景スプライトを作成
+	createSprite(`divRoot`, `backResultSprite`, 0, 0, g_sWidth, g_sHeight);
+	for (let j = 0; j <= g_headerObj.backResultMaxDepth; j++) {
+		createSprite(`backResultSprite`, `backResultSprite${j}`, 0, 0, g_sWidth, g_sHeight);
+	}
 
 	// タイトル文字描画
 	const lblTitle = getTitleDivLabel(`lblTitle`,
@@ -8296,6 +8305,11 @@ function resultInit() {
 	playDataWindow.style.animationDuration = `3s`;
 	playDataWindow.style.animationName = `slowlyAppearing`;
 
+	// マスクスプライトを作成
+	createSprite(`divRoot`, `maskResultSprite`, 0, 0, g_sWidth, g_sHeight);
+	for (let j = 0; j <= g_headerObj.maskResultMaxDepth; j++) {
+		createSprite(`maskResultSprite`, `maskResultSprite${j}`, 0, 0, g_sWidth, g_sHeight);
+	}
 
 	// 戻るボタン描画
 	const btnBack = createButton({
@@ -8312,6 +8326,7 @@ function resultInit() {
 	}, _ => {
 		// タイトル画面へ戻る
 		g_audio.pause();
+		clearTimeout(g_timeoutEvtResultId);
 		clearWindow();
 		titleInit();
 	});
@@ -8346,10 +8361,41 @@ function resultInit() {
 		align: C_ALIGN_CENTER
 	}, _ => {
 		g_audio.pause();
+		clearTimeout(g_timeoutEvtResultId);
 		clearWindow();
 		loadMusic();
 	});
 	divRoot.appendChild(btnRetry);
+
+	/**
+	 * タイトルのモーション設定
+	 */
+	function flowResultTimeline() {
+
+		// ユーザカスタムイベント(フレーム毎)
+		if (typeof customResultEnterFrame === `function`) {
+			customResultEnterFrame();
+			if (typeof customResultEnterFrame2 === `function`) {
+				customResultEnterFrame2();
+			}
+		}
+
+		// 背景表示・背景モーション
+		if (g_headerObj.backResultData[g_scoreObj.backResultFrameNum] !== undefined) {
+			g_scoreObj.backResultFrameNum = drawSpriteData(g_scoreObj.backResultFrameNum, `result`, `back`);
+		}
+
+		// マスク表示・マスクモーション
+		if (g_headerObj.maskResultData[g_scoreObj.maskResultFrameNum] !== undefined) {
+			g_scoreObj.maskResultFrameNum = drawSpriteData(g_scoreObj.maskResultFrameNum, `result`, `mask`);
+		}
+
+		g_scoreObj.backResultFrameNum++;
+		g_scoreObj.maskResultFrameNum++;
+		g_timeoutEvtResultId = setTimeout(_ => flowResultTimeline(), 1000 / 60);
+	}
+
+	g_timeoutEvtResultId = setTimeout(_ => flowResultTimeline(), 1000 / 60);
 
 	// キー操作イベント（デフォルト）
 	document.onkeydown = evt => {


### PR DESCRIPTION
## 変更内容
1. メイン画面で使用する`back_data`、`mask_data`に対して
リバース用の背景・マスクモーションを実装しました。
背景用が`backRev_data`、マスク用が`maskRev_data`です。
使い方は`back_data`、`mask_data`と同じです。
未指定の場合、`back_data`、`mask_data`がリバース時でも表示されます。

2. リザルト画面に対して、リザルトモーションを実装しました。
背景用の`backresult_data`とマスク用の`maskresult_data`があります。
使い方は`backtitle_data`と同じです。

## 変更理由
- Gitter要望より。

## その他コメント
