### PR TITLE
[0056-speed-common] 速度変化表記 (speed_data/change)の統一

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5452,7 +5452,13 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame, _dummyNo = ``) {
 	// 速度変化（全体）データの分解 (2つで1セット)
 	obj.speedData = [];
 	obj.speedData.length = 0;
-	const speedFooter = (g_keyObj.currentKey === `5` ? `_data` : `_change`);
+	let speedFooter = ``;
+	if (_dosObj[`speed${_scoreNo}_data`] !== undefined) {
+		speedFooter = `_data`;
+	}
+	if (_dosObj[`speed${_scoreNo}_change`] !== undefined) {
+		speedFooter = `_change`;
+	}
 	if (_dosObj[`speed${_scoreNo}${speedFooter}`] !== undefined && g_stateObj.d_speed === C_FLG_ON) {
 		let speedIdx = 0;
 		let tmpArrayData = _dosObj[`speed${_scoreNo}${speedFooter}`].split(`\r`).join(`\n`);


### PR DESCRIPTION
## 変更内容
1. 速度変化表記 (speed_data/change)の統一
    - キーの種類によらず、`speed_data`, `speed_change` のどちらでも途中変速として認識するようになりました。

## 変更理由
1. Issue #416 より。

## その他コメント

