### PR TITLE
[0128-fix-localhost] localhost時にフレーム数を表示するように対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6519,7 +6519,7 @@ function MainInit() {
 	}
 
 	// ローカル時のみフレーム数を残す
-	if (location.href.match(`^file`)) {
+	if (location.href.match(`^file`) || location.href.indexOf(`localhost`) !== -1) {
 	} else {
 		document.querySelector(`#lblframe`).style.display = C_DIS_NONE;
 	}


### PR DESCRIPTION
## 変更内容
1. Localhost時にフレーム数を表示するように対応

## 変更理由
1. 今後ローカルサーバーが作成の中心になることを見据え、
localhost時にフレーム数を表示するように対応しました。

## その他コメント

