### PR TITLE
[0136-lyrics-reverse-pos] 下側の歌詞表示位置をステップゾーン位置に追随させる設定を追加　他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2387,6 +2387,7 @@ function headerConvert(_dosObj) {
 	g_stepYR = (isNaN(parseFloat(_dosObj.stepYR)) ? C_STEP_YR : parseFloat(_dosObj.stepYR));
 	g_distY = g_sHeight - g_stepY + g_stepYR;
 	g_reverseStepY = g_distY - g_stepY - C_ARW_WIDTH;
+	obj.buttomWordSetFlg = setVal(_dosObj.buttomWordSet, false, C_TYP_BOOLEAN);
 
 	// 矢印・フリーズアロー判定位置補正
 	g_diffObj.arrowJdgY = (isNaN(parseFloat(_dosObj.arrowJdgY)) ? 0 : parseFloat(_dosObj.arrowJdgY));
@@ -6448,9 +6449,9 @@ function MainInit() {
 	for (let j = 0; j <= g_scoreObj.wordMaxDepth; j++) {
 		let lblWord;
 		if (j % 2 === 0) {
-			lblWord = createSprite(`wordSprite`, `lblword${j}`, 100, 10, g_sWidth - 200, 30);
+			lblWord = createSprite(`wordSprite`, `lblword${j}`, 100, 10, g_sWidth - 200, 50);
 		} else {
-			lblWord = createSprite(`wordSprite`, `lblword${j}`, 100, g_sHeight - 60, g_sWidth - 200, 20);
+			lblWord = createSprite(`wordSprite`, `lblword${j}`, 100, g_headerObj.buttomWordSetFlg ? g_distY + 10 : g_sHeight - 60, g_sWidth - 200, 50);
 		}
 		lblWord.style.fontSize = `14px`;
 		lblWord.style.color = `#ffffff`;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6482,7 +6482,7 @@ function MainInit() {
 
 	const jdgGroups = [`J`, `FJ`];
 	const jdgX = [g_sWidth / 2 - 200, g_sWidth / 2 - 100];
-	const jdgY = [g_sHeight / 2 - 60 + g_diffObj.arrowJdgY, g_sHeight / 2 + 10 + g_diffObj.frzJdgY];
+	const jdgY = [(g_sHeight + g_stepYR) / 2 - 60 + g_diffObj.arrowJdgY, (g_sHeight + g_stepYR) / 2 + 10 + g_diffObj.frzJdgY];
 	const jdgCombos = [`kita`, `ii`];
 
 	jdgGroups.forEach((jdg, j) => {
@@ -6559,7 +6559,7 @@ function MainInit() {
 
 	// Ready?表示
 	if (!g_headerObj.customReadyUse) {
-		const lblReady = createDivCssLabel(`lblReady`, g_sWidth / 2 - 100, g_sHeight / 2 - 75,
+		const lblReady = createDivCssLabel(`lblReady`, g_sWidth / 2 - 100, (g_sHeight + g_stepYR) / 2 - 75,
 			200, 50, 40,
 			`<span style='color:` + g_headerObj.setColor[0] + `;font-size:60px;'>R</span>EADY<span style='font-size:50px;'>?</span>`);
 		lblReady.style.animationDuration = `2.5s`;


### PR DESCRIPTION
## 変更内容
1. 下側の歌詞表示位置をステップゾーン位置に追随させる設定を追加しました。
譜面ヘッダー`buttomWordSet`にて設定します。
下側のステップゾーン位置を`stepYR`で調整できるので、その位置に追随するようになります。
```
|buttomWordSet=true|
|stepYR=-20|
```
2. 判定キャラクタ、ReadyのY座標を下側のステップゾーン位置(stepYR)に合わせて
自動調整するように変更しました。

## 変更理由
1. 下側の歌詞表示位置が楽曲クレジットによりカバーできないことがあるため。
2. 下側のステップゾーン位置のみを変更することは可能でしたが、
判定キャラクタ位置、Readyが自動調整できなかったため、手動で直す必要がありました。

## その他コメント
