### PR TITLE
速度変化が同一フレームにあると正常に動作しなくなる不具合の修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8012,11 +8012,11 @@ function MainInit() {
 		}
 
 		// 速度変化 (途中変速, 個別加速)
-		if (g_workObj.speedData !== undefined && g_scoreObj.frameNum === g_workObj.speedData[speedCnts]) {
+		while (g_workObj.speedData !== undefined && g_scoreObj.frameNum >= g_workObj.speedData[speedCnts]) {
 			g_workObj.currentSpeed = g_workObj.speedData[speedCnts + 1];
 			speedCnts += 2;
 		}
-		if (g_workObj.boostData !== undefined && g_scoreObj.frameNum === g_workObj.boostData[boostCnts]) {
+		while (g_workObj.boostData !== undefined && g_scoreObj.frameNum >= g_workObj.boostData[boostCnts]) {
 			g_workObj.boostSpd = g_workObj.boostData[boostCnts + 1];
 			boostCnts += 2;
 		}


### PR DESCRIPTION
## 変更内容
flowTimeline内の速度変化の処理を修正しました。

## 変更理由
速度変化が同一フレームにあると1番目だけが処理され、
以降の速度変化が適用されず、画面上の矢印と判定位置がずれてしまいます。

譜面データ側に問題が無くてもAdjustmentやFadeinの値によって、
開始フレームでの初期速度設定(Line 6611~6612)と重なると発生します。

## その他コメント
[再現用譜面データ](https://gist.github.com/suzme/45371c57117bea22ffc1579d2aa38e88)
Adjustment=0,Fadein=0で再現すると思います。
