### PR TITLE
[0130-fix-fast-spell] fast時のときの差分フレーム数のスペルミスを修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7725,7 +7725,7 @@ function judgeArrow(_j) {
  */
 function displayDiff(_difFrame, _difCnt) {
 	return `<span class="common_${_difCnt <= 1 ? 'combo' : (_difFrame > 0 ? 'matari' : 'shobon')}">
-		${_difCnt <= 1 ? 'Just!!' : ((_difFrame > 1 ? `Fast ${_difCnt} Frame` : `Slow ${_difCnt} Frames`))}</span>`;
+		${_difCnt <= 1 ? 'Just!!' : ((_difFrame > 1 ? `Fast` : `Slow`)) + ` ${_difCnt} Frames`}</span>`;
 }
 
 /**


### PR DESCRIPTION
## 変更内容
1. Fast時のときの差分フレーム数のスペルミスを修正しました。

## 変更理由
1. 上述の通り。

## その他コメント

