### PR TITLE
[0033-fix-lyrics] word_dataの3番目の要素を省略できるように変更（4番目未指定の場合）

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5414,7 +5414,7 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame, _dummyNo = ``) {
 							obj.wordData[tmpWordData[0] + addFrame].push(tmpWordData[1], tmpWordData[2], tmpWordData[3]);
 							break;
 						} else {
-							obj.wordData[tmpWordData[k] + addFrame].push(tmpWordData[k + 1], tmpWordData[k + 2]);
+							obj.wordData[tmpWordData[k] + addFrame].push(tmpWordData[k + 1], setVal(tmpWordData[k + 2], ``, `string`));
 						}
 					}
 				}


### PR DESCRIPTION
## 変更内容
- word_dataの3番目の要素を省略できるように変更（4番目未指定の場合）

## 変更理由
- word_dataが改行区切り可となった関係で、
3番目の要素を省略すると`undefined`という文字が表示されるようになっていました。

## その他コメント

