### PR TITLE
[0108-fix-iOS] iOSの部分対応（ロードで止まってしまう問題を一部修正）

### DIFF
--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -251,21 +251,27 @@ input[type=range]:focus {
 /* Appearance用 クリッピングマスク */
 .Hidden0 {
 	clip-path: inset(50% 0% 0% 0%);
+	-webkit-clip-path: inset(50% 0% 0% 0%);
 }
 .Hidden1 {
 	clip-path: inset(0% 0% 50% 0%);
+	-webkit-clip-path: inset(0% 0% 50% 0%);
 }
 .Sudden0 {
 	clip-path: inset(0% 0% 40% 0%);
+	-webkit-clip-path: inset(0% 0% 40% 0%);
 }
 .Sudden1 {
 	clip-path: inset(40% 0% 0% 0%);
+	-webkit-clip-path: inset(40% 0% 0% 0%);
 }
 .Slit0 {
 	clip-path: polygon(5% 0%, 100% 0%, 100% 30%, 5% 30%, 5% 45%, 100% 45%, 100% 55%, 5% 55%, 5% 70%, 100% 70%, 100% 100%, 5% 100%);
+	-webkit-clip-path: polygon(5% 0%, 100% 0%, 100% 30%, 5% 30%, 5% 45%, 100% 45%, 100% 55%, 5% 55%, 5% 70%, 100% 70%, 100% 100%, 5% 100%);
 }
 .Slit1 {
 	clip-path: polygon(5% 0%, 100% 0%, 100% 30%, 5% 30%, 5% 45%, 100% 45%, 100% 55%, 5% 55%, 5% 70%, 100% 70%, 100% 100%, 5% 100%);
+	-webkit-clip-path: polygon(5% 0%, 100% 0%, 100% 30%, 5% 30%, 5% 45%, 100% 45%, 100% 55%, 5% 55%, 5% 70%, 100% 70%, 100% 100%, 5% 100%);
 }
 
 /* 設定画面：ゲージ設定詳細 */

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2464,7 +2464,16 @@ async function initWebAudioAPI(_url) {
 	await g_audio.init(arrayBuffer);
 }
 
+/**
+ * 音楽データの設定
+ * iOSの場合はAudioタグによる再生
+ * @param {string} _url 
+ */
 function setAudio(_url) {
+	const isIOS = g_userAgent.indexOf(`iPhone`) >= 0
+		|| g_userAgent.indexOf(`iPad`) >= 0
+		|| g_userAgent.indexOf(`iPod`) >= 0;
+
 	if (g_musicEncodedFlg) {
 		loadScript(_url, _ => {
 			if (typeof musicInit === C_TYP_FUNCTION) {
@@ -2475,12 +2484,39 @@ function setAudio(_url) {
 				musicAfterLoaded();
 			}
 		});
+	} else if (isIOS) {
+		makeUrlButton(_url => {
+			g_audio.src = _url;
+			musicAfterLoaded();
+		});
 	} else if (location.href.match(`^file`)) {
 		g_audio.src = _url;
 		musicAfterLoaded();
 	} else {
 		initWebAudioAPI(_url);
 	}
+}
+
+/**
+ * プレイ続行ボタンの作成
+ * @param {function} _func 
+ */
+function makePlayButton(_func) {
+	// 進むボタン描画
+	const btnPlay = createCssButton({
+		id: `btnPlay`,
+		name: `PLAY!`,
+		x: g_sWidth * 2 / 3,
+		y: g_sHeight - 100,
+		width: g_sWidth / 3,
+		height: C_BTN_HEIGHT,
+		fontsize: C_LBL_BTNSIZE,
+		align: C_ALIGN_CENTER,
+		class: g_cssObj.button_Next,
+	}, _ => {
+		func();
+	});
+	document.querySelector(`#divRoot`).appendChild(btnPlay);
 }
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2470,9 +2470,10 @@ async function initWebAudioAPI(_url) {
  * @param {string} _url 
  */
 function setAudio(_url) {
-	const isIOS = g_userAgent.indexOf(`iPhone`) >= 0
-		|| g_userAgent.indexOf(`iPad`) >= 0
-		|| g_userAgent.indexOf(`iPod`) >= 0;
+	const ua = navigator.userAgent;
+	const isIOS = ua.indexOf(`iPhone`) >= 0
+		|| ua.indexOf(`iPad`) >= 0
+		|| ua.indexOf(`iPod`) >= 0;
 
 	if (g_musicEncodedFlg) {
 		loadScript(_url, _ => {
@@ -2484,39 +2485,31 @@ function setAudio(_url) {
 				musicAfterLoaded();
 			}
 		});
+
 	} else if (isIOS) {
-		makeUrlButton(_url => {
+		const btnPlay = createCssButton({
+			id: `btnPlay`,
+			name: `PLAY!`,
+			x: g_sWidth * 2 / 3,
+			y: g_sHeight - 100,
+			width: g_sWidth / 3,
+			height: C_BTN_HEIGHT,
+			fontsize: C_LBL_BTNSIZE,
+			align: C_ALIGN_CENTER,
+			class: g_cssObj.button_Next,
+		}, _ => {
 			g_audio.src = _url;
 			musicAfterLoaded();
 		});
+		divRoot.appendChild(btnPlay);
+
 	} else if (location.href.match(`^file`)) {
 		g_audio.src = _url;
 		musicAfterLoaded();
+
 	} else {
 		initWebAudioAPI(_url);
 	}
-}
-
-/**
- * プレイ続行ボタンの作成
- * @param {function} _func 
- */
-function makePlayButton(_func) {
-	// 進むボタン描画
-	const btnPlay = createCssButton({
-		id: `btnPlay`,
-		name: `PLAY!`,
-		x: g_sWidth * 2 / 3,
-		y: g_sHeight - 100,
-		width: g_sWidth / 3,
-		height: C_BTN_HEIGHT,
-		fontsize: C_LBL_BTNSIZE,
-		align: C_ALIGN_CENTER,
-		class: g_cssObj.button_Next,
-	}, _ => {
-		func();
-	});
-	document.querySelector(`#divRoot`).appendChild(btnPlay);
 }
 
 /**


### PR DESCRIPTION
## 変更内容
1. iOSの場合にロードで止まってしまう問題を一部修正しました。
iOSの場合は、ロード画面でPLAYボタンを押すとプレイできます。
2. iOSの場合にAppearanceが動作しない問題を修正しました。

## 変更理由
1. iOSの場合に再生ができない問題が発生していたため。
2. Safariの場合、CSSの`clip-path`が未対応のため。
代替として、ベンダープリフィックスをつけた`-webkit-clip-path`を利用しています。

## その他コメント
- base64エンコードされたデータには対応していません。
HTML5のAudio機能にて代替しています。
