### PR TITLE
[0135-life-zero(2)] ライフ0が反映されない問題を修正（再）

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7773,7 +7773,7 @@ function lifeDamage() {
 
 	if (g_workObj.lifeVal <= 0) {
 		g_workObj.lifeVal = 0;
-		lblLife.innerHTML = `0`;
+		document.querySelector(`#lblLife`).innerHTML = `0`;
 	} else if (g_workObj.lifeVal < g_workObj.lifeBorder) {
 		changeLifeColor(`Failed`);
 	} else {


### PR DESCRIPTION
## 変更内容
1. ライフが0になるときにライフの数値表示が反映されない問題を修正しました。
（idを指定する書き方に変更）

## 変更理由
1. 上述の通り。

## その他コメント

