### PR TITLE
[0093-gauge-initial] danoni_setting.jsのSuddenDeath初期値を変更

### DIFF
--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -45,7 +45,7 @@ const g_presetGaugeCustom = {
 	SuddenDeath: {
 		Border: `x`,
 		Recovery: 0,
-		Damage: g_headerObj.maxLifeVal,
+		Damage: setVal(g_rootObj.maxLifeVal, C_VAL_MAXLIFE, C_TYP_FLOAT),
 		Init: 100,
 	},
 	Practice: {


### PR DESCRIPTION
## 変更内容
- danoni_setting.jsのSuddenDeath初期値を変更しました。
g_headerObjではなく、g_rootObjから取得するように変更しています。

## 変更理由
- danoni_setting.js読込タイミングでは、g_headerObjは未定義のため。

## その他コメント

