### PR TITLE
[0034-button-ui(2)] キーコンフィグ画面のボタン配置見直し

### DIFF
--- a/danoni/danoni1.html
+++ b/danoni/danoni1.html
@@ -76,6 +76,7 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 |keyCtrl6=75,79,76,80,187,32/0$75,79,76,80,187,32/0|
 |keyRetry6=9|
 |keyTitleBack=46|
+|transKeyUse=false|
 
 |arrowA2_data=203|arrowE2_data=203|arrowF2_data=264|
 |first_num=203|haba_num=10.1124|haba_page_num=0|rhythm_num=|label_num=0|beat_num=4|

--- a/danoni/danoni1.html
+++ b/danoni/danoni1.html
@@ -76,7 +76,6 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 |keyCtrl6=75,79,76,80,187,32/0$75,79,76,80,187,32/0|
 |keyRetry6=9|
 |keyTitleBack=46|
-|transKeyUse=false|
 
 |arrowA2_data=203|arrowE2_data=203|arrowF2_data=264|
 |first_num=203|haba_num=10.1124|haba_page_num=0|rhythm_num=|label_num=0|beat_num=4|

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4623,7 +4623,7 @@ function keyConfigInit() {
 	}
 	const lblPattern = createDivLabel(`lblPattern`, g_sWidth / 5, g_sHeight - 100,
 		g_sWidth * 3 / 5, C_BTN_HEIGHT / 2, 17, C_CLR_TITLE,
-		`KeyPattern: ${g_keyObj.currentPtn === -1 ? 'Save' : g_keyObj.currentPtn + 1}${lblTransKey}`);
+		`KeyPattern: ${g_keyObj.currentPtn === -1 ? 'Self' : g_keyObj.currentPtn + 1}${lblTransKey}`);
 	lblPattern.style.textAlign = C_ALIGN_CENTER;
 	divRoot.appendChild(lblPattern);
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4061,9 +4061,7 @@ function createOptionWindow(_sprite) {
 			} else {
 
 				// 特殊キーの場合は作品毎のローカルストレージから取得
-				if (g_keyObj.currentPtn === -1) {
-					g_keyObj.currentPtn = 0;
-				}
+				g_keyObj.currentPtn = 0;
 
 				// リバース初期値設定
 				if (g_localStorage[`reverse${g_keyObj.currentKey}`] !== undefined) {
@@ -4617,6 +4615,12 @@ function keyConfigInit() {
 		optionInit();
 	});
 	divRoot.appendChild(btnBack);
+
+	const lblPattern = createDivLabel(`lblPattern`, g_sWidth / 4, g_sHeight - 100,
+		g_sWidth / 2, C_BTN_HEIGHT / 2, C_LBL_BTNSIZE * 2 / 3, C_CLR_TITLE,
+		`KeyPattern: ${g_keyObj.currentPtn === -1 ? 'Save' : g_keyObj.currentPtn + 1}`);
+	lblPattern.style.textAlign = C_ALIGN_CENTER;
+	divRoot.appendChild(lblPattern);
 
 	// パターン変更ボタン描画
 	const btnPtnChangeNext = createButton({

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3388,7 +3388,7 @@ function optionInit() {
 	const btnPlay = createButton({
 		id: `btnPlay`,
 		name: `Play`,
-		x: g_sWidth / 3 * 2,
+		x: g_sWidth * 2 / 3,
 		y: g_sHeight - 100,
 		width: g_sWidth / 3,
 		height: C_BTN_HEIGHT,
@@ -4600,15 +4600,14 @@ function keyConfigInit() {
 	const btnBack = createButton({
 		id: `btnBack`,
 		name: `Back`,
-		x: 0,
-		y: g_sHeight - 100,
+		x: g_sWidth / 3,
+		y: g_sHeight - 75,
 		width: g_sWidth / 3,
-		height: C_BTN_HEIGHT,
-		fontsize: C_LBL_BTNSIZE,
+		height: C_BTN_HEIGHT / 2,
+		fontsize: C_LBL_BTNSIZE * 2 / 3,
 		normalColor: C_CLR_DEFAULTA,
 		hoverColor: C_CLR_BACK,
-		align: C_ALIGN_CENTER,
-		animationName: `smallToNormalY`
+		align: C_ALIGN_CENTER
 	}, _ => {
 		// 設定・オプション画面へ戻る
 		g_currentj = 0;
@@ -4620,18 +4619,17 @@ function keyConfigInit() {
 	divRoot.appendChild(btnBack);
 
 	// パターン変更ボタン描画
-	const btnPtnChange = createButton({
+	const btnPtnChangeNext = createButton({
 		id: `btnPtnChange`,
-		name: `PtnChange`,
-		x: g_sWidth / 3,
+		name: `>>`,
+		x: g_sWidth * 3 / 4,
 		y: g_sHeight - 100,
-		width: g_sWidth / 3,
-		height: C_BTN_HEIGHT,
-		fontsize: C_LBL_BTNSIZE,
+		width: g_sWidth / 4,
+		height: C_BTN_HEIGHT / 2,
+		fontsize: C_LBL_BTNSIZE * 2 / 3,
 		normalColor: C_CLR_DEFAULTB,
 		hoverColor: C_CLR_SETTING,
-		align: C_ALIGN_CENTER,
-		animationName: `smallToNormalY`
+		align: C_ALIGN_CENTER
 	}, _ => {
 		let tempPtn = g_keyObj.currentPtn + 1;
 		while (setVal(g_keyObj[`transKey${g_keyObj.currentKey}_${tempPtn}`], ``, `string`) !== `` &&
@@ -4657,21 +4655,71 @@ function keyConfigInit() {
 		const divideCnt = g_keyObj[`div${keyCtrlPtn}`] - 1;
 		eval(`resetCursor${g_kcType}`)(kWidth, divideCnt, keyCtrlPtn);
 	});
-	divRoot.appendChild(btnPtnChange);
+	divRoot.appendChild(btnPtnChangeNext);
+
+	// パターン変更ボタン描画
+	const btnPtnChangeBack = createButton({
+		id: `btnPtnChange`,
+		name: `<<`,
+		x: 0,
+		y: g_sHeight - 100,
+		width: g_sWidth / 4,
+		height: C_BTN_HEIGHT / 2,
+		fontsize: C_LBL_BTNSIZE * 2 / 3,
+		normalColor: C_CLR_DEFAULTB,
+		hoverColor: C_CLR_SETTING,
+		align: C_ALIGN_CENTER
+	}, _ => {
+		let tempPtn = g_keyObj.currentPtn - 1;
+		while (setVal(g_keyObj[`transKey${g_keyObj.currentKey}_${tempPtn}`], ``, `string`) !== `` &&
+			g_headerObj.transKeyUse === `false`) {
+
+			tempPtn--;
+			if (g_keyObj[`keyCtrl${g_keyObj.currentKey}_${tempPtn}`] === undefined) {
+				break;
+			}
+		}
+		if (g_keyObj[`keyCtrl${g_keyObj.currentKey}_${tempPtn}`] !== undefined) {
+			g_keyObj.currentPtn = tempPtn;
+		} else {
+			tempPtn = 0;
+			while (setVal(g_keyObj[`keyCtrl${g_keyObj.currentKey}_${tempPtn}`], ``, `string`) !== ``) {
+				tempPtn++;
+				if (g_keyObj[`keyCtrl${g_keyObj.currentKey}_${tempPtn}`] === undefined) {
+					break;
+				}
+			}
+			tempPtn--;
+			while (setVal(g_keyObj[`transKey${g_keyObj.currentKey}_${tempPtn}`], ``, `string`) !== `` &&
+				g_headerObj.transKeyUse === `false`) {
+
+				tempPtn--;
+				if (g_keyObj[`keyCtrl${g_keyObj.currentKey}_${tempPtn}`] === undefined) {
+					break;
+				}
+			}
+			g_keyObj.currentPtn = tempPtn;
+		}
+		clearWindow();
+		keyConfigInit();
+		const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
+		const divideCnt = g_keyObj[`div${keyCtrlPtn}`] - 1;
+		eval(`resetCursor${g_kcType}`)(kWidth, divideCnt, keyCtrlPtn);
+	});
+	divRoot.appendChild(btnPtnChangeBack);
 
 	// キーコンフィグリセットボタン描画
 	const btnReset = createButton({
 		id: `btnReset`,
 		name: `Reset`,
-		x: g_sWidth / 3 * 2,
-		y: g_sHeight - 100,
+		x: 0,
+		y: g_sHeight - 75,
 		width: g_sWidth / 3,
-		height: C_BTN_HEIGHT,
-		fontsize: C_LBL_BTNSIZE,
+		height: C_BTN_HEIGHT / 2,
+		fontsize: C_LBL_BTNSIZE * 2 / 3,
 		normalColor: C_CLR_DEFAULTD,
 		hoverColor: C_CLR_RESET,
-		align: C_ALIGN_CENTER,
-		animationName: `smallToNormalY`
+		align: C_ALIGN_CENTER
 	}, _ => {
 		if (window.confirm(`キーを初期配置に戻します。よろしいですか？`)) {
 			g_keyObj.currentKey = g_headerObj.keyLabels[g_stateObj.scoreId];

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -173,6 +173,8 @@ const C_MAX_ADJUSTMENT = 30;
 const C_MAX_SPEED = 10;
 const C_MIN_SPEED = 1;
 
+let g_initialFlg = false;
+
 /** キーコンフィグ設定 */
 let g_kcType = `Main`;
 let g_colorType = `Default`;
@@ -3355,9 +3357,10 @@ function optionInit() {
 		normalColor: C_CLR_DEFAULTA,
 		hoverColor: C_CLR_BACK,
 		align: C_ALIGN_CENTER,
-		animationName: `smallToNormalY`
+		animationName: (g_initialFlg ? `` : `smallToNormalY`)
 	}, _ => {
 		// タイトル画面へ戻る
+		g_initialFlg = true;
 		clearWindow();
 		titleInit();
 	});
@@ -3375,9 +3378,10 @@ function optionInit() {
 		normalColor: C_CLR_DEFAULTB,
 		hoverColor: C_CLR_SETTING,
 		align: C_ALIGN_CENTER,
-		animationName: `smallToNormalY`
+		animationName: (g_initialFlg ? `` : `smallToNormalY`)
 	}, _ => {
 		// キーコンフィグ画面へ遷移
+		g_initialFlg = true;
 		g_kcType = `Main`;
 		clearWindow();
 		keyConfigInit();
@@ -3387,7 +3391,7 @@ function optionInit() {
 	// 進むボタン描画
 	const btnPlay = createButton({
 		id: `btnPlay`,
-		name: `Play`,
+		name: `PLAY!`,
 		x: g_sWidth * 2 / 3,
 		y: g_sHeight - 100,
 		width: g_sWidth / 3,
@@ -3396,8 +3400,9 @@ function optionInit() {
 		normalColor: C_CLR_DEFAULTC,
 		hoverColor: C_CLR_NEXT,
 		align: C_ALIGN_CENTER,
-		animationName: `smallToNormalY`
+		animationName: (g_initialFlg ? `` : `smallToNormalY`)
 	}, _ => {
+		g_initialFlg = true;
 		clearWindow();
 		loadMusic();
 	});
@@ -4265,8 +4270,7 @@ function settingsDisplayInit() {
 		fontsize: C_LBL_BTNSIZE,
 		normalColor: C_CLR_DEFAULTA,
 		hoverColor: C_CLR_BACK,
-		align: C_ALIGN_CENTER,
-		animationName: `smallToNormalY`
+		align: C_ALIGN_CENTER
 	}, _ => {
 		// タイトル画面へ戻る
 		clearWindow();
@@ -4285,8 +4289,7 @@ function settingsDisplayInit() {
 		fontsize: C_LBL_BTNSIZE,
 		normalColor: C_CLR_DEFAULTB,
 		hoverColor: C_CLR_SETTING,
-		align: C_ALIGN_CENTER,
-		animationName: `smallToNormalY`
+		align: C_ALIGN_CENTER
 	}, _ => {
 		// キーコンフィグ画面へ遷移
 		g_kcType = `Main`;
@@ -4298,7 +4301,7 @@ function settingsDisplayInit() {
 	// 進むボタン描画
 	const btnPlay = createButton({
 		id: `btnPlay`,
-		name: `Play`,
+		name: `PLAY!`,
 		x: g_sWidth / 3 * 2,
 		y: g_sHeight - 100,
 		width: g_sWidth / 3,
@@ -4306,8 +4309,7 @@ function settingsDisplayInit() {
 		fontsize: C_LBL_BTNSIZE,
 		normalColor: C_CLR_DEFAULTC,
 		hoverColor: C_CLR_NEXT,
-		align: C_ALIGN_CENTER,
-		animationName: `smallToNormalY`
+		align: C_ALIGN_CENTER
 	}, _ => {
 		clearWindow();
 		loadMusic();
@@ -4597,7 +4599,7 @@ function keyConfigInit() {
 	// 戻るボタン描画
 	const btnBack = createButton({
 		id: `btnBack`,
-		name: `Back`,
+		name: `To Settings`,
 		x: g_sWidth / 3,
 		y: g_sHeight - 75,
 		width: g_sWidth / 3,

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4616,9 +4616,14 @@ function keyConfigInit() {
 	});
 	divRoot.appendChild(btnBack);
 
-	const lblPattern = createDivLabel(`lblPattern`, g_sWidth / 4, g_sHeight - 100,
-		g_sWidth / 2, C_BTN_HEIGHT / 2, C_LBL_BTNSIZE * 2 / 3, C_CLR_TITLE,
-		`KeyPattern: ${g_keyObj.currentPtn === -1 ? 'Save' : g_keyObj.currentPtn + 1}`);
+	// キーパターン表示
+	let lblTransKey = ``;
+	if (setVal(g_keyObj[`transKey${g_keyObj.currentKey}_${g_keyObj.currentPtn}`], ``, `string`) !== ``) {
+		lblTransKey = '(' + setVal(g_keyObj[`transKey${g_keyObj.currentKey}_${g_keyObj.currentPtn}`], ``, `string`) + ')';
+	}
+	const lblPattern = createDivLabel(`lblPattern`, g_sWidth / 5, g_sHeight - 100,
+		g_sWidth * 3 / 5, C_BTN_HEIGHT / 2, 17, C_CLR_TITLE,
+		`KeyPattern: ${g_keyObj.currentPtn === -1 ? 'Save' : g_keyObj.currentPtn + 1}${lblTransKey}`);
 	lblPattern.style.textAlign = C_ALIGN_CENTER;
 	divRoot.appendChild(lblPattern);
 
@@ -4626,9 +4631,9 @@ function keyConfigInit() {
 	const btnPtnChangeNext = createButton({
 		id: `btnPtnChange`,
 		name: `>>`,
-		x: g_sWidth * 3 / 4,
+		x: g_sWidth * 4 / 5,
 		y: g_sHeight - 100,
-		width: g_sWidth / 4,
+		width: g_sWidth / 5,
 		height: C_BTN_HEIGHT / 2,
 		fontsize: C_LBL_BTNSIZE * 2 / 3,
 		normalColor: C_CLR_DEFAULTB,
@@ -4667,7 +4672,7 @@ function keyConfigInit() {
 		name: `<<`,
 		x: 0,
 		y: g_sHeight - 100,
-		width: g_sWidth / 4,
+		width: g_sWidth / 5,
 		height: C_BTN_HEIGHT / 2,
 		fontsize: C_LBL_BTNSIZE * 2 / 3,
 		normalColor: C_CLR_DEFAULTB,


### PR DESCRIPTION
## 変更内容
- キーコンフィグ画面のボタン配置を見直しました。
以下の変更を行っています。

1. キーコンフィグ画面におけるボタンアニメーションを廃止
2. キーコンフィグ画面のボタン配置を見直し
    - 設定画面でKeyConfigボタンがあった場所（中央下段）に戻るボタンを配置
    - PtnChangeボタンをキーコンフィグパターンを変更する2つのボタンに分割し、左右上段に配置。片側は逆回しボタン。
    - Resetボタンを左下段へ移動
3. 現在選択しているキーコンフィグパターンと、別キーモード状態を表示するように変更。以下のように表示します。
    - KeyPattern : Self     // 保存したキーコンフィグ
    - KeyPattern : 1
    - KeyPattern : 2
    - KeyPattern : 3(9B)   // 別キー: 9Bモード

## 変更理由
- Gittter要望より。

## その他コメント

