### PR TITLE
[0067-multiple-files(2)] 相対パス指定時にファイル取り込みが失敗する問題を修正

### DIFF
--- a/danoni/danoni2.html
+++ b/danoni/danoni2.html
@@ -38,8 +38,8 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 <body>
 <table><tr><td>
 <input type="hidden" name="externalDos" id="externalDos" value="danoniA.txt">
-<input type="hidden" name="externalDosDivide" id="externalDosDivide" value="true">
-<input type="hidden" name="externalDosLock" id="externalDosLock" value="true">
+<input type="hidden" name="externalDosDivide" id="externalDosDivide" value="false">
+<input type="hidden" name="externalDosLock" id="externalDosLock" value="false">
 <input type="hidden" name="externalDosCharset" id="externalDosCharset" value="Shift_JIS">
 <div id="canvas-frame" style="width:500px;margin:auto;">
 	<canvas id="layer0" width="500" height="500"></canvas>

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1932,10 +1932,12 @@ function loadDos(_initFlg) {
 		if (dosLockInput !== null) {
 			g_stateObj.scoreLockFlg = setVal(dosLockInput.value, false, `boolean`);
 		}
-		const filenamePair = externalDosInput.value.match(/.+\..*/)[0].split(`.`);
+		const filenameBase = externalDosInput.value.match(/.+\..*/)[0];
+		const filenameExtension = filenameBase.split(`.`).pop();
+		const filenameCommon = filenameBase.split(`.${filenameExtension}`)[0];
 		const scoreIdHeader = (g_stateObj.scoreId > 0 ? g_stateObj.scoreId + 1 : ``);
 		const filename = (_initFlg === true || dosDivideFlg === false ?
-			`${filenamePair[0]}.${filenamePair[1]}` : `${filenamePair[0]}${scoreIdHeader}.${filenamePair[1]}`);
+			`${filenameCommon}.${filenameExtension}` : `${filenameCommon}${scoreIdHeader}.${filenameExtension}`);
 
 		const randTime = new Date().getTime();
 		loadScript(`${filename}?${randTime}`, _ => {


### PR DESCRIPTION
## 変更内容
- 相対パス指定時に外部譜面ファイル取り込みが失敗する問題を修正しました。
- また、サンプル２の譜面分割フラグの初期値を`false`に戻しました。

## 変更理由
- ドット( . )で単純分割していたため、相対パスのドットを拾っていました。
末尾のドットのみを拾うように修正しました。

## その他コメント