### PR TITLE
[0084-mask-clear-all] back/mask_dataにおいてオールクリアできない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2373,7 +2373,7 @@ function drawMainSpriteData(_frame, _depthName) {
 		} else {
 			if (tmpObj.depth === `ALL`) {
 				for (let j = 0; j <= g_scoreObj[`${_depthName}MaxDepth`]; j++) {
-					document.querySelector(`#${_depthName}${spriteUpper}Sprite${tmpObj.depth}`).innerHTML = ``;
+					document.querySelector(`#${_depthName}Sprite${j}`).innerHTML = ``;
 				}
 			} else {
 				baseSprite.innerHTML = ``;


### PR DESCRIPTION
## 変更内容
- back/mask_dataにおいてオールクリアできない問題を修正

## 変更理由
- back/mask_dataにおいて深度にALLを指定すると背景もしくはマスクが全て消えることになっているが、実行時、spriteUpper変数が存在せずエラーとなってしまう。

## その他コメント

