### PR TITLE
[0057-result-motion-div] リザルトモーションの複数譜対応・音楽同期対応

### DIFF
--- a/danoni/danoni1.html
+++ b/danoni/danoni1.html
@@ -77,7 +77,7 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 |keyRetry6=9|
 |keyTitleBack=46|
 
-|arrowA2_data=203|arrowE2_data=203|arrowF2_data=264|
+|arrowA2_data=203,10000|arrowE2_data=203|arrowF2_data=264|
 |first_num=203|haba_num=10.1124|haba_page_num=0|rhythm_num=|label_num=0|beat_num=4|
 |shuffle6=0,0,0,0,0,1|
 |blank6=60|
@@ -118,9 +118,14 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 1300,0
 |
 
-|maskresult_data=
+|maskfailedS_data=
 0,0,../img/frzbar.png,,0,250,500,250,1
 700,0
+|
+
+|maskresult_data=
+0,0,../img/frzbar.png,,0,0,500,250,1
+200,0
 |
 
 |mask_data=

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9038,6 +9038,20 @@ function resultInit() {
 			g_scoreObj.maskResultFrameNum = drawSpriteData(g_scoreObj.maskResultFrameNum, `result`, `mask`);
 		}
 
+		// リザルト画面移行後のフェードアウト処理
+		if (g_scoreObj.fadeOutFrame >= g_scoreObj.frameNum) {
+			g_scoreObj.frameNum++;
+		} else {
+			const tmpVolume = (g_audio.volume - (3 * g_stateObj.volume / 100) / 1000);
+			if (tmpVolume < 0) {
+				g_audio.volume = 0;
+				clearTimeout(g_timeoutEvtId);
+				g_audio.pause();
+			} else {
+				g_audio.volume = tmpVolume;
+			}
+		}
+
 		thisTime = performance.now();
 		buffTime = thisTime - resultStartTime - g_scoreObj.resultFrameNum * 1000 / 60;
 
@@ -9065,33 +9079,6 @@ function resultInit() {
 		}
 	}
 	document.onkeyup = evt => { }
