### PR TITLE
[0082-dummyId] ダミーIDの譜面ヘッダー誤りを修正

### DIFF
--- a/danoni/danoni3.html
+++ b/danoni/danoni3.html
@@ -45,7 +45,7 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 |setColor=0xcc99ff,0xffccff,0xffffff,0xffff99,0xff9966|
 |frzColor=0x00ffff,0x6600ff,0xffff66,0xffff66|
 |scoreLabel=11-070-1,11-070-2|
-|dummyScoreNo=2$1$5|
+|dummyId=2$1$5|
 |startFrame=0|blankFrame=270|
 |musicUrl=nosound.mp3|
 |maxSpeed=20|minSpeed=0.5|setShadowColor=#666666|

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3120,8 +3120,8 @@ function headerConvert(_dosObj) {
 	}
 
 	// ダミー譜面の設定
-	if (_dosObj.dummyScoreNo !== undefined) {
-		obj.dummyScoreNos = _dosObj.dummyScoreNo.split(`$`);
+	if (_dosObj.dummyId !== undefined) {
+		obj.dummyScoreNos = _dosObj.dummyId.split(`$`);
 	}
 
 	// 無音のフレーム数


### PR DESCRIPTION
## 変更内容
- ダミーIDの譜面ヘッダー誤りを修正しました。
  - dummyScoreNo -> dummyId

## 変更理由
- Wikiに記載している譜面ヘッダーと記載内容が異なっていたため。

## その他コメント

