### PR TITLE
[ver8.0.2] ゲームオーバー時の200ミリ秒遅延により、 ハイスコア表示がおかしくなることがある問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/09/15
+ * Revised : 2019/09/16
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 8.0.1`;
-const g_revisedDate = `2019/09/15`;
+const g_version = `Ver 8.0.2`;
+const g_revisedDate = `2019/09/16`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)


### PR DESCRIPTION
## 変更内容
- ゲームオーバー時の200ミリ秒遅延により、
ハイスコア表示がおかしくなることがある問題を修正 ( #428 ) 

## 変更理由
- Pull Request #428 を参照。

## その他コメント

