### PR TITLE
[0165/dummy-step-hit] ダミー矢印のヒット位置が前の通常矢印に引きずられる問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7539,6 +7539,7 @@ function MainInit() {
 						customJudgeDummyArrow2(_cnt);
 					}
 				}
+				stepDivHit.style.top = `-15px`;
 				stepDivHit.style.opacity = 1;
 				stepDivHit.classList.remove(g_cssObj.main_stepDefault, g_cssObj.main_stepDummy, g_cssObj.main_stepIi, g_cssObj.main_stepShakin, g_cssObj.main_stepMatari, g_cssObj.main_stepShobon);
 				stepDivHit.classList.add(g_cssObj.main_stepDummy);


### PR DESCRIPTION
## 変更内容
1. ダミー矢印のヒット位置が前の通常矢印のヒット位置に引きずられる問題を修正しました。
直前の通常矢印でマターリを出していた場合、
その後のダミー矢印のヒットモーションで実際にはジャストタイミングであるにも関わらず、
マターリのようなヒットモーションになっていました。

## 変更理由
1. 上述の通り。

## その他コメント
- v10.4.0にて実装した内容の修正です。v11への修正も必要です。
