### PR TITLE
速度変化が補正込みで負のフレームにあるとき適用されない不具合の修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5937,7 +5937,7 @@ function setSpeedOnFrame(_speedData, _lastFrame) {
 	let currentSpeed = g_stateObj.speed * 2;
 
 	for (let frm = 0, s = 0; frm <= _lastFrame; frm++) {
-		if (_speedData !== undefined && frm === _speedData[s]) {
+		while (_speedData !== undefined && frm >= _speedData[s]) {
 			currentSpeed = _speedData[s + 1] * g_stateObj.speed * 2;
 			s += 2;
 		}


### PR DESCRIPTION
## 変更内容
setSpeedOnFrameを修正しました。

## 変更理由
速度変化が補正込みで負のフレームにあるとき(たとえば`|speed_change=0,0.5|adjustment=-1|`)
それ自身を含め以降の速度変化が発生しません。

## その他コメント
