### PR TITLE
[0097-auto-preload] 背景・マスクに対象拡張子のデータがあれば、自動でpreloadするように変更

### DIFF
--- a/danoni/danoni1.html
+++ b/danoni/danoni1.html
@@ -94,10 +94,10 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 |backtitle_data=
 
 150,-,＜アスキーアートの表示＞
-200,0,../img/c_600.png,,20,20,200,200,0.5,leftToRightFade,120
-200,1,../img/iyo_600.png,,220,220,200,200,1,spinY,120
+200,0,../img/c.png,,20,20,200,200,0.5,leftToRightFade,120
+200,1,../img/iyo.png,,220,220,200,200,1,spinY,120
 300,0
-320,1,../img/iyo_600.png,,220,220,200,200,0,leftToRightFade,120
+320,1,../img/iyo.png,,220,220,200,200,0,leftToRightFade,120
 
 400,-,＜文字表示の開始＞
 400,2,文字のフローテスト,,100,140,36,0,0,fromBig,100
@@ -114,7 +114,7 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 1050,0,[loop],200:700:700
 
 1200,-,＜これ以後はループ終了後の処理＞
-1200,0,../img/giko_600.png,,220,220,200,200,1,spinX,120
+1200,0,../img/giko.png,,220,220,200,200,1,spinX,120
 1300,0
 |
 
@@ -134,10 +134,10 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 |
 
 |back_data=
-200,0,../img/c_600.png,,20,20,200,200,0.5,leftToRightFade,120
-200,1,../img/iyo_600.png,,220,220,200,200,1,spinY,120
+200,0,../img/c.png,,20,20,200,200,0.5,leftToRightFade,120
+200,1,../img/iyo.png,,220,220,200,200,1,spinY,120
 300,0
