### PR TITLE
[0117-fix-difselector-width] 譜面選択リストの長さ間違いを修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3895,7 +3895,7 @@ function makeDifLblCssButton(_id, _name, _heightPos, _func) {
 		name: _name,
 		x: 0,
 		y: C_LEN_SETLBL_HEIGHT * _heightPos,
-		width: C_LEN_SETLBL_WIDTH,
+		width: C_LEN_DIFSELECTOR_WIDTH,
 		height: C_LEN_SETLBL_HEIGHT,
 		fontsize: C_SIZ_DIFSELECTOR,
 		align: C_ALIGN_CENTER,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -128,6 +128,7 @@ const C_BLOCK_KEYS = [
 /** 設定・オプション画面用共通 */
 const C_LEN_SETLBL_LEFT = 160;
 const C_LEN_SETLBL_WIDTH = 210;
+const C_LEN_DIFSELECTOR_WIDTH = 250;
 const C_LEN_SETLBL_HEIGHT = 23;
 const C_SIZ_SETLBL = 17;
 const C_LEN_SETDIFLBL_HEIGHT = 25;


### PR DESCRIPTION
## 変更内容
- 譜面選択リストの長さ間違いを修正しました。

## 変更理由
- 設定画面のボタンサイズを変えたことで影響した部分を修正するため。

## その他コメント

