### PR TITLE
ロード画面に特殊キーのブロック処理を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1271,7 +1271,11 @@ function loadSettingJs() {
 }
 
 function loadMusic() {
-	document.onkeydown = () => { }
+	document.onkeydown = evt => {
+		if (C_BLOCK_KEYS.includes(evt.keyCode)) {
+			return false;
+		}
+	}
 
 	const musicUrl = g_headerObj.musicUrls[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.musicUrls[0];
 	let url;


### PR DESCRIPTION
## 変更内容
ロード画面に特殊キーのブロック処理を追加しました

## 変更理由
#432 で`onkeydown={}`にしてしまったのでロード画面で特殊キーがブロックされません

## その他コメント
