### PR TITLE
[0044-flexible-reload] 譜面読込画面に入ったときに譜面データを再読込できるように変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1865,22 +1865,35 @@ function initialControl() {
 	}
 
 	// 譜面データの読み込み
+	loadDos(`true`);
+}
+
+/**
+ * 譜面読込
+ * @param {string} _initFlg 
+ */
+function loadDos(_initFlg) {
+
 	const dosInput = document.querySelector(`#dos`);
 	const externalDosInput = document.querySelector(`#externalDos`);
 
 	if (dosInput === null && externalDosInput === null) {
 		makeWarningWindow(C_MSG_E_0023);
-		initAfterDosLoaded();
+		initAfterDosLoaded(_initFlg);
 	}
 
 	// HTML埋め込みdos
 	if (dosInput !== null) {
 		g_rootObj = dosConvert(dosInput.value);
 		if (externalDosInput === null) {
-			const randTime = new Date().getTime();
-			loadScript(`../js/danoni_setting.js?${randTime}`, _ => {
-				initAfterDosLoaded();
-			});
+			if (_initFlg === `true`) {
+				const randTime = new Date().getTime();
+				loadScript(`../js/danoni_setting.js?${randTime}`, _ => {
+					initAfterDosLoaded(_initFlg);
+				});
+			} else {
+				initAfterDosLoaded(_initFlg);
+			}
 		}
 	}
 
@@ -1901,18 +1914,27 @@ function initialControl() {
 			} else {
 				makeWarningWindow(C_MSG_E_0022);
 			}
-			const randTime = new Date().getTime();
-			loadScript(`../js/danoni_setting.js?${randTime}`, _ => {
-				initAfterDosLoaded();
-			});
+
+			// danoni_setting.jsは初回時のみ読込
+			if (_initFlg === `true`) {
+				const randTime = new Date().getTime();
+				loadScript(`../js/danoni_setting.js?${randTime}`, _ => {
+					initAfterDosLoaded(_initFlg);
+				});
+			} else {
+				initAfterDosLoaded(_initFlg);
+			}
 		}, charset);
 	}
 }
 
-function initAfterDosLoaded() {
-	g_headerObj = headerConvert(g_rootObj);
-	keysConvert(g_rootObj);
+function initAfterDosLoaded(_initFlg) {
 
+	// 初回時のみ譜面ヘッダー、一時キー設定を行う
+	if (_initFlg === `true`) {
+		g_headerObj = headerConvert(g_rootObj);
+		keysConvert(g_rootObj);
+	}
 	g_keyObj.currentKey = g_headerObj.keyLabels[g_stateObj.scoreId];
 	g_keyObj.currentPtn = 0;
 
@@ -1976,10 +1998,18 @@ function initAfterDosLoaded() {
 	loadScript(`../js/${g_headerObj.customjs}?${randTime}`, _ => {
 		if (g_headerObj.customjs2 !== ``) {
 			loadScript(`../js/${g_headerObj.customjs2}?${randTime}`, _ => {
-				titleInit();
+				if (_initFlg === `true`) {
+					titleInit();
+				} else {
+					loadingScoreInit2();
+				}
 			});
 		} else {
-			titleInit();
+			if (_initFlg === `true`) {
+				titleInit();
+			} else {
+				loadingScoreInit2();
+			}
 		}
 	});
 }
@@ -5026,7 +5056,11 @@ function resetCursorALL(_width, _divideCnt, _keyCtrlPtn) {
  * 読込画面初期化
  */
 function loadingScoreInit() {
+	// 譜面データの読み込み
+	loadDos(`false`);
+}
 
+function loadingScoreInit2() {
 	const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
 	const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
 	g_headerObj.blankFrame = g_headerObj.blankFrameDef;
@@ -5038,7 +5072,6 @@ function loadingScoreInit() {
 		g_canLoadDifInfoFlg = false;
 	}
 
-	// 譜面データの読み込み
 	let scoreIdHeader = ``;
 	let dummyIdHeader = ``;
 	if (g_stateObj.scoreId > 0) {


### PR DESCRIPTION
## 変更内容
- 譜面読込画面に入ったときに譜面データを再読込できるように変更しました。
譜面データの読込タイミングが初回のみだったものが、リトライ時も含め毎回読込に変わります。
ただし、譜面ヘッダーは置き換えません。

## 変更理由
- ローカルやリモートで譜面再読込の際の手間を軽減するため。

## その他コメント
- 読込画面に入ったタイミングで譜面データを再度読み込みます。
具体的には、`g_rootObj`の中身が読込画面に入るたびに更新されます。
譜面ヘッダー群 `g_headerObj` やキーオブジェクト群 `g_keyObj`などは更新されません。

もし、`g_rootObj`に対して後付けで更新を掛ける操作を入れている場合、
修正が必要となる可能性があります。
