### PR TITLE
[0089-reverse-lyrics] リバース用のword_dataを実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5849,10 +5849,15 @@ function scoreConvert(_dosObj, _scoreNo, _preblankFrame, _dummyNo = ``) {
 	if (g_stateObj.d_lyrics === C_FLG_ON) {
 
 		let inputWordData = ``;
-		if (_dosObj[`word${_scoreNo}_data`] !== undefined) {
-			inputWordData = _dosObj[`word${_scoreNo}_data`];
-		} else if (_dosObj.word_data !== undefined) {
-			inputWordData = _dosObj.word_data;
+		let wordDataList;
+		if (g_stateObj.reverse === C_FLG_ON) {
+			wordDataList = [_dosObj[`wordRev${_scoreNo}_data`], _dosObj.wordRev_data, _dosObj[`word${_scoreNo}_data`], _dosObj.word_data];
+		} else {
+			wordDataList = [_dosObj[`word${_scoreNo}_data`], _dosObj.word_data];
+		}
+		const wordData = wordDataList.find((v) => v !== undefined);
+		if (wordData !== undefined) {
+			inputWordData = wordData;
 		}
 		if (inputWordData !== ``) {
 			let tmpArrayData = inputWordData.split(`\r`).join(`\n`);


### PR DESCRIPTION
## 変更内容
- リバース用のword_dataを実装しました。
`wordRev_data`, `wordRev2_data`, ...のように使用し、
リバースがONの場合のみ適用されます。
`back_data`などと同様に、指定が無ければ`word_data`や`word2_data`を参照します。
適用の優先順序についても`back_data`等と同じです。
- 使い方は`word_data`の書式と変わりません。

## 変更理由
- Twitter要望より。
`back_data`や`mask_data`にあって`word_data`だけリバース版の書式が無かったため。

## その他コメント

