### PR TITLE
[ver7.4.0] カラーコードの左パディング機能を実装 他

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported Versions / サポートバージョン
+
+- 修正対象のバージョンは下記の通りです。
+- 基本的には、同一メジャーバージョンの最新版がサポート対象です。
+- v2, v3は**サポートを終了しました。**
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 7.x     | :white_check_mark: |
+| 6.6.x   | :white_check_mark: |
+| 5.12.x  | :white_check_mark: |
+| 4.10.x  | :white_check_mark: |
+| 3.13.x  | :x:                |
+| 2.9.x   | :x:                |
+| 1.15.x  | :white_check_mark: |
+| etc.    | :x:                |
+
+## Reporting a Vulnerability / 脆弱性・不具合情報
+
+- 修正内容の詳細は [Release](../../releases) をご覧ください。
+- サポートを終了したバージョンについては、不具合が残っている可能性があります。  
+[アップグレードガイド](../../wiki/MigrationGuide)、[本体のバージョンアップ](../../wiki/HowToUpdate)を参照して、本体の更新を検討してください。

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1198,7 +1198,7 @@ function getStrLength(str) {
  * 左パディング
  * @param {string} _str 元の文字列 
  * @param {number} _length パディング後の長さ 
- * @param {*} _chr 
+ * @param {string} _chr パディング文字列
  */
 function paddingLeft(_str, _length, _chr) {
 	let paddingStr = _str;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/07/18
+ * Revised : 2019/07/21
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 7.3.1`;
-const g_revisedDate = `2019/07/18`;
+const g_version = `Ver 7.4.0`;
+const g_revisedDate = `2019/07/21`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8830,7 +8830,7 @@ function resultFadeOut() {
 		const tmpVolume = (g_audio.volume - (3 * g_stateObj.volume / 100) / 1000);
 		if (tmpVolume < 0) {
 			g_audio.volume = 0;
-			clearInterval(g_timeoutEvtId);
+			clearTimeout(g_timeoutEvtId);
 			g_audio.pause();
 		} else {
 			g_audio.volume = tmpVolume;


### PR DESCRIPTION
## 変更内容
1. カラーコードの左パディング機能を実装 ( #383 )
2. F5キーのキーブロックを解除 ( #383 )
3. リザルト画面へ移行後に楽曲フェードアウトできるように変更 ( #384 )
4. リザルト画面で、フェードアウト中にTitleBack/Retryするとフェードアウト状態が引き継がれてしまう問題を修正 ( #384 )

## 変更理由
- Pull Request #383, #384を参照。

## その他コメント

