### PR TITLE
[0060-double-push-shortcut] 曲中リトライキーが押しっぱなしにできる問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7160,10 +7160,12 @@ function MainInit() {
 
 		// 曲中リトライ、タイトルバック
 		if (setKey === g_headerObj.keyRetry) {
-			g_audio.pause();
-			clearTimeout(g_timeoutEvtId);
-			clearWindow();
-			musicAfterLoaded();
+			if (g_audio.volume >= g_stateObj.volume / 100 && g_scoreObj.frameNum >= g_headerObj.blankFrame) {
+				g_audio.pause();
+				clearTimeout(g_timeoutEvtId);
+				clearWindow();
+				musicAfterLoaded();
+			}
 
 		} else if (setKey === g_headerObj.keyTitleBack) {
 			g_audio.pause();


### PR DESCRIPTION
## 変更内容
- 曲中リトライキーが押しっぱなしにできる問題を修正しました。
曲開始（もしくは、フェードイン完了）までは曲中リトライできなくなります。

## 変更理由
- 曲中リトライキーが押しっぱなしにできるために、
曲の再生リセットが行われず譜面ズレが起きる可能性があります。
完全な対策にはなっていませんが、問題の大半を解消できると思います。

## その他コメント
