### PR TITLE
[fix-boost-frzAttempt:0.1.0] フェードイン時に個別加速が掛からない問題を修正　他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5831,15 +5831,20 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 	g_workObj.boostData = [];
 	g_workObj.boostData.length = 0;
 	if (_dataObj.boostData !== undefined && _dataObj.boostData.length >= 2) {
-
 		let delBoostIdx = 0;
 		for (let k = _dataObj.boostData.length - 2; k >= 0; k -= 2) {
 			if (_dataObj.boostData[k] < g_scoreObj.frameNum) {
-				delBoostIdx = k;
+				delBoostIdx = k + 2;
 				break;
 			} else {
 				tmpObj = getArrowStartFrame(_dataObj.boostData[k], _speedOnFrame, _motionOnFrame);
-				_dataObj.boostData[k] = tmpObj.frm;
+				if(tmpObj.frm < g_scoreObj.frameNum) {
+					_dataObj.boostData[k] = g_scoreObj.frameNum;
+					delBoostIdx = k;
+					break;
+				} else {
+					_dataObj.boostData[k] = tmpObj.frm;
+				}
 			}
 		}
 		for (let k = 0; k < delBoostIdx; k++) {
@@ -7091,7 +7096,7 @@ function MainInit() {
 		const frzBtmShadow = document.querySelector(`#${_name}BtmShadow${_j}_${_k}`);
 		const dividePos = _frzRoot.getAttribute(`dividePos`);
 		const boostSpdDir = _frzRoot.getAttribute(`boostSpd`);
-		const keyUpFrame = _frzRoot.getAttribute(`frzAttempt`);
+		const keyUpFrame = Number(_frzRoot.getAttribute(`frzAttempt`));
 		const frzBarLength = parseFloat(frzBar.style.height) - g_workObj.currentSpeed * Math.abs(boostSpdDir);
 
 		_frzRoot.setAttribute(`frzBarLength`, frzBarLength);


### PR DESCRIPTION
## 変更内容
1. フェードイン時に個別加速が掛からない問題を修正
2. 譜面ヘッダー：frzAttemptが掛からない問題を修正

## 変更理由
1. Gitter以下コメントより。
> izkdic @vdos2643_twitter 16:24
> ver6.5.0で、個別加速（boost_data）が1回以上適用された後の地点からFadeinで始めると、以降の個別加速が反映されないようです。
> （|boost_data=1000,2,1500,1,2000,2,2500,1|となっているときに、500Fから始めた場合は問題ないのですが、たとえば1600Fから始めると2000Fの2倍速が反映されない）

2. Gitterコメントより。
keyUpFrameが文字列として扱われていたため。

## その他コメント

