### PR TITLE
[0035-color-legacy] 色変化の過去バージョン互換対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3051,6 +3051,9 @@ function headerConvert(_dosObj) {
 	// 結果画面用のマスク透過設定
 	obj.maskresultButton = setVal(_dosObj.maskresultButton, `false`, `string`);
 
+	// color_dataの過去バージョン互換設定
+	obj.colorDataType = setVal(_dosObj.colorDataType, ``, `string`);
+
 	return obj;
 }
 
@@ -6166,7 +6169,7 @@ function getArrowStartFrame(_frame, _speedOnFrame, _motionOnFrame) {
  * @param {number} _val 
  */
 function isFrzHitColor(_val) {
-	return ((_val >= 40 && _val < 50) || (_val >= 55 && _val < 60) || _val === 61) ? true : false;
+	return (g_headerObj.colorDataType === `` && ((_val >= 40 && _val < 50) || (_val >= 55 && _val < 60) || _val === 61)) ? true : false;
 }
 
 /**


### PR DESCRIPTION
## 変更内容
- ver7.1.0 ( #369 )にて、個別色変化（フリーズアローヒット時）のタイミング変更を実装したが、
過去作品においてはタイミングを修正しなければならず、数が多い場合手間となる。
これを省略するため、以下の設定を譜面ヘッダーに入れることで
従来の個別色変化（フリーズアローヒット時）を実装する。
```
|colorDataType=v6|
```

## 変更理由
- 上述の通り。

## その他コメント