-	if (g_headerObj.fadeFrame !== undefined && g_headerObj.fadeFrame !== ``) {
-		if (isNaN(parseInt(g_headerObj.fadeFrame[g_stateObj.scoreId]))) {
-		} else {
-			g_timeoutEvtId = setTimeout(_ => resultFadeOut(), 1000 / 60);
-		}
-	}
-}
-
-/**
- * リザルト画面移行後のフェードアウト処理
- */
-function resultFadeOut() {
-
-	if (g_scoreObj.fadeOutFrame >= g_scoreObj.frameNum) {
-		g_scoreObj.frameNum++;
-	} else {
-		const tmpVolume = (g_audio.volume - (3 * g_stateObj.volume / 100) / 1000);
-		if (tmpVolume < 0) {
-			g_audio.volume = 0;
-			clearTimeout(g_timeoutEvtId);
-			g_audio.pause();
-		} else {
-			g_audio.volume = tmpVolume;
-		}
-	}
-
-	g_timeoutEvtId = setTimeout(_ => resultFadeOut(), 1000 / 60);
 }
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8502,6 +8502,7 @@ function resultInit() {
 	drawDefaultBackImage(``);
 
 	// 結果画面用フレーム初期化
+	g_scoreObj.resultFrameNum = 0;
 	g_scoreObj.backResultFrameNum = 0;
 	g_scoreObj.maskResultFrameNum = 0;
 
@@ -8510,6 +8511,11 @@ function resultInit() {
 	g_scoreObj.maskResultLoopCount = 0;
 
 	const divRoot = document.querySelector(`#divRoot`);
+
+	// 曲時間制御変数
+	let thisTime;
+	let buffTime;
+	let resultStartTime = performance.now();
 
 	if (g_stateObj.d_background === C_FLG_OFF && g_headerObj.resultMotionSet === `true`) {
 	} else {
@@ -9022,9 +9028,13 @@ function resultInit() {
 			g_scoreObj.maskResultFrameNum = drawSpriteData(g_scoreObj.maskResultFrameNum, `result`, `mask`);
 		}
 
+		thisTime = performance.now();
+		buffTime = thisTime - resultStartTime - g_scoreObj.resultFrameNum * 1000 / 60;
+
+		g_scoreObj.resultFrameNum++;
 		g_scoreObj.backResultFrameNum++;
 		g_scoreObj.maskResultFrameNum++;
-		g_timeoutEvtResultId = setTimeout(_ => flowResultTimeline(), 1000 / 60);
+		g_timeoutEvtResultId = setTimeout(_ => flowResultTimeline(), 1000 / 60 - buffTime);
 	}
 
 	g_timeoutEvtResultId = setTimeout(_ => flowResultTimeline(), 1000 / 60);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2312,6 +2312,7 @@ function titleInit() {
 	drawDefaultBackImage(``);
 
 	// タイトル用フレーム初期化
+	g_scoreObj.titleFrameNum = 0;
 	g_scoreObj.backTitleFrameNum = 0;
 	g_scoreObj.maskTitleFrameNum = 0;
 
@@ -2328,6 +2329,11 @@ function titleInit() {
 		g_canLoadDifInfoFlg = false;
 	}
 	const divRoot = document.querySelector(`#divRoot`);
+
+	// 曲時間制御変数
+	let thisTime;
+	let buffTime;
+	let titleStartTime = performance.now();
 
 	// タイトル文字描画
 	const lblTitle = getTitleDivLabel(`lblTitle`,
@@ -2647,9 +2653,13 @@ function titleInit() {
 			g_scoreObj.maskTitleFrameNum = drawSpriteData(g_scoreObj.maskTitleFrameNum, `title`, `mask`);
 		}
 
+		thisTime = performance.now();
+		buffTime = thisTime - titleStartTime - g_scoreObj.titleFrameNum * 1000 / 60;
+
+		g_scoreObj.titleFrameNum++;
 		g_scoreObj.backTitleFrameNum++;
 		g_scoreObj.maskTitleFrameNum++;
-		g_timeoutEvtTitleId = setTimeout(_ => flowTitleTimeline(), 1000 / 60);
+		g_timeoutEvtTitleId = setTimeout(_ => flowTitleTimeline(), 1000 / 60 - buffTime);
 	}
 
 	g_timeoutEvtTitleId = setTimeout(_ => flowTitleTimeline(), 1000 / 60);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5680,25 +5680,42 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame, _dummyNo = ``) {
 		}
 	}
 
+	let scoreIdHeader = ``;
+	if (g_stateObj.scoreId > 0) {
+		scoreIdHeader = Number(g_stateObj.scoreId) + 1;
+	}
+
 	// 結果画面用・背景データ(クリア時)の分解 (下記すべてで1セット、改行区切り)
 	// [フレーム数,階層,背景パス,class(CSSで別定義),X,Y,width,height,opacity,animationName,animationDuration]
 	g_headerObj.backResultData = [];
 	g_headerObj.backResultData.length = 0;
 	g_headerObj.backResultMaxDepth = -1;
+	let tmpBackResultData = ``;
 
 	if (g_stateObj.d_background === C_FLG_OFF && g_headerObj.resultMotionSet === `true`) {
-	} else if (_dosObj.backresult_data !== undefined) {
-		[g_headerObj.backResultData, g_headerObj.backResultMaxDepth] = makeSpriteData(_dosObj.backresult_data);
+	} else {
+		if (_dosObj[`backresult${scoreIdHeader}_data`] !== undefined) {
+			tmpBackResultData = _dosObj[`backresult${scoreIdHeader}_data`];
+		} else if (_dosObj.backresult_data !== undefined) {
+			tmpBackResultData = _dosObj.backresult_data;
+		}
+		[g_headerObj.backResultData, g_headerObj.backResultMaxDepth] = makeSpriteData(tmpBackResultData);
 	}
 
 	// 結果画面用・マスクデータ(クリア時)の分解 (下記すべてで1セット、改行区切り)
 	g_headerObj.maskResultData = [];
 	g_headerObj.maskResultData.length = 0;
 	g_headerObj.maskResultMaxDepth = -1;
+	let tmpMaskResultData = ``;
 
 	if (g_stateObj.d_background === C_FLG_OFF && g_headerObj.resultMotionSet === `true`) {
-	} else if (_dosObj.maskresult_data !== undefined) {
-		[g_headerObj.maskResultData, g_headerObj.maskResultMaxDepth] = makeSpriteData(_dosObj.maskresult_data);
+	} else {
+		if (_dosObj[`maskresult${scoreIdHeader}_data`] !== undefined) {
+			tmpMaskResultData = _dosObj[`maskresult${scoreIdHeader}_data`];
+		} else if (_dosObj.maskresult_data !== undefined) {
+			tmpMaskResultData = _dosObj.maskresult_data;
+		}
+		[g_headerObj.maskResultData, g_headerObj.maskResultMaxDepth] = makeSpriteData(tmpMaskResultData);
 	}
 
 	// 結果画面用・背景データ(失敗時)の分解 (下記すべてで1セット、改行区切り)
@@ -5708,12 +5725,16 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame, _dummyNo = ``) {
 	g_headerObj.backFailedMaxDepth = -1;
 
 	if (g_stateObj.d_background === C_FLG_OFF && g_headerObj.resultMotionSet === `true`) {
-	} else if (_dosObj[`backfailed${g_gaugeType.slice(0, 1)}_data`] !== undefined) {
-		[g_headerObj.backFailedData, g_headerObj.backFailedMaxDepth] = makeSpriteData(_dosObj[`backfailed${g_gaugeType.slice(0, 1)}_data`]);
-	} else if (_dosObj.backfailed_data !== undefined) {
-		[g_headerObj.backFailedData, g_headerObj.backFailedMaxDepth] = makeSpriteData(_dosObj.backfailed_data);
-	} else if (_dosObj.backresult_data !== undefined) {
-		[g_headerObj.backFailedData, g_headerObj.backFailedMaxDepth] = makeSpriteData(_dosObj.backresult_data);
+	} else {
+		let tmpBackFailedData = ``;
+		if (_dosObj[`backfailed${g_gaugeType.slice(0, 1)}${scoreIdHeader}_data`] !== undefined) {
+			tmpBackFailedData = _dosObj[`backfailed${g_gaugeType.slice(0, 1)}${scoreIdHeader}_data`];
+		} else if (_dosObj[`backfailed${g_gaugeType.slice(0, 1)}_data`] !== undefined) {
+			tmpBackFailedData = _dosObj[`backfailed${g_gaugeType.slice(0, 1)}_data`];
+		} else {
+			tmpBackFailedData = tmpBackResultData;
+		}
+		[g_headerObj.backFailedData, g_headerObj.backFailedMaxDepth] = makeSpriteData(tmpBackFailedData);
 	}
 
 	// 結果画面用・マスクデータ(失敗時)の分解 (下記すべてで1セット、改行区切り)
@@ -5722,10 +5743,16 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame, _dummyNo = ``) {
 	g_headerObj.maskFailedMaxDepth = -1;
 
 	if (g_stateObj.d_background === C_FLG_OFF && g_headerObj.resultMotionSet === `true`) {
-	} else if (_dosObj[`maskfailed${g_gaugeType.slice(0, 1)}_data`] !== undefined) {
-		[g_headerObj.maskFailedData, g_headerObj.maskFailedMaxDepth] = makeSpriteData(_dosObj[`maskfailed${g_gaugeType.slice(0, 1)}_data`]);
-	} else if (_dosObj.maskresult_data !== undefined) {
-		[g_headerObj.maskFailedData, g_headerObj.maskFailedMaxDepth] = makeSpriteData(_dosObj.maskresult_data);
+	} else {
+		let tmpMaskFailedData = ``;
+		if (_dosObj[`maskfailed${g_gaugeType.slice(0, 1)}${scoreIdHeader}_data`] !== undefined) {
+			tmpMaskFailedData = _dosObj[`maskfailed${g_gaugeType.slice(0, 1)}${scoreIdHeader}_data`];
+		} else if (_dosObj[`maskfailed${g_gaugeType.slice(0, 1)}_data`] !== undefined) {
+			tmpMaskFailedData = _dosObj[`maskfailed${g_gaugeType.slice(0, 1)}_data`];
+		} else {
+			tmpMaskFailedData = tmpMaskResultData;
+		}
+		[g_headerObj.maskFailedData, g_headerObj.maskFailedMaxDepth] = makeSpriteData(tmpMaskFailedData);
 	}
 
 	return obj;
@@ -8488,10 +8515,19 @@ function resultInit() {
 	} else {
 		// ゲームオーバー時は失敗時のリザルトモーションを適用
 		if (!g_finishFlg) {
-			if (g_rootObj.backfailedS_data !== undefined) {
+			let scoreIdHeader = ``;
+			if (g_stateObj.scoreId > 0) {
+				scoreIdHeader = Number(g_stateObj.scoreId) + 1;
+			}
+
+			if (g_rootObj[`backfailedS${scoreIdHeader}_data`] !== undefined) {
+				[g_headerObj.backResultData, g_headerObj.backResultMaxDepth] = makeSpriteData(g_rootObj[`backfailedS${scoreIdHeader}_data`]);
+			} else if (g_rootObj.backfailedS_data !== undefined) {
 				[g_headerObj.backResultData, g_headerObj.backResultMaxDepth] = makeSpriteData(g_rootObj.backfailedS_data);
 			}
-			if (g_rootObj.maskfailedS_data !== undefined) {
+			if (g_rootObj[`maskfailedS${scoreIdHeader}_data`] !== undefined) {
+				[g_headerObj.maskResultData, g_headerObj.maskResultMaxDepth] = makeSpriteData(g_rootObj[`maskfailedS${scoreIdHeader}_data`]);
+			} else if (g_rootObj.maskfailedS_data !== undefined) {
 				[g_headerObj.maskResultData, g_headerObj.maskResultMaxDepth] = makeSpriteData(g_rootObj.maskfailedS_data);
 			}
 		} else if (g_gameOverFlg) {


### PR DESCRIPTION
## 変更内容
1. リザルトモーションを譜面別に区別できるように変更
    - リザルトモーションを譜面別に拡張しました。

|画面|背景用モーション|マスク用モーション|
|----|----|----|
|リザルト(クリア時)|backresult_data<br>backresult2_data<br>...|maskresult_data<br>maskresult2_data<br>...|
|リザルト(途中終了時)|backfailedS_data<br>backfailedS2_data<br>...|maskfailedS_data<br>maskfailedS2_data<br>...|
|リザルト(ノルマ失敗時)|backfailedB_data<br>backfailedB2_data<br>...|maskfailedB_data<br>maskfailedB2_data<br>...|

指定が無い場合、例えば 2譜面目のリザルト(ノルマ失敗時) については以下の順で適用されます。

|適用順|適用モーション|意味|
|----|----|----|
|1|backfailedB2_data|リザルト(ノルマ失敗時)の２譜面目|
|2|backfailedB_data|リザルト(ノルマ失敗時)の１譜面目|
|3|backresult2_data|リザルト(クリア時)の２譜面目|
|4|backresult_data|リザルト(クリア時)の１譜面目|

2. タイトル・リザルトモーションの音楽同期に対応
    - メイン画面と同様に、フレーム毎の処理時間を考慮して時間計算するようになりました。

## 変更理由
1. リザルトモーションの場合、譜面本体の背景・マスクモーションと一体で動くことが多いと思われるため。
2. リザルトモーションの範囲に音楽が流れ込むケースが発生しているため。
タイトルモーションについても、これを機に仕様を揃える。

## その他コメント

