### PR TITLE
[0050-reset-keypattern] キーコンフィグの別パターンが選択できない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1939,9 +1939,9 @@ function initAfterDosLoaded(_initFlg) {
 	if (_initFlg === `true`) {
 		g_headerObj = headerConvert(g_rootObj);
 		keysConvert(g_rootObj);
+		g_keyObj.currentPtn = 0;
 	}
 	g_keyObj.currentKey = g_headerObj.keyLabels[g_stateObj.scoreId];
-	g_keyObj.currentPtn = 0;
 
 	// 画像ファイルの読み込み
 	preloadFile(`image`, C_IMG_ARROW, ``, ``);


### PR DESCRIPTION
## 変更内容
- キーコンフィグの別パターンが選択できない問題を修正。

## 変更理由
- ver7.7.0より、譜面を毎回再読込する仕様に変更したが、
その際にキーコンフィグパターンも初期化していたため、
別パターンでプレイできない状態になっていた。

## その他コメント
- ver7.7.0以降で発生します。
