### PR TITLE
[0091-gauge-start] ゲージ詳細のライフ初期値を整数に変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3011,7 +3011,7 @@ function headerConvert(_dosObj) {
 	};
 
 	// カスタムゲージ設定
-	// |customGauge=Original::S,Normal::B,Escape::B|
+	// |customGauge=Original::F,Normal::V,Escape::V|
 	if (_dosObj.customGauge !== undefined) {
 		const customGauges = _dosObj.customGauge.split(`,`);
 		for (let j = 0; j < customGauges.length; j++) {
@@ -4192,8 +4192,8 @@ function createOptionWindow(_sprite) {
 			lifeValCss = ` class="lifeVal"`;
 		}
 
-		// 整形用に数値を小数第1位で丸める
-		const init = Math.round(initVal * 10) / 10;
+		// 整形用にライフ初期値を整数、回復・ダメージ量を小数第1位で丸める
+		const init = Math.round(initVal);
 		const border = (borderVal !== `-` ? Math.round(borderVal * 10) / 10 : `-`);
 		const rcv = Math.round(_rcv * 10) / 10;
 		const dmg = Math.round(_dmg * 10) / 10;


### PR DESCRIPTION
## 変更内容
- ゲージ詳細のライフ初期値を整数に変更しました。

## 変更理由
- ライフ初期値が最大ライフの関係で小数の場合、小数で表示されますが
メイン画面上には小数表記は出てこないため。

## その他コメント
- 内部計算上は小数で計算されます。
これは、回復・ダメージ量についても同じです。（表示上は小数第1位で丸め）
