### PR TITLE
[0085-code-refactoring] コード見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8426,7 +8426,7 @@ function changeCssMotions(_mkCssMotion, _mkCssMotionName, _name) {
  */
 function changeHitFrz(_j, _k, _name) {
 
-	document.querySelector(`#frzHit${_j}`).style.opacity = 0.95;
+	document.querySelector(`#frzHit${_j}`).style.opacity = 0.9;
 	document.querySelector(`#${_name}Top${_j}_${_k}`).style.opacity = 0;
 
 	const frzBar = document.querySelector(`#${_name}Bar${_j}_${_k}`);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8426,7 +8426,7 @@ function changeCssMotions(_mkCssMotion, _mkCssMotionName, _name) {
  */
 function changeHitFrz(_j, _k, _name) {
 
-	document.querySelector(`#frzHit${_j}`).style.opacity = 0.75;
+	document.querySelector(`#frzHit${_j}`).style.opacity = 1;
 	document.querySelector(`#${_name}Top${_j}_${_k}`).style.opacity = 0;
 
 	const frzBar = document.querySelector(`#${_name}Bar${_j}_${_k}`);
@@ -8448,6 +8448,7 @@ function changeHitFrz(_j, _k, _name) {
 	frzBtmShadow.style.top = `${parseFloat(frzBtmShadow.style.top) - delFrzLength}px`;
 	frzBar.style.top = `${parseFloat(frzBar.style.top) - delFrzLength * dividePos}px`;
 	frzBar.style.height = `${parseFloat(frzBar.style.height) - delFrzLength * g_workObj.scrollDir[_j]}px`;
+	frzBar.style.opacity = 0.75;
 
 	frzRoot.setAttribute(`isMoving`, `false`);
 }
@@ -8462,6 +8463,7 @@ function changeFailedFrz(_j, _k) {
 	document.querySelector(`#frzTop${_j}_${_k}`).style.opacity = 1;
 	document.querySelector(`#frzTop${_j}_${_k}`).style.backgroundColor = `#cccccc`;
 	document.querySelector(`#frzBar${_j}_${_k}`).style.backgroundColor = `#999999`;
+	document.querySelector(`#frzBar${_j}_${_k}`).style.opacity = 1;
 	document.querySelector(`#frzBtm${_j}_${_k}`).style.backgroundColor = `#cccccc`;
 }
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8427,19 +8427,18 @@ function changeCssMotions(_mkCssMotion, _mkCssMotionName, _name) {
  */
 function changeHitFrz(_j, _k, _name) {
 
-	document.querySelector(`#frzHit${_j}`).style.opacity = 0.9;
-	document.querySelector(`#${_name}Top${_j}_${_k}`).style.opacity = 0;
-
+	if (_name === `frz`) {
+		document.querySelector(`#frzHit${_j}`).style.opacity = 0.9;
+		document.querySelector(`#frzTop${_j}_${_k}`).style.opacity = 0;
+	}
 	const frzBar = document.querySelector(`#${_name}Bar${_j}_${_k}`);
 	const frzRoot = document.querySelector(`#${_name}${_j}_${_k}`);
 	const frzBtm = document.querySelector(`#${_name}Btm${_j}_${_k}`);
 	const frzBtmShadow = document.querySelector(`#${_name}BtmShadow${_j}_${_k}`);
 	const dividePos = Number(frzRoot.getAttribute(`dividePos`));
 
-	if (_name === `frz`) {
-		frzBar.style.backgroundColor = g_workObj.frzHitBarColors[_j];
-		frzBtm.style.backgroundColor = g_workObj.frzHitColors[_j];
-	}
+	frzBar.style.backgroundColor = g_workObj[`${_name}HitBarColors`][_j];
+	frzBtm.style.backgroundColor = g_workObj[`${_name}HitColors`][_j];
 
 	// フリーズアロー位置の修正（ステップゾーン上に来るように）
 	const delFrzLength = parseFloat(document.querySelector(`#step${_j}`).style.top) - parseFloat(frzRoot.style.top);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7859,9 +7859,10 @@ function MainInit() {
 		// 後に作成するほど前面に表示される。
 
 		// フリーズアロー帯(frzBar)
-		frzRoot.appendChild(createColorObject(`${_name}Bar${_j}_${_arrowCnt}`, _barColor,
+		const frzBar = frzRoot.appendChild(createColorObject(`${_name}Bar${_j}_${_arrowCnt}`, _barColor,
 			5, C_ARW_WIDTH / 2 - frzLength * g_workObj.boostSpd * dividePos,
 			C_ARW_WIDTH - 10, frzLength * g_workObj.boostSpd, 0, `frzBar`));
+		frzBar.style.opacity = 0.75;
 
 		// 開始矢印の塗り部分。ヒット時は前面に出て光る。
 		frzRoot.appendChild(createColorObject(`${_name}TopShadow${_j}_${_arrowCnt}`, `#000000`,
@@ -8426,7 +8427,7 @@ function changeCssMotions(_mkCssMotion, _mkCssMotionName, _name) {
  */
 function changeHitFrz(_j, _k, _name) {
 
-	document.querySelector(`#frzHit${_j}`).style.opacity = 1;
+	document.querySelector(`#frzHit${_j}`).style.opacity = 0.9;
 	document.querySelector(`#${_name}Top${_j}_${_k}`).style.opacity = 0;
 
 	const frzBar = document.querySelector(`#${_name}Bar${_j}_${_k}`);
@@ -8448,7 +8449,6 @@ function changeHitFrz(_j, _k, _name) {
 	frzBtmShadow.style.top = `${parseFloat(frzBtmShadow.style.top) - delFrzLength}px`;
 	frzBar.style.top = `${parseFloat(frzBar.style.top) - delFrzLength * dividePos}px`;
 	frzBar.style.height = `${parseFloat(frzBar.style.height) - delFrzLength * g_workObj.scrollDir[_j]}px`;
-	frzBar.style.opacity = 0.75;
 
 	frzRoot.setAttribute(`isMoving`, `false`);
 }

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4875,7 +4875,7 @@ function keyConfigInit() {
 		}
 		keyconSprite.appendChild(createArrowEffect(`arrow${j}`, g_headerObj.setColor[g_keyObj[`color${keyCtrlPtn}`][j]],
 			g_keyObj.blank * stdPos + (kWidth - C_ARW_WIDTH) / 2,
-			C_KYC_HEIGHT * dividePos, 50,
+			C_KYC_HEIGHT * dividePos, C_ARW_WIDTH,
 			g_keyObj[`stepRtn${keyCtrlPtn}`][j]));
 
 		for (let k = 0; k < g_keyObj[`keyCtrl${keyCtrlPtn}`][j].length; k++) {
@@ -7061,20 +7061,20 @@ function MainInit() {
 			const stepShadow = createColorObject(`stepShadow${j}`, `#000000`,
 				g_workObj.stepX[j],
 				g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j],
-				50, 50, g_workObj.stepRtn[j], `arrowShadow`);
+				C_ARW_WIDTH, C_ARW_WIDTH, g_workObj.stepRtn[j], `arrowShadow`);
 			mainSprite.appendChild(stepShadow);
 			stepShadow.style.opacity = 0.7;
 		}
 
 		const step = createArrowEffect(`step${j}`, `#999999`,
 			g_workObj.stepX[j],
-			g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j], 50,
+			g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j], C_ARW_WIDTH,
 			g_workObj.stepRtn[j]);
 		mainSprite.appendChild(step);
 
 		const stepHit = createArrowEffect(`stepHit${j}`, `#999999`,
 			g_workObj.stepX[j] - 15,
-			g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j] - 15, 80,
+			g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j] - 15, C_ARW_WIDTH + 30,
 			g_workObj.stepRtn[j]);
 		stepHit.style.opacity = 0;
 		stepHit.setAttribute(`cnt`, 0);
@@ -7102,7 +7102,7 @@ function MainInit() {
 	for (let j = 0; j < keyNum; j++) {
 		const frzHit = createSprite(`mainSprite`, `frzHit${j}`,
 			g_workObj.stepX[j], g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j],
-			50, 50);
+			C_ARW_WIDTH, C_ARW_WIDTH);
 		frzHit.style.opacity = 0;
 		if (isNaN(Number(g_workObj.stepRtn[j]))) {
 			frzHit.appendChild(createColorObject(`frzHitShadow${j}`, `#000000`,
@@ -7115,9 +7115,8 @@ function MainInit() {
 
 		} else {
 			frzHit.appendChild(createColorObject(`frzHitTop${j}`, `#ffffff`,
-				- 10,
-				- 10,
-				70, 70, g_workObj.stepRtn[j], `arrowShadow`));
+				-10, -10,
+				C_ARW_WIDTH + 20, C_ARW_WIDTH + 20, g_workObj.stepRtn[j], `arrowShadow`));
 		}
 	}
 
@@ -7524,8 +7523,6 @@ function MainInit() {
 					if (g_workObj[`frz${_state}Colors`][_j] === toColorCode) {
 						if (_state === `Normal`) {
 							frzTop.style.backgroundColor = toColorCode;
-						} else {
-							document.querySelector(`#frzHitTop${_j}`).style.backgroundColor = toColorCode;
 						}
 						frzBtm.style.backgroundColor = toColorCode;
 						frzBtm.setAttribute(`color`, toColorCode);
@@ -8384,6 +8381,9 @@ function changeFrzColors(_mkColor, _mkColorCd, _colorPatterns, _keyNum, _allFlg)
 							g_workObj.frzHitColors[k] = _mkColorCd[j];
 							if (_allFlg === `A`) {
 								g_workObj.frzHitColorsAll[k] = _mkColorCd[j];
+								if (isNaN(Number(g_workObj.stepRtn[k]))) {
+									document.querySelector(`#frzHitTop${k}`).style.backgroundColor = _mkColorCd[j];
+								}
 							}
 						}
 					}
@@ -8426,7 +8426,7 @@ function changeCssMotions(_mkCssMotion, _mkCssMotionName, _name) {
  */
 function changeHitFrz(_j, _k, _name) {
 
-	document.querySelector(`#frzHit${_j}`).style.opacity = 0.9;
+	document.querySelector(`#frzHit${_j}`).style.opacity = 0.75;
 	document.querySelector(`#${_name}Top${_j}_${_k}`).style.opacity = 0;
 
 	const frzBar = document.querySelector(`#${_name}Bar${_j}_${_k}`);


### PR DESCRIPTION
## 変更内容
### 1. メイン画面のフレームカウント条件の見直し
- 従来は一定時間経過で強制的にフレームカウントしていましたが、
ゲーム終了条件を満たした場合はフレームカウントしないように変更しました。

### 2. フリーズアローヒット部分の描画変更
- フリーズアローヒット部分をステップゾーン位置へ分離配置しました。
これにより、Hidden時でもフリーズアローがヒット中かどうかを判別できるようになります。
- 矢印のヒットモーションと同じように、ステップゾーン上に常時配置されて表示・非表示が切り替わるイメージです。
- (追記) ダミーフリーズアローではこの分離したオブジェクトは使用しません。
末尾矢印と同様に作用します。
（Hiddenと併用した場合はステップゾーン上には表示されません）

### 3. 矢印描画で対応していたIE/Edge互換設定の撤去
- 矢印やその周辺描画で使用していた、
 `createArrowEffect` 並びに `createColorObject`を簡素化しました。
CSSの`mask-image`を使用した方法に統一しています。

### 4. フリーズアローバーの透明度設定
- フリーズアローバーの透明度を常時75％に設定しました。

## 変更理由
1. 意図しないタイミングでフレームカウントした結果、
不具合を起こす可能性を少しでも減らすため。
2.   Hidden時にフリーズアローがヒットしたかどうかがわからないため。
また、フリーズアロー本体個々に行っていたヒット時描画をやめることによる
処理負荷軽減（わずかですが）を図るため。
3. 以前よりIEは動作対象外としており、
この対応を切ったとしても影響はほぼないと考えられるため。
Edgeについても、今後はChromiumへ移行するためほぼ影響はないと考える。
4. ParaFla版では透明度設定されていたが、これまでCW Editionではされていなかったため
移植作でフリーズアローバーが白色の場合、矢印ヒット色と重複していた。

## その他コメント

