### PR TITLE
[0031-frzhit-colors] 個別色変化（フリーズアローヒット時）のタイミング変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5975,7 +5975,6 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 				tmpObj = getArrowStartFrame(_dataObj.colorData[k], _speedOnFrame, _motionOnFrame);
 				frmPrev = tmpObj.frm;
 				if (!isFrzHitColor(_dataObj.colorData[k + 1])) {
-					console.log(_dataObj.colorData[k + 1]);
 					_dataObj.colorData[k] = tmpObj.frm;
 				}
 				g_workObj.arrivalFrame[frmPrev] = tmpObj.arrivalFrm;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5940,6 +5940,7 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 	}
 
 	// 個別色変化のタイミング更新
+	// フリーズアロー(ヒット時)の場合のみ、逆算をしない
 	if (_dataObj.colorData !== undefined && _dataObj.colorData.length >= 3) {
 		if (_dataObj.speedData !== undefined) {
 			spdk = _dataObj.speedData.length - 2;
@@ -5953,7 +5954,8 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 		tmpObj = getArrowStartFrame(_dataObj.colorData[lastk], _speedOnFrame, _motionOnFrame);
 		frmPrev = tmpObj.frm;
 		g_workObj.arrivalFrame[frmPrev] = tmpObj.arrivalFrm;
-		pushColors(``, tmpObj.frm, _dataObj.colorData[lastk + 1], _dataObj.colorData[lastk + 2].replace(`0x`, `#`));
+		pushColors(``, isFrzHitColor(_dataObj.colorData[lastk + 1]) ? _dataObj.colorData[lastk] : tmpObj.frm,
+			_dataObj.colorData[lastk + 1], _dataObj.colorData[lastk + 2].replace(`0x`, `#`));
 
 		for (let k = lastk - 3; k >= 0; k -= 3) {
 
@@ -5961,7 +5963,9 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 				break;
 			} else if ((_dataObj.colorData[k] - g_workObj.arrivalFrame[frmPrev] > spdPrev
 				&& _dataObj.colorData[k] < spdNext)) {
-				_dataObj.colorData[k] -= g_workObj.arrivalFrame[frmPrev];
+				if (!isFrzHitColor(_dataObj.colorData[k + 1])) {
+					_dataObj.colorData[k] -= g_workObj.arrivalFrame[frmPrev];
+				}
 			} else {
 				if (_dataObj.colorData[k] < spdPrev) {
 					spdk -= 2;
@@ -5970,7 +5974,10 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 				}
 				tmpObj = getArrowStartFrame(_dataObj.colorData[k], _speedOnFrame, _motionOnFrame);
 				frmPrev = tmpObj.frm;
-				_dataObj.colorData[k] = tmpObj.frm;
+				if (!isFrzHitColor(_dataObj.colorData[k + 1])) {
+					console.log(_dataObj.colorData[k + 1]);
+					_dataObj.colorData[k] = tmpObj.frm;
+				}
 				g_workObj.arrivalFrame[frmPrev] = tmpObj.arrivalFrm;
 			}
 			pushColors(``, _dataObj.colorData[k], _dataObj.colorData[k + 1], _dataObj.colorData[k + 2].replace(`0x`, `#`));
@@ -6074,6 +6081,14 @@ function getArrowStartFrame(_frame, _speedOnFrame, _motionOnFrame) {
 	}
 
 	return obj;
+}
+
+/**
+ * 個別色変化におけるフリーズアロー(ヒット時)判定
+ * @param {number} _val 
+ */
+function isFrzHitColor(_val) {
+	return ((_val >= 40 && _val < 50) || (_val >= 55 && _val < 60) || _val === 61) ? true : false;
 }
 
 /**


### PR DESCRIPTION
## 変更内容
- 個別色変化（フリーズアローヒット時）のタイミングを変更し、
この場合のみ、個別色変化のための逆算をしないように変更。

## 変更理由
- Issue #354 より。

## その他コメント
- 個別色変化（フリーズアローヒット時）を設定する場合、ステップゾーン到達時を基準にすれば良くなりました。
ただし押したタイミングにより、ステップゾーン到達時より手前でフリーズアローがヒット中になることがあります。
実際に設定する場合は、キターの判定領域分だけ値を小さくすることを推奨します。