-320,1,../img/iyo_600.png,,220,220,200,200,0,leftToRightFade,120
+320,1,../img/iyo.png,,220,220,200,200,0,leftToRightFade,120
 400,2,文字のフローテスト,,100,140,36,0,0,fromBig,100
 500,2,文字のフローテスト,,100,140,36,0,0,upToDown,100
 600,2,文字のフローテスト,,100,140,36,0,1,spinX,100

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1163,7 +1163,7 @@ function preloadFile(_as, _href, _type = ``, _crossOrigin = ``) {
 			link.type = _type;
 		}
 		if (_crossOrigin !== ``) {
-			link.crossOrigin = _crossOrigin
+			link.crossOrigin = _crossOrigin;
 		}
 		document.head.appendChild(link);
 	}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1735,9 +1735,11 @@ function makeSpriteData(_data, _calcFrame = _frame => _frame) {
 					const tmpAnimationName = escapeHtml(setVal(tmpSpriteData[9], C_DIS_NONE, C_TYP_STRING));
 					const tmpAnimationDuration = setVal(tmpSpriteData[10], 0, C_TYP_NUMBER) / g_fps;
 
-					if (tmpPath.indexOf(`.png`) !== -1 || tmpPath.indexOf(`.gif`) !== -1 ||
-						tmpPath.indexOf(`.bmp`) !== -1 || tmpPath.indexOf(`.jpg`) !== -1) {
-						preloadFile(`image`, tmpPath);
+					if (g_headerObj.autoPreload) {
+						if (tmpPath.indexOf(`.png`) !== -1 || tmpPath.indexOf(`.gif`) !== -1 ||
+							tmpPath.indexOf(`.bmp`) !== -1 || tmpPath.indexOf(`.jpg`) !== -1) {
+							preloadFile(`image`, tmpPath);
+						}
 					}
 					if (tmpDepth !== `ALL` && tmpDepth > maxDepth) {
 						maxDepth = tmpDepth;
@@ -3198,6 +3200,9 @@ function headerConvert(_dosObj) {
 	if (_dosObj.hashTag !== undefined) {
 		obj.hashTag = _dosObj.hashTag;
 	}
+
+	// 自動プリロードの設定
+	obj.autoPreload = setVal(_dosObj.autoPreload, false, C_TYP_BOOLEAN);
 
 	// 読込対象の画像を指定(rel:preload)と同じ
 	obj.preloadImages = [];

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3203,6 +3203,7 @@ function headerConvert(_dosObj) {
 
 	// 自動プリロードの設定
 	obj.autoPreload = setVal(_dosObj.autoPreload, false, C_TYP_BOOLEAN);
+	g_headerObj.autoPreload = obj.autoPreload;
 
 	// 読込対象の画像を指定(rel:preload)と同じ
 	obj.preloadImages = [];

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -131,6 +131,8 @@ const g_imgObj = {
 	lifeBorder: C_IMG_LIFEBORDER,
 };
 
+const g_preloadImgs = [];
+
 const C_ARW_WIDTH = 50;
 
 // 音楽ファイル エンコードフラグ
@@ -1146,18 +1148,25 @@ function checkArrayVal(_checkArray, _type, _minLength) {
  * @param {string} _type 
  * @param {string} _crossOrigin 
  */
-function preloadFile(_as, _href, _type, _crossOrigin) {
-	const link = document.createElement(`link`);
-	link.rel = `preload`;
-	link.as = _as;
-	link.href = _href;
-	if (_type !== ``) {
-		link.type = _type;
+function preloadFile(_as, _href, _type = ``, _crossOrigin = ``) {
+
+	const preloadFlg = g_preloadImgs.find(v => v === _href);
+
+	if (preloadFlg === undefined) {
+		g_preloadImgs.push(_href);
+
+		const link = document.createElement(`link`);
+		link.rel = `preload`;
+		link.as = _as;
+		link.href = _href;
+		if (_type !== ``) {
+			link.type = _type;
+		}
+		if (_crossOrigin !== ``) {
+			link.crossOrigin = _crossOrigin
+		}
+		document.head.appendChild(link);
 	}
-	if (_crossOrigin !== ``) {
-		link.crossOrigin = _crossOrigin
-	}
-	document.head.appendChild(link);
 }
 
 /**
@@ -1726,6 +1735,10 @@ function makeSpriteData(_data, _calcFrame = _frame => _frame) {
 					const tmpAnimationName = escapeHtml(setVal(tmpSpriteData[9], C_DIS_NONE, C_TYP_STRING));
 					const tmpAnimationDuration = setVal(tmpSpriteData[10], 0, C_TYP_NUMBER) / g_fps;
 
+					if (tmpPath.indexOf(`.png`) !== -1 || tmpPath.indexOf(`.gif`) !== -1 ||
+						tmpPath.indexOf(`.bmp`) !== -1 || tmpPath.indexOf(`.jpg`) !== -1) {
+						preloadFile(`image`, tmpPath);
+					}
 					if (tmpDepth !== `ALL` && tmpDepth > maxDepth) {
 						maxDepth = tmpDepth;
 					}
@@ -1996,18 +2009,18 @@ function initAfterDosLoaded() {
 	g_keyObj.currentPtn = 0;
 
 	// 画像ファイルの読み込み
-	preloadFile(`image`, C_IMG_ARROW, ``, ``);
-	preloadFile(`image`, C_IMG_ARROWSD, ``, ``);
-	preloadFile(`image`, C_IMG_ONIGIRI, ``, ``);
-	preloadFile(`image`, C_IMG_AASD, ``, ``);
-	preloadFile(`image`, C_IMG_GIKO, ``, ``);
-	preloadFile(`image`, C_IMG_IYO, ``, ``);
-	preloadFile(`image`, C_IMG_C, ``, ``);
-	preloadFile(`image`, C_IMG_MORARA, ``, ``);
-	preloadFile(`image`, C_IMG_MONAR, ``, ``);
-	preloadFile(`image`, C_IMG_CURSOR, ``, ``);
-	preloadFile(`image`, C_IMG_FRZBAR, ``, ``);
-	preloadFile(`image`, C_IMG_LIFEBORDER, ``, ``);
+	preloadFile(`image`, C_IMG_ARROW);
+	preloadFile(`image`, C_IMG_ARROWSD);
+	preloadFile(`image`, C_IMG_ONIGIRI);
+	preloadFile(`image`, C_IMG_AASD);
+	preloadFile(`image`, C_IMG_GIKO);
+	preloadFile(`image`, C_IMG_IYO);
+	preloadFile(`image`, C_IMG_C);
+	preloadFile(`image`, C_IMG_MORARA);
+	preloadFile(`image`, C_IMG_MONAR);
+	preloadFile(`image`, C_IMG_CURSOR);
+	preloadFile(`image`, C_IMG_FRZBAR);
+	preloadFile(`image`, C_IMG_LIFEBORDER);
 
 	// その他の画像ファイルの読み込み
 	for (let j = 0, len = g_headerObj.preloadImages.length; j < len; j++) {
@@ -2037,11 +2050,11 @@ function initAfterDosLoaded() {
 					paddingLen = String(setVal(tmpPreloadImages[1], 1, C_TYP_STRING)).length;
 				}
 				for (let k = startCnt; k <= lastCnt; k++) {
-					preloadFile(`image`, tmpPreloadImages[0].replace(`*`, paddingLeft(String(k), paddingLen, `0`)), ``, ``);
+					preloadFile(`image`, tmpPreloadImages[0].replace(`*`, paddingLeft(String(k), paddingLen, `0`)));
 				}
 			} else {
 				// Pattern Aの場合
-				preloadFile(`image`, g_headerObj.preloadImages[j], ``, ``);
+				preloadFile(`image`, g_headerObj.preloadImages[j]);
 			}
 		}
 	}


### PR DESCRIPTION
## 変更内容
- 背景・マスクモーションに対象拡張子のデータがあれば、自動でpreloadするように変更
（譜面ヘッダー：`autoPreload`を`true`にする必要があります）
- 以下のようなケースの場合、preloadImagesに追加しなくても自動でpreloadします。

```
|autoPreload=true|
|back_data=
200,0,testA.png,...// 途中略
400,1,../img/testB.jpg,... // 途中略
800,1,../img/testB.jpg,... // 途中略
|
```
この場合、以下の設定が自動で設定されます。（下記の記載は不要）
```
|preloadImages=testA.png,../img/testB.jpg|
```

## 変更理由
- preloadImagesに追加する手間を省くため。

## その他コメント
- Chrome系のブラウザのみpreloadします。Firefoxではデフォルト無効です。（従来通り）
- 背景・マスクモーション（タイトル・リザルト含む）に記載の画像ファイルが対象です。
それ以外で定義した画像ファイルは対象外です。
