### PR TITLE
[0150/preload-dos] 速度変化、譜面密度関連のデータを事前読込へ変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1008,7 +1008,7 @@ function initialControl() {
 	loadLocalStorage();
 
 	// 譜面データの読み込み
-	loadDos(_ => loadSettingJs(), true);
+	loadDos(_ => loadSettingJs(), 0);
 }
 
 /**
@@ -1063,9 +1063,9 @@ function loadLocalStorage() {
 /**
  * 譜面読込
  * @param {function} _afterFunc 実行後の処理
- * @param {boolean} _initFlg 初期化フラグ(true: 常時1譜面目を読込, false: 指定された譜面を読込)
+ * @param {number} _scoreId 譜面番号
  */
-function loadDos(_afterFunc, _initFlg = false) {
+function loadDos(_afterFunc, _scoreId = g_stateObj.scoreId) {
 
 	const dosInput = document.querySelector(`#dos`);
 	const externalDosInput = document.querySelector(`#externalDos`);
@@ -1113,9 +1113,9 @@ function loadDos(_afterFunc, _initFlg = false) {
 		const filenameBase = externalDosInput.value.match(/.+\..*/)[0];
 		const filenameExtension = filenameBase.split(`.`).pop();
 		const filenameCommon = filenameBase.split(`.${filenameExtension}`)[0];
-		const scoreIdHeader = (g_stateObj.scoreId > 0 ? g_stateObj.scoreId + 1 : ``);
-		const filename = (_initFlg || !dosDivideFlg ?
-			`${filenameCommon}.${filenameExtension}` : `${filenameCommon}${scoreIdHeader}.${filenameExtension}`);
+		const filename = (!dosDivideFlg ?
+			`${filenameCommon}.${filenameExtension}` :
+			`${filenameCommon}${setScoreIdHeader(_scoreId)}.${filenameExtension}`);
 
 		const randTime = new Date().getTime();
 		loadScript(`${filename}?${randTime}`, _ => {
@@ -3828,7 +3828,7 @@ function createOptionWindow(_sprite) {
 		setSetting(0, `speed`, ` x`);
 		if (g_headerObj.scoreDetailUse) {
 			loadDos(_ => {
-				const scoreObj = scoreConvert(g_rootObj, setScoreIdHeader(), 0, ``, true);
+				const scoreObj = scoreConvert(g_rootObj, setScoreIdHeader(g_stateObj.scoreId, g_stateObj.scoreLockFlg), 0, ``, true);
 				drawSpeedGraph(scoreObj);
 				drawDensityGraph(scoreObj);
 			});
@@ -4804,9 +4804,9 @@ function loadingScoreInit() {
 	loadDos(_ => loadCustomjs(_ => loadingScoreInit2()));
 }
 
-function setScoreIdHeader() {
-	if (g_stateObj.scoreId > 0 && g_stateObj.scoreLockFlg === false) {
-		return Number(g_stateObj.scoreId) + 1;
+function setScoreIdHeader(_scoreId = 0, _scoreLockFlg = false) {
+	if (_scoreId > 0 && _scoreLockFlg === false) {
+		return Number(_scoreId) + 1;
 	}
 	return ``;
 }
@@ -4823,7 +4823,7 @@ function loadingScoreInit2() {
 		g_canLoadDifInfoFlg = false;
 	}
 
-	let scoreIdHeader = setScoreIdHeader();
+	let scoreIdHeader = setScoreIdHeader(g_stateObj.scoreId, g_stateObj.scoreLockFlg);
 	let dummyIdHeader = ``;
 	if (g_stateObj.dummyId !== ``) {
 		if (g_stateObj.dummyId === 0 || g_stateObj.dummyId === 1) {
@@ -8226,10 +8226,7 @@ function resultInit() {
 	} else {
 		// ゲームオーバー時は失敗時のリザルトモーションを適用
 		if (!g_finishFlg) {
-			let scoreIdHeader = ``;
-			if (g_stateObj.scoreId > 0) {
-				scoreIdHeader = Number(g_stateObj.scoreId) + 1;
-			}
+			const scoreIdHeader = setScoreIdHeader(g_stateObj.scoreId, g_stateObj.scoreLockFlg);
 
 			[`back`, `mask`].forEach(sprite => {
 				if (g_rootObj[`${sprite}failedS${scoreIdHeader}_data`] !== undefined) {


### PR DESCRIPTION
## 変更内容
1. 速度変化、譜面密度関連のデータを譜面毎に再取得ではなく事前読込するよう変更しました。
2. loadDos関数の引数を変更しました。
    - 変更前：_afterFunc (関数後に実行する処理), _initFlg (1譜面目を読み込みするかどうか)
    - 変更後：_afterFunc (関数後に実行する処理), _scoreId (譜面番号　※デフォルト：１)
3. setScoreIdHeader関数の引数を変更しました。
    - 変更前：なし
    - 変更後：_scoreId (譜面番号), _scoreLockFlg (譜面番号固定フラグ　※デフォルト：false)
4. 譜面番号固定時、リザルトモーションが反映されないことがある問題を修正しました。

## 変更理由
1. 将来的にツール値を実装する際に、html側からデータ取得できる余地を残すため。
2. `g_stateObj.scoreId`に依存した関数になっていることで、融通が利かない関数になっていたため。
3. 2.と同上
4. 譜面番号固定時の条件が一部抜けていたため。

## その他コメント
- 1.の変更により、譜面明細画面に表示している情報の更新タイミングが
リロード時に限定されます。
サーバ上では譜面が常時変わることはないため、それほど影響はないと考えています。
