### PR TITLE
[0151/preload-dos] scoreConvert関数が譜面番号依存だった問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1169,8 +1169,7 @@ function reloadDos(_scoreId) {
 	_scoreId++;
 	if (_scoreId < g_headerObj.keyLabels.length) {
 		loadDos(_ => {
-			const keyCtrlPtn = `${g_headerObj.keyLabels[_scoreId]}_0`;
-			storeBaseData(_scoreId, scoreConvert(g_rootObj, _scoreId, 0, ``, keyCtrlPtn, true), keyCtrlPtn);
+			getScoreDetailData(_scoreId);
 		}, _scoreId, true);
 	}
 }
@@ -1260,11 +1259,19 @@ function initAfterDosLoaded() {
 	// customjsの読み込み後、譜面詳細情報取得のために譜面をロード
 	loadCustomjs(_ => {
 		loadDos(_ => {
-			const keyCtrlPtn = `${g_headerObj.keyLabels[0]}_0`;
-			storeBaseData(0, scoreConvert(g_rootObj, 0, 0, ``, keyCtrlPtn, true), keyCtrlPtn);
+			getScoreDetailData(0);
 		}, 0, true);
 		titleInit();
 	});
+}
+
+/**
+ * 譜面ファイル読込後処理（譜面詳細情報取得用）
+ * @param {number} _scoreId 
+ */
+function getScoreDetailData(_scoreId) {
+	const keyCtrlPtn = `${g_headerObj.keyLabels[_scoreId]}_0`;
+	storeBaseData(_scoreId, scoreConvert(g_rootObj, _scoreId, 0, ``, keyCtrlPtn, true), keyCtrlPtn);
 }
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1238,7 +1238,7 @@ function initAfterDosLoaded() {
 				const keyCtrlPtn = `${g_headerObj.keyLabels[j]}_0`;
 				storeBaseData(
 					j, scoreConvert(g_rootObj, j, 0, ``, keyCtrlPtn, true),
-					g_keyObj[`chara${keyCtrlPtn}`].length
+					keyCtrlPtn
 				);
 			}, j);
 		}
