### PR TITLE
titlegrdが1行分だけ指定されているとき2行目が表示されない問題の修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2014,6 +2014,8 @@ function titleInit() {
 			titlefontgrd = makeColorGradation(g_headerObj.titlegrds[0], false, false, `titleMusic`);
 			if (g_headerObj.titlegrds.length > 1) {
 				titlefontgrd2 = makeColorGradation(g_headerObj.titlegrds[1], false, false, `titleMusic`);
+			} else {
+				titlefontgrd2 = titlefontgrd;
 			}
 		}
 


### PR DESCRIPTION
## 変更内容
titlegrdの2行目分($区切り以降)省略時、1行目分の値を使うようにしました。

## 変更理由
以下のように指定するとタイトル1行目(foo)のみが表示され、2行目(bar)が表示されません。
```
|titlegrd=#ff0000|
|musicTitle=foo<br>bar|
```

## その他コメント
[MFV2さんのツイートより](https://twitter.com/MFV2_/status/1233047646505275393)