### PR TITLE
[ver12.0.0] 矢印色のグラデーション実装、レベル計算ツール++移植

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2020/02/05
+ * Revised : 2020/02/09
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 11.4.0`;
-const g_revisedDate = `2020/02/05`;
+const g_version = `Ver 12.0.0`;
+const g_revisedDate = `2020/02/09`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9237,16 +9237,21 @@ function makeCssResultSymbol(_id, _x, _class, _heightPos, _text, _align) {
 // ライセンス原文、以下は削除しないでください
 /*-----------------------------------------------------------*/
 /*
+
 MIT License
+
 Copyright (c) 2018 tickle
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
+
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
+
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -9254,5 +9259,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
  */
 /*-----------------------------------------------------------*/

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -5,7 +5,7 @@
  *
  * Source by tickle
  * Created : 2019/11/19
- * Revised : 2020/01/29
+ * Revised : 2020/02/09
  *
  * https://github.com/cwtickle/danoniplus
  */


### PR DESCRIPTION
## 変更内容
- 矢印色・フリーズアロー色のグラデーション実装 ( #601 )
- レベル計算ツール++移植 ( #602 )

## 変更理由
- それぞれのPull Requestを参照。

## その他コメント

