### PR TITLE
[0143/graph-details] 速度変化数・プレイ時間・APMの表示対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3247,7 +3247,7 @@ function createOptionWindow(_sprite) {
 			context.font = `14px ${getBasicFont()}`;
 			context.fillText(speedType, lineX + 35, 218);
 
-			scoreDetailLabel(`Speed`, `${speedType.slice(0, 1).toUpperCase()}${speedType.slice(1)}`, speedObj[`${speedType}`].cnt, j);
+			makeScoreDetailLabel(`Speed`, `${speedType.slice(0, 1).toUpperCase()}${speedType.slice(1)}`, speedObj[`${speedType}`].cnt, j);
 		});
 	}
 
@@ -3306,13 +3306,13 @@ function createOptionWindow(_sprite) {
 		}
 
 		const apm = Math.round(allData / (playingFrame / g_fps / 60));
-		scoreDetailLabel(`Density`, `APM`, apm, 0);
+		makeScoreDetailLabel(`Density`, `APM`, apm, 0);
 		const minutes = Math.floor(playingFrame / g_fps / 60);
 		const seconds = `00${Math.floor((playingFrame / g_fps) % 60)}`.slice(-2);
 		const playingTime = `${minutes}:${seconds}`;
-		scoreDetailLabel(`Density`, `Time`, playingTime, 1);
-		scoreDetailLabel(`Density`, `Arrow`, g_workObj.arrowCnt.reduce((p, x) => p + x), 3);
-		scoreDetailLabel(`Density`, `Frz`, g_workObj.frzCnt.reduce((p, x) => p + x), 4);
+		makeScoreDetailLabel(`Density`, `Time`, playingTime, 1);
+		makeScoreDetailLabel(`Density`, `Arrow`, g_workObj.arrowCnt.reduce((p, x) => p + x), 3);
+		makeScoreDetailLabel(`Density`, `Frz`, g_workObj.frzCnt.reduce((p, x) => p + x), 4);
 	}
 
 	/**
@@ -3322,7 +3322,7 @@ function createOptionWindow(_sprite) {
 	 * @param {string} _value 
 	 * @param {number} _pos 表示位置
 	 */
-	function scoreDetailLabel(_name, _label, _value, _pos = 0) {
+	function makeScoreDetailLabel(_name, _label, _value, _pos = 0) {
 		if (document.querySelector(`#data${_label}`) === null) {
 			const lbl = createDivCssLabel(`lbl${_label}`, 10, 65 + _pos * 20, 100, 20, 14, `${_label}`);
 			lbl.style.textAlign = C_ALIGN_LEFT;


### PR DESCRIPTION
## 変更内容
1. 譜面明細画面で速度変化数・プレイ時間・APM・
総矢印／フリーズアロー数を表示するように対応しました。
速度変化グラフにおいてSpeed/Boost数の表示、
譜面密度グラフにおいてAPM(Arrows Per Minute)、プレイ時間、
総矢印／フリーズアロー数の表示を追加しています。

2. 譜面明細表示のオブジェクト構造を一部変更しました。
- 速度変化グラフ
scoreDetail -> detailSpeed (div要素)-> graphSpeed (canvas)
- 譜面密度グラフ
scoreDetail -> detailDensity (div要素) -> graphDensity (canvas)

3. createGraph関数をcreateScoreDetail関数に変更しました。
また引数に `_graphUseFlg`を追加し、グラフのない画面も作成できるようにしました。

## 変更理由
1. Issue #417 の一環です。
2. 文字表示部分(div要素)とグラフ描画部分(canvas)を分離し、
グラフとそれ以外の部分を扱いやすくするため。
3. レベル計算ツールの値を表示するための画面を準備するため。

## その他コメント
- 今後、レベル計算ツールの値をSpeedやDensityとは別の画面で表示することを想定しています。
表示内容は、ツール値、同時押し補正、縦連補正、矢印毎のノート数 及び
ハイスコア、ハイスコア日時（※別途取得必要）です。
矢印毎のノート数に関しては、今回の対応でデータが取れるように設定しています。
変数名は`g_workObj.arrowCnt[j]`と`g_workObj.frzCnt[j]`です。（`j`は矢印番号を表します）
