### PR TITLE
[0162/score-override] スコア上書きのためにハイスコア差分が計算されない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8968,9 +8968,12 @@ function resultInit() {
 		score: 0,
 	};
 
-	if (g_stateObj.autoPlay === C_FLG_OFF && g_stateObj.shuffle === C_FLG_OFF &&
-		setVal(g_keyObj[`transKey${keyCtrlPtn}`], ``, C_TYP_STRING) === ``) {
+	const highscoreCondition = (g_stateObj.autoPlay === C_FLG_OFF && g_stateObj.shuffle === C_FLG_OFF &&
+		setVal(g_keyObj[`transKey${keyCtrlPtn}`], ``, C_TYP_STRING) === ``);
 
+	if (highscoreCondition) {
+
+		// ハイスコア差分描画
 		judgeIds.forEach((id, j) => {
 			if (id === `Score`) {
 			} else if (id !== ``) {
@@ -8994,8 +8997,7 @@ function resultInit() {
 		}
 	}
 
-	if (g_stateObj.autoPlay === C_FLG_OFF && g_stateObj.shuffle === C_FLG_OFF &&
-		setVal(g_keyObj[`transKey${keyCtrlPtn}`], ``, C_TYP_STRING) === ``) {
+	if (highscoreCondition) {
 
 		if (scoreName in g_localStorage.highscores) {
 			judgeScores.forEach(judge => {
@@ -9020,7 +9022,7 @@ function resultInit() {
 			localStorage.setItem(g_localStorageUrl, JSON.stringify(g_localStorage));
 		}
 
-		// ハイスコア差分描画
+		// ハイスコア差分値適用、ハイスコア部分作成
 		judgeIds.forEach((id, j) => {
 			if (id === `Score`) {
 				resultWindow.appendChild(makeCssResultSymbol(`lbl${id}L1`, C_RLT_BRACKET_L, `${highscoreDfObj.score > 0 ? g_cssObj.result_scoreHiPlus : g_cssObj.result_scoreHiBlanket}`,

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8968,6 +8968,24 @@ function resultInit() {
 		score: 0,
 	};
 
+	if (g_stateObj.autoPlay === C_FLG_OFF && g_stateObj.shuffle === C_FLG_OFF &&
+		setVal(g_keyObj[`transKey${keyCtrlPtn}`], ``, C_TYP_STRING) === ``) {
+
+		judgeIds.forEach((id, j) => {
+			if (id === `Score`) {
+			} else if (id !== ``) {
+				resultWindow.appendChild(makeCssResultSymbol(`lbl${id}L1`, C_RLT_BRACKET_L, g_cssObj.result_scoreHiBlanket, j, `(+`, C_ALIGN_LEFT));
+				resultWindow.appendChild(makeCssResultSymbol(`lbl${id}LS`, C_RLT_HIDIF_X, g_cssObj.result_scoreHi, j, 0, C_ALIGN_RIGHT));
+				resultWindow.appendChild(makeCssResultSymbol(`lbl${id}L2`, C_RLT_BRACKET_R, g_cssObj.result_scoreHiBlanket, j, `)`, C_ALIGN_LEFT));
+			}
+		});
+
+	} else {
+		resultWindow.appendChild(makeCssResultSymbol(`lblAutoView`, 230, g_cssObj.result_noRecord, 4, `(No Record)`, C_ALIGN_LEFT));
+		const lblAutoView = document.querySelector(`#lblAutoView`);
+		lblAutoView.style.fontSize = `24px`;
+	}
+
 	// ユーザカスタムイベント(初期)
 	if (typeof customResultInit === C_TYP_FUNCTION) {
 		customResultInit();
@@ -9012,16 +9030,11 @@ function resultInit() {
 				resultWindow.appendChild(makeCssResultSymbol(`lbl${id}L2`, C_RLT_BRACKET_R, `${highscoreDfObj.score > 0 ? g_cssObj.result_scoreHiPlus : g_cssObj.result_scoreHiBlanket}`,
 					j, `)`, C_ALIGN_LEFT));
 			} else if (id !== ``) {
-				resultWindow.appendChild(makeCssResultSymbol(`lbl${id}L1`, C_RLT_BRACKET_L, g_cssObj.result_scoreHiBlanket, j, `(${highscoreDfObj[judgeScores[j]] >= 0 ? "+" : "－"}`, C_ALIGN_LEFT));
-				resultWindow.appendChild(makeCssResultSymbol(`lbl${id}LS`, C_RLT_HIDIF_X, g_cssObj.result_scoreHi, j, Math.abs(highscoreDfObj[judgeScores[j]]), C_ALIGN_RIGHT));
-				resultWindow.appendChild(makeCssResultSymbol(`lbl${id}L2`, C_RLT_BRACKET_R, g_cssObj.result_scoreHiBlanket, j, `)`, C_ALIGN_LEFT));
+				document.querySelector(`#lbl${id}L1`).innerHTML = `(${highscoreDfObj[judgeScores[j]] >= 0 ? "+" : "－"}`;
+				document.querySelector(`#lbl${id}LS`).innerHTML = Math.abs(highscoreDfObj[judgeScores[j]]);
 			}
 		});
 
-	} else {
-		resultWindow.appendChild(makeCssResultSymbol(`lblAutoView`, 230, g_cssObj.result_noRecord, 4, `(No Record)`, C_ALIGN_LEFT));
-		const lblAutoView = document.querySelector(`#lblAutoView`);
-		lblAutoView.style.fontSize = `24px`;
 	}
 
 	// Twitter用リザルト

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8908,6 +8908,48 @@ function resultInit() {
 	lblRank.style.textAlign = C_ALIGN_CENTER;
 	resultWindow.appendChild(lblRank);
 
+	// Cleared & Failed表示
+	const lblResultPre = createDivCssLabel(`lblResultPre`, g_sWidth / 2 - 150, g_sHeight / 2 - 160,
+		200, 50, 60, `<span class="result_Cleared">CLEARED!</span>`, g_cssObj.result_Cleared);
+	lblResultPre.classList.add(g_cssObj.result_Window);
+	divRoot.appendChild(lblResultPre);
+	lblResultPre.style.opacity = 0;
+
+	let resultFlgTmp = ``;
+
+	if (playingArrows === fullArrows) {
+		if (g_resultObj.ii + g_resultObj.kita === fullArrows) {
+			resultFlgTmp = `<span class="result_AllPerfect">All Perfect!!</span>`;
+		} else if (g_resultObj.ii + g_resultObj.shakin + g_resultObj.kita === fullArrows) {
+			resultFlgTmp = `<span class="result_Perfect">Perfect!!</span>`;
+		} else if (g_resultObj.uwan === 0 && g_resultObj.shobon === 0 && g_resultObj.iknai === 0) {
+			resultFlgTmp = `<span class="result_FullCombo">FullCombo!</span>`;
+		} else {
+			resultFlgTmp = `<span class="result_Cleared">CLEARED!</span>`;
+		}
+	} else {
+		resultFlgTmp = ``;
+	}
+
+	const lblResultPre2 = createDivCssLabel(`lblResultPre2`, g_sWidth / 2 + 50, 40,
+		200, 30, 20, resultFlgTmp, g_cssObj.result_Cleared);
+	divRoot.appendChild(lblResultPre2);
+
+	if (!g_gameOverFlg) {
+		lblResultPre.style.animationDuration = `2.5s`;
+		lblResultPre.style.animationName = `leftToRightFade`;
+	} else {
+		lblResultPre.style.animationDuration = `3s`;
+		lblResultPre.innerHTML = `<span class="result_Failed">FAILED...</span>`;
+		lblResultPre.style.animationName = `upToDownFade`;
+
+		lblResultPre2.innerHTML = `<span class="result_Failed">FAILED...</span>`;
+	}
+
+	// プレイデータは Cleared & Failed に合わせて表示
+	playDataWindow.style.animationDuration = `3s`;
+	playDataWindow.style.animationName = `slowlyAppearing`;
+
 	// ハイスコア差分計算
 	let scoreName = `${g_headerObj.keyLabels[g_stateObj.scoreId]}k-${g_headerObj.difLabels[g_stateObj.scoreId]}`;
 	if (g_headerObj.makerView) {
@@ -8925,6 +8967,14 @@ function resultInit() {
 		fmaxCombo: 0,
 		score: 0,
 	};
+
+	// ユーザカスタムイベント(初期)
+	if (typeof customResultInit === C_TYP_FUNCTION) {
+		customResultInit();
+		if (typeof customResultInit2 === C_TYP_FUNCTION) {
+			customResultInit2();
+		}
+	}
 
 	if (g_stateObj.autoPlay === C_FLG_OFF && g_stateObj.shuffle === C_FLG_OFF &&
 		setVal(g_keyObj[`transKey${keyCtrlPtn}`], ``, C_TYP_STRING) === ``) {
@@ -8995,57 +9045,6 @@ function resultInit() {
 		${g_resultObj.maxCombo}-${g_resultObj.fmaxCombo} 
 		${g_localStorageUrl}`.replace(/[\t\n]/g, ``);
 	const tweetResult = `https://twitter.com/intent/tweet?text=${encodeURIComponent(tweetResultTmp)}`;
-
-
-	// Cleared & Failed表示
-	const lblResultPre = createDivCssLabel(`lblResultPre`, g_sWidth / 2 - 150, g_sHeight / 2 - 160,
-		200, 50, 60, `<span class="result_Cleared">CLEARED!</span>`, g_cssObj.result_Cleared);
-	lblResultPre.classList.add(g_cssObj.result_Window);
-	divRoot.appendChild(lblResultPre);
-	lblResultPre.style.opacity = 0;
-
-	let resultFlgTmp = ``;
-
-	if (playingArrows === fullArrows) {
-		if (g_resultObj.ii + g_resultObj.kita === fullArrows) {
-			resultFlgTmp = `<span class="result_AllPerfect">All Perfect!!</span>`;
-		} else if (g_resultObj.ii + g_resultObj.shakin + g_resultObj.kita === fullArrows) {
-			resultFlgTmp = `<span class="result_Perfect">Perfect!!</span>`;
-		} else if (g_resultObj.uwan === 0 && g_resultObj.shobon === 0 && g_resultObj.iknai === 0) {
-			resultFlgTmp = `<span class="result_FullCombo">FullCombo!</span>`;
-		} else {
-			resultFlgTmp = `<span class="result_Cleared">CLEARED!</span>`;
-		}
-	} else {
-		resultFlgTmp = ``;
-	}
-
-	const lblResultPre2 = createDivCssLabel(`lblResultPre2`, g_sWidth / 2 + 50, 40,
-		200, 30, 20, resultFlgTmp, g_cssObj.result_Cleared);
-	divRoot.appendChild(lblResultPre2);
-
-	if (!g_gameOverFlg) {
-		lblResultPre.style.animationDuration = `2.5s`;
-		lblResultPre.style.animationName = `leftToRightFade`;
-	} else {
-		lblResultPre.style.animationDuration = `3s`;
-		lblResultPre.innerHTML = `<span class="result_Failed">FAILED...</span>`;
-		lblResultPre.style.animationName = `upToDownFade`;
-
-		lblResultPre2.innerHTML = `<span class="result_Failed">FAILED...</span>`;
-	}
-
-	// プレイデータは Cleared & Failed に合わせて表示
-	playDataWindow.style.animationDuration = `3s`;
-	playDataWindow.style.animationName = `slowlyAppearing`;
-
-	// ユーザカスタムイベント(初期)
-	if (typeof customResultInit === C_TYP_FUNCTION) {
-		customResultInit();
-		if (typeof customResultInit2 === C_TYP_FUNCTION) {
-			customResultInit2();
-		}
-	}
 
 	// 戻るボタン描画
 	const btnBack = createCssButton({


### PR DESCRIPTION
## 変更内容
1. スコア上書きのためにハイスコア差分が計算されない問題を修正しました。
カスタムイベントの位置を以下のように見直しています。

- ハイスコア差分のdiv要素作成
- カスタムイベント
- ハイスコア差分の値計算、ハイスコアdiv要素の作成及び値計算

## 変更理由
1. ver10.5.0において #557 を修正したことの影響修正です。

## その他コメント

