### PR TITLE
[0120-hitpos-change] 矢印のヒット部分を押したタイミングに応じて変わるように変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7045,6 +7045,7 @@ function MainInit() {
 
 		// 移動
 		if (g_workObj.currentSpeed !== 0) {
+			arrow.setAttribute(`prevPosY`, parseFloat(arrow.style.top));
 			arrow.style.top = `${parseFloat(arrow.style.top) -
 				(g_workObj.currentSpeed + g_workObj.motionOnFrames[boostCnt]) * boostSpdDir}px`;
 			arrow.setAttribute(`boostCnt`, --boostCnt);
@@ -7735,10 +7736,11 @@ function judgeArrow(_j) {
 			const difFrame = Number(judgArrow.getAttribute(`cnt`));
 			const difCnt = Math.abs(judgArrow.getAttribute(`cnt`));
 			const judgEndFlg = judgArrow.getAttribute(`judgEndFlg`);
-			const dividePos = Number(judgArrow.getAttribute(`dividePos`));
-			const arrowSprite = document.querySelector(`#arrowSprite${dividePos}`);
+			const arrowSprite = document.querySelector(`#arrowSprite${judgArrow.getAttribute(`dividePos`)}`);
 
 			if (difCnt <= g_judgObj.arrowJ[C_JDG_UWAN] && judgEndFlg === `false`) {
+				stepDivHit.style.top = `${parseFloat(judgArrow.getAttribute(`prevPosY`)) -
+					parseFloat(document.querySelector(`#stepRoot${_j}`).style.top) - 15}px`;
 				stepDivHit.style.opacity = 0.75;
 				stepDivHit.classList.remove(g_cssObj.main_stepDefault, g_cssObj.main_stepDummy, g_cssObj.main_stepIi, g_cssObj.main_stepShakin, g_cssObj.main_stepMatari, g_cssObj.main_stepShobon);
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7037,7 +7037,6 @@ function MainInit() {
 	function movArrow(_j, _k, _name) {
 		const arrow = document.querySelector(`#${_name}${_j}_${_k}`);
 		let boostCnt = arrow.getAttribute(`boostCnt`);
-		const boostSpdDir = arrow.getAttribute(`boostSpd`);
 		let cnt = arrow.getAttribute(`cnt`);
 
 		// 全体色変化 (移動時)
@@ -7045,9 +7044,10 @@ function MainInit() {
 
 		// 移動
 		if (g_workObj.currentSpeed !== 0) {
-			arrow.setAttribute(`prevPosY`, parseFloat(arrow.style.top));
-			arrow.style.top = `${parseFloat(arrow.style.top) -
-				(g_workObj.currentSpeed + g_workObj.motionOnFrames[boostCnt]) * boostSpdDir}px`;
+			const currentY = parseFloat(arrow.style.top);
+			arrow.setAttribute(`prevPosY`, currentY);
+			arrow.style.top = `${currentY - (g_workObj.currentSpeed +
+				g_workObj.motionOnFrames[boostCnt]) * parseFloat(arrow.getAttribute(`boostSpd`))}px`;
 			arrow.setAttribute(`boostCnt`, --boostCnt);
 		}
 		arrow.setAttribute(`cnt`, --cnt);


### PR DESCRIPTION
## 変更内容
- 矢印のヒット部分を押したタイミングに応じて変わるように変更しました。
常時ステップゾーンの真上だったものから変更しています。

## 変更理由
- 押したタイミングによって位置補正されてしまい、ズレがわかりにくくなるため。
最初期のソース仕様に近い状態になっています。

## その他コメント