### PR TITLE
[ver7.7.0] 読込画面移動時に譜面を再読込する仕様に変更　他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/08/18
+ * Revised : 2019/08/25
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 7.6.0`;
-const g_revisedDate = `2019/08/18`;
+const g_version = `Ver 7.7.0`;
+const g_revisedDate = `2019/08/25`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)


### PR DESCRIPTION
## 変更内容
1. 譜面読込画面に入ったときに譜面データを再読込できるように変更 ( #397 )
2. 歌詞表示・背景/マスクモーションにおいて同一フレームの同時描画に対応 ( #398 )
3. 背景/マスクモーションにおいて、深度に「ALL」を指定することで、
全てのオブジェクトを一斉クリアできるように対応 ( #398 )

## 変更理由
- Pull Request #397, #398 を参照。

## その他コメント

