### PR TITLE
[0156/synchronized-loading-dos] 譜面詳細用データを全て読み込んでからタイトルへ移動するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1198,6 +1198,8 @@ function reloadDos(_scoreId) {
 		loadDos(_ => {
 			getScoreDetailData(_scoreId);
 		}, _scoreId, true);
+	} else {
+		titleInit();
 	}
 }
 
@@ -1288,7 +1290,6 @@ function initAfterDosLoaded() {
 		loadDos(_ => {
 			getScoreDetailData(0);
 		}, 0, true);
-		titleInit();
 	});
 }
 


### PR DESCRIPTION
## 変更内容
1. 譜面詳細用データを全て読み込んでからタイトルへ移動するよう変更しました。
`loadDos`関数で譜面詳細用データを取り切った後、`titleInit`を処理するよう変更しています。

## 変更理由
1. `loadDos`関数が非同期処理にも関わらず、`titleInit`と同時に処理するようになっていました。
これにより、`loadDos`関数（実際には`reloadDos`）の処理がデータ出力を作成する`makeDifInfo`関数の開始に間に合わず、一部の譜面データが未出力となる事象が発生していました。

## その他コメント
- この変更で、譜面数が多い作品のタイトル画面の表示が若干遅くなる可能性がありますが
気にするレベルでは無いと思います。