@@ -1250,12 +1250,13 @@ function initAfterDosLoaded() {
  * 譜面詳細データの格納
  * @param {number} _scoreId 
  * @param {object} _scoreObj 
- * @param {number} _keyNum 
+ * @param {number} _keyCtrlPtn 
  */
-function storeBaseData(_scoreId, _scoreObj, _keyNum) {
-	const lastFrame = getLastFrame(_scoreObj) + g_headerObj.blankFrame + 1;
-	const startFrame = getStartFrame(lastFrame);
+function storeBaseData(_scoreId, _scoreObj, _keyCtrlPtn) {
+	const lastFrame = getLastFrame(_scoreObj, _keyCtrlPtn) + g_headerObj.blankFrame + 1;
+	const startFrame = getStartFrame(lastFrame, 0, _scoreId);
 	const playingFrame = lastFrame - startFrame;
+	const keyNum = g_keyObj[`chara${_keyCtrlPtn}`].length;
 
 	// 譜面密度グラフ用のデータ作成
 	const arrowCnt = [];
@@ -1266,7 +1267,7 @@ function storeBaseData(_scoreId, _scoreObj, _keyNum) {
 		densityData[j] = 0;
 	}
 
-	for (let j = 0; j < _keyNum; j++) {
+	for (let j = 0; j < keyNum; j++) {
 		arrowCnt[j] = 0;
 		frzCnt[j] = 0;
 		_scoreObj.arrowData[j].forEach(note => {
@@ -5546,12 +5547,12 @@ function calcLifeVal(_val, _allArrows) {
 /**
  * 最終フレーム数の取得
  * @param {object} _dataObj 
+ * @param {string} _keyCtrlPtn
  */
-function getLastFrame(_dataObj) {
+function getLastFrame(_dataObj, _keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`) {
 
 	let tmpLastNum = 0;
-	const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
-	const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
+	const keyNum = g_keyObj[`chara${_keyCtrlPtn}`].length;
 
 	for (let j = 0; j < keyNum; j++) {
 		const data = [
@@ -5575,12 +5576,12 @@ function getLastFrame(_dataObj) {
 /**
  * 最初の矢印フレームの取得
  * @param {object} _dataObj 
+ * @param {string} _keyCtrlPtn
  */
-function getFirstArrowFrame(_dataObj) {
+function getFirstArrowFrame(_dataObj, _keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`) {
 
 	let tmpFirstNum = Infinity;
-	const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
-	const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
+	const keyNum = g_keyObj[`chara${_keyCtrlPtn}`].length;
 
 	for (let j = 0; j < keyNum; j++) {
 		const data = [
@@ -5606,11 +5607,13 @@ function getFirstArrowFrame(_dataObj) {
 /**
  * 開始フレームの取得
  * @param {number} _lastFrame 
+ * @param {number} _fadein
+ * @param {number} _scoreId
  */
-function getStartFrame(_lastFrame, _fadein = 0) {
+function getStartFrame(_lastFrame, _fadein = 0, _scoreId = g_stateObj.scoreId) {
 	let frameNum = 0;
 	if (g_headerObj.startFrame !== undefined) {
-		frameNum = parseInt(g_headerObj.startFrame[g_stateObj.scoreId] || g_headerObj.startFrame[0] || 0);
+		frameNum = parseInt(g_headerObj.startFrame[_scoreId] || g_headerObj.startFrame[0] || 0);
 	}
 	if (_lastFrame >= frameNum) {
 		frameNum = Math.round(_fadein / 100 * (_lastFrame - frameNum)) + frameNum;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5137,8 +5137,10 @@ function applySRandom(_keyNum, _shuffleGroup, _arrowHeader, _frzHeader) {
 /**
  * 譜面データの分解
  * @param {object} _dosObj 
- * @param {number} _scoreId
- * @param {string} _dummyNo
+ * @param {number} _scoreId 譜面番号
+ * @param {number} _preblankFrame 補完フレーム数
+ * @param {string} _dummyNo ダミー用譜面番号添え字
+ * @param {string} _keyCtrlPtn 選択キー及びパターン
  * @param {boolean} _scoreAnalyzeFlg (default : false)
  */
 function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1100,7 +1100,7 @@ function loadDos(_afterFunc, _scoreId = g_stateObj.scoreId, _cyclicFlg = false) 
 	if (dosLockInput !== null) {
 		g_stateObj.scoreLockFlg = setVal(dosLockInput.value, false, C_TYP_BOOLEAN);
 	}
-	if (dosDivideFlg && g_stateObj.scoreLockFlg) {
+	if (externalDosInput !== null && dosDivideFlg && g_stateObj.scoreLockFlg) {
 		const scoreList = Object.keys(g_rootObj).filter(data => {
 			return data.endsWith(`_data`) || data.endsWith(`_change`);
 		});
@@ -1114,6 +1114,9 @@ function loadDos(_afterFunc, _scoreId = g_stateObj.scoreId, _cyclicFlg = false) 
 		Object.assign(g_rootObj, dosConvert(dosInput.value));
 		if (externalDosInput === null) {
 			_afterFunc();
+			if (_cyclicFlg) {
+				reloadDos(_scoreId);
+			}
 		}
 	}
 
@@ -1150,15 +1153,23 @@ function loadDos(_afterFunc, _scoreId = g_stateObj.scoreId, _cyclicFlg = false) 
 			}
 			_afterFunc();
 			if (_cyclicFlg) {
-				_scoreId++;
-				if (_scoreId < g_headerObj.keyLabels.length) {
-					loadDos(_ => {
-						const keyCtrlPtn = `${g_headerObj.keyLabels[_scoreId]}_0`;
-						storeBaseData(_scoreId, scoreConvert(g_rootObj, _scoreId, 0, ``, keyCtrlPtn, true), keyCtrlPtn);
-					}, _scoreId, true);
-				}
+				reloadDos(_scoreId);
 			}
 		}, false, charset);
+	}
+}
+
+/**
+ * 譜面情報の再取得を行う（譜面詳細情報取得用）
+ * @param {number} _scoreId 
+ */
+function reloadDos(_scoreId) {
+	_scoreId++;
+	if (_scoreId < g_headerObj.keyLabels.length) {
+		loadDos(_ => {
+			const keyCtrlPtn = `${g_headerObj.keyLabels[_scoreId]}_0`;
+			storeBaseData(_scoreId, scoreConvert(g_rootObj, _scoreId, 0, ``, keyCtrlPtn, true), keyCtrlPtn);
+		}, _scoreId, true);
 	}
 }
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1236,10 +1236,7 @@ function initAfterDosLoaded() {
 		for (let j = 0; j < g_headerObj.keyLabels.length; j++) {
 			loadDos(_ => {
 				const keyCtrlPtn = `${g_headerObj.keyLabels[j]}_0`;
-				storeBaseData(
-					j, scoreConvert(g_rootObj, j, 0, ``, keyCtrlPtn, true),
-					keyCtrlPtn
-				);
+				storeBaseData(j, scoreConvert(g_rootObj, j, 0, ``, keyCtrlPtn, true), keyCtrlPtn);
 			}, j);
 		}
 		titleInit();
@@ -5153,13 +5150,12 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	g_allFrz = 0;
 
 	const scoreIdHeader = setScoreIdHeader(_scoreId, g_stateObj.scoreLockFlg);
-	const keyCtrlPtn = _keyCtrlPtn;
-	const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
+	const keyNum = g_keyObj[`chara${_keyCtrlPtn}`].length;
 	obj.arrowData = [];
 	obj.frzData = [];
 	obj.dummyArrowData = [];
 	obj.dummyFrzData = [];
-	const headerAdjustment = parseInt(g_headerObj.adjustment[g_stateObj.scoreId] || g_headerObj.adjustment[0]);
+	const headerAdjustment = parseInt(g_headerObj.adjustment[_scoreId] || g_headerObj.adjustment[0]);
 	const realAdjustment = parseInt(g_stateObj.adjustment) + headerAdjustment + _preblankFrame;
 	g_stateObj.realAdjustment = realAdjustment;
 	const blankFrame = g_headerObj.blankFrame;
@@ -5168,7 +5164,7 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	for (let j = 0; j < keyNum; j++) {
 
 		// 矢印データの分解
-		const arrowName = g_keyObj[`chara${keyCtrlPtn}`][j];
+		const arrowName = g_keyObj[`chara${_keyCtrlPtn}`][j];
 		obj.arrowData[j] = storeArrowData(_dosObj[`${arrowName}${scoreIdHeader}_data`]);
 		g_allArrow += (isNaN(parseFloat(obj.arrowData[j][0])) ? 0 : obj.arrowData[j].length);
 
@@ -5177,7 +5173,7 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 		}
 
 		// 矢印名からフリーズアロー名への変換
-		let frzName = g_keyObj[`chara${keyCtrlPtn}`][j].replace(`leftdia`, `frzLdia`);
+		let frzName = g_keyObj[`chara${_keyCtrlPtn}`][j].replace(`leftdia`, `frzLdia`);
 		frzName = frzName.replace(`rightdia`, `frzRdia`);
 		frzName = frzName.replace(`left`, `frzLeft`);
 		frzName = frzName.replace(`down`, `frzDown`);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1097,7 +1097,7 @@ function loadDos(_afterFunc, _scoreId = g_stateObj.scoreId) {
 	if (dosLockInput !== null) {
 		g_stateObj.scoreLockFlg = setVal(dosLockInput.value, false, C_TYP_BOOLEAN);
 	}
-	if (externalDosInput !== null && dosDivideFlg && g_stateObj.scoreLockFlg) {
+	if (dosDivideFlg && g_stateObj.scoreLockFlg) {
 		const scoreList = Object.keys(g_rootObj).filter(data => {
 			return data.endsWith(`_data`) || data.endsWith(`_change`);
 		});
@@ -1136,14 +1136,16 @@ function loadDos(_afterFunc, _scoreId = g_stateObj.scoreId) {
 				}
 
 				// 外部データを読込
+				const tmpExternalDos = g_externalDos;
 				externalDosInit();
-				Object.assign(g_rootObj, dosConvert(g_externalDos));
+				if (tmpExternalDos === g_externalDos && _scoreId !== 0) {
+				} else {
+					Object.assign(g_rootObj, dosConvert(g_externalDos));
+				}
 
 			} else {
 				makeWarningWindow(C_MSG_E_0022);
 			}
-
-			// danoni_setting.jsは初回時のみ読込
 			_afterFunc();
 		}, false, charset);
 	}
@@ -1239,6 +1241,24 @@ function initAfterDosLoaded() {
 				storeBaseData(j, scoreConvert(g_rootObj, j, 0, ``, keyCtrlPtn, true), keyCtrlPtn);
 			}, j);
 		}
+		/*
+		loadDos(_ => {
+			const keyCtrlPtn = `${g_headerObj.keyLabels[0]}_0`;
+			storeBaseData(0, scoreConvert(g_rootObj, 0, 0, ``, keyCtrlPtn, true), keyCtrlPtn);
+			loadDos(_ => {
+				const keyCtrlPtn = `${g_headerObj.keyLabels[1]}_0`;
+				storeBaseData(1, scoreConvert(g_rootObj, 1, 0, ``, keyCtrlPtn, true), keyCtrlPtn);
+				loadDos(_ => {
+					const keyCtrlPtn = `${g_headerObj.keyLabels[2]}_0`;
+					storeBaseData(2, scoreConvert(g_rootObj, 2, 0, ``, keyCtrlPtn, true), keyCtrlPtn);
+					loadDos(_ => {
+						const keyCtrlPtn = `${g_headerObj.keyLabels[3]}_0`;
+						storeBaseData(3, scoreConvert(g_rootObj, 3, 0, ``, keyCtrlPtn, true), keyCtrlPtn);
+					}, 3);
+				}, 2);
+			}, 1);
+		}, 0);
+		*/
 		titleInit();
 	});
 }
@@ -1268,6 +1288,9 @@ function storeBaseData(_scoreId, _scoreObj, _keyCtrlPtn) {
 		arrowCnt[j] = 0;
 		frzCnt[j] = 0;
 		_scoreObj.arrowData[j].forEach(note => {
+			if (isNaN(parseFloat(note))) {
+				return;
+			}
 			const point = Math.floor((note - startFrame) / playingFrame * C_LEN_DENSITY_DIVISION);
 			if (point >= 0) {
 				densityData[point]++;
@@ -1276,6 +1299,9 @@ function storeBaseData(_scoreId, _scoreObj, _keyCtrlPtn) {
 			}
 		});
 		_scoreObj.frzData[j].forEach((note, k) => {
+			if (isNaN(parseFloat(note))) {
+				return;
+			}
 			if (k % 2 === 0 && note !== ``) {
 				const point = Math.floor((note - startFrame) / playingFrame * C_LEN_DENSITY_DIVISION);
 				if (point >= 0) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -703,6 +703,7 @@ function clearWindow() {
 
 /**
  * 外部jsファイルの読込
+ * 読込可否を g_loadObj[ファイル名] で管理 (true: 読込成功, false: 読込失敗)
  * @param {string} _url 
  * @param {function} _callback 
  * @param {boolean} _requiredFlg (default : true / 読込必須)
@@ -1078,6 +1079,7 @@ function loadLocalStorage() {
  * 譜面読込
  * @param {function} _afterFunc 実行後の処理
  * @param {number} _scoreId 譜面番号
+ * @param {boolean} _cyclicFlg 再読込フラグ（譜面詳細情報取得用、再帰的にloadDosを呼び出す）
  */
 function loadDos(_afterFunc, _scoreId = g_stateObj.scoreId, _cyclicFlg = false) {
 
@@ -1141,7 +1143,7 @@ function loadDos(_afterFunc, _scoreId = g_stateObj.scoreId, _cyclicFlg = false) 
 					divRoot.removeChild(document.querySelector(`#lblLoading`));
 				}
 
-				// 外部データを読込
+				// 外部データを読込（ファイルが見つからなかった場合は譜面追記をスキップ）
 				externalDosInit();
 				if (!g_loadObj[filename]) {
 				} else {


### PR DESCRIPTION
## 変更内容
1. 譜面詳細情報取得時、キー数が異なるとデータがおかしくなる問題を修正しました。
2. scoreConvert関数が譜面番号依存だった問題を修正しました。
引数を以下のように変更しました。
    - 変更前：_dosObj (譜面情報), _scoreNo (譜面番号添え字), _preblankFrame, _dummyNo, _scoreAnalyzeFlg
    - 変更後：_dosObj (譜面情報), **_scoreId (譜面番号)**, _preblankFrame, _dummyNo, 
**_keyCtrlPtn (キー数・パターン)**, _scoreAnalyzeFlg
3. 共通で使用する以下の関数の引数に、keyCtrlPtn (キー数・パターン) や
scoreId (譜面番号) を追加しました。
    - getLastFrame
    - getStartFrame
    - getFirstArrowFrame
4. loadScript関数を改良し、読込成功・失敗をフラグで持たせました。
g_loadObj[ファイル名]で取得可能です。（true: 読込成功、false: 読込失敗)
また、ファイルが取得できない場合に読み込んだ譜面データを上書きしないよう対応しました。
5. loadDos関数について、必要に応じて再帰呼び出しする仕様に変更しました。

## 変更理由
1. キー数指定に`g_stateObj.scoreId`を指定していましたが、
譜面を全て取り込む場合、常に最初に指定したキーで固定されてしまうため。
2. 1.の問題に付随した修正です。
キー数指定に同じく`g_stateObj.scoreId`を指定していました。
3. 1.の問題に付随した修正です。
4. 読込成功・失敗を管理できるようにするため。
5. 譜面詳細情報をまとめて取得する際の問題に対応するため。

## その他コメント
- pushArrow関数にも同様の譜面番号依存が見られますが、
譜面の再生部分本体（mkArrow他）に手を入れる可能性は低いため、今回の対象外とします。
