### PR TITLE
[0058-failed-blank] ゲームオーバー時の200ミリ秒遅延をカット

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7993,6 +7993,17 @@ function MainInit() {
 				clearWindow();
 				resultInit();
 			}, 100);
+		} else if (g_workObj.lifeVal === 0) {
+
+			// ライフ制＆ライフ０の場合は途中終了
+			if (g_workObj.lifeBorder === 0) {
+				g_audio.pause();
+				clearTimeout(g_timeoutEvtId);
+				clearWindow();
+				g_gameOverFlg = true;
+				g_finishFlg = false;
+				resultInit();
+			}
 		}
 	}
 	g_timeoutEvtId = setTimeout(_ => flowTimeline(), 1000 / 60);
@@ -8285,14 +8296,6 @@ function lifeDamage() {
 	g_workObj.lifeVal -= g_workObj.lifeDmg;
 	if (g_workObj.lifeVal <= 0) {
 		g_workObj.lifeVal = 0;
-		if (g_workObj.lifeBorder === 0) {
-			g_audio.pause();
-			clearTimeout(g_timeoutEvtId);
-			clearWindow();
-			g_gameOverFlg = true;
-			g_finishFlg = false;
-			resultInit();
-		}
 	} else if (g_workObj.lifeVal < g_workObj.lifeBorder) {
 		lifeColor = C_CLR_DEFAULTLIFE;
 	} else {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8288,12 +8288,10 @@ function lifeDamage() {
 		if (g_workObj.lifeBorder === 0) {
 			g_audio.pause();
 			clearTimeout(g_timeoutEvtId);
-			setTimeout(_ => {
-				clearWindow();
-				g_gameOverFlg = true;
-				g_finishFlg = false;
-				resultInit();
-			}, 200);
+			clearWindow();
+			g_gameOverFlg = true;
+			g_finishFlg = false;
+			resultInit();
 		}
 	} else if (g_workObj.lifeVal < g_workObj.lifeBorder) {
 		lifeColor = C_CLR_DEFAULTLIFE;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7165,16 +7165,14 @@ function MainInit() {
 		} else if (setKey === g_headerObj.keyTitleBack) {
 			g_audio.pause();
 			clearTimeout(g_timeoutEvtId);
-			setTimeout(_ => {
-				clearWindow();
-				if (keyIsDown(16)) {
-					g_gameOverFlg = true;
-					g_finishFlg = false;
-					resultInit();
-				} else {
-					titleInit();
-				}
-			}, 200);
+			clearWindow();
+			if (keyIsDown(16)) {
+				g_gameOverFlg = true;
+				g_finishFlg = false;
+				resultInit();
+			} else {
+				titleInit();
+			}
 		}
 
 		for (let j = 0; j < C_BLOCK_KEYS.length; j++) {


### PR DESCRIPTION
## 変更内容
- ゲームオーバー時にリザルト画面へ移動する際の200ミリ秒遅延をカット

## 変更理由
- Gitter報告より。

### izkdicさんからの報告
- 途中で死亡するゲージ設定の時に、ライフが0になってからリザルトに行くまでの間に判定が発生すると死体蹴りが起き、リザルト画面が2回起動します。
この際、nullのgetAttributeErrorが発生します。
当方のバージョンは7.5.1ですが、8.0.1でも起きるようです。
- 死亡してからリザルトに行くまでに、setTimeOutで0.2秒の猶予時間があり、
それが悪さをしている可能性が高いという見解をMFV2さんが示されていました。

### MFV2さんからの報告
・ゲームオーバー時、1回目のリザルトでハイスコアが記録される
・死体蹴りで2回目のリザルトに行く
・1回目死んだ時に記録されたハイスコアを参照する
・結果、ハイスコアが全て±0 で結果が出力される
という現象が発生しています。

原因を調べた所、lifeDamage関数内の
```
            setTimeout(_ => {
                clearWindow();
                g_gameOverFlg = true;
                g_finishFlg = false;
                resultInit();
            }, 200);
```
という記述で、死んだ瞬間に結果画面に行かず、
setTimeout関数で200msのディレイをかけてる間に
矢印が流れてくるのが死体蹴りの原因と見ました。

ここのsetTimeout関数内に置いてある処理を外に出して
```
        if (g_workObj.lifeBorder === 0) {
            g_audio.pause();
            clearTimeout(g_timeoutEvtId);
            clearWindow();
            g_gameOverFlg = true;
            g_finishFlg = false;
            resultInit();
        }
```
という記述にすれば、死体蹴り現象はなくなり当該の問題は全て消えました。


## その他コメント

