### PR TITLE
[0135-life-zero(3)] ライフ0が反映されない問題を修正（再）

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7773,7 +7773,7 @@ function lifeDamage() {
 
 	if (g_workObj.lifeVal <= 0) {
 		g_workObj.lifeVal = 0;
-		document.querySelector(`#lblLife`).innerHTML = `0`;
+		changeLifeColor();
 	} else if (g_workObj.lifeVal < g_workObj.lifeBorder) {
 		changeLifeColor(`Failed`);
 	} else {


### PR DESCRIPTION
## 変更内容
1. ライフ0が反映されない問題を修正を再修正しました。

## 変更理由
1. ライフゲージバーが反映されていなかったため。

## その他コメント

