### PR TITLE
[0063-multi-makers-result(2)] 譜面別データ(LocalStorage)に制作者名を付加できるように変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8834,7 +8834,10 @@ function resultInit() {
 	}
 
 	// ハイスコア差分計算
-	const scoreName = `${g_headerObj.keyLabels[g_stateObj.scoreId]}k-${g_headerObj.difLabels[g_stateObj.scoreId]}`;
+	let scoreName = `${g_headerObj.keyLabels[g_stateObj.scoreId]}k-${g_headerObj.difLabels[g_stateObj.scoreId]}`;
+	if (g_headerObj.makerView === `true`) {
+		scoreName += `-${g_headerObj.creatorNames[g_stateObj.scoreId]}`;
+	}
 	let iiDf = 0;
 	let shakinDf = 0;
 	let matariDf = 0;


### PR DESCRIPTION
## 変更内容
- 譜面別データ(LocalStorage)に制作者名を付加できるように変更

## 変更理由
- 先の変更で譜面名が同一になる可能性があったため、
譜面ヘッダー：makerViewを`true`にすることで、LocalStorageの譜面別設定名を変更できます。

|makerViewの値|LocalStorage(譜面別)のキー名|
|----|----|
|false (デフォルト)|キー数-譜面名|
|true|キー数-譜面名-制作者名|

## その他コメント
- 既存作品に適用すると、ハイスコアが初期化されます。
適用する場合はご注意ください。
