### PR TITLE
[0080-escape-html(2)] エスケープ文字の修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6018,7 +6018,7 @@ function escapeHtml(_str) {
 	let newstr = _str.split(`&`).join(`&amp;`);
 	newstr = newstr.split(`<`).join(`&lt;`);
 	newstr = newstr.split(`>`).join(`&gt;`);
-	newstr = newstr.split("`").join(`&quot;`);
+	newstr = newstr.split(`"`).join(`&quot;`);
 
 	return newstr;
 }


### PR DESCRIPTION
## 変更内容
1. エスケープ文字の修正

## 変更理由
1. ver2以降で文字列の括りをダブルクォートからバッククォートへ変更したが、
その時に合わせてバッククォートをエスケープするようになっていたため。

## その他コメント

