### PR TITLE
[0080-escape-html] エスケープ文字の適用順序誤りを修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6015,10 +6015,10 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame, _dummyNo = ``) {
  * @param {string} _str 
  */
 function escapeHtml(_str) {
-	let newstr = _str.split(`<`).join(`&lt;`);
+	let newstr = _str.split(`&`).join(`&amp;`);
 	newstr = newstr.split(`>`).join(`&gt;`);
+	newstr = newstr.split(`<`).join(`&lt;`);
 	newstr = newstr.split("`").join(`&quot;`);
-	newstr = newstr.split(`&`).join(`&amp;`);
 
 	return newstr;
 }

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6016,8 +6016,8 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame, _dummyNo = ``) {
  */
 function escapeHtml(_str) {
 	let newstr = _str.split(`&`).join(`&amp;`);
-	newstr = newstr.split(`>`).join(`&gt;`);
 	newstr = newstr.split(`<`).join(`&lt;`);
+	newstr = newstr.split(`>`).join(`&gt;`);
 	newstr = newstr.split("`").join(`&quot;`);
 
 	return newstr;


### PR DESCRIPTION
## 変更内容
1. エスケープ文字の適用順序誤りを修正
「&」->「<」->「>」->「\`」の順に適用するように変更しました。

## 変更理由
1. 「<」->「>」->「\`」->「&」の順にエスケープ処理を行っていたが、
この順序の場合、前3つがエスケープされた後、「&」が合致するため
二重にエスケープされてしまう。これを回避する。

## その他コメント
- back/mask_dataで「>」や「<」を使った場合に発生します。
