### PR TITLE
[ver8.2.0] 曲名（複数行）を結合する場合の半角スペース抜きに対応　他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2019/09/23
+ * Revised : 2019/09/24
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 8.1.0`;
-const g_revisedDate = `2019/09/23`;
+const g_version = `Ver 8.2.0`;
+const g_revisedDate = `2019/09/24`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)


### PR DESCRIPTION
## 変更内容
1. 曲名（複数行）を結合する場合の半角スペース抜き、全角スペース置換表記に対応 ( #437 )
2. 制作者表示の複数化に対応（設定・結果画面、リザルトコピー）( #438 )
3. 譜面別データ(LocalStorage)に制作者名を付加できるように変更 ( #439 )

## 変更理由
- Pull Request #437, #438, #439 を参照。

## その他コメント

