### PR TITLE
[0152/color-gradation] 色変化のグラデーションに対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1678,11 +1678,11 @@ function drawMainSpriteData(_frame, _depthName) {
 /**
  * グラデーション用のカラーフォーマットを作成
  * @param {string} _colorStr 
- * @param {boolean} _defaultColorGrd
+ * @param {boolean} _defaultColorgrd
  * @param {boolean} _colorCdPaddingUse
  * @param {boolean} _musicTitleFlg
  */
-function makeColorGradation(_colorStr, _defaultColorGrd = g_headerObj.defaultColorGrd,
+function makeColorGradation(_colorStr, _defaultColorgrd = g_headerObj.defaultColorgrd,
 	_colorCdPaddingUse = false, _musicTitleFlg = false) {
 
 	// |color_data=300,20,45deg:#ffff99:#ffffff:#9999ff@linear-gradient|
@@ -1703,7 +1703,7 @@ function makeColorGradation(_colorStr, _defaultColorGrd = g_headerObj.defaultCol
 	if (colorArray.length === 1) {
 		if (_musicTitleFlg) {
 			convertColorStr = `to right, ${colorArray[0]} 100%, #eeeeee 0%`;
-		} else if (_defaultColorGrd) {
+		} else if (_defaultColorgrd) {
 			convertColorStr = `to right, ${colorArray[0]}, #eeeeee, ${colorArray[0]}`;
 		} else {
 			convertColorStr = `to right, ${colorArray[0]}, ${colorArray[0]}`;
@@ -2313,7 +2313,7 @@ function headerConvert(_dosObj) {
 	}
 
 	// 矢印の色変化を常時グラデーションさせる設定
-	obj.defaultColorGrd = setVal(_dosObj.defaultColorGrd, false, C_TYP_BOOLEAN);
+	obj.defaultColorgrd = setVal(_dosObj.defaultColorgrd, false, C_TYP_BOOLEAN);
 
 	// カラーコードのゼロパディング有無設定
 	obj.colorCdPaddingUse = setVal(_dosObj.colorCdPaddingUse, false, C_TYP_BOOLEAN);
@@ -2380,11 +2380,11 @@ function headerConvert(_dosObj) {
 			if (obj.colorCdPaddingUse) {
 				obj.setColorOrg[j] = `#${paddingLeft(obj.setColorOrg[j].slice(1), 6, `0`)}`;
 			}
-			obj.setColor[j] = makeColorGradation(obj.setColor[j], obj.defaultColorGrd, obj.colorCdPaddingUse);
+			obj.setColor[j] = makeColorGradation(obj.setColor[j], obj.defaultColorgrd, obj.colorCdPaddingUse);
 		}
 		for (let j = obj.setColor.length; j < obj.setColorInit.length; j++) {
 			obj.setColorOrg[j] = obj.setColor[j];
-			obj.setColor[j] = makeColorGradation(obj.setColorInit[j], obj.defaultColorGrd);
+			obj.setColor[j] = makeColorGradation(obj.setColorInit[j], obj.defaultColorgrd);
 		}
 	} else {
 		obj.setColorOrg = JSON.parse(JSON.stringify(obj.setColorInit));
@@ -2416,10 +2416,10 @@ function headerConvert(_dosObj) {
 			obj.frzColor[j] = tmpFrzColors[j].split(`,`);
 
 			for (let k = 0; k < obj.frzColor[j].length; k++) {
-				obj.frzColor[j][k] = makeColorGradation(obj.frzColor[j][k], obj.defaultColorGrd, obj.colorCdPaddingUse);
+				obj.frzColor[j][k] = makeColorGradation(obj.frzColor[j][k], obj.defaultColorgrd, obj.colorCdPaddingUse);
 			}
 			for (let k = obj.frzColor[j].length; k < obj.frzColorInit.length; k++) {
-				obj.frzColor[j][k] = makeColorGradation(obj.frzColorInit[k], obj.defaultColorGrd, obj.colorCdPaddingUse);
+				obj.frzColor[j][k] = makeColorGradation(obj.frzColorInit[k], obj.defaultColorgrd, obj.colorCdPaddingUse);
 			}
 
 			obj.frzColorDefault[j] = JSON.parse(JSON.stringify(obj.frzColor[j]));

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1680,10 +1680,10 @@ function drawMainSpriteData(_frame, _depthName) {
  * @param {string} _colorStr 
  * @param {boolean} _defaultColorgrd
  * @param {boolean} _colorCdPaddingUse
- * @param {boolean} _musicTitleFlg
+ * @param {boolean} _objType (normal: 汎用, titleMusic: タイトル曲名, titleArrow: タイトル矢印)
  */
 function makeColorGradation(_colorStr, _defaultColorgrd = g_headerObj.defaultColorgrd,
-	_colorCdPaddingUse = false, _musicTitleFlg = false) {
+	_colorCdPaddingUse = false, _objType = `normal`) {
 
 	// |color_data=300,20,45deg:#ffff99:#ffffff:#9999ff@linear-gradient|
 	// |color_data=300,20,#ffff99:#ffffff:#9999ff@radial-gradient|
@@ -1700,16 +1700,17 @@ function makeColorGradation(_colorStr, _defaultColorgrd = g_headerObj.defaultCol
 	}
 
 	const gradationType = (tmpColorStr.length > 1 ? tmpColorStr[1] : `linear-gradient`);
+	const defaultDir = (_objType === `titleArrow` ? `to left` : `to right`);
 	if (colorArray.length === 1) {
-		if (_musicTitleFlg) {
-			convertColorStr = `to right, ${colorArray[0]} 100%, #eeeeee 0%`;
+		if (_objType === `titleMusic`) {
+			convertColorStr = `${defaultDir}, ${colorArray[0]} 100%, #eeeeee 0%`;
 		} else if (_defaultColorgrd) {
-			convertColorStr = `to right, ${colorArray[0]}, #eeeeee, ${colorArray[0]}`;
+			convertColorStr = `${defaultDir}, ${colorArray[0]}, #eeeeee, ${colorArray[0]}`;
 		} else {
-			convertColorStr = `to right, ${colorArray[0]}, ${colorArray[0]}`;
+			convertColorStr = `${defaultDir}, ${colorArray[0]}, ${colorArray[0]}`;
 		}
 	} else if (gradationType === `linear-gradient` && colorArray[0].slice(0, 1) === `#`) {
-		convertColorStr = `to right, ${colorArray.join(', ')}`;
+		convertColorStr = `${defaultDir}, ${colorArray.join(', ')}`;
 	} else {
 		convertColorStr = `${colorArray.join(', ')}`;
 	}
@@ -1749,7 +1750,9 @@ function titleInit() {
 
 	// 背景の矢印オブジェクトを表示
 	if (!g_headerObj.customTitleArrowUse) {
-		const lblArrow = createColorObject(`lblArrow`, makeColorGradation(g_headerObj.setColorDefault[0], false, false),
+		const titlecolor = (g_headerObj.titlearrowgrds.length === 0 ?
+			`${g_headerObj.setColorDefault[0]}` : g_headerObj.titlearrowgrds[0]);
+		const lblArrow = createColorObject(`lblArrow`, makeColorGradation(titlecolor, false, false, `titleArrow`),
 			(g_sWidth - 500) / 2, -15 + (g_sHeight - 500) / 2,
 			500, 500, 180);
 		lblArrow.style.opacity = 0.25;
@@ -1780,12 +1783,12 @@ function titleInit() {
 		// グラデーションの指定がない場合、
 		// 矢印色の1番目と3番目を使ってタイトルをグラデーション
 		if (g_headerObj.titlegrds.length === 0) {
-			titlefontgrd = makeColorGradation(`${g_headerObj.setColorDefault[0]},${g_headerObj.setColorDefault[2]}`, false, false, true);
+			titlefontgrd = makeColorGradation(`${g_headerObj.setColorDefault[0]},${g_headerObj.setColorDefault[2]}`, false, false, `titleMusic`);
 			titlefontgrd2 = titlefontgrd;
 		} else {
-			titlefontgrd = makeColorGradation(g_headerObj.titlegrds[0], false, false, true);
+			titlefontgrd = makeColorGradation(g_headerObj.titlegrds[0], false, false, `titleMusic`);
 			if (g_headerObj.titlegrds.length > 1) {
-				titlefontgrd2 = makeColorGradation(g_headerObj.titlegrds[1], false, false, true);
+				titlefontgrd2 = makeColorGradation(g_headerObj.titlegrds[1], false, false, `titleMusic`);
 			}
 		}
 
@@ -2582,13 +2585,17 @@ function headerConvert(_dosObj) {
 	// デフォルト曲名表示のフォント名
 	obj.titlefont = setVal(_dosObj.titlefont, ``, C_TYP_STRING);
 
-	// デフォルト曲名表示のグラデーション指定css
+	// デフォルト曲名表示, 背景矢印のグラデーション指定css
 	obj.titlegrds = [];
-	if (_dosObj.titlegrd !== undefined) {
-		const tmpTitlegrd = _dosObj.titlegrd.replace(/,/g, `:`);
-		obj.titlegrds = tmpTitlegrd.split(`$`);
-		obj.titlegrd = setVal(obj.titlegrds[0], ``, C_TYP_STRING);
-	}
+	obj.titlearrowgrds = [];
+
+	[`titlegrd`, `titlearrowgrd`].forEach(_name => {
+		if (_dosObj[_name] !== undefined) {
+			const tmpTitlegrd = _dosObj[_name].replace(/,/g, `:`);
+			obj[`${_name}s`] = tmpTitlegrd.split(`$`);
+			obj[`${_name}`] = setVal(obj[`${_name}s`][0], ``, C_TYP_STRING);
+		}
+	});
 
 	// デフォルト曲名表示の表示位置調整
 	obj.titlepos = setVal(_dosObj.titlepos, ``, C_TYP_STRING);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2358,12 +2358,11 @@ function headerConvert(_dosObj) {
 		obj.setColor = _dosObj.setColor.split(`,`);
 		for (let j = 0; j < obj.setColor.length; j++) {
 
-			obj.setColorOrg[j] = obj.setColor[j].replace(/0x/g, `#`);
+			obj.setColorOrg[j] = obj.setColor[j].replace(/0x/g, `#`).split(`:`)[0];
 			if (obj.colorCdPaddingUse) {
 				obj.setColorOrg[j] = `#${paddingLeft(obj.setColorOrg[j].slice(1), 6, `0`)}`;
 			}
 			obj.setColor[j] = makeColorGradation(obj.setColor[j], obj.colorGradation, obj.colorCdPaddingUse);
-
 			/*
 			obj.setColor[j] = obj.setColor[j].replace(/0x/g, `#`);
 			if (obj.colorCdPaddingUse) {
@@ -2653,9 +2652,14 @@ function headerConvert(_dosObj) {
 /**
  * グラデーション用のカラーフォーマットを作成
  * @param {string} _colorStr 
+ * @param {boolean} _colorGradation
+ * @param {boolean} _colorCdPaddingUse
  */
 function makeColorGradation(_colorStr, _colorGradation = g_headerObj.colorGradation, _colorCdPaddingUse = false) {
-	// |color_data=300,20,to right:#ffff99:#ffffff:#9999ff@radial-gradient|
+
+	// |color_data=300,20,45deg:#ffff99:#ffffff:#9999ff@linear-gradient|
+	// |color_data=300,20,#ffff99:#ffffff:#9999ff@radial-gradient|
+	// |color_data=300,20,#ffff99:#ffffff:#9999ff@conic-gradient|
 
 	let convertColorStr;
 	const tmpColorStr = _colorStr.split(`@`);
@@ -2667,18 +2671,19 @@ function makeColorGradation(_colorStr, _colorGradation = g_headerObj.colorGradat
 		}
 	}
 
+	const gradationType = (tmpColorStr.length > 1 ? tmpColorStr[1] : `linear-gradient`);
 	if (colorArray.length === 1) {
 		if (_colorGradation) {
 			convertColorStr = `to right, ${colorArray[0]}, #ffffff, ${colorArray[0]}`;
 		} else {
 			convertColorStr = `to right, ${colorArray[0]}, ${colorArray[0]}`;
 		}
-	} else if (colorArray[0].slice(0, 1) === `#`) {
+	} else if (gradationType === `linear-gradient` && colorArray[0].slice(0, 1) === `#`) {
 		convertColorStr = `to right, ${colorArray.join(',')}`;
 	} else {
 		convertColorStr = `${colorArray.join(',')}`;
 	}
-	const gradationType = (tmpColorStr.length > 1 ? tmpColorStr[1] : `linear-gradient`);
+
 
 	return `${gradationType}(${convertColorStr})`;
 }

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1678,11 +1678,11 @@ function drawMainSpriteData(_frame, _depthName) {
 /**
  * グラデーション用のカラーフォーマットを作成
  * @param {string} _colorStr 
- * @param {boolean} _colorGradation
+ * @param {boolean} _defaultColorGrd
  * @param {boolean} _colorCdPaddingUse
  * @param {boolean} _musicTitleFlg
  */
-function makeColorGradation(_colorStr, _colorGradation = g_headerObj.colorGradation,
+function makeColorGradation(_colorStr, _defaultColorGrd = g_headerObj.defaultColorGrd,
 	_colorCdPaddingUse = false, _musicTitleFlg = false) {
 
 	// |color_data=300,20,45deg:#ffff99:#ffffff:#9999ff@linear-gradient|
@@ -1703,7 +1703,7 @@ function makeColorGradation(_colorStr, _colorGradation = g_headerObj.colorGradat
 	if (colorArray.length === 1) {
 		if (_musicTitleFlg) {
 			convertColorStr = `to right, ${colorArray[0]} 100%, #eeeeee 0%`;
-		} else if (_colorGradation) {
+		} else if (_defaultColorGrd) {
 			convertColorStr = `to right, ${colorArray[0]}, #eeeeee, ${colorArray[0]}`;
 		} else {
 			convertColorStr = `to right, ${colorArray[0]}, ${colorArray[0]}`;
@@ -2313,7 +2313,7 @@ function headerConvert(_dosObj) {
 	}
 
 	// 矢印の色変化を常時グラデーションさせる設定
-	obj.colorGradation = setVal(_dosObj.colorGradation, false, C_TYP_BOOLEAN);
+	obj.defaultColorGrd = setVal(_dosObj.defaultColorGrd, false, C_TYP_BOOLEAN);
 
 	// カラーコードのゼロパディング有無設定
 	obj.colorCdPaddingUse = setVal(_dosObj.colorCdPaddingUse, false, C_TYP_BOOLEAN);
@@ -2380,11 +2380,11 @@ function headerConvert(_dosObj) {
 			if (obj.colorCdPaddingUse) {
 				obj.setColorOrg[j] = `#${paddingLeft(obj.setColorOrg[j].slice(1), 6, `0`)}`;
 			}
-			obj.setColor[j] = makeColorGradation(obj.setColor[j], obj.colorGradation, obj.colorCdPaddingUse);
+			obj.setColor[j] = makeColorGradation(obj.setColor[j], obj.defaultColorGrd, obj.colorCdPaddingUse);
 		}
 		for (let j = obj.setColor.length; j < obj.setColorInit.length; j++) {
 			obj.setColorOrg[j] = obj.setColor[j];
-			obj.setColor[j] = makeColorGradation(obj.setColorInit[j], obj.colorGradation);
+			obj.setColor[j] = makeColorGradation(obj.setColorInit[j], obj.defaultColorGrd);
 		}
 	} else {
 		obj.setColorOrg = JSON.parse(JSON.stringify(obj.setColorInit));
@@ -2416,10 +2416,10 @@ function headerConvert(_dosObj) {
 			obj.frzColor[j] = tmpFrzColors[j].split(`,`);
 
 			for (let k = 0; k < obj.frzColor[j].length; k++) {
-				obj.frzColor[j][k] = makeColorGradation(obj.frzColor[j][k], obj.colorGradation, obj.colorCdPaddingUse);
+				obj.frzColor[j][k] = makeColorGradation(obj.frzColor[j][k], obj.defaultColorGrd, obj.colorCdPaddingUse);
 			}
 			for (let k = obj.frzColor[j].length; k < obj.frzColorInit.length; k++) {
-				obj.frzColor[j][k] = makeColorGradation(obj.frzColorInit[k], obj.colorGradation, obj.colorCdPaddingUse);
+				obj.frzColor[j][k] = makeColorGradation(obj.frzColorInit[k], obj.defaultColorGrd, obj.colorCdPaddingUse);
 			}
 
 			obj.frzColorDefault[j] = JSON.parse(JSON.stringify(obj.frzColor[j]));


### PR DESCRIPTION
## 変更内容
### 1. 矢印色、フリーズアロー色のグラデーション
- setColor, frzColor, color_data, acolor_dataに対応しています。
※titlegrdにも対応しました。詳細は3. にて。

#### 基本フォーマット
- `グラデーション記述@グラデーションの種類`
※グラデーション記述はカンマではなくコロン`:`で区切る
※グラデーション種類のうち、`linear-gradient`は省略可

#### 記述例
```
|setColor=#9999ff:#ffffff@radial-gradient,#99ffff:#ffffff@radial-gradient,#ffffff|

|color_data=300,20,45deg:#ffff99:#ffffff:#9999ff@linear-gradient|
|color_data=300,20,#ffff99:#ffffff:#9999ff@radial-gradient|
|acolor_data=300,20,#ffff99:#ffffff:#9999ff@conic-gradient|
```
#### グラデーション指定の省略について
- グラデーション種類を省略した場合：linear-gradient が指定されます。
- linear-gradient でグラデーション方向を省略した場合：`to right`が指定されます。
- 矢印色1種類を指定した場合：グラデーションのない単色になります。
（実際はlinear-gradientで開始色と終了色が同じ）

### 2. 常時グラデーション設定（タイトルは除く）
- 矢印色1種類を指定した場合、
自動で下記に設定する譜面ヘッダー｢defaultColorgrd｣を追加しました。
｢true｣で有効化します。
`linear-gradient(to right, 矢印色, #ffffff, 矢印色)`

### 3. タイトル曲名文字のグラデーション拡張
- 今回の変更に合わせ、仕様を統一しました。
タイトル曲名文字についても、`radial-gradient`などが適用できるようになりました。
記法もsetColorやcolor_dataと同じ形式で記述できます（これまでの記法もOK）。
```
|titlegrd=#ffff99:#ff9999@radial-gradient| // 新形式
|titlegrd=45deg:#ffff99:#ff9999| // 新形式 (linear-gradient)
|titlegrd=45deg,#ffff99,#ff9999| // 従来形式 (linear-gradient)
```

### 4. タイトル背景矢印のグラデーション実装
- `titlegrd`と同様、背景矢印も個別指定が可能となりました。`titlearrowgrd`で指定します。
```
|titlearrowgrd=#ffff99:#ff9999@radial-gradient| // 新形式
|titlearrowgrd=45deg:#ffff99:#ff9999| // 新形式 (linear-gradient)
```


## 変更理由
1. 矢印色のバリエーション拡張のため。
2. 手軽にグラデーションを利用できるようにするため。
3. タイトル曲名文字の仕様と類似しているため。
4. Issue #390 の一環です。

## その他コメント
- メイン画面のライフゲージ関連、ステップゾーンは対象外です。