### PR TITLE
[0083-dummy-frame] ダミー用カスタム変数が定義できない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7616,9 +7616,9 @@ function MainInit() {
 				const stepDivHit = document.querySelector(`#stepHit${_j}`);
 
 				if (typeof customJudgeDummyArrow === `function`) {
-					customJudgeDummyArrow(difFrame);
+					customJudgeDummyArrow(_cnt);
 					if (typeof customJudgeDummyArrow2 === `function`) {
-						customJudgeDummyArrow2(difFrame);
+						customJudgeDummyArrow2(_cnt);
 					}
 				}
 				stepDivHit.style.opacity = 1;
@@ -7638,9 +7638,9 @@ function MainInit() {
 		// ダミーフリーズアロー(成功時)
 		dummyFrzOK: (_j, _k, _frzRoot, _cnt) => {
 			if (typeof customJudgeDummyFrz === `function`) {
-				customJudgeDummyFrz(difFrame);
+				customJudgeDummyFrz(_cnt);
 				if (typeof customJudgeDummyFrz2 === `function`) {
-					customJudgeDummyFrz2(difFrame);
+					customJudgeDummyFrz2(_cnt);
 				}
 			}
 			_frzRoot.setAttribute(`judgEndFlg`, `true`);


### PR DESCRIPTION
## 変更内容
- ダミー用カスタム変数が定義できない問題を修正しました。

## 変更理由
- customJudgeDummyArrow(difFrame), customJudgeDummyFrz(difFrame)の引数が未定義だったため。

## その他コメント

