### PR TITLE
ロード画面に特殊キーのブロック処理を追加　ほか

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4342,7 +4342,10 @@ function keyConfigInit() {
 	document.onkeydown = evt => {
 		const keyCdObj = document.querySelector(`#keycon${g_currentj}_${g_currentk}`);
 		const cursor = document.querySelector(`#cursor`);
-		const setKey = evt.keyCode;
+		let setKey = evt.keyCode;
+		if (setKey === 59) {
+			setKey = 187;
+		}
 
 		// 全角切替、BackSpace、Deleteキー、Escキーは割り当て禁止
 		// また、直前と同じキーを押した場合(BackSpaceを除く)はキー操作を無効にする
@@ -6593,7 +6596,10 @@ function MainInit() {
 
 	// キー操作イベント
 	document.onkeydown = evt => {
-		const setKey = evt.keyCode;
+		let setKey = evt.keyCode;
+		if (setKey === 59) {
+			setKey = 187;
+		}
 		g_inputKeyBuffer[setKey] = true;
 		mainKeyDownActFunc[g_stateObj.autoPlay](setKey);
 
@@ -6643,7 +6649,10 @@ function MainInit() {
 	};
 
 	document.onkeyup = evt => {
-		const setKey = evt.keyCode;
+		let setKey = evt.keyCode;
+		if (setKey === 59) {
+			setKey = 187;
+		}
 		g_inputKeyBuffer[setKey] = false;
 		mainKeyUpActFunc[g_stateObj.autoPlay]();
 	}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1271,7 +1271,11 @@ function loadSettingJs() {
 }
 
 function loadMusic() {
-	document.onkeydown = () => { }
+	document.onkeydown = evt => {
+		if (C_BLOCK_KEYS.includes(evt.keyCode)) {
+			return false;
+		}
+	}
 
 	const musicUrl = g_headerObj.musicUrls[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.musicUrls[0];
 	let url;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1905,16 +1905,14 @@ function titleInit() {
 
 	// キー操作イベント（デフォルト）
 	document.onkeydown = evt => {
-		const setKey = (g_userAgent.indexOf(`firefox`) !== -1 ? evt.which : event.keyCode);
+		const setKey = evt.keyCode;
 		if (setKey === 13) {
 			clearTimeout(g_timeoutEvtTitleId);
 			clearWindow();
 			optionInit();
 		}
-		for (let j = 0; j < C_BLOCK_KEYS.length; j++) {
-			if (setKey === C_BLOCK_KEYS[j]) {
-				return false;
-			}
+		if (C_BLOCK_KEYS.includes(setKey)) {
+			return false;
 		}
 	}
 
@@ -2870,15 +2868,13 @@ function optionInit() {
 
 	// キー操作イベント（デフォルト）
 	document.onkeydown = evt => {
-		const setKey = (g_userAgent.indexOf(`firefox`) !== -1 ? evt.which : event.keyCode);
+		const setKey = evt.keyCode;
 		if (setKey === 13) {
 			clearWindow();
 			loadMusic();
 		}
-		for (let j = 0; j < C_BLOCK_KEYS.length; j++) {
-			if (setKey === C_BLOCK_KEYS[j]) {
-				return false;
-			}
+		if (C_BLOCK_KEYS.includes(setKey)) {
+			return false;
 		}
 	}
 	document.onkeyup = evt => { }
@@ -3910,15 +3906,13 @@ function settingsDisplayInit() {
 
 	// キー操作イベント（デフォルト）
 	document.onkeydown = evt => {
-		const setKey = (g_userAgent.indexOf(`firefox`) !== -1 ? evt.which : event.keyCode);
+		const setKey = evt.keyCode;
 		if (setKey === 13) {
 			clearWindow();
 			loadMusic();
 		}
-		for (let j = 0; j < C_BLOCK_KEYS.length; j++) {
-			if (setKey === C_BLOCK_KEYS[j]) {
-				return false;
-			}
+		if (C_BLOCK_KEYS.includes(setKey)) {
+			return false;
 		}
 	}
 	document.onkeyup = evt => { }
@@ -4344,7 +4338,7 @@ function keyConfigInit() {
 	document.onkeydown = evt => {
 		const keyCdObj = document.querySelector(`#keycon${g_currentj}_${g_currentk}`);
 		const cursor = document.querySelector(`#cursor`);
-		const setKey = (g_userAgent.indexOf(`firefox`) !== -1 ? evt.which : event.keyCode);
+		const setKey = evt.keyCode;
 
 		// 全角切替、BackSpace、Deleteキー、Escキーは割り当て禁止
 		// また、直前と同じキーを押した場合(BackSpaceを除く)はキー操作を無効にする
@@ -4415,10 +4409,8 @@ function keyConfigInit() {
 				eval(`resetCursor${g_kcType}`)(kWidth, divideCnt, keyCtrlPtn);
 			}
 		}
-		for (let j = 0; j < C_BLOCK_KEYS.length; j++) {
-			if (setKey === C_BLOCK_KEYS[j]) {
-				return false;
-			}
+		if (C_BLOCK_KEYS.includes(setKey)) {
+			return false;
 		}
 	}
 
@@ -6597,7 +6589,7 @@ function MainInit() {
 
 	// キー操作イベント
 	document.onkeydown = evt => {
-		const setKey = (g_userAgent.indexOf(`firefox`) !== -1 ? evt.which : event.keyCode);
+		const setKey = evt.keyCode;
 		g_inputKeyBuffer[setKey] = true;
 		mainKeyDownActFunc[g_stateObj.autoPlay](setKey);
 
@@ -6625,10 +6617,8 @@ function MainInit() {
 			document.onkeyup = _ => { };
 		}
 
-		for (let j = 0; j < C_BLOCK_KEYS.length; j++) {
-			if (setKey === C_BLOCK_KEYS[j]) {
-				return false;
-			}
+		if (C_BLOCK_KEYS.includes(setKey)) {
+			return false;
 		}
 	}
 
@@ -6649,7 +6639,7 @@ function MainInit() {
 	};
 
 	document.onkeyup = evt => {
-		const setKey = (g_userAgent.indexOf(`firefox`) !== -1 ? evt.which : event.keyCode);
+		const setKey = evt.keyCode;
 		g_inputKeyBuffer[setKey] = false;
 		mainKeyUpActFunc[g_stateObj.autoPlay]();
 	}
@@ -8497,11 +8487,8 @@ function resultInit() {
 
 	// キー操作イベント（デフォルト）
 	document.onkeydown = evt => {
-		const setKey = (g_userAgent.indexOf(`firefox`) !== -1 ? evt.which : event.keyCode);
-		for (let j = 0; j < C_BLOCK_KEYS.length; j++) {
-			if (setKey === C_BLOCK_KEYS[j]) {
-				return false;
-			}
+		if (C_BLOCK_KEYS.includes(evt.keyCode)) {
+			return false;
 		}
 	}
 	document.onkeyup = evt => { }


### PR DESCRIPTION
## 変更内容
- ロード画面に特殊キーのブロック処理を追加しました
- Firefoxでセミコロンが判定されない問題を修正しました
- キーイベントをリファクタリングしました
  - ブラウザによる分岐を無くしました
  - ブロック判定をfor文の代わりに`Array.includes`にしました

## 変更理由
- #432 で`onkeydown={}`にしてしまったのでロード画面で特殊キーがブロックされません
- ブラウザによって一部キーコードが違うようです
- 主要なすべてのブラウザで`keyCode`が取れます

## その他コメント
[`keyCode`](https://developer.mozilla.org/ja/docs/Web/API/KeyboardEvent/keyCode)も[`which`](https://developer.mozilla.org/ja/docs/Web/API/KeyboardEvent/which)も非推奨(deprecated)になっているので[`code`](https://developer.mozilla.org/ja/docs/Web/API/KeyboardEvent/code)とかを使うのがよさそうですが、
戻り値が全然違うので簡単にはできそうにないですね…。