### PR TITLE
[0081-frzstart-calc] 低速時かつフリーズアロー開始判定時にPF判定が早まる問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5384,11 +5384,6 @@ function loadingScoreInit2() {
 	}
 	g_scoreObj = scoreConvert(g_rootObj, scoreIdHeader, 0, dummyIdHeader);
 
-	// ライフ回復・ダメージ量の計算
-	// フリーズ始点でも通常判定させる場合は総矢印数を水増しする
-	if (g_headerObj.frzStartjdgUse) {
-		g_allArrow += g_allFrz / 2;
-	}
 	calcLifeVals(g_allArrow + g_allFrz / 2);
 
 	// 最終フレーム数の取得
@@ -5703,6 +5698,12 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame, _dummyNo = ``) {
 		if (g_stateObj.dummyId !== ``) {
 			obj.dummyFrzData[j] = storeArrowData(_dosObj[`${frzName}${_dummyNo}_data`]);
 		}
+	}
+
+	// ライフ回復・ダメージ量の計算
+	// フリーズ始点でも通常判定させる場合は総矢印数を水増しする
+	if (g_headerObj.frzStartjdgUse) {
+		g_allArrow += g_allFrz / 2;
 	}
 
 	/**


### PR DESCRIPTION
## 変更内容
- 低速時かつフリーズアロー開始判定時にPF判定が早まる問題を修正
    - フリーズアロー開始判定時の矢印数加算を`scoreConvert`関数内へ移動する。

## 変更理由
- 低速時、`scoreConvert`関数が2回以上動くことがあるが、
2回以上動いた後にフリーズアロー開始判定分を加算していないため、ズレが起こる。

## その他コメント
- 実装時点からの不具合と思われます。
