### PR TITLE
[0039-preload-numbering] 譜面ヘッダー:preloadImagesの複数まとめ記述の実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1925,13 +1925,36 @@ function initAfterDosLoaded() {
 	// その他の画像ファイルの読み込み
 	for (let j = 0, len = g_headerObj.preloadImages.length; j < len; j++) {
 		if (setVal(g_headerObj.preloadImages[j], ``, `string`) !== ``) {
+
+			// Pattern A: |preloadImages=file.png|
+			// Pattern B: |preloadImages=file*.png@10|  -> file01.png ~ file10.png
+			// Pattern C: |preloadImages=file*.png@2-9| -> file2.png  ~ file9.png
+			// Pattern D: |preloadImages=file*.png@003-018| -> file003.png  ~ file018.png
+
 			const tmpPreloadImages = g_headerObj.preloadImages[j].split(`@`);
 			if (tmpPreloadImages.length > 1) {
-				const roopCnt = setVal(tmpPreloadImages[1], 0, `number`);
-				for (let k = 1; k <= roopCnt; k++) {
-					preloadFile(`image`, tmpPreloadImages[0].replace(`*`, paddingLeft(String(k), 4, `0`)), ``, ``);
+				const termRoopCnts = tmpPreloadImages[1].split(`-`);
+				let startCnt;
+				let lastCnt;
+				let paddingLen;
+
+				if (termRoopCnts.length > 1) {
+					// Pattern C, Dの場合
+					startCnt = setVal(termRoopCnts[0], 1, `number`);
+					lastCnt = setVal(termRoopCnts[1], 1, `number`);
+					paddingLen = String(setVal(termRoopCnts[1], 1, `string`)).length;
+				} else {
+					// Pattern Bの場合
+					startCnt = 1;
+					lastCnt = setVal(tmpPreloadImages[1], 1, `number`);
+					paddingLen = String(setVal(tmpPreloadImages[1], 1, `string`)).length;
+				}
+				for (let k = startCnt; k <= lastCnt; k++) {
+					console.log(tmpPreloadImages[0].replace(`*`, paddingLeft(String(k), paddingLen, `0`)));
+					preloadFile(`image`, tmpPreloadImages[0].replace(`*`, paddingLeft(String(k), paddingLen, `0`)), ``, ``);
 				}
 			} else {
+				// Pattern Aの場合
 				preloadFile(`image`, g_headerObj.preloadImages[j], ``, ``);
 			}
 		}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1950,7 +1950,6 @@ function initAfterDosLoaded() {
 					paddingLen = String(setVal(tmpPreloadImages[1], 1, `string`)).length;
 				}
 				for (let k = startCnt; k <= lastCnt; k++) {
-					console.log(tmpPreloadImages[0].replace(`*`, paddingLeft(String(k), paddingLen, `0`)));
 					preloadFile(`image`, tmpPreloadImages[0].replace(`*`, paddingLeft(String(k), paddingLen, `0`)), ``, ``);
 				}
 			} else {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1925,7 +1925,15 @@ function initAfterDosLoaded() {
 	// その他の画像ファイルの読み込み
 	for (let j = 0, len = g_headerObj.preloadImages.length; j < len; j++) {
 		if (setVal(g_headerObj.preloadImages[j], ``, `string`) !== ``) {
-			preloadFile(`image`, g_headerObj.preloadImages[j], ``, ``);
+			const tmpPreloadImages = g_headerObj.preloadImages[j].split(`@`);
+			if (tmpPreloadImages.length > 1) {
+				const roopCnt = setVal(tmpPreloadImages[1], 0, `number`);
+				for (let k = 1; k <= roopCnt; k++) {
+					preloadFile(`image`, tmpPreloadImages[0].replace(`*`, paddingLeft(String(k), String(roopCnt).length, `0`)), ``, ``);
+				}
+			} else {
+				preloadFile(`image`, g_headerObj.preloadImages[j], ``, ``);
+			}
 		}
 	}
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1929,7 +1929,7 @@ function initAfterDosLoaded() {
 			if (tmpPreloadImages.length > 1) {
 				const roopCnt = setVal(tmpPreloadImages[1], 0, `number`);
 				for (let k = 1; k <= roopCnt; k++) {
-					preloadFile(`image`, tmpPreloadImages[0].replace(`*`, paddingLeft(String(k), String(roopCnt).length, `0`)), ``, ``);
+					preloadFile(`image`, tmpPreloadImages[0].replace(`*`, paddingLeft(String(k), 4, `0`)), ``, ``);
 				}
 			} else {
 				preloadFile(`image`, g_headerObj.preloadImages[j], ``, ``);


### PR DESCRIPTION
## 変更内容
- 譜面ヘッダーのpreloadImagesにおいて、限定用途で複数ファイルをまとめて記述できるようにしました。
例えば以下のように記述すると、file1.png～file4.pngまでを読み込むようになります。
```
|preloadImages=file*.png@4|
```
- アスタリスク（*）の部分が4桁の連番に置き換わり、
アットマーク（@）以後の数字が連番の上限値を表します。
- 連番は1からカウントします。

- また、開始・終了点を指定して、範囲指定することもできます。
連番の桁数は、大きい方に合わせて0で左詰めされます。
意図的に0を入れて、桁数を増やすこともできます。
```
|preloadImages=file*.png@2-9|   // -> file2.png ~ file9.png
|preloadImages=file*.png@5-10|     // -> file05.png ~ file10.png
|preloadImages=file*.png@01-08|     // -> file01.png ~ file08.png
```

## 変更理由
- 画像ファイルが多い場合の手間を軽減するため。

## その他コメント
- jsの制約上、今のところ動的にできるのは数字だけです。
- アスタリスクを複数指定することはできません。