### PR TITLE
デフォルトで選択状態にする譜面をURLで指定できる機能を実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1774,6 +1774,23 @@ function makeSpriteData(_data, _calcFrame = _frame => _frame) {
 	return [spriteData, maxDepth];
 }
 
+/**
+ * 現在URLのクエリパラメータから指定した値を取得
+ * @param {string} _name
+ */
+function getQueryParamVal(_name) {
+    const url = window.location.href;
+    const name = _name.replace(/[\[\]]/g, `\\$&`);
+
+    const regex = new RegExp(`[?&]${name}(=([^&#]*)|&|#|$)`);
+    const results = regex.exec(url);
+
+    if (!results) return null;
+    if (!results[2]) return ``;
+
+    return decodeURIComponent(results[2].replace(/\+/g, ` `));
+}
+
 /*-----------------------------------------------------------*/
 /* Scene : TITLE [melon] */
 /*-----------------------------------------------------------*/
@@ -1895,6 +1912,10 @@ function initAfterDosLoaded() {
 			preloadFile(`image`, g_headerObj.preloadImages[j], ``, ``);
 		}
 	}
+
+	// クエリで譜面番号が指定されていればセット
+	const specifiedScoreId = getQueryParamVal(`score_id`);
+	g_stateObj.scoreId = g_headerObj.keyLabels[specifiedScoreId] ? specifiedScoreId : 0;
 
 	// customjs、音楽ファイルの読み込み
 	const randTime = new Date().getTime();


### PR DESCRIPTION
## 変更内容
URLのクエリから譜面番号を取得し、オプション画面にて該当の譜面を選択状態にする機能を追加しました

## 変更理由
難易度表や多鍵DBなど、譜面単位でリンクを貼りたいときの使用を想定しています

## その他コメント
`http://cw7.sakura.ne.jp/danoni/2013/0237_Cllema.html?score_id=1`
のように指定すると、オプション画面で2譜面目の「7key / Rhythm」が選択された状態になります
指定されていない場合や該当する譜面がない場合は、通常通り1譜面目が選択されます
