### PR TITLE
[0166/judge-diff] Fast/Slowの表示をcustom関数の前に来るように修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8389,15 +8389,12 @@ function judgeArrow(_j) {
 			if (difCnt <= g_judgObj.arrowJ[C_JDG_II]) {
 				judgeIi(difFrame);
 				stepDivHit.classList.add(g_cssObj.main_stepIi);
-				document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
 			} else if (difCnt <= g_judgObj.arrowJ[C_JDG_SHAKIN]) {
 				judgeShakin(difFrame);
 				stepDivHit.classList.add(g_cssObj.main_stepShakin);
-				document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
 			} else if (difCnt <= g_judgObj.arrowJ[C_JDG_MATARI]) {
 				judgeMatari(difFrame);
 				stepDivHit.classList.add(g_cssObj.main_stepMatari);
-				document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
 			} else {
 				judgeShobon(difFrame);
 				stepDivHit.classList.add(g_cssObj.main_stepShobon);
@@ -8422,13 +8419,10 @@ function judgeArrow(_j) {
 				const difFrame = Number(judgFrz.getAttribute(`cnt`));
 				if (difCnt <= g_judgObj.arrowJ[C_JDG_II]) {
 					judgeIi(difFrame);
-					document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
 				} else if (difCnt <= g_judgObj.arrowJ[C_JDG_SHAKIN]) {
 					judgeShakin(difCnt);
-					document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
 				} else if (difCnt <= g_judgObj.arrowJ[C_JDG_MATARI]) {
 					judgeMatari(difCnt);
-					document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, difCnt);
 				} else {
 					judgeShobon(difCnt);
 				}
@@ -8524,6 +8518,7 @@ function judgeIi(difFrame) {
 		document.querySelector(`#lblMCombo`).innerHTML = g_resultObj.maxCombo;
 	}
 	document.querySelector(`#comboJ`).innerHTML = `${g_resultObj.combo} Combo!!`;
+	document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, Math.abs(difFrame));
 
 	lifeRecovery();
 	finishViewing();
@@ -8548,6 +8543,7 @@ function judgeShakin(difFrame) {
 		document.querySelector(`#lblMCombo`).innerHTML = g_resultObj.maxCombo;
 	}
 	document.querySelector(`#comboJ`).innerHTML = `${g_resultObj.combo} Combo!!`;
+	document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, Math.abs(difFrame));
 
 	lifeRecovery();
 	finishViewing();
@@ -8567,7 +8563,7 @@ function judgeShakin(difFrame) {
 function judgeMatari(difFrame) {
 	changeJudgeCharacter(`matari`, C_JCR_MATARI);
 	document.querySelector(`#comboJ`).innerHTML = ``;
-	document.querySelector(`#diffJ`).innerHTML = ``;
+	document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, Math.abs(difFrame));
 
 	finishViewing();
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8507,17 +8507,24 @@ function changeJudgeCharacter(_name, _character, _freezeFlg = ``) {
 }
 
 /**
+ * コンボの更新
+ */
+function updateCombo() {
+	if (++g_resultObj.combo > g_resultObj.maxCombo) {
+		g_resultObj.maxCombo = g_resultObj.combo;
+		document.querySelector(`#lblMCombo`).innerHTML = g_resultObj.maxCombo;
+	}
+	document.querySelector(`#comboJ`).innerHTML = `${g_resultObj.combo} Combo!!`;
+}
+
+/**
  * 判定処理：イイ
  * @param {number} difFrame 
  */
 function judgeIi(difFrame) {
 	changeJudgeCharacter(`ii`, C_JCR_II);
 
-	if (++g_resultObj.combo > g_resultObj.maxCombo) {
-		g_resultObj.maxCombo = g_resultObj.combo;
-		document.querySelector(`#lblMCombo`).innerHTML = g_resultObj.maxCombo;
-	}
-	document.querySelector(`#comboJ`).innerHTML = `${g_resultObj.combo} Combo!!`;
+	updateCombo();
 	document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, Math.abs(difFrame));
 
 	lifeRecovery();
@@ -8538,11 +8545,7 @@ function judgeIi(difFrame) {
 function judgeShakin(difFrame) {
 	changeJudgeCharacter(`shakin`, C_JCR_SHAKIN);
 
-	if (++g_resultObj.combo > g_resultObj.maxCombo) {
-		g_resultObj.maxCombo = g_resultObj.combo;
-		document.querySelector(`#lblMCombo`).innerHTML = g_resultObj.maxCombo;
-	}
-	document.querySelector(`#comboJ`).innerHTML = `${g_resultObj.combo} Combo!!`;
+	updateCombo();
 	document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, Math.abs(difFrame));
 
 	lifeRecovery();

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8442,7 +8442,7 @@ function judgeArrow(_j) {
  * @param {number} _difCnt 
  */
 function displayDiff(_difFrame, _difCnt) {
-	return `<span class="common_${_difCnt <= 1 ? 'combo' : (_difFrame > 0 ? 'matari' : 'shobon')}">
+	document.querySelector(`#diffJ`).innerHTML = `<span class="common_${_difCnt <= 1 ? 'combo' : (_difFrame > 0 ? 'matari' : 'shobon')}">
 		${_difCnt <= 1 ? 'Just!!' : ((_difFrame > 1 ? `Fast` : `Slow`)) + ` ${_difCnt} Frames`}</span>`;
 }
 
@@ -8525,7 +8525,7 @@ function judgeIi(difFrame) {
 	changeJudgeCharacter(`ii`, C_JCR_II);
 
 	updateCombo();
-	document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, Math.abs(difFrame));
+	displayDiff(difFrame, Math.abs(difFrame));
 
 	lifeRecovery();
 	finishViewing();
@@ -8546,7 +8546,7 @@ function judgeShakin(difFrame) {
 	changeJudgeCharacter(`shakin`, C_JCR_SHAKIN);
 
 	updateCombo();
-	document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, Math.abs(difFrame));
+	displayDiff(difFrame, Math.abs(difFrame));
 
 	lifeRecovery();
 	finishViewing();
@@ -8566,8 +8566,8 @@ function judgeShakin(difFrame) {
 function judgeMatari(difFrame) {
 	changeJudgeCharacter(`matari`, C_JCR_MATARI);
 	document.querySelector(`#comboJ`).innerHTML = ``;
-	document.querySelector(`#diffJ`).innerHTML = displayDiff(difFrame, Math.abs(difFrame));
 
+	displayDiff(difFrame, Math.abs(difFrame));
 	finishViewing();
 
 	if (typeof customJudgeMatari === C_TYP_FUNCTION) {


### PR DESCRIPTION
## 変更内容
1. Fast/Slowの表示をcustom関数の前に来るように修正しました。

## 変更理由
1. Fast/Slowの表示がcustom関数の後にあったため、設定を上書きすることができませんでした。
今回の変更以降は上書きが可能になります。

```javascript
function customJudgeIi(difFrame){
    document.querySelector(`#diffJ`).innerHTML = ``;
}
```

## その他コメント

