### PR TITLE
[0065-scorelist] 譜面変更用セレクターの実装

### DIFF
--- a/danoni/danoni3.html
+++ b/danoni/danoni3.html
@@ -41,6 +41,7 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 
 |musicTitle=twinkle star,‚¦‚Þ,http://em--mk.xrea.bz/index.htm|
 |difData=11,Normal,3.5,x,2,7$11,Hard,3.5,75,2,7$12,Hard$5,Easy,1.5,75,1,5$7,Normal,2,5,1,5$7i,ˆÕ‚µ‚¢,2,5,1,5$8,Normal+,2.75,75,1,5$9A,SemiHard,2.75,75,1,5$9B,Hard,2.75,75,1,5$9i,Enjoyable,2.75,75,1,5$11,Normal,3.5,75,1,5$11L,Normal+,3.25,75,1,5$12,Hard,3.75,75,1,5$14,Hard+,4,75,1,5$17,Very Hard,4.5,75,1,5$11i,Very Hard,4.5,75,1,5$14i,Very Hard,4.5,75,1,5$16i,Extra,4.5,75,1,5$15B,Very Hard,4.5,75,1,5$13,Hard,4.5,75,1,5|
+|difSelectorUse=true|
 |setColor=0xcc99ff,0xffccff,0xffffff,0xffff99,0xff9966|
 |frzColor=0x00ffff,0x6600ff,0xffff66,0xffff66|
 |scoreLabel=11-070-1,11-070-2|

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3757,6 +3757,16 @@ function createOptionWindow(_sprite) {
 							optionsprite.removeChild(difCover);
 						}));
 					}
+					const lnkDifRandom = makeDifLblButton(`difRandom`, `RANDOM`, 0, _ => {
+						g_stateObj.scoreId = Math.floor(Math.random() * g_headerObj.keyLabels.length);
+						setDifficulty(true);
+						deleteChildspriteAll(`difList`);
+						optionsprite.removeChild(difList);
+						optionsprite.removeChild(difCover);
+					});
+					difCover.appendChild(lnkDifRandom);
+					lnkDifRandom.style.width = `120px`;
+
 				} else {
 					resetDifWindow();
 				}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2822,6 +2822,9 @@ function headerConvert(_dosObj) {
 		obj.artistUrl = location.href;
 	}
 
+	// 譜面変更セレクターの利用有無
+	obj.difSelectorUse = setVal(_dosObj.difSelectorUse, `false`, `string`);
+
 	// 最小・最大速度の設定
 	obj.minSpeed = Math.round(setVal(_dosObj.minSpeed, C_MIN_SPEED, `float`) * 4) / 4;
 	obj.maxSpeed = Math.round(setVal(_dosObj.maxSpeed, C_MAX_SPEED, `float`) * 4) / 4;
@@ -3715,14 +3718,53 @@ function createOptionWindow(_sprite) {
 		`<span style=color:#ff9999>D</span>ifficulty`);
 	optionsprite.appendChild(lblDifficulty);
 
+	function resetDifWindow() {
+		if (document.querySelector(`#difList`) !== null) {
+			deleteChildspriteAll(`difList`);
+			optionsprite.removeChild(document.querySelector(`#difList`));
+			optionsprite.removeChild(document.querySelector(`#difCover`));
+		}
+	}
+
 	const lnkDifficulty = makeSettingLblButton(`lnkDifficulty`,
 		``, setNoDifficulty, _ => {
-			g_stateObj.scoreId = (g_stateObj.scoreId < g_headerObj.keyLabels.length - 1 ? ++g_stateObj.scoreId : 0);
-			setDifficulty(true);
+			if (g_headerObj.difSelectorUse === `false`) {
+				g_stateObj.scoreId = (g_stateObj.scoreId < g_headerObj.keyLabels.length - 1 ? ++g_stateObj.scoreId : 0);
+				setDifficulty(true);
+			} else {
+				if (document.querySelector(`#difList`) === null) {
+					const difList = createSprite(`optionsprite`, `difList`, 140, 45, 280, 255);
+					difList.style.overflow = `auto`;
+					difList.style.backgroundColor = `#111111`;
+					const difCover = createSprite(`optionsprite`, `difCover`, 0, 45, 140, 255);
+					difCover.style.backgroundColor = `#111111`;
+					difCover.style.opacity = 0.95;
+
+					for (let j = 0; j < g_headerObj.keyLabels.length; j++) {
+						let text = `${g_headerObj.keyLabels[j]}key / ${g_headerObj.difLabels[j]}`;
+						if (g_headerObj.makerView === `true`) {
+							text += ` (${g_headerObj.creatorNames[j]})`;
+						}
+						difList.appendChild(makeDifLblButton(`dif${j}`, text, j, _ => {
+							g_stateObj.scoreId = j;
+							setDifficulty(true);
+							deleteChildspriteAll(`difList`);
+							optionsprite.removeChild(difList);
+							optionsprite.removeChild(difCover);
+						}));
+					}
+				} else {
+					resetDifWindow();
+				}
+			}
 		});
 	lnkDifficulty.oncontextmenu = _ => {
-		g_stateObj.scoreId = (g_stateObj.scoreId > 0 ? --g_stateObj.scoreId : g_headerObj.keyLabels.length - 1);
-		setDifficulty(true);
+		if (g_headerObj.difSelectorUse === `false`) {
+			g_stateObj.scoreId = (g_stateObj.scoreId > 0 ? --g_stateObj.scoreId : g_headerObj.keyLabels.length - 1);
+			setDifficulty(true);
+		} else {
+			resetDifWindow();
+		}
 		return false;
 	}
 	optionsprite.appendChild(lnkDifficulty);
