### PR TITLE
fpsが小数の時に時間表示が動かなくなる不具合の修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8219,13 +8219,14 @@ function MainInit() {
 		g_timeoutEvtId = setTimeout(_ => flowTimeline(), 1000 / g_fps - buffTime);
 
 		// タイマー
-		if (g_scoreObj.nominalFrameNum % g_fps === 0) {
+		if (Math.floor(g_scoreObj.nominalFrameNum % g_fps) === 0) {
 			if (g_scoreObj.nominalFrameNum >= 0) {
 				const currentMin = Math.floor(g_scoreObj.nominalFrameNum / 60 / g_fps);
-				const currentSec = `00${(g_scoreObj.nominalFrameNum / g_fps) % 60}`.slice(-2);
+				const currentSec = `00${Math.floor(g_scoreObj.nominalFrameNum / g_fps) % 60}`.slice(-2);
 				lblTime1.innerHTML = `${currentMin}:${currentSec}`;
 			}
 		}
+
 		// 曲終了判定
 		if (g_scoreObj.frameNum >= fullFrame) {
 			if (g_scoreObj.fadeOutFrame === Infinity && isNaN(parseInt(g_headerObj.endFrame))) {


### PR DESCRIPTION
## 変更内容
1. 時間表示の処理を毎フレーム行うようにしました
2. 秒の計算に切り捨てを追加しました

## 変更理由
g_fpsに小数を指定すると現在時間表示が「-:--」のまま動かなくなります。

## その他コメント
[twitterより](https://twitter.com/MFV2_/status/1180322959992295424)
