### PR TITLE
[0163/div-gauge-table] ゲージ詳細テーブルをdiv要素に変更

### DIFF
--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -274,28 +274,17 @@ input[type=range]:focus {
 	-webkit-clip-path: polygon(5% 0%, 100% 0%, 100% 30%, 5% 30%, 5% 45%, 100% 45%, 100% 55%, 5% 55%, 5% 70%, 100% 70%, 100% 100%, 5% 100%);
 }
 
-/* 設定画面：ゲージ設定詳細:table版 */
+/* 設定画面：ゲージ設定詳細 */
 .settings_gaugeVal {
 	font-size:12px;
 }
-.settings_gaugeTable {
-	width: 280px;
-	margin: 0 auto;
-	border: 1px #666666 solid; 
-	border-collapse: collapse;
-}
-.settings_gaugeTable td {
-	width: 65px;
-}
-
-/* 設定画面：ゲージ設定詳細:Div版 */
 .settings_gaugeDivCover {
 	border: 1px #666666 solid;
 	width: 280px;
 }
 .settings_gaugeDivTable {
 	display: table;
-	width: 278px;
+	width: 279px;
 }
 .settings_gaugeDivTableCol {
 	display: table-cell;

--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -291,15 +291,21 @@ input[type=range]:focus {
 /* 設定画面：ゲージ設定詳細:Div版 */
 .settings_gaugeDivCover {
 	border: 1px #666666 solid;
+	width: 280px;
 }
 .settings_gaugeDivTable {
 	display: table;
-	width: 280px;
+	width: 278px;
 }
 .settings_gaugeDivTableCol {
 	display: table-cell;
-	width: 65px;
 	border-collapse: collapse;
+}
+.settings_gaugeStart {
+	width: 85px;
+}
+.settings_gaugeEtc {
+	width: 65px;
 }
 
 /* ライフゲージボーダー */

--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -274,7 +274,7 @@ input[type=range]:focus {
 	-webkit-clip-path: polygon(5% 0%, 100% 0%, 100% 30%, 5% 30%, 5% 45%, 100% 45%, 100% 55%, 5% 55%, 5% 70%, 100% 70%, 100% 100%, 5% 100%);
 }
 
-/* 設定画面：ゲージ設定詳細 */
+/* 設定画面：ゲージ設定詳細:table版 */
 .settings_gaugeVal {
 	font-size:12px;
 }
@@ -286,6 +286,20 @@ input[type=range]:focus {
 }
 .settings_gaugeTable td {
 	width: 65px;
+}
+
+/* 設定画面：ゲージ設定詳細:Div版 */
+.settings_gaugeDivCover {
+	border: 1px #666666 solid;
+}
+.settings_gaugeDivTable {
+	display: table;
+	width: 280px;
+}
+.settings_gaugeDivTableCol {
+	display: table-cell;
+	width: 65px;
+	border-collapse: collapse;
 }
 
 /* ライフゲージボーダー */

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4068,7 +4068,7 @@ function createOptionWindow(_sprite) {
 
 		let lifeValCss = ``;
 		if (_lifeValFlg === C_FLG_ON) {
-			lifeValCss = ` class="settings_lifeVal"`;
+			lifeValCss = ` settings_lifeVal`;
 		}
 
 		// 整形用にライフ初期値を整数、回復・ダメージ量を小数第1位で丸める
@@ -4077,7 +4077,40 @@ function createOptionWindow(_sprite) {
 		const rcv = Math.round(_rcv * 100) / 100;
 		const dmg = Math.round(_dmg * 100) / 100;
 
-		return `<table class="settings_gaugeTable settings_gaugeTableBorder">
+		return `<div class="settings_gaugeDivCover">
+					<div class="settings_gaugeDivTable">
+						<div class="settings_gaugeDivTableCol" style="width=85px;">
+							Start
+						</div>
+						<div class="settings_gaugeDivTableCol">
+							Border
+						</div>
+						<div class="settings_gaugeDivTableCol">
+							Recovery
+						</div>
+						<div class="settings_gaugeDivTableCol">
+							Damage
+						</div>
+					</div>
+					<div class="settings_gaugeDivTable">
+						<div class="settings_gaugeDivTableCol" style="width=85px;">
+							${init}/${g_headerObj.maxLifeVal}
+						</div>
+						<div class="settings_gaugeDivTableCol">
+							${border}
+						</div>
+						<div class="settings_gaugeDivTableCol${lifeValCss}">
+							${rcv}
+						</div>
+						<div class="settings_gaugeDivTableCol${lifeValCss}">
+							${dmg}
+						</div>
+					</div>
+				</div>
+				`;
+
+		/*
+				<table class="settings_gaugeTable settings_gaugeTableBorder">
 					<tr>
 						<td>Start</td>
 						<td>Border</td>
@@ -4091,7 +4124,7 @@ function createOptionWindow(_sprite) {
 						<td${lifeValCss}>${dmg}</td>
 					</tr>
 				</table>
-				`;
+		*/
 	}
 
 	// ---------------------------------------------------

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4079,52 +4079,35 @@ function createOptionWindow(_sprite) {
 
 		return `<div class="settings_gaugeDivCover">
 					<div class="settings_gaugeDivTable">
-						<div class="settings_gaugeDivTableCol" style="width=85px;">
+						<div class="settings_gaugeDivTableCol settings_gaugeStart">
 							Start
 						</div>
-						<div class="settings_gaugeDivTableCol">
+						<div class="settings_gaugeDivTableCol settings_gaugeEtc">
 							Border
 						</div>
-						<div class="settings_gaugeDivTableCol">
+						<div class="settings_gaugeDivTableCol settings_gaugeEtc">
 							Recovery
 						</div>
-						<div class="settings_gaugeDivTableCol">
+						<div class="settings_gaugeDivTableCol settings_gaugeEtc">
 							Damage
 						</div>
 					</div>
 					<div class="settings_gaugeDivTable">
-						<div class="settings_gaugeDivTableCol" style="width=85px;">
+						<div class="settings_gaugeDivTableCol settings_gaugeVal settings_gaugeStart">
 							${init}/${g_headerObj.maxLifeVal}
 						</div>
-						<div class="settings_gaugeDivTableCol">
+						<div class="settings_gaugeDivTableCol settings_gaugeVal settings_gaugeEtc">
 							${border}
 						</div>
-						<div class="settings_gaugeDivTableCol${lifeValCss}">
+						<div class="settings_gaugeDivTableCol settings_gaugeVal settings_gaugeEtc${lifeValCss}">
 							${rcv}
 						</div>
-						<div class="settings_gaugeDivTableCol${lifeValCss}">
+						<div class="settings_gaugeDivTableCol settings_gaugeVal settings_gaugeEtc${lifeValCss}">
 							${dmg}
 						</div>
 					</div>
 				</div>
 				`;
-
-		/*
-				<table class="settings_gaugeTable settings_gaugeTableBorder">
-					<tr>
-						<td>Start</td>
-						<td>Border</td>
-						<td>Recovery</td>
-						<td>Damage</td>
-					</tr>
-					<tr class="settings_gaugeVal">
-						<td style="width:85px;">${init}/${g_headerObj.maxLifeVal}</td>
-						<td>${border}</td>
-						<td${lifeValCss}>${rcv}</td>
-						<td${lifeValCss}>${dmg}</td>
-					</tr>
-				</table>
-		*/
 	}
 
 	// ---------------------------------------------------


### PR DESCRIPTION
## 変更内容
1. ゲージ詳細テーブルをdiv要素に変更しました。

## 変更理由
1. table要素を別にCSSクラスで定義していた場合、スタイルが上書きできないため。

## その他コメント

