### PR TITLE
[0034-button-ui(3)] Display画面へ遷移したときにボタンアニメーションが解除されない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3360,7 +3360,6 @@ function optionInit() {
 		animationName: (g_initialFlg ? `` : `smallToNormalY`)
 	}, _ => {
 		// タイトル画面へ戻る
-		g_initialFlg = true;
 		clearWindow();
 		titleInit();
 	});
@@ -3381,7 +3380,6 @@ function optionInit() {
 		animationName: (g_initialFlg ? `` : `smallToNormalY`)
 	}, _ => {
 		// キーコンフィグ画面へ遷移
-		g_initialFlg = true;
 		g_kcType = `Main`;
 		clearWindow();
 		keyConfigInit();
@@ -3402,7 +3400,6 @@ function optionInit() {
 		align: C_ALIGN_CENTER,
 		animationName: (g_initialFlg ? `` : `smallToNormalY`)
 	}, _ => {
-		g_initialFlg = true;
 		clearWindow();
 		loadMusic();
 	});
@@ -3475,6 +3472,7 @@ function optionInit() {
 	btnSave.style.color = (g_stateObj.dataSaveFlg ? `#ffffff` : `#666666`);
 	btnSave.style.borderStyle = `solid`;
 	btnSave.style.borderColor = (g_stateObj.dataSaveFlg ? `#000000 #cccccc` : `#000000 #333333`);
+	g_initialFlg = true;
 }
 
 function musicAfterLoaded() {


### PR DESCRIPTION
## 変更内容
- Display画面へ遷移したときにボタンアニメーションが解除されない問題を修正

## 変更理由
- Setting -> Display -> Settingと遷移した場合にアニメーションが残ってしまう。

## その他コメント

