### PR TITLE
[0125-display-extensions] Displayの拡張設定を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7455,24 +7455,17 @@ function MainInit() {
 		}
 
 		// 判定キャラクタ消去
-		let charaJCnt = document.querySelector(`#charaJ`).getAttribute(`cnt`);
-		if (charaJCnt > 0) {
-			document.querySelector(`#charaJ`).setAttribute(`cnt`, --charaJCnt);
-			if (charaJCnt === 0) {
-				document.querySelector(`#charaJ`).innerHTML = ``;
-				document.querySelector(`#comboJ`).innerHTML = ``;
-				document.querySelector(`#diffJ`).innerHTML = ``;
+		jdgGroups.forEach(jdg => {
+			let charaJCnt = document.querySelector(`#chara${jdg}`).getAttribute(`cnt`);
+			if (charaJCnt > 0) {
+				document.querySelector(`#chara${jdg}`).setAttribute(`cnt`, --charaJCnt);
+				if (charaJCnt === 0) {
+					document.querySelector(`#chara${jdg}`).innerHTML = ``;
+					document.querySelector(`#combo${jdg}`).innerHTML = ``;
+					document.querySelector(`#diff${jdg}`).innerHTML = ``;
+				}
 			}
-		}
-		let charaFJCnt = document.querySelector(`#charaFJ`).getAttribute(`cnt`);
-		if (charaFJCnt > 0) {
-			document.querySelector(`#charaFJ`).setAttribute(`cnt`, --charaFJCnt);
-			if (charaFJCnt === 0) {
-				document.querySelector(`#charaFJ`).innerHTML = ``;
-				document.querySelector(`#comboFJ`).innerHTML = ``;
-				document.querySelector(`#diffFJ`).innerHTML = ``;
-			}
-		}
+		});
 
 		// 曲終了判定
 		if (g_scoreObj.frameNum >= fullFrame) {
@@ -7744,8 +7737,7 @@ function judgeArrow(_j) {
 					stepDivHit.classList.add(g_cssObj.main_stepShobon);
 				}
 				stepDivHit.setAttribute(`cnt`, C_FRM_HITMOTION);
-				document.querySelector(`#diffJ`).innerHTML = `<span class="common_${difFrame === 0 ? 'combo' : (difFrame > 0 ? 'ii' : 'matari')}">
-					${difFrame === 0 ? 'Just!!' : ((difFrame > 0 ? `Slow ${difCnt} Frame` : `Fast ${difCnt} Frame`))}</span>`;
+				document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
 
 				arrowSprite.removeChild(judgArrow);
 				g_workObj.judgArrowCnt[_j]++;
@@ -7776,9 +7768,7 @@ function judgeArrow(_j) {
 						}
 						g_workObj.judgFrzHitCnt[_j] = fcurrentNo + 1;
 					}
-					document.querySelector(`#diffJ`).innerHTML = `<span class="common_${difFrame === 0 ? 'combo' : (difFrame > 0 ? 'ii' : 'matari')}">
-						${difFrame === 0 ? 'Just!!' : ((difFrame > 0 ? `Slow ${difCnt} Frame` : `Fast ${difCnt} Frame`))}
-					</span>`;
+					document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
 				}
 				changeHitFrz(_j, fcurrentNo, `frz`);
 				g_judgObj.lockFlgs[_j] = false;
@@ -7789,6 +7779,16 @@ function judgeArrow(_j) {
 		stepDiv.style.display = `inherit`;
 		g_judgObj.lockFlgs[_j] = false;
 	}
