### PR TITLE
2譜面目以降で背景、矢印モーションが指定されていない場合、1譜面目のデータを読み込むように変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5851,7 +5851,13 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame, _dummyNo = ``) {
 	 * @param {string} _scoreNo 
 	 */
 	function setCssMotionData(_header, _scoreNo) {
-		const dosCssMotionData = _dosObj[`${_header}Motion${_scoreNo}_data`];
+		let dosCssMotionData;
+		if (_dosObj[`${_header}Motion${_scoreNo}_data`] !== undefined) {
+			dosCssMotionData = _dosObj[`${_header}Motion${_scoreNo}_data`];
+		} else if (_dosObj[`${_header}Motion_data`] !== undefined) {
+			dosCssMotionData = _dosObj[`${_header}Motion_data`];
+		}
+
 		let cssMotionData = [];
 
 		if (dosCssMotionData !== undefined && dosCssMotionData !== `` && g_stateObj.d_arroweffect === C_FLG_ON) {
@@ -5940,14 +5946,15 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame, _dummyNo = ``) {
 	obj.maskData = [];
 	obj.maskData.length = 0;
 	if (g_stateObj.d_background === C_FLG_ON) {
+		let maskDataList;
 		if (g_stateObj.reverse === C_FLG_ON) {
-			if (_dosObj[`maskRev${_scoreNo}_data`] !== undefined) {
-				[obj.maskData, obj.maskMaxDepth] = makeSpriteData(_dosObj[`maskRev${_scoreNo}_data`], calcFrame);
-			} else if (_dosObj[`mask${_scoreNo}_data`] !== undefined) {
-				[obj.maskData, obj.maskMaxDepth] = makeSpriteData(_dosObj[`mask${_scoreNo}_data`], calcFrame);
-			}
-		} else if (_dosObj[`mask${_scoreNo}_data`] !== undefined) {
-			[obj.maskData, obj.maskMaxDepth] = makeSpriteData(_dosObj[`mask${_scoreNo}_data`], calcFrame);
+			maskDataList = [_dosObj[`maskRev${_scoreNo}_data`], _dosObj.maskRev_data, _dosObj[`mask${_scoreNo}_data`], _dosObj.mask_data];
+		} else {
+			maskDataList = [_dosObj[`mask${_scoreNo}_data`], _dosObj.mask_data];
+		}
+		const maskData = maskDataList.find((v) => v !== undefined);
+		if (maskData !== undefined) {
+			[obj.maskData, obj.maskMaxDepth] = makeSpriteData(maskData, calcFrame);
 		}
 	}
 
@@ -5956,14 +5963,15 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame, _dummyNo = ``) {
 	obj.backData = [];
 	obj.backData.length = 0;
 	if (g_stateObj.d_background === C_FLG_ON) {
+		let backDataList;
 		if (g_stateObj.reverse === C_FLG_ON) {
-			if (_dosObj[`backRev${_scoreNo}_data`] !== undefined) {
-				[obj.backData, obj.backMaxDepth] = makeSpriteData(_dosObj[`backRev${_scoreNo}_data`], calcFrame);
-			} else if (_dosObj[`back${_scoreNo}_data`] !== undefined) {
-				[obj.backData, obj.backMaxDepth] = makeSpriteData(_dosObj[`back${_scoreNo}_data`], calcFrame);
-			}
-		} else if (_dosObj[`back${_scoreNo}_data`] !== undefined) {
-			[obj.backData, obj.backMaxDepth] = makeSpriteData(_dosObj[`back${_scoreNo}_data`], calcFrame);
+			backDataList = [_dosObj[`backRev${_scoreNo}_data`], _dosObj.backRev_data, _dosObj[`back${_scoreNo}_data`], _dosObj.back_data];
+		} else {
+			backDataList = [_dosObj[`back${_scoreNo}_data`], _dosObj.back_data];
+		}
+		const backData = backDataList.find((v) => v !== undefined);
+		if (backData !== undefined) {
+			[obj.backData, obj.backMaxDepth] = makeSpriteData(backData, calcFrame);
 		}
 	}
 


### PR DESCRIPTION
## 変更内容
2譜面目以降で以下の画面効果が指定されていないとき、1譜面目の情報を読み込むようにしました。
- mask(Rev)_data
- back(Rev)_data
- arrowMotion_data
- frzMotion_data

## 変更理由
画面効果を全譜面統一したい場合の多重指定の手間を省くため（word_data 等に合わせる形）

## その他コメント
mask_data に関して、2譜面目以降のリバース時には以下の優先順位で読み込んでいます。
back_data も同様。
1. maskRev(譜面番号)_data
2. maskRev_data
3. mask(譜面番号)_data
4. mask_data
