### PR TITLE
[0109-ios-webaudioapi] MacOS/iOSにおける動作不具合を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5953,8 +5953,13 @@ function loadingScoreInit2() {
 		}
 	}
 
-	clearWindow();
-	MainInit();
+	const tempId = setInterval(() => {
+		if (g_audio.duration !== undefined) {
+			clearInterval(tempId);
+			clearWindow();
+			MainInit();
+		}
+	}, 0.5);
 }
 
 /**
@@ -8754,9 +8759,6 @@ function MainInit() {
 
 		// 曲終了判定
 		if (g_scoreObj.frameNum >= fullFrame) {
-			if (g_scoreObj.fadeOutFrame === Infinity && isNaN(parseInt(g_headerObj.endFrame))) {
-				g_audio.pause();
-			}
 			if (g_stateObj.lifeMode === C_LFE_BORDER && g_workObj.lifeVal < g_workObj.lifeBorder) {
 				g_gameOverFlg = true;
 			}
@@ -9881,7 +9883,6 @@ function resultInit() {
 			if (tmpVolume < 0) {
 				g_audio.volume = 0;
 				clearTimeout(g_timeoutEvtId);
-				g_audio.pause();
 			} else {
 				g_audio.volume = tmpVolume;
 			}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1858,6 +1858,7 @@ function loadScript(_url, _callback, _requiredFlg = true, _charset = `UTF-8`) {
 // WebAudioAPIでAudio要素風に再生するクラス
 class AudioPlayer {
 	constructor() {
+		const AudioContext = window.AudioContext || window.webkitAudioContext;
 		this._context = new AudioContext();
 		this._gain = this._context.createGain();
 		this._gain.connect(this._context.destination);
@@ -2481,11 +2482,25 @@ function setAudio(_url) {
 	if (g_musicEncodedFlg) {
 		loadScript(_url, _ => {
 			if (typeof musicInit === C_TYP_FUNCTION) {
-				if (isIOS) {
-					makeWarningWindow(C_MSG_E_0035);
-				}
 				musicInit();
-				initWebAudioAPI(`data:audio/mp3;base64,${g_musicdata}`);
+				if (isIOS) {
+					const btnPlay = createCssButton({
+						id: `btnPlay`,
+						name: `PLAY!`,
+						x: g_sWidth * 2 / 3,
+						y: g_sHeight - 100,
+						width: g_sWidth / 3,
+						height: C_BTN_HEIGHT,
+						fontsize: C_LBL_BTNSIZE,
+						align: C_ALIGN_CENTER,
+						class: g_cssObj.button_Next,
+					}, _ => {
+						initWebAudioAPI(`data:audio/mp3;base64,${g_musicdata}`);
+					});
+					divRoot.appendChild(btnPlay);
+				} else {
+					initWebAudioAPI(`data:audio/mp3;base64,${g_musicdata}`);
+				}
 			} else {
 				makeWarningWindow(C_MSG_E_0031);
 				musicAfterLoaded();
@@ -2504,8 +2519,12 @@ function setAudio(_url) {
 			align: C_ALIGN_CENTER,
 			class: g_cssObj.button_Next,
 		}, _ => {
-			g_audio.src = _url;
-			musicAfterLoaded();
+			if (location.href.match(`^file`)) {
+				g_audio.src = _url;
+				musicAfterLoaded();
+			} else {
+				initWebAudioAPI(_url);
+			}
 		});
 		divRoot.appendChild(btnPlay);
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9782,7 +9782,9 @@ function resultInit() {
 		class: g_cssObj.button_Back,
 	}, _ => {
 		// タイトル画面へ戻る
-		g_audio.pause();
+		if (g_finishFlg) {
+			g_audio.pause();
+		}
 		clearTimeout(g_timeoutEvtId);
 		clearTimeout(g_timeoutEvtResultId);
 		clearWindow();
@@ -9818,7 +9820,9 @@ function resultInit() {
 		animationName: `smallToNormalY`,
 		class: g_cssObj.button_Reset,
 	}, _ => {
-		g_audio.pause();
+		if (g_finishFlg) {
+			g_audio.pause();
+		}
 		clearTimeout(g_timeoutEvtId);
 		clearTimeout(g_timeoutEvtResultId);
 		clearWindow();

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2484,6 +2484,7 @@ function setAudio(_url) {
 			if (typeof musicInit === C_TYP_FUNCTION) {
 				musicInit();
 				if (isIOS) {
+					document.querySelector(`#lblLoading`).innerText = `Click to Start!`;
 					const btnPlay = createCssButton({
 						id: `btnPlay`,
 						name: `PLAY!`,
@@ -2495,6 +2496,7 @@ function setAudio(_url) {
 						align: C_ALIGN_CENTER,
 						class: g_cssObj.button_Next,
 					}, _ => {
+						divRoot.removeChild(btnPlay);
 						initWebAudioAPI(`data:audio/mp3;base64,${g_musicdata}`);
 					});
 					divRoot.appendChild(btnPlay);
@@ -2508,6 +2510,7 @@ function setAudio(_url) {
 		});
 
 	} else if (isIOS) {
+		document.querySelector(`#lblLoading`).innerText = `Click to Start!`;
 		const btnPlay = createCssButton({
 			id: `btnPlay`,
 			name: `PLAY!`,
@@ -2519,6 +2522,7 @@ function setAudio(_url) {
 			align: C_ALIGN_CENTER,
 			class: g_cssObj.button_Next,
 		}, _ => {
+			divRoot.removeChild(btnPlay);
 			if (location.href.match(`^file`)) {
 				g_audio.src = _url;
 				musicAfterLoaded();


### PR DESCRIPTION
## 変更内容
1. MacOS, iOS (Safari)においてWeb Audio APIが動作しない問題を修正しました。
2. iOS (iPod, iPhone, iPad)において音量が調整できない問題を修正しました。

## 変更理由
1, 2. MacOS/iOS (Safari)における動作不良のため。

## その他コメント
- Safariでは Web Audio API がベンダープレフィックス必須となっており、
Chromeで使用されている`AudioContext`が使用できず、
`webkitAudioContext`を使用する必要がありました。
- また、すでに曲が止まっている状態（一度`g_audio.pause()`を実行）で再度`g_audio.pause()`を行うとSafariでは止まる問題があったため、以下の対処を行っています。
  - 楽曲終了まで到達した場合の`g_audio.pause()`を除去
  - 楽曲途中で終了した場合の「Back」「Retry」ボタンによる`g_audio.pause()`を除去
