### PR TITLE
[0054-object-pos-change] ステップゾーン(下)位置を変更できる設定を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3061,7 +3061,7 @@ function headerConvert(_dosObj) {
 	// ステップゾーン位置
 	g_stepY = (isNaN(parseFloat(_dosObj.stepY)) ? C_STEP_Y : parseFloat(_dosObj.stepY));
 	g_stepYR = (isNaN(parseFloat(_dosObj.stepYR)) ? C_STEP_YR : parseFloat(_dosObj.stepYR));
-	g_distY = g_sHeight - g_stepY - g_stepYR;
+	g_distY = g_sHeight - g_stepY + g_stepYR;
 
 	// musicフォルダ設定
 	obj.musicFolder = setVal(_dosObj.musicFolder, `music`, `string`);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -396,8 +396,10 @@ let g_sHeight;
 
 // ステップゾーン位置、到達距離(後で指定)
 const C_STEP_Y = 70;
+const C_STEP_YR = 0;
 let g_stepY;
 let g_distY;
+let g_stepYR;
 
 // キーコンフィグカーソル
 let g_currentj = 0;
@@ -3057,12 +3059,9 @@ function headerConvert(_dosObj) {
 	}
 
 	// ステップゾーン位置
-	if (isNaN(parseFloat(_dosObj.stepY))) {
-		g_stepY = C_STEP_Y;
-	} else {
-		g_stepY = parseFloat(_dosObj.stepY);
-	}
-	g_distY = g_sHeight - g_stepY;
+	g_stepY = (isNaN(parseFloat(_dosObj.stepY)) ? C_STEP_Y : parseFloat(_dosObj.stepY));
+	g_stepYR = (isNaN(parseFloat(_dosObj.stepYR)) ? C_STEP_YR : parseFloat(_dosObj.stepYR));
+	g_distY = g_sHeight - g_stepY - g_stepYR;
 
 	// musicフォルダ設定
 	obj.musicFolder = setVal(_dosObj.musicFolder, `music`, `string`);


### PR DESCRIPTION
## 変更内容
  - ステップゾーン(下)位置を変更できる設定を追加
指定した分だけ下側のステップゾーンだけ下がり（上がり）ます。
```
|stepYR=-100|
```

## 変更理由
1. ステップゾーン(下)のエリアの確保が必要なケースがたまにあるため。

## その他コメント
- Y座標に沿って変わります。
数字はプラスにすると下がり、マイナスにすると上がります。
大きくすると画面から外れるのでご注意ください。