### PR TITLE
[0153/include-dif-tools] レベル計算ツールの移植

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -104,6 +104,7 @@ const g_detailObj = {
 	playingFrame: [],
 	speedData: [],
 	boostData: [],
+	toolDif: [],
 };
 
 const g_workObj = {
@@ -374,6 +375,32 @@ function paddingLeft(_str, _length, _chr) {
 		paddingStr = _chr + paddingStr;
 	}
 	return paddingStr;
+}
+
+/**
+ * クリップボードコピー関数
+ * 入力値をクリップボードへコピーする
+ * @param {string} _textVal 入力値
+ */
+function copyTextToClipboard(_textVal) {
+	// テキストエリアを用意する
+	let copyFrom = document.createElement(`textarea`);
+	// テキストエリアへ値をセット
+	copyFrom.textContent = _textVal;
+
+	// bodyタグの要素を取得
+	var bodyElm = document.getElementsByTagName(`body`)[0];
+	// 子要素にテキストエリアを配置
+	bodyElm.appendChild(copyFrom);
+
+	// テキストエリアの値を選択
+	copyFrom.select();
+	// コピーコマンド発行
+	var retVal = document.execCommand(`copy`);
+	// 追加テキストエリアを削除
+	bodyElm.removeChild(copyFrom);
+	// 処理結果を返却
+	return retVal;
 }
 
 /**
@@ -1324,6 +1351,7 @@ function storeBaseData(_scoreId, _scoreObj, _keyCtrlPtn) {
 		});
 	}
 
+	g_detailObj.toolDif[_scoreId] = calcLevel(_scoreObj);
 	g_detailObj.speedData[_scoreId] = _scoreObj.speedData.concat();
 	g_detailObj.boostData[_scoreId] = _scoreObj.boostData.concat();
 
@@ -1384,6 +1412,216 @@ function loadSettingJs() {
 		}
 		initAfterDosLoaded();
 	}, false);
+}
+
+/**
+ * ツール計算
+ * @param {object} _scoreObj 
+ */
+function calcLevel(_scoreObj) {
+	//--------------------------------------------------------------
+	//＜フリーズデータ分解＞
+	//  フリーズデータを分解し、矢印データに組み込む
+	//
+	//  (イメージ)
+	//    &left_data=400,500,700&
+	//    &frzLeft_data=550,650&
+	//  ⇒
+	//    left_data=[400,500,550,700];  // フリーズの始点を組込
+	//    frzStartData=[550];	// フリーズ始点
+	//    frzEndData  =[650];	// フリーズ終点
+	//--------------------------------------------------------------
+	let frzStartData = [];
+	let frzEndData = [];
+
+	for (let j = 0; j < _scoreObj.frzData.length; j++) {
+		if (_scoreObj.frzData[j].length > 1) {
+			for (let k = 0; k < _scoreObj.frzData[j].length; k += 2) {
+				_scoreObj.arrowData[j].push(_scoreObj.frzData[j][k]);
+				frzStartData.push(_scoreObj.frzData[j][k]);
+				frzEndData.push(_scoreObj.frzData[j][k + 1]);
+			}
+		}
+		_scoreObj.arrowData[j].sort((a, b) => a - b);
+	}
+
+	frzStartData.sort((a, b) => a - b);
+	frzEndData.sort((a, b) => a - b);
+
+	//--------------------------------------------------------------
+	//＜データ結合･整理＞
+	//  矢印データを連結してソートする。
+	//
+	//  重複は後の同時押し補正で使用する。
+	//  後の同時押し補正の都合上、firstFrame-100, lastFrame+100 のデータを末尾に追加。
+	//
+	//  (イメージ)
+	//    &left_data=300,400,550&	// フリーズデータ(始点)を含む
+	//    &down_data=500&
+	//    &up_data=600&
+	//    &right_data=700,800&
+	//    &space_data=200,300,1000&
+	//    frzEndData = [650];	// フリーズデータ(終点) ※allScorebook対象外
+	//  ⇒
+	//    allScorebook = [100,200,300,300,400,500,550,600,700,800,1000,1100];
+	//
+	//--------------------------------------------------------------
+	let allScorebook = [];
+	let firstFrame = 0;
+	let lastFrame = 0;
+
+	for (let j = 0; j < _scoreObj.arrowData.length; j++) {
+		allScorebook = allScorebook.concat(_scoreObj.arrowData[j]);
+	}
+
+	allScorebook.sort((a, b) => a - b);
+	allScorebook.unshift(allScorebook[0] - 100);
+	allScorebook.push(allScorebook[allScorebook.length - 1] + 100);
+
+	frzEndData.push(allScorebook[allScorebook.length - 1]);
+
+	// ファーストナンバー、ラストナンバーの特定
+	if (!isNaN(parseFloat(allScorebook[1]))) {
+		firstFrame = allScorebook[1];
+	} else {
+		firstFrame = 0;
+	}
+	if (!isNaN(parseFloat(allScorebook[allScorebook.length - 2]))) {
+		lastFrame = allScorebook[allScorebook.length - 2];
+		if (!isNaN(parseFloat(frzEndData[frzEndData.length - 2]))) {
+			let arrEnd = Math.round(allScorebook[allScorebook.length - 2]);
+			let frzEnd = Math.round(frzEndData[frzEndData.length - 2]);
+			if (frzEnd > arrEnd) {
+				lastFrame = frzEnd;
+			}
+		}
+	} else {
+		lastFrame = 0;
+	}
+
+	//--------------------------------------------------------------
+	//＜間隔フレーム数の調和平均計算+いろいろ補正＞
+	//  レベル計算メイン。
+	//
+	//  [レベル計算ツール++ ver1.18] 3つ押し以上でも同時押し補正ができるよう調整
+	//--------------------------------------------------------------
+	let levelcount = 0;   // 難易度レベル
+	let leveltmp;
+	let freezenum = 0; // フリーズアロー数
+	let pushCnt = 1;   // 同時押し数カウント
+	let twoPushCount = 0; // 同時押し補正値
+	let push3cnt = [];    // 3つ押し判定数
+
+	for (let i = 1; i < allScorebook.length - 2; ++i) {
+		// フリーズ始点の検索
+		while (frzStartData[0] == allScorebook[i]) {
+			// 同時押しの場合
+			if (allScorebook[i] == allScorebook[i + 1]) {
+				break;
+			}
+
+			// 現フレームに存在するフリーズ数を1増やす
+			// (フリーズアローの同時チェック開始)
+			frzStartData.shift();
+			freezenum++;
+		}
+
+		// フリーズ終点の検索
+		while (frzEndData[0] < allScorebook[i + 1]) {
+			// 現フレームに存在するフリーズ数を1減らす
+			frzEndData.shift();
+			freezenum--;
+		}
+
+		// 同時押し補正処理(フリーズアローが絡まない場合)
+		if (allScorebook[i + 1] == allScorebook[i] && !freezenum) {
+
+			let chk = (allScorebook[i + 2] - allScorebook[i + 1]) * (allScorebook[i] - allScorebook[i - pushCnt]);
+			if (chk != 0) {
+				twoPushCount += 40 / chk;
+			} else {
+				// 3つ押しが絡んだ場合は加算しない
+				push3cnt.push(allScorebook[i]);
+			}
+			pushCnt++;
+
+			// 単押し＋フリーズアローの補正処理(フリーズアロー中の矢印)
+		} else {
+			pushCnt = 1;
+			let chk2 = (2 - freezenum) * (allScorebook[i + 1] - allScorebook[i]);
+			if (chk2 > 0) {
+				levelcount += 2 / chk2;
+			} else {
+				// 3つ押しが絡んだ場合は加算しない
+				push3cnt.push(allScorebook[i]);
+			}
+		}
+	}
+	levelcount += twoPushCount;
+	leveltmp = levelcount;
+
+	//--------------------------------------------------------------
+	//＜同方向連打補正＞
+	//  同方向矢印(フリーズアロー)の隣接間隔が10フレーム未満の場合に加算する。
+	//--------------------------------------------------------------
+	for (let j = 0; j < _scoreObj.arrowData.length; j++) {
+		for (let k = 0; k < _scoreObj.arrowData[j].length; ++k) {
+			_scoreObj.arrowData[j][k]
+			if (_scoreObj.arrowData[j][k + 1] - _scoreObj.arrowData[j][k] < 10) {
+				levelcount += 10 / (_scoreObj.arrowData[j][k + 1] - _scoreObj.arrowData[j][k])
+					/ (_scoreObj.arrowData[j][k + 1] - _scoreObj.arrowData[j][k]) - 1 / 10;
+			}
+		}
+	}
+
+	//--------------------------------------------------------------
+	//＜表示＞
+	//  曲長補正を行い、最終的な難易度レベル値を表示する。
+	//--------------------------------------------------------------
+	// 難易度レベル(最終)
+	let print = Math.round(levelcount / Math.sqrt(allScorebook.length - push3cnt.length - 3) * 400) / 100;
+
+	// 難易度レベル(縦連打以外)
+	let tmp = Math.round(leveltmp / Math.sqrt(allScorebook.length - push3cnt.length - 3) * 400) / 100;
+
+	// 縦連打補正値計算
+	let tate = Math.round((print - tmp) * 100) / 100;
+	if (isNaN(tate) || tate == Infinity) {
+		tate = 0;
+	}
+	// 同時押し補正値計算
+	let douji = Math.round(twoPushCount / Math.sqrt(allScorebook.length - push3cnt.length - 3) * 400) / 100;
+	if (isNaN(douji) || douji == Infinity) {
+		douji = 0;
+	}
+
+	//--------------------------------------------------------------
+	//＜難易度レベル(最終)を小数第2位までに丸める＞
+	//  [レベル計算ツール++ ver1.18] 3つ押し補正適用
+	//  [レベル計算ツール++ ver1.28] 矢印数1の場合の処理追加
+	//--------------------------------------------------------------
+	let subPrint;
+	if (allScorebook.length == 3) {
+		print = `0.01`;
+		tmp = `0.01`;
+	} else {
+		print = Math.round(print * 100 * (allScorebook.length - 3) / (allScorebook.length - push3cnt.length - 3)) / 100;
+		subPrint = Math.round((print * 100) % 100);
+		subPrint = (subPrint < 10 ? "0" + subPrint : "" + subPrint);
+		print = `${Math.floor(print)}.${subPrint}${(push3cnt.length > 0 ? "*" : "")}`;
+	}
+
+	//--------------------------------------------------------------
+	//＜計算結果を格納＞
+	//--------------------------------------------------------------
+	let toolDif = {
+		tool: print,
+		tate: tate,
+		douji: douji,
+		push3cnt: push3cnt.length,
+		push3: push3cnt,
+	};
+	return toolDif;
 }
 
 function loadMusic() {
@@ -3220,6 +3458,7 @@ function createOptionWindow(_sprite) {
 		scoreDetail.style.visibility = `hidden`;
 		scoreDetail.appendChild(createScoreDetail(`Speed`));
 		scoreDetail.appendChild(createScoreDetail(`Density`));
+		scoreDetail.appendChild(createScoreDetail(`ToolDif`, false));
 
 		const btnGraph = createCssButton({
 			id: `btnGraph`,
@@ -3405,9 +3644,9 @@ function createOptionWindow(_sprite) {
 	 * @param {string} _value 
 	 * @param {number} _pos 表示位置
 	 */
-	function makeScoreDetailLabel(_name, _label, _value, _pos = 0) {
+	function makeScoreDetailLabel(_name, _label, _value, _pos = 0, _labelname = _label) {
 		if (document.querySelector(`#data${_label}`) === null) {
-			const lbl = createDivCssLabel(`lbl${_label}`, 10, 65 + _pos * 20, 100, 20, 14, `${_label}`);
+			const lbl = createDivCssLabel(`lbl${_label}`, 10, 65 + _pos * 20, 100, 20, 14, `${_labelname}`);
 			lbl.style.textAlign = C_ALIGN_LEFT;
 			document.querySelector(`#detail${_name}`).appendChild(lbl);
 			const data = createDivCssLabel(`data${_label}`, 10, 65 + _pos * 20, 100, 20, 14, `${_value}`);
@@ -3459,6 +3698,118 @@ function createOptionWindow(_sprite) {
 			_context.strokeStyle = `#646464`;
 		}
 		_context.stroke();
+	}
+
+	/**
+	 * 譜面の難易度情報
+	 * @param {number} _scoreId 
+	 */
+	function makeDifInfo(_scoreId) {
+
+		const arrowCnts = g_detailObj.arrowCnt[_scoreId].reduce((p, x) => p + x);
+		const frzCnts = g_detailObj.frzCnt[_scoreId].reduce((p, x) => p + x);
+		let lbl;
+		let data;
+
+		// ツール難易度
+		if (document.querySelector(`#lblTooldif`) === null) {
+			lbl = createDivCssLabel(`lblTooldif`, 125, 10, 250, 35, 20, `ツール難易度:`);
+			lbl.style.textAlign = C_ALIGN_LEFT;
+			document.querySelector(`#detailToolDif`).appendChild(lbl);
+
+			data = createDivCssLabel(`dataTooldif`, 290, 10, 120, 35, 20, g_detailObj.toolDif[_scoreId].tool);
+			data.style.textAlign = C_ALIGN_CENTER;
+			document.querySelector(`#detailToolDif`).appendChild(data);
+		} else {
+			document.querySelector(`#dataTooldif`).innerHTML = g_detailObj.toolDif[_scoreId].tool;
+		}
+
+		let ArrowInfo = `${arrowCnts + frzCnts} (${arrowCnts} + ${frzCnts})`;
+		let ArrowInfo2 = `<br>(${g_detailObj.arrowCnt[_scoreId]})<br><br>(${g_detailObj.frzCnt[_scoreId]})`.split(`,`).join(`/`);
+		// ノーツ数詳細
+		if (document.querySelector(`#lblArrowInfo`) === null) {
+			lbl = createDivCssLabel(`lblArrowInfo`, 125, 40, 250, 35, 18, `矢印数:`);
+			lbl.style.textAlign = C_ALIGN_LEFT;
+			document.querySelector(`#detailToolDif`).appendChild(lbl);
+
+			data = createDivCssLabel(`dataArrowInfo`, 150, 40, 300, 35, 18, ArrowInfo);
+			data.style.textAlign = C_ALIGN_CENTER;
+			document.querySelector(`#detailToolDif`).appendChild(data);
+
+			lbl = createDivCssLabel(`lblArrowInfo2`, 125, 70, 50, 90, 14, `通常:<br><br>氷矢:`);
+			lbl.style.textAlign = C_ALIGN_LEFT;
+			document.querySelector(`#detailToolDif`).appendChild(lbl);
+
+			data = createDivCssLabel(`dataArrowInfo2`, 125, 70, 285, 90, 14, ArrowInfo2);
+			data.style.textAlign = C_ALIGN_LEFT;
+			data.style.overflow = `auto`;
+			document.querySelector(`#detailToolDif`).appendChild(data);
+		} else {
+			document.querySelector(`#dataArrowInfo`).innerHTML = ArrowInfo;
+			document.querySelector(`#dataArrowInfo2`).innerHTML = ArrowInfo2;
+		}
+
+		// 詳細データ
+		makeScoreDetailLabel(`ToolDif`, `douji`, g_detailObj.toolDif[_scoreId].douji, 1, `同時`);
+		makeScoreDetailLabel(`ToolDif`, `tate`, g_detailObj.toolDif[_scoreId].tate, 2, `縦連`);
+		makeScoreDetailLabel(`ToolDif`, `push3cnt`, g_detailObj.toolDif[_scoreId].push3cnt, 4, `3つ押し数`);
+
+		// 3つ押しリスト
+		makeScoreDetailLabel(`ToolDif`, `push3`, ``, 5, `3つ押しリスト`);
+		if (document.querySelector(`#datapush3list`) === null) {
+			const push3 = createDivCssLabel(`datapush3list`, 10, 65 + 6 * 20, 400, 35, 14, g_detailObj.toolDif[_scoreId].push3);
+			push3.style.textAlign = C_ALIGN_LEFT;
+			push3.style.overflow = `auto`;
+			document.querySelector(`#detailToolDif`).appendChild(push3);
+		} else {
+			document.querySelector(`#datapush3list`).innerHTML = g_detailObj.toolDif[_scoreId].push3;
+		}
+		document.querySelector(`#lblpush3`).innerHTML = (g_detailObj.toolDif[_scoreId].push3cnt > 0 ? `3つ押しリスト` : ``);
+
+		// データ出力ボタン
+		if (document.querySelector(`#lnkDifInfo`) === null) {
+			let printData = ``;
+			for (let j = 0; j < g_detailObj.arrowCnt.length; j++) {
+				const arrowCnts = g_detailObj.arrowCnt[j].reduce((p, x) => p + x);
+				const frzCnts = g_detailObj.frzCnt[j].reduce((p, x) => p + x);
+				const apm = Math.round((arrowCnts + frzCnts) / (g_detailObj.playingFrame[j] / g_fps / 60));
+				const minutes = Math.floor(g_detailObj.playingFrame[j] / g_fps / 60);
+				const seconds = `00${Math.floor((g_detailObj.playingFrame[j] / g_fps) % 60)}`.slice(-2);
+				const playingTime = `${minutes}:${seconds}`;
+
+				printData +=
+					// 譜面番号
+					`[${j + 1}]\t` +
+					// ツール値
+					`${g_detailObj.toolDif[j].tool}\t` +
+					// 同時
+					`${g_detailObj.toolDif[j].douji}\t` +
+					// 縦連
+					`${g_detailObj.toolDif[j].tate}\t` +
+					// 総矢印数
+					`${(arrowCnts + frzCnts)}\t` +
+					// 矢印
+					`${arrowCnts}\t` +
+					// フリーズアロー
+					`${frzCnts}\t` +
+					// APM
+					`${apm}\t` +
+					// 時間(分秒)
+					`${playingTime}\r\n`;
+			}
+			const lnk = makeSettingLblCssButton(`lnkDifInfo`, `データ出力`, 0, _ => {
+				copyTextToClipboard(
+					`****** Dancing☆Onigiri レベル計算ツール+++ [${g_version}] ******\r\n\r\n`
+					+ `\t難易度\t同時\t縦連\t総数\t矢印\t氷矢印\tAPM\t時間\r\n\r\n${printData}`
+				);
+			});
+			lnk.style.left = `10px`;
+			lnk.style.top = `30px`;
+			lnk.style.width = `100px`;
+			lnk.style.borderStyle = `solid`;
+			lnk.classList.add(g_cssObj.button_RevON);
+			document.querySelector(`#detailToolDif`).appendChild(lnk);
+		}
 	}
 
 	// ---------------------------------------------------
@@ -3912,6 +4263,7 @@ function createOptionWindow(_sprite) {
 		if (g_headerObj.scoreDetailUse) {
 			drawSpeedGraph(g_stateObj.scoreId);
 			drawDensityGraph(g_stateObj.scoreId);
+			makeDifInfo(g_stateObj.scoreId);
 		}
 
 		// リバース設定 (Reverse, Scroll)

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -336,7 +336,7 @@ let g_volumeNum = g_volumes.length - 1;
 let g_appearances = [`Visible`, `Hidden`, `Sudden`, `Slit`];
 let g_appearanceNum = 0;
 
-let g_scoreDetails = [`Speed`, `Density`];
+let g_scoreDetails = [`Speed`, `Density`, `ToolDif`];
 let g_scoreDetailNum = 0;
 
 let g_displays = [`stepZone`, `judgement`, `lifeGauge`, `musicInfo`, `special`,


### PR DESCRIPTION
## 変更内容
- Dancing☆Onigiri レベル計算ツール++ [Ver1.31]の機能を本体に組み込みました。
(Pull Request #602 と内容は同じです)

1. 譜面から自動でレベル計算を行う機能（ツール値, 同時押し補正、縦連打補正）
2. 3つ押し数及び該当箇所を表示する機能
3. レーンごとの矢印数を表示する機能
4. 全譜面のツール値情報をクリップボードへコピーする機能

## 変更理由
- ツール難易度の計算の手間を省くため。

## その他コメント
- Pull Request #602 でソースの巻き戻しがあったため、
差分を抽出し新PRとして上げ直しました。