### PR TITLE
[0129-crossorigin-enabled] file起動以外の場合にpreloadにcrossOrigin属性を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -274,7 +274,7 @@ function toCapitalize(_str) {
  * @param {string} _type 
  * @param {string} _crossOrigin 
  */
-function preloadFile(_as, _href, _type = ``, _crossOrigin = ``) {
+function preloadFile(_as, _href, _type = ``, _crossOrigin = `crossorigin`) {
 
 	const preloadFlg = g_preloadImgs.find(v => v === _href);
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -274,7 +274,7 @@ function toCapitalize(_str) {
  * @param {string} _type 
  * @param {string} _crossOrigin 
  */
-function preloadFile(_as, _href, _type = ``, _crossOrigin = `crossorigin`) {
+function preloadFile(_as, _href, _type = ``, _crossOrigin = `anonymous`) {
 
 	const preloadFlg = g_preloadImgs.find(v => v === _href);
 
@@ -288,7 +288,8 @@ function preloadFile(_as, _href, _type = ``, _crossOrigin = `crossorigin`) {
 		if (_type !== ``) {
 			link.type = _type;
 		}
-		if (_crossOrigin !== ``) {
+		if (location.href.match(`^file`)) {
+		} else {
 			link.crossOrigin = _crossOrigin;
 		}
 		document.head.appendChild(link);


### PR DESCRIPTION
## 変更内容
1. file起動以外の場合にpreloadにcrossOrigin属性「anonymous」を追加しました。

## 変更理由
1. 同一オリジンであっても本来指定が必要なため。
なお、まだhtmlファイル直起動があることを考慮し、htmlファイル直起動のときは
crossOrigin属性を指定していません（同一オリジンで無いため、画像が取得できない）。

## その他コメント

