### PR TITLE
[0075-clear-window] 初回読込時のclearWindowをカット 他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1904,7 +1904,6 @@ function loadDos(_initFlg) {
 	const dosInput = document.querySelector(`#dos`);
 	const externalDosInput = document.querySelector(`#externalDos`);
 	const divRoot = document.querySelector(`#divRoot`);
-	const lblLoading = document.querySelector(`#lblLoading`);
 
 	if (dosInput === null && externalDosInput === null) {
 		makeWarningWindow(C_MSG_E_0023);
@@ -1937,7 +1936,9 @@ function loadDos(_initFlg) {
 			if (_initFlg) {
 				const randTime = new Date().getTime();
 				loadScript(`../js/danoni_setting.js?${randTime}`, _ => {
-					divRoot.removeChild(lblLoading);
+					if (document.querySelector(`#lblLoading`) !== null) {
+						divRoot.removeChild(document.querySelector(`#lblLoading`));
+					}
 					initAfterDosLoaded();
 				});
 			} else {
@@ -1963,7 +1964,9 @@ function loadDos(_initFlg) {
 		const randTime = new Date().getTime();
 		loadScript(`${filename}?${randTime}`, _ => {
 			if (typeof externalDosInit === `function`) {
-				divRoot.removeChild(lblLoading);
+				if (document.querySelector(`#lblLoading`) !== null) {
+					divRoot.removeChild(document.querySelector(`#lblLoading`));
+				}
 
 				// 外部データを読込
 				externalDosInit();

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1903,6 +1903,8 @@ function loadDos(_initFlg) {
 
 	const dosInput = document.querySelector(`#dos`);
 	const externalDosInput = document.querySelector(`#externalDos`);
+	const divRoot = document.querySelector(`#divRoot`);
+	const lblLoading = document.querySelector(`#lblLoading`);
 
 	if (dosInput === null && externalDosInput === null) {
 		makeWarningWindow(C_MSG_E_0023);
@@ -1933,9 +1935,9 @@ function loadDos(_initFlg) {
 		Object.assign(g_rootObj, dosConvert(dosInput.value));
 		if (externalDosInput === null) {
 			if (_initFlg) {
-				clearWindow();
 				const randTime = new Date().getTime();
 				loadScript(`../js/danoni_setting.js?${randTime}`, _ => {
+					divRoot.removeChild(lblLoading);
 					initAfterDosLoaded();
 				});
 			} else {
@@ -1946,7 +1948,6 @@ function loadDos(_initFlg) {
 
 	// 外部dos読み込み
 	if (externalDosInput !== null) {
-		clearWindow();
 		let charset = document.characterSet;
 		const charsetInput = document.querySelector(`#externalDosCharset`);
 		if (charsetInput !== null) {
@@ -1962,6 +1963,7 @@ function loadDos(_initFlg) {
 		const randTime = new Date().getTime();
 		loadScript(`${filename}?${randTime}`, _ => {
 			if (typeof externalDosInit === `function`) {
+				divRoot.removeChild(lblLoading);
 
 				// 外部データを読込
 				externalDosInit();
@@ -2753,6 +2755,7 @@ function makeWarningWindow(_text) {
 		lblWarning = getTitleDivLabel(`lblWarning`, `<p>${_text}</p>`, 0, 70);
 		lblWarning.style.backgroundColor = `#ffcccc`;
 		lblWarning.style.opacity = 0.9;
+		divRoot.appendChild(lblWarning);
 	} else {
 		lblWarning = document.querySelector(`#lblWarning`);
 		lblWarning.innerHTML += `<p>${_text}</p>`;
@@ -2765,8 +2768,6 @@ function makeWarningWindow(_text) {
 	lblWarning.style.color = `#660000`;
 	lblWarning.style.textAlign = C_ALIGN_LEFT;
 	lblWarning.style.fontFamily = getBasicFont();
-
-	divRoot.appendChild(lblWarning);
 }
 
 /**
@@ -3723,6 +3724,12 @@ function musicAfterLoaded() {
 		g_audio.addEventListener(`canplaythrough`, (_ => function f() {
 			g_audio.removeEventListener(`canplaythrough`, f, false);
 			loadingScoreInit();
+		})(), false);
+
+		// エラー時
+		g_audio.addEventListener(`error`, (_ => function f() {
+			g_audio.removeEventListener(`error`, f, false);
+			makeWarningWindow(C_MSG_E_0041.split(`{0}`).join(g_audio.src));
 		})(), false);
 	}
 }


### PR DESCRIPTION
## 変更内容
1. 初回読込時のclearWindowをカット
1. ローカルmp3の読込失敗時のメッセージ追加

## 変更理由
1. 初回読込時に一瞬消えたような挙動になるのと、
そのタイミングでdivRoot以外のオブジェクトが参照されたときにエラーとなるため。
1. ローカルmp3の読込失敗時のメッセージを確認する方法が無かったため。

## その他コメント