@@ -3731,10 +3773,12 @@ function createOptionWindow(_sprite) {
 	optionsprite.appendChild(makeMiniButton(`lnkDifficulty`, `R`, setNoDifficulty, _ => {
 		g_stateObj.scoreId = (g_stateObj.scoreId < g_headerObj.keyLabels.length - 1 ? ++g_stateObj.scoreId : 0);
 		setDifficulty(true);
+		resetDifWindow();
 	}));
 	optionsprite.appendChild(makeMiniButton(`lnkDifficulty`, `L`, setNoDifficulty, _ => {
 		g_stateObj.scoreId = (g_stateObj.scoreId > 0 ? --g_stateObj.scoreId : g_headerObj.keyLabels.length - 1);
 		setDifficulty(true);
+		resetDifWindow();
 	}));
 
 	// 譜面変更ボタンのみ 10pxプラス
@@ -4422,6 +4466,25 @@ function makeSettingLblButton(_id, _name, _heightPos, _func) {
 	}, _func);
 
 	return settingLblButton;
+}
+
+function makeDifLblButton(_id, _name, _heightPos, _func) {
+	const difLblButton = createButton({
+		id: _id,
+		name: _name,
+		x: 0,
+		y: C_LEN_SETLBL_HEIGHT * _heightPos,
+		width: C_LEN_SETLBL_WIDTH,
+		height: C_LEN_SETLBL_HEIGHT,
+		fontsize: 14,
+		normalColor: C_CLR_LNK,
+		hoverColor: C_CLR_DEFHOVER,
+		align: C_ALIGN_CENTER
+	}, _func);
+	difLblButton.style.borderStyle = `solid`;
+	difLblButton.style.borderColor = `#000000 #cccccc`;
+
+	return difLblButton;
 }
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -159,6 +159,7 @@ const C_LEN_SETDIFLBL_HEIGHT = 25;
 const C_SIZ_SETDIFLBL = 17;
 const C_LEN_SETMINI_WIDTH = 40;
 const C_SIZ_SETMINI = 18;
+const C_SIZ_DIFSELECTOR = 14;
 
 const C_LBL_SETMINIL = `<`;
 const C_LEN_SETMINIL_LEFT = C_LEN_SETLBL_LEFT - C_LEN_SETMINI_WIDTH / 2;
@@ -3718,6 +3719,9 @@ function createOptionWindow(_sprite) {
 		`<span style=color:#ff9999>D</span>ifficulty`);
 	optionsprite.appendChild(lblDifficulty);
 
+	/**
+	 * 譜面変更セレクターの削除
+	 */
 	function resetDifWindow() {
 		if (document.querySelector(`#difList`) !== null) {
 			deleteChildspriteAll(`difList`);
@@ -4468,6 +4472,13 @@ function makeSettingLblButton(_id, _name, _heightPos, _func) {
 	return settingLblButton;
 }
 
+/**
+ * 譜面変更セレクター用ボタン
+ * @param {string} _id
+ * @param {string} _name 初期設定文字
+ * @param {number} _heightPos 上からの配置順
+ * @param {function} _func
+ */
 function makeDifLblButton(_id, _name, _heightPos, _func) {
 	const difLblButton = createButton({
 		id: _id,
@@ -4476,7 +4487,7 @@ function makeDifLblButton(_id, _name, _heightPos, _func) {
 		y: C_LEN_SETLBL_HEIGHT * _heightPos,
 		width: C_LEN_SETLBL_WIDTH,
 		height: C_LEN_SETLBL_HEIGHT,
-		fontsize: 14,
+		fontsize: C_SIZ_DIFSELECTOR,
 		normalColor: C_CLR_LNK,
 		hoverColor: C_CLR_DEFHOVER,
 		align: C_ALIGN_CENTER


### PR DESCRIPTION
## 変更内容
- 譜面変更用セレクターの実装
- 設定画面の譜面名をクリックすると譜面の一覧が表示され、
対象の譜面をクリックするとその譜面の設定が反映されるセレクターを作成しました。
数が多い場合は自動で縦スクロールが出るようになっています。
譜面ヘッダー「difSelectorUse」を`true`にする必要があります。

## 変更理由
- 持ち寄り合作などで多くの譜面を選ぶときに使用することを想定しています。

## その他コメント
- セレクター表示中は他の設定を変更できないようにしています。
画面移動するか、もう一度譜面名を押すと元に戻ります。