+}
+
+/**
+ * タイミングズレを表示
+ * @param {number} _difFrame 
+ * @param {number} _difCnt 
+ */
+function displayDiff(_difFrame, _difCnt) {
+	return `<span class="common_${_difFrame === 0 ? 'combo' : (_difFrame > 0 ? 'ii' : 'matari')}">
+		${_difFrame === 0 ? 'Just!!' : ((_difFrame > 0 ? `Slow ${_difCnt} Frame` : `Fast ${_difCnt} Frame`))}</span>`;
 }
 
 function lifeRecovery() {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7782,8 +7782,8 @@ function judgeArrow(_j) {
  * @param {number} _difCnt 
  */
 function displayDiff(_difFrame, _difCnt) {
-	return `<span class="common_${_difFrame === 0 ? 'combo' : (_difFrame > 0 ? 'ii' : 'matari')}">
-		${_difFrame === 0 ? 'Just!!' : ((_difFrame > 0 ? `Slow ${_difCnt} Frame` : `Fast ${_difCnt} Frame`))}</span>`;
+	return `<span class="common_${_difFrame === 0 ? 'combo' : (_difFrame > 0 ? 'matari' : 'shobon')}">
+		${_difFrame === 0 ? 'Just!!' : ((_difFrame > 0 ? `Fast ${_difCnt} Frame` : `Slow ${_difCnt} Frame`))}</span>`;
 }
 
 function lifeRecovery() {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6506,23 +6506,15 @@ function MainInit() {
 
 	// 判定系OFF設定
 	if (g_stateObj.d_judgement === C_FLG_OFF) {
-		document.querySelector(`#lblIi`).style.display = C_DIS_NONE;
-		document.querySelector(`#lblShakin`).style.display = C_DIS_NONE;
-		document.querySelector(`#lblMatari`).style.display = C_DIS_NONE;
-		document.querySelector(`#lblShobon`).style.display = C_DIS_NONE;
-		document.querySelector(`#lblUwan`).style.display = C_DIS_NONE;
-		document.querySelector(`#lblMCombo`).style.display = C_DIS_NONE;
-
-		document.querySelector(`#lblKita`).style.display = C_DIS_NONE;
-		document.querySelector(`#lblIknai`).style.display = C_DIS_NONE;
-		document.querySelector(`#lblFCombo`).style.display = C_DIS_NONE;
-
-		document.querySelector(`#comboJ`).style.display = C_DIS_NONE;
-		document.querySelector(`#charaJ`).style.display = C_DIS_NONE;
-		document.querySelector(`#diffJ`).style.display = C_DIS_NONE;
-		document.querySelector(`#comboFJ`).style.display = C_DIS_NONE;
-		document.querySelector(`#charaFJ`).style.display = C_DIS_NONE;
-		document.querySelector(`#diffFJ`).style.display = C_DIS_NONE;
+		const hideObjs = [
+			`Ii`, `Shakin`, `Matari`, `Shobon`, `Uwan`, `MCombo`, `Kita`, `Iknai`, `FCombo`
+		];
+		hideObjs.forEach(hideObj => {
+			document.querySelector(`#lbl${hideObj}`).style.display = C_DIS_NONE;
+		});
+		jdgGroups.forEach(jdg => {
+			document.querySelector(`#diff${jdg}`).style.display = C_DIS_NONE;
+		});
 	}
 
 	// 曲情報OFF
@@ -7955,8 +7947,10 @@ function makeFinishView(_text) {
 	document.querySelector(`#finishView`).style.opacity = 1;
 	document.querySelector(`#charaJ`).innerHTML = ``;
 	document.querySelector(`#comboJ`).innerHTML = ``;
+	document.querySelector(`#diffJ`).innerHTML = ``;
 	document.querySelector(`#charaFJ`).innerHTML = ``;
 	document.querySelector(`#comboFJ`).innerHTML = ``;
+	document.querySelector(`#diffFJ`).innerHTML = ``;
 }
 
 function finishViewing() {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6545,7 +6545,7 @@ function MainInit() {
 		judgeSprite.appendChild(comboJ);
 
 		// Fast/Slow表示
-		const diffJ = createDivCssLabel(`diff${jdg}`, jdgX[j], jdgY[j] + 25,
+		const diffJ = createDivCssLabel(`diff${jdg}`, jdgX[j] + 150, jdgY[j] + 25,
 			C_LEN_JDGCHARA_WIDTH, C_LEN_JDGCHARA_HEIGHT, 14, ``, g_cssObj.common_combo);
 		diffJ.style.textAlign = C_ALIGN_CENTER;
 		judgeSprite.appendChild(diffJ);
@@ -7726,9 +7726,11 @@ function judgeArrow(_j) {
 				if (difCnt <= g_judgObj.arrowJ[C_JDG_II]) {
 					judgeIi(difFrame);
 					stepDivHit.classList.add(g_cssObj.main_stepIi);
+					document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
 				} else if (difCnt <= g_judgObj.arrowJ[C_JDG_SHAKIN]) {
 					judgeShakin(difFrame);
 					stepDivHit.classList.add(g_cssObj.main_stepShakin);
+					document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
 				} else if (difCnt <= g_judgObj.arrowJ[C_JDG_MATARI]) {
 					judgeMatari(difFrame);
 					stepDivHit.classList.add(g_cssObj.main_stepMatari);
@@ -7737,7 +7739,6 @@ function judgeArrow(_j) {
 					stepDivHit.classList.add(g_cssObj.main_stepShobon);
 				}
 				stepDivHit.setAttribute(`cnt`, C_FRM_HITMOTION);
-				document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
 
 				arrowSprite.removeChild(judgArrow);
 				g_workObj.judgArrowCnt[_j]++;
@@ -7758,9 +7759,11 @@ function judgeArrow(_j) {
 					const difFrame = Number(judgFrz.getAttribute(`cnt`));
 					if (g_workObj.judgFrzHitCnt[_j] === undefined || g_workObj.judgFrzHitCnt[_j] <= fcurrentNo) {
 						if (difCnt <= g_judgObj.arrowJ[C_JDG_II]) {
-							judgeIi(difCnt);
+							judgeIi(difFrame);
+							document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
 						} else if (difCnt <= g_judgObj.arrowJ[C_JDG_SHAKIN]) {
 							judgeShakin(difCnt);
+							document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
 						} else if (difCnt <= g_judgObj.arrowJ[C_JDG_MATARI]) {
 							judgeMatari(difCnt);
 						} else {
@@ -7768,7 +7771,6 @@ function judgeArrow(_j) {
 						}
 						g_workObj.judgFrzHitCnt[_j] = fcurrentNo + 1;
 					}
-					document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
 				}
 				changeHitFrz(_j, fcurrentNo, `frz`);
 				g_judgObj.lockFlgs[_j] = false;
@@ -7912,6 +7914,7 @@ function judgeShakin(difFrame) {
 function judgeMatari(difFrame) {
 	changeJudgeCharacter(`matari`, C_JCR_MATARI);
 	document.querySelector(`#comboJ`).innerHTML = ``;
+	document.querySelector(`#diffJ`).innerHTML = ``;
 
 	finishViewing();
 
@@ -7931,6 +7934,7 @@ function judgeShobon(difFrame) {
 	changeJudgeCharacter(`shobon`, C_JCR_SHOBON);
 	g_resultObj.combo = 0;
 	document.querySelector(`#comboJ`).innerHTML = ``;
+	document.querySelector(`#diffJ`).innerHTML = ``;
 
 	lifeDamage();
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7755,22 +7755,21 @@ function judgeArrow(_j) {
 			const judgEndFlg = judgFrz.getAttribute(`judgEndFlg`);
 
 			if (difCnt <= g_judgObj.frzJ[C_JDG_SFSF] && judgEndFlg === `false`) {
-				if (g_headerObj.frzStartjdgUse) {
+				if (g_headerObj.frzStartjdgUse &&
+					(g_workObj.judgFrzHitCnt[_j] === undefined || g_workObj.judgFrzHitCnt[_j] <= fcurrentNo)) {
 					const difFrame = Number(judgFrz.getAttribute(`cnt`));
-					if (g_workObj.judgFrzHitCnt[_j] === undefined || g_workObj.judgFrzHitCnt[_j] <= fcurrentNo) {
-						if (difCnt <= g_judgObj.arrowJ[C_JDG_II]) {
-							judgeIi(difFrame);
-							document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
-						} else if (difCnt <= g_judgObj.arrowJ[C_JDG_SHAKIN]) {
-							judgeShakin(difCnt);
-							document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
-						} else if (difCnt <= g_judgObj.arrowJ[C_JDG_MATARI]) {
-							judgeMatari(difCnt);
-						} else {
-							judgeShobon(difCnt);
-						}
-						g_workObj.judgFrzHitCnt[_j] = fcurrentNo + 1;
+					if (difCnt <= g_judgObj.arrowJ[C_JDG_II]) {
+						judgeIi(difFrame);
+						document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
+					} else if (difCnt <= g_judgObj.arrowJ[C_JDG_SHAKIN]) {
+						judgeShakin(difCnt);
+						document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
+					} else if (difCnt <= g_judgObj.arrowJ[C_JDG_MATARI]) {
+						judgeMatari(difCnt);
+					} else {
+						judgeShobon(difCnt);
 					}
+					g_workObj.judgFrzHitCnt[_j] = fcurrentNo + 1;
 				}
 				changeHitFrz(_j, fcurrentNo, `frz`);
 				g_judgObj.lockFlgs[_j] = false;
@@ -7927,16 +7926,22 @@ function judgeMatari(difFrame) {
 }
 
 /**
+ * ダメージ系共通処理
+ */
+function judgeDamage() {
+	g_resultObj.combo = 0;
+	document.querySelector(`#comboJ`).innerHTML = ``;
+	document.querySelector(`#diffJ`).innerHTML = ``;
+	lifeDamage();
+}
+
+/**
  * 判定処理：ショボーン
  * @param {number} difFrame 
  */
 function judgeShobon(difFrame) {
 	changeJudgeCharacter(`shobon`, C_JCR_SHOBON);
-	g_resultObj.combo = 0;
-	document.querySelector(`#comboJ`).innerHTML = ``;
-	document.querySelector(`#diffJ`).innerHTML = ``;
-
-	lifeDamage();
+	judgeDamage();
 
 	if (typeof customJudgeShobon === C_TYP_FUNCTION) {
 		customJudgeShobon(difFrame);
@@ -7952,11 +7957,7 @@ function judgeShobon(difFrame) {
  */
 function judgeUwan(difFrame) {
 	changeJudgeCharacter(`uwan`, C_JCR_UWAN);
-	g_resultObj.combo = 0;
-	document.querySelector(`#comboJ`).innerHTML = ``;
-	document.querySelector(`#diffJ`).innerHTML = ``;
-
-	lifeDamage();
+	judgeDamage();
 
 	if (typeof customJudgeUwan === C_TYP_FUNCTION) {
 		customJudgeUwan(difFrame);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2412,6 +2412,10 @@ function headerConvert(_dosObj) {
 	g_distY = g_sHeight - g_stepY + g_stepYR;
 	g_reverseStepY = g_distY - g_stepY - C_ARW_WIDTH;
 
+	// 矢印・フリーズアロー判定位置補正
+	g_diffObj.arrowJdgY = (isNaN(parseFloat(_dosObj.arrowJdgY)) ? 0 : parseFloat(_dosObj.arrowJdgY));
+	g_diffObj.frzJdgY = (isNaN(parseFloat(_dosObj.frzJdgY)) ? 0 : parseFloat(_dosObj.frzJdgY));
+
 	// musicフォルダ設定
 	obj.musicFolder = setVal(_dosObj.musicFolder, `music`, C_TYP_STRING);
 
@@ -6521,28 +6525,28 @@ function MainInit() {
 	infoSprite.appendChild(lblTime2);
 
 	// 判定キャラクタ表示：矢印
-	const charaJ = createDivCssLabel(`charaJ`, g_sWidth / 2 - 200, g_sHeight / 2 - 50,
+	const charaJ = createDivCssLabel(`charaJ`, g_sWidth / 2 - 200, g_sHeight / 2 - 50 + g_diffObj.arrowJdgY,
 		C_LEN_JDGCHARA_WIDTH, C_LEN_JDGCHARA_HEIGHT, C_SIZ_JDGCHARA, ``, g_cssObj.common_ii);
 	charaJ.style.textAlign = C_ALIGN_CENTER;
 	charaJ.setAttribute(`cnt`, 0);
 	judgeSprite.appendChild(charaJ);
 
 	// コンボ表示：矢印
-	const comboJ = createDivCssLabel(`comboJ`, g_sWidth / 2 - 50, g_sHeight / 2 - 50,
+	const comboJ = createDivCssLabel(`comboJ`, g_sWidth / 2 - 50, g_sHeight / 2 - 50 + g_diffObj.arrowJdgY,
 		C_LEN_JDGCHARA_WIDTH, C_LEN_JDGCHARA_HEIGHT, C_SIZ_JDGCHARA, ``, g_cssObj.common_kita);
 	comboJ.style.textAlign = C_ALIGN_CENTER;
 	comboJ.setAttribute(`cnt`, 0);
 	judgeSprite.appendChild(comboJ);
 
 	// 判定キャラクタ表示：フリーズアロー
-	const charaFJ = createDivCssLabel(`charaFJ`, g_sWidth / 2 - 100, g_sHeight / 2,
+	const charaFJ = createDivCssLabel(`charaFJ`, g_sWidth / 2 - 100, g_sHeight / 2 + g_diffObj.frzJdgY,
 		C_LEN_JDGCHARA_WIDTH, C_LEN_JDGCHARA_HEIGHT, C_SIZ_JDGCHARA, ``, g_cssObj.common_kita);
 	charaFJ.style.textAlign = C_ALIGN_CENTER;
 	charaFJ.setAttribute(`cnt`, 0);
 	judgeSprite.appendChild(charaFJ);
 
 	// コンボ表示：フリーズアロー
-	const comboFJ = createDivCssLabel(`comboFJ`, g_sWidth / 2 + 50, g_sHeight / 2,
+	const comboFJ = createDivCssLabel(`comboFJ`, g_sWidth / 2 + 50, g_sHeight / 2 + g_diffObj.frzJdgY,
 		C_LEN_JDGCHARA_WIDTH, C_LEN_JDGCHARA_HEIGHT, C_SIZ_JDGCHARA, ``, g_cssObj.common_ii);
 	comboFJ.style.textAlign = C_ALIGN_CENTER;
 	comboFJ.setAttribute(`cnt`, 0);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3990,7 +3990,7 @@ function createSettingsDisplayWindow(_sprite) {
 
 		const flg = g_stateObj[`d_${_name.toLowerCase()}`];
 
-		if (g_stateObj[`d_${_name.toLowerCase()}`] === C_FLG_ON) {
+		if (g_headerObj[`${_name}Use`]) {
 			const lnk = makeSettingLblCssButton(`lnk${_name}`, `${toCapitalize(_name)}`, _heightPos, _ => {
 				g_stateObj[`d_${_name.toLowerCase()}`] = (g_stateObj[`d_${_name.toLowerCase()}`] === C_FLG_OFF ? C_FLG_ON : C_FLG_OFF);
 				if (g_stateObj[`d_${_name.toLowerCase()}`] === C_FLG_OFF) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2410,6 +2410,7 @@ function headerConvert(_dosObj) {
 	g_stepY = (isNaN(parseFloat(_dosObj.stepY)) ? C_STEP_Y : parseFloat(_dosObj.stepY));
 	g_stepYR = (isNaN(parseFloat(_dosObj.stepYR)) ? C_STEP_YR : parseFloat(_dosObj.stepYR));
 	g_distY = g_sHeight - g_stepY + g_stepYR;
+	g_reverseStepY = g_distY - g_stepY - C_ARW_WIDTH;
 
 	// musicフォルダ設定
 	obj.musicFolder = setVal(_dosObj.musicFolder, `music`, C_TYP_STRING);
@@ -6233,7 +6234,7 @@ function MainInit() {
 
 		const stepRoot = createSprite(`mainSprite`, `stepRoot${j}`,
 			g_workObj.stepX[j],
-			g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j],
+			g_stepY + g_reverseStepY * g_workObj.dividePos[j],
 			C_ARW_WIDTH, C_ARW_WIDTH);
 
 		// 矢印の内側を塗りつぶすか否か
@@ -6287,13 +6288,13 @@ function MainInit() {
 
 		// ステップゾーンの代わり
 		const stepBar0 = createColorObject(`stepBar`, ``,
-			0, g_stepY + (g_distY - g_stepY - 50) * (g_stateObj.reverse === C_FLG_OFF ? 0 : 1),
+			0, g_stepY + g_reverseStepY * (g_stateObj.reverse === C_FLG_OFF ? 0 : 1),
 			g_sWidth - 50, 1, ``, `lifeBar`);
 		stepBar0.classList.add(g_cssObj.life_Failed);
 		mainSprite.appendChild(stepBar0);
 
 		const stepBar1 = createColorObject(`stepBar`, ``,
-			0, g_stepY + (g_distY - g_stepY - 50) * (g_stateObj.reverse === C_FLG_OFF ? 0 : 1) + C_ARW_WIDTH,
+			0, g_stepY + g_reverseStepY * (g_stateObj.reverse === C_FLG_OFF ? 0 : 1) + C_ARW_WIDTH,
 			g_sWidth - 50, 1, ``, `lifeBar`);
 		stepBar1.classList.add(g_cssObj.life_Failed);
 		mainSprite.appendChild(stepBar1);
@@ -6315,7 +6316,7 @@ function MainInit() {
 	// フリーズアローヒット部分
 	for (let j = 0; j < keyNum; j++) {
 		const frzHit = createSprite(`mainSprite`, `frzHit${j}`,
-			g_workObj.stepX[j], g_stepY + (g_distY - g_stepY - 50) * g_workObj.dividePos[j],
+			g_workObj.stepX[j], g_stepY + g_reverseStepY * g_workObj.dividePos[j],
 			C_ARW_WIDTH, C_ARW_WIDTH);
 		frzHit.style.opacity = 0;
 		if (isNaN(Number(g_workObj.arrowRtn[j]))) {
@@ -6974,7 +6975,7 @@ function MainInit() {
 
 		const stepRoot = createSprite(`arrowSprite${dividePos}`, `${_name}${_j}_${_arrowCnt}`,
 			g_workObj.stepX[_j],
-			g_stepY + (g_distY - g_stepY - 50) * dividePos + g_workObj.initY[g_scoreObj.frameNum] * boostSpdDir,
+			g_stepY + g_reverseStepY * dividePos + g_workObj.initY[g_scoreObj.frameNum] * boostSpdDir,
 			C_ARW_WIDTH, C_ARW_WIDTH);
 		stepRoot.setAttribute(`cnt`, g_workObj.arrivalFrame[g_scoreObj.frameNum] + 1);
 		stepRoot.setAttribute(`boostCnt`, g_workObj.motionFrame[g_scoreObj.frameNum]);
@@ -7049,8 +7050,8 @@ function MainInit() {
 
 		const frzRoot = createSprite(`arrowSprite${dividePos}`, `${_name}${_j}_${_arrowCnt}`,
 			g_workObj.stepX[_j],
-			g_stepY + (g_distY - g_stepY - 50) * dividePos + g_workObj.initY[g_scoreObj.frameNum] * boostSpdDir,
-			50, 100 + frzLength);
+			g_stepY + g_reverseStepY * dividePos + g_workObj.initY[g_scoreObj.frameNum] * boostSpdDir,
+			C_ARW_WIDTH, C_ARW_WIDTH + frzLength);
 		frzRoot.setAttribute(`cnt`, g_workObj.arrivalFrame[g_scoreObj.frameNum] + 1);
 		frzRoot.setAttribute(`boostCnt`, g_workObj.motionFrame[g_scoreObj.frameNum]);
 		frzRoot.setAttribute(`judgEndFlg`, `false`);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6524,33 +6524,32 @@ function MainInit() {
 	lblTime1.style.textAlign = C_ALIGN_RIGHT;
 	infoSprite.appendChild(lblTime2);
 
-	// 判定キャラクタ表示：矢印
-	const charaJ = createDivCssLabel(`charaJ`, g_sWidth / 2 - 200, g_sHeight / 2 - 50 + g_diffObj.arrowJdgY,
-		C_LEN_JDGCHARA_WIDTH, C_LEN_JDGCHARA_HEIGHT, C_SIZ_JDGCHARA, ``, g_cssObj.common_ii);
-	charaJ.style.textAlign = C_ALIGN_CENTER;
-	charaJ.setAttribute(`cnt`, 0);
-	judgeSprite.appendChild(charaJ);
+	const jdgGroups = [`J`, `FJ`];
+	const jdgX = [g_sWidth / 2 - 200, g_sWidth / 2 - 100];
+	const jdgY = [g_sHeight / 2 - 60 + g_diffObj.arrowJdgY, g_sHeight / 2 + 10 + g_diffObj.frzJdgY];
+	const jdgCombos = [`kita`, `ii`];
 
-	// コンボ表示：矢印
-	const comboJ = createDivCssLabel(`comboJ`, g_sWidth / 2 - 50, g_sHeight / 2 - 50 + g_diffObj.arrowJdgY,
-		C_LEN_JDGCHARA_WIDTH, C_LEN_JDGCHARA_HEIGHT, C_SIZ_JDGCHARA, ``, g_cssObj.common_kita);
-	comboJ.style.textAlign = C_ALIGN_CENTER;
-	comboJ.setAttribute(`cnt`, 0);
-	judgeSprite.appendChild(comboJ);
+	jdgGroups.forEach((jdg, j) => {
 
-	// 判定キャラクタ表示：フリーズアロー
-	const charaFJ = createDivCssLabel(`charaFJ`, g_sWidth / 2 - 100, g_sHeight / 2 + g_diffObj.frzJdgY,
-		C_LEN_JDGCHARA_WIDTH, C_LEN_JDGCHARA_HEIGHT, C_SIZ_JDGCHARA, ``, g_cssObj.common_kita);
-	charaFJ.style.textAlign = C_ALIGN_CENTER;
-	charaFJ.setAttribute(`cnt`, 0);
-	judgeSprite.appendChild(charaFJ);
+		// キャラクタ表示
+		const charaJ = createDivCssLabel(`chara${jdg}`, jdgX[j], jdgY[j],
+			C_LEN_JDGCHARA_WIDTH, C_LEN_JDGCHARA_HEIGHT, C_SIZ_JDGCHARA, ``, g_cssObj.common_ii);
+		charaJ.style.textAlign = C_ALIGN_CENTER;
+		charaJ.setAttribute(`cnt`, 0);
+		judgeSprite.appendChild(charaJ);
 
-	// コンボ表示：フリーズアロー
-	const comboFJ = createDivCssLabel(`comboFJ`, g_sWidth / 2 + 50, g_sHeight / 2 + g_diffObj.frzJdgY,
-		C_LEN_JDGCHARA_WIDTH, C_LEN_JDGCHARA_HEIGHT, C_SIZ_JDGCHARA, ``, g_cssObj.common_ii);
-	comboFJ.style.textAlign = C_ALIGN_CENTER;
-	comboFJ.setAttribute(`cnt`, 0);
-	judgeSprite.appendChild(comboFJ);
+		// コンボ表示
+		const comboJ = createDivCssLabel(`combo${jdg}`, jdgX[j] + 150, jdgY[j],
+			C_LEN_JDGCHARA_WIDTH, C_LEN_JDGCHARA_HEIGHT, C_SIZ_JDGCHARA, ``, g_cssObj[`common_${jdgCombos[j]}`]);
+		comboJ.style.textAlign = C_ALIGN_CENTER;
+		judgeSprite.appendChild(comboJ);
+
+		// Fast/Slow表示
+		const diffJ = createDivCssLabel(`diff${jdg}`, jdgX[j], jdgY[j] + 25,
+			C_LEN_JDGCHARA_WIDTH, C_LEN_JDGCHARA_HEIGHT, 14, ``, g_cssObj.common_combo);
+		diffJ.style.textAlign = C_ALIGN_CENTER;
+		judgeSprite.appendChild(diffJ);
+	});
 
 	// パーフェクト演出
 	const finishView = createDivCssLabel(`finishView`, g_sWidth / 2 - 150, g_sHeight / 2 - 50,
@@ -6573,8 +6572,10 @@ function MainInit() {
 
 		document.querySelector(`#comboJ`).style.display = C_DIS_NONE;
 		document.querySelector(`#charaJ`).style.display = C_DIS_NONE;
+		document.querySelector(`#diffJ`).style.display = C_DIS_NONE;
 		document.querySelector(`#comboFJ`).style.display = C_DIS_NONE;
 		document.querySelector(`#charaFJ`).style.display = C_DIS_NONE;
+		document.querySelector(`#diffFJ`).style.display = C_DIS_NONE;
 	}
 
 	// 曲情報OFF
@@ -7460,6 +7461,7 @@ function MainInit() {
 			if (charaJCnt === 0) {
 				document.querySelector(`#charaJ`).innerHTML = ``;
 				document.querySelector(`#comboJ`).innerHTML = ``;
+				document.querySelector(`#diffJ`).innerHTML = ``;
 			}
 		}
 		let charaFJCnt = document.querySelector(`#charaFJ`).getAttribute(`cnt`);
@@ -7468,6 +7470,7 @@ function MainInit() {
 			if (charaFJCnt === 0) {
 				document.querySelector(`#charaFJ`).innerHTML = ``;
 				document.querySelector(`#comboFJ`).innerHTML = ``;
+				document.querySelector(`#diffFJ`).innerHTML = ``;
 			}
 		}
 
@@ -7741,6 +7744,8 @@ function judgeArrow(_j) {
 					stepDivHit.classList.add(g_cssObj.main_stepShobon);
 				}
 				stepDivHit.setAttribute(`cnt`, C_FRM_HITMOTION);
+				document.querySelector(`#diffJ`).innerHTML = `<span class="common_${difFrame === 0 ? 'combo' : (difFrame > 0 ? 'ii' : 'matari')}">
+					${difFrame === 0 ? 'Just!!' : ((difFrame > 0 ? `Slow ${difCnt} Frame` : `Fast ${difCnt} Frame`))}</span>`;
 
 				arrowSprite.removeChild(judgArrow);
 				g_workObj.judgArrowCnt[_j]++;
@@ -7758,6 +7763,7 @@ function judgeArrow(_j) {
 
 			if (difCnt <= g_judgObj.frzJ[C_JDG_SFSF] && judgEndFlg === `false`) {
 				if (g_headerObj.frzStartjdgUse) {
+					const difFrame = Number(judgFrz.getAttribute(`cnt`));
 					if (g_workObj.judgFrzHitCnt[_j] === undefined || g_workObj.judgFrzHitCnt[_j] <= fcurrentNo) {
 						if (difCnt <= g_judgObj.arrowJ[C_JDG_II]) {
 							judgeIi(difCnt);
@@ -7770,6 +7776,9 @@ function judgeArrow(_j) {
 						}
 						g_workObj.judgFrzHitCnt[_j] = fcurrentNo + 1;
 					}
+					document.querySelector(`#diffJ`).innerHTML = `<span class="common_${difFrame === 0 ? 'combo' : (difFrame > 0 ? 'ii' : 'matari')}">
+						${difFrame === 0 ? 'Just!!' : ((difFrame > 0 ? `Slow ${difCnt} Frame` : `Fast ${difCnt} Frame`))}
+					</span>`;
 				}
 				changeHitFrz(_j, fcurrentNo, `frz`);
 				g_judgObj.lockFlgs[_j] = false;
@@ -7941,6 +7950,7 @@ function judgeUwan(difFrame) {
 	changeJudgeCharacter(`uwan`, C_JCR_UWAN);
 	g_resultObj.combo = 0;
 	document.querySelector(`#comboJ`).innerHTML = ``;
+	document.querySelector(`#diffJ`).innerHTML = ``;
 
 	lifeDamage();
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2488,12 +2488,17 @@ function headerConvert(_dosObj) {
 	obj.makerView = setVal(_dosObj.makerView, false, C_TYP_BOOLEAN);
 
 	// オプション利用可否設定
-	const usingOptions = [`motion`, `scroll`, `shuffle`, `autoPlay`, `gauge`, `appearance`];
+	let usingOptions = [`motion`, `scroll`, `shuffle`, `autoPlay`, `gauge`, `appearance`];
+	usingOptions = usingOptions.concat(g_displays);
 
 	usingOptions.forEach(option => {
 		obj[`${option}Use`] = setVal(_dosObj[`${option}Use`],
 			(typeof g_presetSettingUse === C_TYP_OBJECT ?
 				setVal(g_presetSettingUse[option], true, C_TYP_BOOLEAN) : true), C_TYP_BOOLEAN);
+	});
+
+	g_displays.forEach(option => {
+		g_stateObj[`d_${option.toLowerCase()}`] = (obj[`${option}Use`] ? C_FLG_ON : C_FLG_OFF);
 	});
 
 	// 別キーパターンの使用有無
@@ -3966,15 +3971,9 @@ function createSettingsDisplayWindow(_sprite) {
 		`[クリックでON/OFFを切替、灰色でOFF]`);
 	document.querySelector(`#${_sprite}`).appendChild(sdDesc);
 
-	makeDisplayButton(`stepZone`, 0, 0);
-	makeDisplayButton(`judgement`, 1, 0);
-	makeDisplayButton(`lifeGauge`, 2, 0);
-	makeDisplayButton(`musicInfo`, 3, 0);
-	makeDisplayButton(`speed`, 0, 1);
-	makeDisplayButton(`color`, 1, 1);
-	makeDisplayButton(`lyrics`, 2, 1);
-	makeDisplayButton(`background`, 3, 1);
-	makeDisplayButton(`arrowEffect`, 4, 1);
+	g_displays.forEach((name, j) => {
+		makeDisplayButton(name, j % 5, Math.floor(j / 5));
+	});
 
 	// ---------------------------------------------------
 	// 矢印の見え方 (Appearance)
@@ -3990,19 +3989,37 @@ function createSettingsDisplayWindow(_sprite) {
 	function makeDisplayButton(_name, _heightPos, _widthPos) {
 
 		const flg = g_stateObj[`d_${_name.toLowerCase()}`];
-		const lnk = makeSettingLblCssButton(`lnk${_name}`, `${toCapitalize(_name)}`, _heightPos, _ => {
-			g_stateObj[`d_${_name.toLowerCase()}`] = (g_stateObj[`d_${_name.toLowerCase()}`] === C_FLG_OFF ? C_FLG_ON : C_FLG_OFF);
-			if (g_stateObj[`d_${_name.toLowerCase()}`] === C_FLG_OFF) {
-				lnk.classList.replace(g_cssObj.button_ON, g_cssObj.button_OFF);
-			} else {
-				lnk.classList.replace(g_cssObj.button_OFF, g_cssObj.button_ON);
-			}
-		});
-		lnk.style.width = `170px`;
-		lnk.style.left = `calc(30px + 180px * ${_widthPos})`;
-		lnk.style.borderStyle = `solid`;
-		lnk.classList.add(`button_${flg}`);
-		displaySprite.appendChild(lnk);
+
+		if (g_stateObj[`d_${_name.toLowerCase()}`] === C_FLG_ON) {
+			const lnk = makeSettingLblCssButton(`lnk${_name}`, `${toCapitalize(_name)}`, _heightPos, _ => {
+				g_stateObj[`d_${_name.toLowerCase()}`] = (g_stateObj[`d_${_name.toLowerCase()}`] === C_FLG_OFF ? C_FLG_ON : C_FLG_OFF);
+				if (g_stateObj[`d_${_name.toLowerCase()}`] === C_FLG_OFF) {
+					lnk.classList.replace(g_cssObj.button_ON, g_cssObj.button_OFF);
+				} else {
+					lnk.classList.replace(g_cssObj.button_OFF, g_cssObj.button_ON);
+				}
+			});
+			lnk.style.width = `170px`;
+			lnk.style.left = `calc(30px + 180px * ${_widthPos})`;
+			lnk.style.borderStyle = `solid`;
+			lnk.classList.add(`button_${flg}`);
+			displaySprite.appendChild(lnk);
+		} else {
+			displaySprite.appendChild(makeDisabledDisplayLabel(`lnk${_name}`, _heightPos, _widthPos, toCapitalize(_name)));
+		}
+	}
+
+	/**
+	 * 無効化用ラベル作成
+	 * @param {string} _id 
+	 * @param {number} _heightPos 
+	 * @param {string} _defaultStr 
+	 */
+	function makeDisabledDisplayLabel(_id, _heightPos, _widthPos, _defaultStr) {
+		const lbl = createDivCssLabel(_id, 30 + 180 * _widthPos, C_LEN_SETLBL_HEIGHT * _heightPos,
+			170, C_LEN_SETLBL_HEIGHT, C_SIZ_SETLBL, _defaultStr, g_cssObj.settings_Disabled);
+		lbl.style.textAlign = C_ALIGN_CENTER;
+		return lbl;
 	}
 
 }

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7733,6 +7733,7 @@ function judgeArrow(_j) {
 			} else if (difCnt <= g_judgObj.arrowJ[C_JDG_MATARI]) {
 				judgeMatari(difFrame);
 				stepDivHit.classList.add(g_cssObj.main_stepMatari);
+				document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
 			} else {
 				judgeShobon(difFrame);
 				stepDivHit.classList.add(g_cssObj.main_stepShobon);
@@ -7763,6 +7764,7 @@ function judgeArrow(_j) {
 					document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
 				} else if (difCnt <= g_judgObj.arrowJ[C_JDG_MATARI]) {
 					judgeMatari(difCnt);
+					document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
 				} else {
 					judgeShobon(difCnt);
 				}
@@ -7782,8 +7784,8 @@ function judgeArrow(_j) {
  * @param {number} _difCnt 
  */
 function displayDiff(_difFrame, _difCnt) {
-	return `<span class="common_${_difFrame === 0 ? 'combo' : (_difFrame > 0 ? 'matari' : 'shobon')}">
-		${_difFrame === 0 ? 'Just!!' : ((_difFrame > 0 ? `Fast ${_difCnt} Frame` : `Slow ${_difCnt} Frame`))}</span>`;
+	return `<span class="common_${_difCnt <= 1 ? 'combo' : (_difFrame > 0 ? 'matari' : 'shobon')}">
+		${_difCnt <= 1 ? 'Just!!' : ((_difFrame > 1 ? `Fast ${_difCnt} Frame` : `Slow ${_difCnt} Frames`))}</span>`;
 }
 
 function lifeRecovery() {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6634,11 +6634,13 @@ function MainInit() {
 			const matchKeys = g_workObj.keyCtrl;
 
 			for (let j = 0; j < keyNum; j++) {
-				for (let k = 0; k < matchKeys[j].length; k++) {
-					if (_keyCode === matchKeys[j][k] && !g_workObj.keyHitFlg[j][k]) {
+				matchKeys[j].forEach((key, k) => {
+					if (_keyCode === key && !g_workObj.keyHitFlg[j][k] && !g_judgObj.lockFlgs[j]) {
+						g_judgObj.lockFlgs[j] = true;
 						judgeArrow(j);
+						g_judgObj.lockFlgs[j] = false;
 					}
-				}
+				});
 			}
 		},
 
@@ -7702,84 +7704,76 @@ function keyIsDown(_keyCode) {
  */
 function judgeArrow(_j) {
 
-	if (!g_judgObj.lockFlgs[_j]) {
-		g_judgObj.lockFlgs[_j] = true;
+	const currentNo = g_workObj.judgArrowCnt[_j];
+	const stepDivHit = document.querySelector(`#stepHit${_j}`);
+	const judgArrow = document.querySelector(`#arrow${_j}_${currentNo}`);
 
-		const currentNo = g_workObj.judgArrowCnt[_j];
-		const stepDivHit = document.querySelector(`#stepHit${_j}`);
-		const judgArrow = document.querySelector(`#arrow${_j}_${currentNo}`);
+	const fcurrentNo = g_workObj.judgFrzCnt[_j];
 
-		const fcurrentNo = g_workObj.judgFrzCnt[_j];
+	if (judgArrow !== null) {
+		const difFrame = Number(judgArrow.getAttribute(`cnt`));
+		const difCnt = Math.abs(judgArrow.getAttribute(`cnt`));
+		const judgEndFlg = judgArrow.getAttribute(`judgEndFlg`);
+		const arrowSprite = document.querySelector(`#arrowSprite${judgArrow.getAttribute(`dividePos`)}`);
 
-		if (judgArrow !== null) {
-			const difFrame = Number(judgArrow.getAttribute(`cnt`));
-			const difCnt = Math.abs(judgArrow.getAttribute(`cnt`));
-			const judgEndFlg = judgArrow.getAttribute(`judgEndFlg`);
-			const arrowSprite = document.querySelector(`#arrowSprite${judgArrow.getAttribute(`dividePos`)}`);
+		if (difCnt <= g_judgObj.arrowJ[C_JDG_UWAN] && judgEndFlg === `false`) {
+			stepDivHit.style.top = `${parseFloat(judgArrow.getAttribute(`prevPosY`)) -
+				parseFloat(document.querySelector(`#stepRoot${_j}`).style.top) - 15}px`;
+			stepDivHit.style.opacity = 0.75;
+			stepDivHit.classList.remove(g_cssObj.main_stepDefault, g_cssObj.main_stepDummy, g_cssObj.main_stepIi, g_cssObj.main_stepShakin, g_cssObj.main_stepMatari, g_cssObj.main_stepShobon);
 
-			if (difCnt <= g_judgObj.arrowJ[C_JDG_UWAN] && judgEndFlg === `false`) {
-				stepDivHit.style.top = `${parseFloat(judgArrow.getAttribute(`prevPosY`)) -
-					parseFloat(document.querySelector(`#stepRoot${_j}`).style.top) - 15}px`;
-				stepDivHit.style.opacity = 0.75;
-				stepDivHit.classList.remove(g_cssObj.main_stepDefault, g_cssObj.main_stepDummy, g_cssObj.main_stepIi, g_cssObj.main_stepShakin, g_cssObj.main_stepMatari, g_cssObj.main_stepShobon);
+			if (difCnt <= g_judgObj.arrowJ[C_JDG_II]) {
+				judgeIi(difFrame);
+				stepDivHit.classList.add(g_cssObj.main_stepIi);
+				document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
+			} else if (difCnt <= g_judgObj.arrowJ[C_JDG_SHAKIN]) {
+				judgeShakin(difFrame);
+				stepDivHit.classList.add(g_cssObj.main_stepShakin);
+				document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
+			} else if (difCnt <= g_judgObj.arrowJ[C_JDG_MATARI]) {
+				judgeMatari(difFrame);
+				stepDivHit.classList.add(g_cssObj.main_stepMatari);
+			} else {
+				judgeShobon(difFrame);
+				stepDivHit.classList.add(g_cssObj.main_stepShobon);
+			}
+			stepDivHit.setAttribute(`cnt`, C_FRM_HITMOTION);
 
+			arrowSprite.removeChild(judgArrow);
+			g_workObj.judgArrowCnt[_j]++;
+			return;
+		}
+	}
+
+	const judgFrz = document.querySelector(`#frz${_j}_${fcurrentNo}`);
+
+	if (judgFrz !== null) {
+		const difCnt = Math.abs(judgFrz.getAttribute(`cnt`));
+		const judgEndFlg = judgFrz.getAttribute(`judgEndFlg`);
+
+		if (difCnt <= g_judgObj.frzJ[C_JDG_SFSF] && judgEndFlg === `false`) {
+			if (g_headerObj.frzStartjdgUse &&
+				(g_workObj.judgFrzHitCnt[_j] === undefined || g_workObj.judgFrzHitCnt[_j] <= fcurrentNo)) {
+				const difFrame = Number(judgFrz.getAttribute(`cnt`));
 				if (difCnt <= g_judgObj.arrowJ[C_JDG_II]) {
 					judgeIi(difFrame);
-					stepDivHit.classList.add(g_cssObj.main_stepIi);
 					document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
 				} else if (difCnt <= g_judgObj.arrowJ[C_JDG_SHAKIN]) {
-					judgeShakin(difFrame);
-					stepDivHit.classList.add(g_cssObj.main_stepShakin);
+					judgeShakin(difCnt);
 					document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
 				} else if (difCnt <= g_judgObj.arrowJ[C_JDG_MATARI]) {
-					judgeMatari(difFrame);
-					stepDivHit.classList.add(g_cssObj.main_stepMatari);
+					judgeMatari(difCnt);
 				} else {
-					judgeShobon(difFrame);
-					stepDivHit.classList.add(g_cssObj.main_stepShobon);
+					judgeShobon(difCnt);
 				}
-				stepDivHit.setAttribute(`cnt`, C_FRM_HITMOTION);
-
-				arrowSprite.removeChild(judgArrow);
-				g_workObj.judgArrowCnt[_j]++;
-
-				g_judgObj.lockFlgs[_j] = false;
-				return;
+				g_workObj.judgFrzHitCnt[_j] = fcurrentNo + 1;
 			}
+			changeHitFrz(_j, fcurrentNo, `frz`);
+			return;
 		}
-
-		const judgFrz = document.querySelector(`#frz${_j}_${fcurrentNo}`);
-
-		if (judgFrz !== null) {
-			const difCnt = Math.abs(judgFrz.getAttribute(`cnt`));
-			const judgEndFlg = judgFrz.getAttribute(`judgEndFlg`);
-
-			if (difCnt <= g_judgObj.frzJ[C_JDG_SFSF] && judgEndFlg === `false`) {
-				if (g_headerObj.frzStartjdgUse &&
-					(g_workObj.judgFrzHitCnt[_j] === undefined || g_workObj.judgFrzHitCnt[_j] <= fcurrentNo)) {
-					const difFrame = Number(judgFrz.getAttribute(`cnt`));
-					if (difCnt <= g_judgObj.arrowJ[C_JDG_II]) {
-						judgeIi(difFrame);
-						document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
-					} else if (difCnt <= g_judgObj.arrowJ[C_JDG_SHAKIN]) {
-						judgeShakin(difCnt);
-						document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
-					} else if (difCnt <= g_judgObj.arrowJ[C_JDG_MATARI]) {
-						judgeMatari(difCnt);
-					} else {
-						judgeShobon(difCnt);
-					}
-					g_workObj.judgFrzHitCnt[_j] = fcurrentNo + 1;
-				}
-				changeHitFrz(_j, fcurrentNo, `frz`);
-				g_judgObj.lockFlgs[_j] = false;
-				return;
-			}
-		}
-		const stepDiv = document.querySelector(`#stepDiv${_j}`);
-		stepDiv.style.display = `inherit`;
-		g_judgObj.lockFlgs[_j] = false;
 	}
+	const stepDiv = document.querySelector(`#stepDiv${_j}`);
+	stepDiv.style.display = `inherit`;
 }
 
 /**

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -278,7 +278,7 @@ const g_stateObj = {
     d_judgement: C_FLG_ON,
     d_lifegauge: C_FLG_ON,
     d_musicinfo: C_FLG_ON,
-    d_customeffect: C_FLG_ON,
+    d_special: C_FLG_ON,
     d_color: C_FLG_ON,
     d_speed: C_FLG_ON,
     d_arroweffect: C_FLG_ON,
@@ -326,7 +326,7 @@ let g_volumeNum = g_volumes.length - 1;
 let g_appearances = [`Visible`, `Hidden`, `Sudden`, `Slit`];
 let g_appearanceNum = 0;
 
-let g_displays = [`stepZone`, `judgement`, `lifeGauge`, `musicInfo`, `customEffect`,
+let g_displays = [`stepZone`, `judgement`, `lifeGauge`, `musicInfo`, `special`,
     `speed`, `color`, `lyrics`, `background`, `arrowEffect`];
 
 // サイズ(後で指定)

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -338,6 +338,7 @@ const C_STEP_Y = 70;
 const C_STEP_YR = 0;
 let g_stepY;
 let g_distY;
+let g_reverseStepY;
 let g_stepYR;
 
 // キーコンフィグカーソル

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -278,6 +278,7 @@ const g_stateObj = {
     d_judgement: C_FLG_ON,
     d_lifegauge: C_FLG_ON,
     d_musicinfo: C_FLG_ON,
+    d_customeffect: C_FLG_ON,
     d_color: C_FLG_ON,
     d_speed: C_FLG_ON,
     d_arroweffect: C_FLG_ON,
@@ -324,6 +325,9 @@ let g_volumeNum = g_volumes.length - 1;
 
 let g_appearances = [`Visible`, `Hidden`, `Sudden`, `Slit`];
 let g_appearanceNum = 0;
+
+let g_displays = [`stepZone`, `judgement`, `lifeGauge`, `musicInfo`, `customEffect`,
+    `speed`, `color`, `lyrics`, `background`, `arrowEffect`];
 
 // サイズ(後で指定)
 let g_sWidth;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -341,6 +341,11 @@ let g_distY;
 let g_reverseStepY;
 let g_stepYR;
 
+const g_diffObj = {
+    arrowJdgY: 0,
+    frzJdgY: 0,
+};
+
 // キーコンフィグカーソル
 let g_currentj = 0;
 let g_currentk = 0;


### PR DESCRIPTION
## 変更内容
1. Displayオプションのデフォルト設定ができるように変更しました。
`false`にした場合、OFFにするだけでなくON/OFF設定自体が無効化されます。
```
|stepZoneUse=false|
|judgementUse=false|
|lifeGaugeUse=false|
|musicInfoUse=false|
|speedUse=false|
|colorUse=false|
|lyricsUse=false|
|backgroundUse=false|
|arrowEffectUse=false|
```

2. カスタム用のDisplayオプション「Special」を追加しました。
`g_stateObj.d_special`の`ON`, `OFF`で制御できます。
Displayオプションのデフォルト設定にも対応しています。
```
|specialUse=false|
```

3. 判定キャラクタの下にFast/Slow/Just表記を追加しました。

## 変更理由
1. 作品により、DisplayオプションのON/OFF制御が必要な作品があるため。
2. 特殊な作品の演出のON/OFFが必要な場合に備えて実装しました。
3. プレイ中の早押し・タイミング遅れを把握できるようにするため。

## その他コメント

