### PR TITLE
[0070-speed-initial] scoreIdをクエリ指定した場合の初期速度の不具合を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1979,14 +1979,16 @@ function loadDos(_initFlg) {
  */
 function initAfterDosLoaded() {
 
+	// クエリで譜面番号が指定されていればセット
+	g_stateObj.scoreId = setVal(getQueryParamVal(`scoreId`), 0, `number`);
+
+	// 譜面ヘッダー、特殊キー情報の読込
 	g_headerObj = headerConvert(g_rootObj);
 	keysConvert(g_rootObj);
-	g_keyObj.currentPtn = 0;
 
-	// クエリで譜面番号が指定されていればセット
-	const specifiedScoreId = getQueryParamVal(`scoreId`);
-	g_stateObj.scoreId = g_headerObj.keyLabels[specifiedScoreId] ? specifiedScoreId : 0;
+	// キー数情報を初期化
 	g_keyObj.currentKey = g_headerObj.keyLabels[g_stateObj.scoreId];
+	g_keyObj.currentPtn = 0;
 
 	// 画像ファイルの読み込み
 	preloadFile(`image`, C_IMG_ARROW, ``, ``);
@@ -2896,6 +2898,8 @@ function headerConvert(_dosObj) {
 		obj.lifeDamages = [];
 		obj.lifeInits = [];
 		obj.creatorNames = [];
+		g_stateObj.scoreId = (g_stateObj.scoreId < difs.length ? g_stateObj.scoreId : 0);
+
 		for (let j = 0; j < difs.length; j++) {
 			const difDetails = difs[j].split(`,`);
 
@@ -2954,12 +2958,11 @@ function headerConvert(_dosObj) {
 	});
 	obj.keyLists = keyLists.sort((a, b) => parseInt(a) - parseInt(b));
 
-	if (obj.initSpeeds[0] !== undefined) {
-		g_stateObj.speed = obj.initSpeeds[0];
-		g_speedNum = g_speeds.findIndex(speed => speed === g_stateObj.speed);
-		if (g_speedNum < 0) {
-			g_speedNum = 0;
-		}
+	// 初期速度の設定
+	g_stateObj.speed = obj.initSpeeds[g_stateObj.scoreId];
+	g_speedNum = g_speeds.findIndex(speed => speed === g_stateObj.speed);
+	if (g_speedNum < 0) {
+		g_speedNum = 0;
 	}
 
 	// カラーコードのゼロパディング有無設定

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1930,7 +1930,7 @@ function loadDos(_initFlg) {
 					initAfterDosLoaded();
 				});
 			} else {
-				loadingScoreInit2();
+				loadCustomjs(_initFlg);
 			}
 		}
 	}
@@ -1968,14 +1968,14 @@ function loadDos(_initFlg) {
 					initAfterDosLoaded();
 				});
 			} else {
-				loadingScoreInit2();
+				loadCustomjs(_initFlg);
 			}
 		}, charset);
 	}
 }
 
 /**
- * 初回読込後に画像プリロード・カスタムjsを読み込む処理
+ * 初回読込後に画像プリロードを設定する処理
  */
 function initAfterDosLoaded() {
 
@@ -2042,14 +2042,30 @@ function initAfterDosLoaded() {
 	}
 
 	// customjsの読み込み
+	loadCustomjs(true);
+}
+
+/**
+ * customjsの読込
+ * @param {boolean} _initFlg 
+ */
+function loadCustomjs(_initFlg) {
 	const randTime = new Date().getTime();
 	loadScript(`../js/${g_headerObj.customjs}?${randTime}`, _ => {
 		if (g_headerObj.customjs2 !== ``) {
 			loadScript(`../js/${g_headerObj.customjs2}?${randTime}`, _ => {
-				titleInit();
+				if (_initFlg) {
+					titleInit();
+				} else {
+					loadingScoreInit2();
+				}
 			});
 		} else {
-			titleInit();
+			if (_initFlg) {
+				titleInit();
+			} else {
+				loadingScoreInit2();
+			}
 		}
 	});
 }


### PR DESCRIPTION
## 変更内容
1. scoreIdをクエリ指定した場合の初期速度の不具合を修正
    - クエリ指定した場合に常時1譜面目の速度になってしまう問題を修正しました。
2. ゲージ設定について、処理が二重定義されている箇所を見直し

## 変更理由
1. Gitter指摘より。
2. `headerConvert`で定義しているゲージの初期設定が、
`setDifficulty`で定義している設定と重複しているため、集約しました。

## その他コメント

