### PR TITLE
[0062-musicname-split] 曲名（複数行）を結合する場合の半角スペース抜きに対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2743,6 +2743,24 @@ function dosConvert(_dos) {
 }
 
 /**
+ * 曲名（1行）の取得
+ * @param {string} _musicName 
+ */
+function getMusicNameSimple(_musicName) {
+	const tmpName = _musicName.split(`<br>`).join(` `);
+	return tmpName.split(`<nbr>`).join(``);
+}
+
+/**
+ * 曲名（複数行）の取得
+ * @param {string} _musicName 
+ */
+function getMusicNameMultiLine(_musicName) {
+	const tmpName = _musicName.split(`<nbr>`).join(`<br>`);
+	return tmpName.split(`<br>`);
+}
+
+/**
  * 譜面ヘッダーの分解
  * @param {object} _dosObj 譜面データオブジェクト
  */
@@ -2768,13 +2786,13 @@ function headerConvert(_dosObj) {
 			const musics = musicData[j].split(`,`);
 
 			if (obj.musicNos.length >= j) {
-				obj.musicTitles[j] = musics[0].split(`<br>`).join(` `);
-				obj.musicTitlesForView[j] = musics[0].split("<br>");
+				obj.musicTitles[j] = getMusicNameSimple(musics[0]);
+				obj.musicTitlesForView[j] = getMusicNameMultiLine(musics[0]);
 				obj.artistNames[j] = setVal(musics[1], ``, `string`);
 			}
-			if (j == 0) {
-				obj.musicTitle = musics[0].split(`<br>`).join(` `);
-				obj.musicTitleForView = musics[0].split("<br>");
+			if (j === 0) {
+				obj.musicTitle = getMusicNameSimple(musics[0]);
+				obj.musicTitleForView = getMusicNameMultiLine(musics[0]);
 				if (musics.length > 1) {
 					obj.artistName = musics[1];
 				} else {
@@ -2784,8 +2802,8 @@ function headerConvert(_dosObj) {
 				if (musics.length > 2) {
 					obj.artistUrl = musics[2];
 					if (musics.length > 3) {
-						obj.musicTitles[j] = musics[3].split(`<br>`).join(` `);
-						obj.musicTitlesForView[j] = musics[3].split("<br>");
+						obj.musicTitles[j] = getMusicNameSimple(musics[3]);
+						obj.musicTitlesForView[j] = getMusicNameMultiLine(musics[3]);
 					}
 				} else {
 					obj.artistUrl = location.href;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2747,8 +2747,9 @@ function dosConvert(_dos) {
  * @param {string} _musicName 
  */
 function getMusicNameSimple(_musicName) {
-	const tmpName = _musicName.split(`<br>`).join(` `);
-	return tmpName.split(`<nbr>`).join(``);
+	let tmpName = _musicName.split(`<br>`).join(` `);
+	tmpName = tmpName.split(`<nbr>`).join(``);
+	return tmpName.split(`<dbr>`).join(`　`);
 }
 
 /**
@@ -2756,7 +2757,8 @@ function getMusicNameSimple(_musicName) {
  * @param {string} _musicName 
  */
 function getMusicNameMultiLine(_musicName) {
-	const tmpName = _musicName.split(`<nbr>`).join(`<br>`);
+	let tmpName = _musicName.split(`<nbr>`).join(`<br>`);
+	tmpName = tmpName.split(`<dbr>`).join(`<br>`);
 	return tmpName.split(`<br>`);
 }
 


### PR DESCRIPTION
## 変更内容
- 曲名（複数行）を結合する場合の半角スペース抜き表記に対応
- 複数行曲を1行に表記する場合（メイン画面・リザルトコピー）に、
2行を結合するときに半角スペースを入れるかどうかをタグで区別する。

### 半角スペースで置換するケース（従来の方法。&lt;br&gt;で折り返す）
```
|musicTitle=曲名が長い曲<br>半角スペース入り,アーティスト,http://|
```
- 1行にすると「曲名が長い曲_半角スペース入り」("_" は半角スペース)と表記される。

### 半角スペースで置換しないケース（&lt;nbr&gt;で折り返す）
```
|musicTitle=曲名が長い曲<nbr>半角スペース抜き,アーティスト,http://|
```
- 1行にすると「曲名が長い曲半角スペース抜き」と表記される。

## 変更理由
- 譜面ヘッダーの`musicTitle`で、曲名（複数行）時の場合でもメイン画面では1行に表示する。
その場合には半角スペースを挟む仕様になっており、その必要がない曲に対応できていなかった。

## その他コメント

