### PR TITLE
[0119-resultdiff-rename(2)] リザルト画面のid重複を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8257,7 +8257,7 @@ function resultInit() {
 	if (display2Data !== ``) {
 		display2Data += ` : OFF`;
 	}
-	playDataWindow.appendChild(makeCssResultPlayData(`lblDisplayData`, 60, g_cssObj.result_style, 5,
+	playDataWindow.appendChild(makeCssResultPlayData(`lblDisplay2Data`, 60, g_cssObj.result_style, 5,
 		display2Data, C_ALIGN_CENTER));
 
 	/**


### PR DESCRIPTION
## 変更内容
- リザルト画面のId重複を修正しました。
プレイスタイルの2行目のIdが1行目と重複していました。

### 変更後
- lblDisplayData
- lblDisplay2Data

## 変更理由
- 先の #545 の修正漏れです。

## その他コメント

