### PR TITLE
ロード画面でEnterを押すと複数回ロードが発生する問題の修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2031,6 +2031,8 @@ function initAfterDosLoaded(_initFlg) {
 }
 
 function loadMusic() {
+	document.onkeydown = () => {}
+
 	const musicUrl = g_headerObj.musicUrls[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.musicUrls[0];
 	const url = `../${g_headerObj.musicFolder}/${musicUrl}`;
 


### PR DESCRIPTION
## 変更内容
loadMusic呼び出し時にonkeydownイベントリスナを削除するようにしました。

## 変更理由
ロード画面でEnterを押すと複数回ロードが発生し、正常にプレイ開始できなくなります。

## その他コメント
