### PR TITLE
[0052-back-failed] クリア失敗時のリザルトモーションを実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5663,7 +5663,7 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame, _dummyNo = ``) {
 		}
 	}
 
-	// 結果画面用・背景データの分解 (下記すべてで1セット、改行区切り)
+	// 結果画面用・背景データ(クリア時)の分解 (下記すべてで1セット、改行区切り)
 	// [フレーム数,階層,背景パス,class(CSSで別定義),X,Y,width,height,opacity,animationName,animationDuration]
 	g_headerObj.backResultData = [];
 	g_headerObj.backResultData.length = 0;
@@ -5674,7 +5674,7 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame, _dummyNo = ``) {
 		[g_headerObj.backResultData, g_headerObj.backResultMaxDepth] = makeSpriteData(_dosObj.backresult_data);
 	}
 
-	// 結果画面用・マスクデータの分解 (下記すべてで1セット、改行区切り)
+	// 結果画面用・マスクデータ(クリア時)の分解 (下記すべてで1セット、改行区切り)
 	g_headerObj.maskResultData = [];
 	g_headerObj.maskResultData.length = 0;
 	g_headerObj.maskResultMaxDepth = -1;
@@ -5682,6 +5682,33 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame, _dummyNo = ``) {
 	if (g_stateObj.d_background === C_FLG_OFF && g_headerObj.resultMotionSet === `true`) {
 	} else if (_dosObj.maskresult_data !== undefined) {
 		[g_headerObj.maskResultData, g_headerObj.maskResultMaxDepth] = makeSpriteData(_dosObj.maskresult_data);
+	}
+
+	// 結果画面用・背景データ(失敗時)の分解 (下記すべてで1セット、改行区切り)
+	// [フレーム数,階層,背景パス,class(CSSで別定義),X,Y,width,height,opacity,animationName,animationDuration]
+	g_headerObj.backFailedData = [];
+	g_headerObj.backFailedData.length = 0;
+	g_headerObj.backFailedMaxDepth = -1;
+
+	if (g_stateObj.d_background === C_FLG_OFF && g_headerObj.resultMotionSet === `true`) {
+	} else if (_dosObj[`backfailed${g_gaugeType.slice(0, 1)}_data`] !== undefined) {
+		[g_headerObj.backFailedData, g_headerObj.backFailedMaxDepth] = makeSpriteData(_dosObj[`backfailed${g_gaugeType.slice(0, 1)}_data`]);
+	} else if (_dosObj.backfailed_data !== undefined) {
+		[g_headerObj.backFailedData, g_headerObj.backFailedMaxDepth] = makeSpriteData(_dosObj.backfailed_data);
+	} else if (_dosObj.backresult_data !== undefined) {
+		[g_headerObj.backFailedData, g_headerObj.backFailedMaxDepth] = makeSpriteData(_dosObj.backresult_data);
+	}
+
+	// 結果画面用・マスクデータ(失敗時)の分解 (下記すべてで1セット、改行区切り)
+	g_headerObj.maskFailedData = [];
+	g_headerObj.maskFailedData.length = 0;
+	g_headerObj.maskFailedMaxDepth = -1;
+
+	if (g_stateObj.d_background === C_FLG_OFF && g_headerObj.resultMotionSet === `true`) {
+	} else if (_dosObj[`maskfailed${g_gaugeType.slice(0, 1)}_data`] !== undefined) {
+		[g_headerObj.maskFailedData, g_headerObj.maskFailedMaxDepth] = makeSpriteData(_dosObj[`maskfailed${g_gaugeType.slice(0, 1)}_data`]);
+	} else if (_dosObj.maskresult_data !== undefined) {
+		[g_headerObj.maskFailedData, g_headerObj.maskFailedMaxDepth] = makeSpriteData(_dosObj.maskresult_data);
 	}
 
 	return obj;
@@ -8880,6 +8907,13 @@ function resultInit() {
 		maskResultSprite.style.pointerEvents = `none`;
 	}
 
+	// ゲームオーバー時は失敗時のリザルトモーションを適用
+	if (g_gameOverFlg) {
+		g_headerObj.maskResultData = g_headerObj.maskFailedData.concat();
+		g_headerObj.backResultData = g_headerObj.backFailedData.concat();
+	}
+
+	// リザルトモーションの0フレーム対応
 	if (g_scoreObj.maskResultFrameNum === 0) {
 
 		// マスク表示・マスクモーション(0フレーム指定)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -296,6 +296,7 @@ const g_pointAllocation = {
 let g_maxScore = 1000000;
 
 let g_gameOverFlg = false;
+let g_finishFlg = true;
 
 const g_userAgent = window.navigator.userAgent.toLowerCase(); // msie, edge, chrome, safari, firefox, opera
 
@@ -6634,6 +6635,7 @@ function getArrowSettings() {
 
 	g_workObj.lifeVal = Math.round(g_workObj.lifeInit);
 	g_gameOverFlg = false;
+	g_finishFlg = true;
 
 	if (g_stateObj.dataSaveFlg && setVal(g_keyObj[`transKey${keyCtrlPtn}`], ``, `string`) === ``) {
 
@@ -7099,6 +7101,7 @@ function MainInit() {
 				clearWindow();
 				if (keyIsDown(16)) {
 					g_gameOverFlg = true;
+					g_finishFlg = false;
 					resultInit();
 				} else {
 					titleInit();
@@ -8220,6 +8223,7 @@ function lifeDamage() {
 			setTimeout(_ => {
 				clearWindow();
 				g_gameOverFlg = true;
+				g_finishFlg = false;
 				resultInit();
 			}, 200);
 		}
@@ -8463,6 +8467,24 @@ function resultInit() {
 	g_scoreObj.maskResultLoopCount = 0;
 
 	const divRoot = document.querySelector(`#divRoot`);
+
+	if (g_stateObj.d_background === C_FLG_OFF && g_headerObj.resultMotionSet === `true`) {
+	} else {
+		// ゲームオーバー時は失敗時のリザルトモーションを適用
+		if (!g_finishFlg) {
+			if (g_rootObj.backfailedS_data !== undefined) {
+				[g_headerObj.backResultData, g_headerObj.backResultMaxDepth] = makeSpriteData(g_rootObj.backfailedS_data);
+			}
+			if (g_rootObj.maskfailedS_data !== undefined) {
+				[g_headerObj.maskResultData, g_headerObj.maskResultMaxDepth] = makeSpriteData(g_rootObj.maskfailedS_data);
+			}
+		} else if (g_gameOverFlg) {
+			g_headerObj.backResultData = g_headerObj.backFailedData.concat();
+			g_headerObj.maskResultData = g_headerObj.maskFailedData.concat();
+			g_headerObj.backResultMaxDepth = g_headerObj.backFailedMaxDepth;
+			g_headerObj.maskResultMaxDepth = g_headerObj.maskFailedMaxDepth;
+		}
+	}
 
 	// 背景スプライトを作成
 	createSprite(`divRoot`, `backResultSprite`, 0, 0, g_sWidth, g_sHeight);
@@ -8907,27 +8929,21 @@ function resultInit() {
 		maskResultSprite.style.pointerEvents = `none`;
 	}
 
-	// ゲームオーバー時は失敗時のリザルトモーションを適用
-	if (g_gameOverFlg) {
-		g_headerObj.maskResultData = g_headerObj.maskFailedData.concat();
-		g_headerObj.backResultData = g_headerObj.backFailedData.concat();
-	}
-
 	// リザルトモーションの0フレーム対応
-	if (g_scoreObj.maskResultFrameNum === 0) {
-
-		// マスク表示・マスクモーション(0フレーム指定)
-		if (g_headerObj.maskResultData[0] !== undefined) {
-			g_scoreObj.maskResultFrameNum = drawSpriteData(0, `result`, `mask`);
-			g_headerObj.maskResultData[0] = undefined;
-		}
-	}
 	if (g_scoreObj.backResultFrameNum === 0) {
 
 		// 背景表示・背景モーション(0フレーム指定)
 		if (g_headerObj.backResultData[0] !== undefined) {
 			g_scoreObj.backResultFrameNum = drawSpriteData(0, `result`, `back`);
 			g_headerObj.backResultData[0] = undefined;
+		}
+	}
+	if (g_scoreObj.maskResultFrameNum === 0) {
+
+		// マスク表示・マスクモーション(0フレーム指定)
+		if (g_headerObj.maskResultData[0] !== undefined) {
+			g_scoreObj.maskResultFrameNum = drawSpriteData(0, `result`, `mask`);
+			g_headerObj.maskResultData[0] = undefined;
 		}
 	}
 


### PR DESCRIPTION
## 変更内容
- クリア失敗時のリザルトモーションを実装。
以下のように使い分けます。

|名称|用途|
|----|----|
|back(mask)result_data|クリア成功時のリザルトモーション<br>※失敗時のモーションが指定されていない場合も適用されます。|
|back(mask)failedS_data|途中終了時のリザルトモーション|
|back(mask)failedB_data|ノルマ制ゲージで、ノルマに達しなかった場合のリザルトモーション|

## 変更理由
- Twitter要望より。

## その他コメント
