### PR TITLE
[0107-skin-divback] skinTypeがdefault以外の場合、背景オブジェクトを作成するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2255,7 +2255,7 @@ function initAfterDosLoaded() {
 	if (document.querySelector(`#layer0`) === null) {
 		document.querySelector(`#divRoot`).removeChild(document.querySelector(`#divBack`));
 		createSprite(`divRoot`, `divBack`, 0, 0, g_sWidth, g_sHeight);
-	} else if (g_headerObj.skinType !== `default`) {
+	} else if (g_headerObj.skinType !== `default` && !g_headerObj.customBackUse) {
 		createSprite(`divRoot`, `divBack`, 0, 0, g_sWidth, g_sHeight);
 	}
 
@@ -2501,14 +2501,15 @@ function drawDefaultBackImage(_key) {
 
 		// 画面背景を指定 (background-color)
 		const grd = l0ctx.createLinearGradient(0, 0, 0, g_sHeight);
-		if (!g_headerObj[`customBack${_key}Use`] || !g_headerObj[`customBack${_key}Use`]) {
+		if (!g_headerObj[`customBack${_key}Use`]) {
 			grd.addColorStop(0, `#000000`);
 			grd.addColorStop(1, `#222222`);
 			l0ctx.fillStyle = grd;
 			l0ctx.fillRect(0, 0, g_sWidth, g_sHeight);
-		}
-		if (g_headerObj.skinType !== `default`) {
-			createSprite(`divRoot`, `divBack`, 0, 0, g_sWidth, g_sHeight);
+
+			if (g_headerObj.skinType !== `default`) {
+				createSprite(`divRoot`, `divBack`, 0, 0, g_sWidth, g_sHeight);
+			}
 		}
 	} else {
 		createSprite(`divRoot`, `divBack`, 0, 0, g_sWidth, g_sHeight);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2255,6 +2255,8 @@ function initAfterDosLoaded() {
 	if (document.querySelector(`#layer0`) === null) {
 		document.querySelector(`#divRoot`).removeChild(document.querySelector(`#divBack`));
 		createSprite(`divRoot`, `divBack`, 0, 0, g_sWidth, g_sHeight);
+	} else if (g_headerObj.skinType !== `default`) {
+		createSprite(`divRoot`, `divBack`, 0, 0, g_sWidth, g_sHeight);
 	}
 
 	// CSSファイルの読み込み
@@ -2504,6 +2506,9 @@ function drawDefaultBackImage(_key) {
 			grd.addColorStop(1, `#222222`);
 			l0ctx.fillStyle = grd;
 			l0ctx.fillRect(0, 0, g_sWidth, g_sHeight);
+		}
+		if (g_headerObj.skinType !== `default`) {
+			createSprite(`divRoot`, `divBack`, 0, 0, g_sWidth, g_sHeight);
 		}
 	} else {
 		createSprite(`divRoot`, `divBack`, 0, 0, g_sWidth, g_sHeight);


### PR DESCRIPTION
## 変更内容
1. skinTypeがdefault以外の場合、背景オブジェクト(divback)を作成するよう変更しました。
背景オブジェクトに背景色が設定されていた場合、Canvas上の背景情報は無視されます。

## 変更理由
1. v9まででCanvasタグを使っていることが多く、後から削除するのが容易ではないため。

## その他コメント

