### PR TITLE
[0088-custom-gauge] カスタムゲージの実装

### DIFF
--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -133,6 +133,21 @@ input[type=range]::-moz-range-thumb{
 input[type=range]:focus {
 	outline: 0;
 }
+.gaugeVal {
+	font-size:12px;
+}
+.lifeVal {
+	color: #ff9966;
+}
+.gaugeTable {
+	width: 250px;
+	margin: 0 auto;
+	border: 1px #666666 solid; 
+	border-collapse: collapse;
+}
+.gaugeTable td {
+	width: 55px;
+}
 
 /* 左から右へ */
 @keyframes leftToRight {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2996,15 +2996,17 @@ function headerConvert(_dosObj) {
 		rcvSurvival: [6, 6, 0, 0, 0],
 		dmgSurvival: [40, 20, 50, obj.maxLifeVal, 0],
 		typeSurvival: [C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL],
+		varSurvival: [C_FLG_OFF, C_FLG_OFF, C_FLG_OFF, C_FLG_OFF, C_FLG_OFF],
 		clearSurvival: [0, 0, 0, 0, 0],
 
 		initBorder: [25, 25, 100, 100],
 		rcvBorder: [2, 2, 1, 0],
 		dmgBorder: [7, 4, 50, obj.maxLifeVal],
 		typeBorder: [C_LFE_BORDER, C_LFE_BORDER, C_LFE_BORDER, C_LFE_SURVIVAL],
+		varBorder: [C_FLG_ON, C_FLG_ON, C_FLG_ON, C_FLG_OFF],
 		clearBorder: [70, 70, 0, 0],
 
-		typeCustom: [],
+		varCustom: [],
 	};
 
 	// カスタムゲージ設定
@@ -3014,7 +3016,7 @@ function headerConvert(_dosObj) {
 		for (let j = 0; j < customGauges.length; j++) {
 			const customGaugeSets = customGauges[j].split(`::`);
 			g_gaugeOptionObj.custom[j] = customGaugeSets[0];
-			g_gaugeOptionObj.typeCustom[j] = (customGaugeSets[1] === `F` ? C_LFE_SURVIVAL : C_LFE_BORDER);
+			g_gaugeOptionObj.varCustom[j] = (customGaugeSets[1] !== `V` ? C_FLG_OFF : C_FLG_ON);
 		}
 	}
 
@@ -4099,14 +4101,16 @@ function createOptionWindow(_sprite) {
 					g_gaugeType = C_LFE_SURVIVAL;
 					g_stateObj.lifeBorder = 0;
 					g_stateObj.lifeMode = C_LFE_SURVIVAL;
+					g_stateObj.lifeVariable = C_FLG_OFF;
 				} else {
 					g_gaugeType = C_LFE_BORDER;
 					g_stateObj.lifeBorder = g_headerObj.lifeBorders[g_stateObj.scoreId];
 					g_stateObj.lifeMode = C_LFE_BORDER;
+					g_stateObj.lifeVariable = C_FLG_ON;
 				}
 				if (g_gaugeOptionObj.custom.length > 0) {
 					g_gaugeType = C_LFE_CUSTOM;
-					g_stateObj.lifeMode = g_gaugeOptionObj.typeCustom[_gaugeNum];
+					g_stateObj.lifeVariable = g_gaugeOptionObj.varCustom[_gaugeNum];
 				}
 				g_gauges = JSON.parse(JSON.stringify(g_gaugeOptionObj[g_gaugeType.toLowerCase()]));
 				g_stateObj.gauge = g_gauges[g_gaugeNum];
@@ -4122,14 +4126,16 @@ function createOptionWindow(_sprite) {
 			}
 		} else {
 			// 設定されたゲージ設定、カーソルに合わせて設定値を更新
-			g_stateObj.lifeMode = g_gaugeOptionObj[`type${g_gaugeType}`][_gaugeNum];
+			g_stateObj.lifeVariable = g_gaugeOptionObj[`var${g_gaugeType}`][_gaugeNum];
 			if (g_gaugeOptionObj.custom.length === 0) {
+				g_stateObj.lifeMode = g_gaugeOptionObj[`type${g_gaugeType}`][_gaugeNum];
 				g_stateObj.lifeBorder = g_gaugeOptionObj[`clear${g_gaugeType}`][_gaugeNum];
 				g_stateObj.lifeInit = g_gaugeOptionObj[`init${g_gaugeType}`][_gaugeNum];
 				g_stateObj.lifeRcv = g_gaugeOptionObj[`rcv${g_gaugeType}`][_gaugeNum];
 				g_stateObj.lifeDmg = g_gaugeOptionObj[`dmg${g_gaugeType}`][_gaugeNum];
 			}
 		}
+		console.log(g_stateObj.lifeVariable);
 
 		// ゲージ設定(Light, Easy)の初期化
 		if (g_stateObj.gauge == `Light` || g_stateObj.gauge == `Easy`) {
@@ -4154,8 +4160,10 @@ function createOptionWindow(_sprite) {
 			if (setVal(tmpGaugeObj.lifeBorders[tmpScoreId], ``, C_TYP_STRING) !== ``) {
 				if (tmpGaugeObj.lifeBorders[tmpScoreId] === `x`) {
 					g_stateObj.lifeBorder = 0;
+					g_stateObj.lifeMode = C_LFE_SURVIVAL;
 				} else {
 					g_stateObj.lifeBorder = tmpGaugeObj.lifeBorders[tmpScoreId];
+					g_stateObj.lifeMode = C_LFE_BORDER;
 				}
 			}
 			if (setVal(tmpGaugeObj.lifeRecoverys[tmpScoreId], ``, C_TYP_FLOAT) !== ``) {
@@ -6072,7 +6080,7 @@ function escapeHtml(_str) {
  */
 function calcLifeVals(_allArrows) {
 
-	if (g_stateObj.lifeMode === C_LFE_BORDER) {
+	if (g_stateObj.lifeVariable === C_FLG_ON) {
 		g_workObj.lifeRcv = calcLifeVal(g_stateObj.lifeRcv, _allArrows);
 		g_workObj.lifeDmg = calcLifeVal(g_stateObj.lifeDmg, _allArrows);
 	} else {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4101,6 +4101,7 @@ function createOptionWindow(_sprite) {
 				}
 				if (g_gaugeOptionObj.custom.length > 0) {
 					g_gaugeType = C_LFE_CUSTOM;
+					g_stateObj.lifeMode = g_gaugeOptionObj.typeCustom[_gaugeNum];
 				}
 				g_gauges = JSON.parse(JSON.stringify(g_gaugeOptionObj[g_gaugeType.toLowerCase()]));
 				g_stateObj.gauge = g_gauges[g_gaugeNum];

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -374,6 +374,7 @@ let C_CLR_BORDER = `#555555`;
 let C_CLR_BACKLIFE = `#222222`;
 const C_LFE_SURVIVAL = `Survival`;
 const C_LFE_BORDER = `Border`;
+const C_LFE_CUSTOM = `Custom`;
 
 let g_gaugeOptionObj = {};
 let g_gaugeType;
@@ -2988,6 +2989,7 @@ function headerConvert(_dosObj) {
 	g_gaugeOptionObj = {
 		survival: [`Original`, `Light`, `NoRecovery`, `SuddenDeath`, `Practice`],
 		border: [`Normal`, `Easy`, `Hard`, `SuddenDeath`],
+		custom: [],
 
 		initSurvival: [25, 25, 100, 100, 50],
 		rcvSurvival: [6, 6, 0, 0, 0],
@@ -2999,8 +3001,21 @@ function headerConvert(_dosObj) {
 		rcvBorder: [2, 2, 1, 0],
 		dmgBorder: [7, 4, 50, obj.maxLifeVal],
 		typeBorder: [C_LFE_BORDER, C_LFE_BORDER, C_LFE_BORDER, C_LFE_SURVIVAL],
-		clearBorder: [70, 70, 0, 0]
+		clearBorder: [70, 70, 0, 0],
+
+		typeCustom: [],
 	};
+
+	// カスタムゲージ設定
+	// |customGauge=Original::S,Normal::B,Escape::B|
+	if (_dosObj.customGauge !== undefined) {
+		const customGauges = _dosObj.customGauge.split(`,`);
+		for (let j = 0; j < customGauges.length; j++) {
+			const customGaugeSets = customGauges[j].split(`::`);
+			g_gaugeOptionObj.custom[j] = customGaugeSets[0];
+			g_gaugeOptionObj.typeCustom[j] = (customGaugeSets[1] === `F` ? C_LFE_SURVIVAL : C_LFE_BORDER);
+		}
+	}
 
 	// ライフ設定のカスタム部分取得（譜面ヘッダー加味）
 	for (let j = 0; j < g_gaugeOptionObj.survival.length; j++) {
@@ -3008,6 +3023,9 @@ function headerConvert(_dosObj) {
 	}
 	for (let j = 0; j < g_gaugeOptionObj.border.length; j++) {
 		getGaugeSetting(_dosObj, g_gaugeOptionObj.border[j], obj);
+	}
+	for (let j = 0; j < g_gaugeOptionObj.custom.length; j++) {
+		getGaugeSetting(_dosObj, g_gaugeOptionObj.custom[j], obj);
 	}
 
 	// 初期色情報
@@ -4081,6 +4099,9 @@ function createOptionWindow(_sprite) {
 					g_stateObj.lifeBorder = g_headerObj.lifeBorders[g_stateObj.scoreId];
 					g_stateObj.lifeMode = C_LFE_BORDER;
 				}
+				if (g_gaugeOptionObj.custom.length > 0) {
+					g_gaugeType = C_LFE_CUSTOM;
+				}
 				g_gauges = JSON.parse(JSON.stringify(g_gaugeOptionObj[g_gaugeType.toLowerCase()]));
 				g_stateObj.gauge = g_gauges[g_gaugeNum];
 			}
@@ -4096,10 +4117,12 @@ function createOptionWindow(_sprite) {
 		} else {
 			// 設定されたゲージ設定、カーソルに合わせて設定値を更新
 			g_stateObj.lifeMode = g_gaugeOptionObj[`type${g_gaugeType}`][_gaugeNum];
-			g_stateObj.lifeBorder = g_gaugeOptionObj[`clear${g_gaugeType}`][_gaugeNum];
-			g_stateObj.lifeInit = g_gaugeOptionObj[`init${g_gaugeType}`][_gaugeNum];
-			g_stateObj.lifeRcv = g_gaugeOptionObj[`rcv${g_gaugeType}`][_gaugeNum];
-			g_stateObj.lifeDmg = g_gaugeOptionObj[`dmg${g_gaugeType}`][_gaugeNum];
+			if (g_gaugeOptionObj.custom.length === 0) {
+				g_stateObj.lifeBorder = g_gaugeOptionObj[`clear${g_gaugeType}`][_gaugeNum];
+				g_stateObj.lifeInit = g_gaugeOptionObj[`init${g_gaugeType}`][_gaugeNum];
+				g_stateObj.lifeRcv = g_gaugeOptionObj[`rcv${g_gaugeType}`][_gaugeNum];
+				g_stateObj.lifeDmg = g_gaugeOptionObj[`dmg${g_gaugeType}`][_gaugeNum];
+			}
 		}
 
 		// ゲージ設定(Light, Easy)の初期化

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -351,6 +351,7 @@ const g_stateObj = {
 	lifeMode: `Border`,
 	lifeBorder: 70,
 	lifeInit: 25,
+	lifeVariable: C_FLG_OFF,
 
 	extraKeyFlg: false,
 	dataSaveFlg: true,
@@ -4042,8 +4043,8 @@ function createOptionWindow(_sprite) {
 	optionsprite.appendChild(lblGauge);
 
 	// ゲージ設定詳細　縦位置: ゲージ設定+1
-	const lblGauge2 = createDivLabel(`lblGauge2`, C_LEN_SETLBL_LEFT, C_LEN_SETLBL_HEIGHT * (setNoGauge + 1) - 3,
-		C_LEN_SETLBL_WIDTH, C_LEN_SETLBL_HEIGHT, 11, C_CLR_TITLE, ``);
+	const lblGauge2 = createDivLabel(`lblGauge2`, C_LEN_SETLBL_LEFT, C_LEN_SETLBL_HEIGHT * (setNoGauge + 1),
+		C_LEN_SETLBL_WIDTH, C_LEN_SETLBL_HEIGHT * 2, 11, C_CLR_TITLE, ``);
 	optionsprite.appendChild(lblGauge2);
 
 	if (g_headerObj.gaugeUse) {
@@ -4085,7 +4086,8 @@ function createOptionWindow(_sprite) {
 		if (_scrollNum !== 0) {
 			gaugeChange(g_gaugeNum);
 		}
-		document.querySelector(`#lblGauge2`).innerHTML = gaugeFormat(g_stateObj.lifeMode, g_stateObj.lifeBorder, g_stateObj.lifeRcv, g_stateObj.lifeDmg, g_stateObj.lifeInit);
+		document.querySelector(`#lblGauge2`).innerHTML = gaugeFormat(g_stateObj.lifeMode,
+			g_stateObj.lifeBorder, g_stateObj.lifeRcv, g_stateObj.lifeDmg, g_stateObj.lifeInit, g_stateObj.lifeVariable);
 	}
 
 	/**
@@ -4135,7 +4137,6 @@ function createOptionWindow(_sprite) {
 				g_stateObj.lifeDmg = g_gaugeOptionObj[`dmg${g_gaugeType}`][_gaugeNum];
 			}
 		}
-		console.log(g_stateObj.lifeVariable);
 
 		// ゲージ設定(Light, Easy)の初期化
 		if (g_stateObj.gauge == `Light` || g_stateObj.gauge == `Easy`) {
@@ -4181,16 +4182,37 @@ function createOptionWindow(_sprite) {
 	/**
 	 * ゲージ設定の詳細表示を整形
 	 */
-	function gaugeFormat(_mode, _border, _rcv, _dmg, _init) {
+	function gaugeFormat(_mode, _border, _rcv, _dmg, _init, _lifeValFlg) {
 		const initVal = g_headerObj.maxLifeVal * _init / 100;
-		const borderVal = g_headerObj.maxLifeVal * _border / 100;
+		const borderVal = (_mode === C_LFE_BORDER && _border !== 0 ?
+			g_headerObj.maxLifeVal * _border / 100 : `-`);
 
-		if (_mode === C_LFE_BORDER) {
-			if (borderVal !== 0) {
-				return `[Start:${initVal}, Border:${borderVal}, <br>Rcv:${_rcv}, Dmg:${_dmg}]`;
-			}
+		let lifeValCss = ``;
+		if (_lifeValFlg === C_FLG_ON) {
+			lifeValCss = ` class="lifeVal"`;
 		}
-		return `[Start:${initVal}, Rcv:${_rcv}, Dmg:${_dmg}]`;
+
+		// 整形用に数値を小数第1位で丸める
+		const init = Math.round(initVal * 10) / 10;
+		const border = (borderVal !== `-` ? Math.round(borderVal * 10) / 10 : `-`);
+		const rcv = Math.round(_rcv * 10) / 10;
+		const dmg = Math.round(_dmg * 10) / 10;
+
+		return `<table class="gaugeTable">
+					<tr>
+						<td>Start</td>
+						<td>Border</td>
+						<td>Recovery</td>
+						<td>Damage</td>
+					</tr>
+					<tr class="gaugeVal">
+						<td style="width:85px;">${init}/${g_headerObj.maxLifeVal}</td>
+						<td>${border}</td>
+						<td${lifeValCss}>${rcv}</td>
+						<td${lifeValCss}>${dmg}</td>
+					</tr>
+				</table>
+				`;
 	}
 
 	// ---------------------------------------------------

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -36,6 +36,18 @@ const g_presetGaugeCustom = {
 		Damage: 50,
 		Init: 100,
 	},
+	NoRecovery: {
+		Border: `x`,
+		Recovery: 0,
+		Damage: 50,
+		Init: 100,
+	},
+	SuddenDeath: {
+		Border: `x`,
+		Recovery: 0,
+		Damage: 1000,
+		Init: 100,
+	},
 };
 
 // デフォルトのデザインを使用せず、独自のデザインを使用するかを指定

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -45,9 +45,15 @@ const g_presetGaugeCustom = {
 	SuddenDeath: {
 		Border: `x`,
 		Recovery: 0,
-		Damage: 1000,
+		Damage: g_headerObj.maxLifeVal,
 		Init: 100,
 	},
+	Practice: {
+		Border: `x`,
+		Recovery: 0,
+		Damage: 0,
+		Init: 50,
+	}
 };
 
 // デフォルトのデザインを使用せず、独自のデザインを使用するかを指定


### PR DESCRIPTION
## 変更内容
### 1. 譜面ヘッダー：customGaugeの追加
- 譜面側からゲージ設定を丸ごと設定できる譜面ヘッダーを追加します。

以下のように、`customGauge`を指定します。
「ゲージ名::回復/ダメージ量設定」の組み合わせで設定します。
回復/ダメージ量設定は、「F」なら矢印数によらず固定、「V」なら矢印数により変動します。
```
|customGauge=Original::F,Normal::V,Escape::V|
|gaugeOriginal=x,4,60,25$x,3,20,25|
|gaugeNormal=50,70,1,25$x,3,25,25|
|gaugeEscape=0,1,50,100$x,5,30,25|
```
なお、ライフ制/ノルマ制の区別は各個別のゲージ設定にて行います。
このため、ノルマ制ながら回復/ダメージ量は固定にするといった設定が可能になります。

また、`danoni_setting.js`の`g_presetGaugeCustom`に追加するゲージ設定を記載することで
どの作品に対してもカスタムゲージを適用できるようになります。
```javascript
// ゲージ設定（デフォルト以外）
const g_presetGaugeCustom = {
	// (省略)
	Escape: {
		Border: 70,
		Recovery: 1,
		Damage: 50,
		Init: 70,
	},
};
```

### 2. `danoni_setting.js`の`g_presetGaugeCustom`の設定追加
- 新たに NoRecovery, SuddenDeath, Practiceを追加しています。

### 3. ゲージ設定詳細の表示方法変更
- ゲージ設定詳細を表形式に変更しました。
回復・ダメージ量が矢印数により変動する場合は、オレンジ色で表記します。
- 表示例：

|Start<br>(初期ライフ/最大ライフ)|Border<br>(クリアボーダー)|Recovery<br>回復量(率)|Damage<br>ダメージ量(率)|
|----|----|----|----|
|250/1000|700|4|40|

## 変更理由
1. 作品別のゲージ設定の幅を広げるため。
2. カスタムゲージ実装に伴い、デフォルト値設定の指定箇所がなくなり
意図しない値が設定されることを避けるため。

## その他コメント・留意点
- カスタムゲージを指定した場合は`gaugeXXX`の指定 もしくは 
`danoni_setting.js`の`g_presetGaugeCustom`の設定が必須です。
また、`Original`と`Normal`がデフォルトゲージで無い場合についても、
設定が必須となります。ご注意ください。
- 原則、ライフ設定は`difData`ではなく`gaugeXXX`で行い、
自動設定されているゲージ設定についても、個別に設定してください。
（NoRecovery, SuddenDeath, Practiceについては
　今回の`danoni_setting.js`以後は設定不要となります）
- カスタムゲージを設定した場合、その作品全体でゲージ設定が共有されます。
特定の譜面だけ別のゲージ名を採用することはできません。設定値は譜面毎に設定できます。