### PR TITLE
[0172/color-gradation-alpha] frzShadowColorを6桁カラーコードで指定した場合の問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2637,12 +2637,12 @@ function headerConvert(_dosObj) {
 	}
 
 	// フリーズアローのデフォルト色セットの利用有無 (true: 使用, false: 矢印色を優先してセット)
-	if (_dosObj.defaultFrzUse !== undefined) {
-		obj.defaultFrzUse = setVal(_dosObj.defaultFrzUse, true, C_TYP_BOOLEAN);
+	if (_dosObj.defaultFrzColorUse !== undefined) {
+		obj.defaultFrzColorUse = setVal(_dosObj.defaultFrzColorUse, true, C_TYP_BOOLEAN);
 	} else if (typeof g_presetFrzColors === C_TYP_BOOLEAN) {
-		obj.defaultFrzUse = (g_presetFrzColor ? true : false);
+		obj.defaultFrzColorUse = (g_presetFrzColors ? true : false);
 	} else {
-		obj.defaultFrzUse = true;
+		obj.defaultFrzColorUse = true;
 	}
 
 	// 初期色情報
@@ -2685,15 +2685,15 @@ function headerConvert(_dosObj) {
 		obj[`${_frzName}Org`] = [];
 		const tmpFrzColors = (_dosObj[_frzName] !== undefined ? _dosObj[_frzName].split(`$`) : []);
 		for (let j = 0; j < obj.setColorInit.length; j++) {
-			let defaultFrz;
-			if (obj.defaultFrzUse) {
-				defaultFrz = (j === 0 ? obj[`${_frzName}Init`] : obj[`${_frzName}Org`][0]);
+			let defaultFrzColor;
+			if (obj.defaultFrzColorUse) {
+				defaultFrzColor = (j === 0 ? obj[`${_frzName}Init`] : obj[`${_frzName}Org`][0]);
 			} else {
-				defaultFrz = new Array(obj.setColorInit.length).fill(obj[`${_name}Str`][j]);
+				defaultFrzColor = new Array(obj.setColorInit.length).fill(obj[`${_name}Str`][j]);
 			}
 
 			[obj[`${_frzName}`][j], obj[`${_frzName}Str`][j], obj[`${_frzName}Org`][j]] =
-				setColorList(tmpFrzColors[j], defaultFrz, {
+				setColorList(tmpFrzColors[j], defaultFrzColor, {
 					defaultColorgrd: obj.defaultColorgrd,
 					colorCdPaddingUse: obj.colorCdPaddingUse,
 					objType: `frz`,

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1928,7 +1928,9 @@ function makeColorGradation(_colorStr, _options = {}) {
 		return `Default`;
 	}
 
-	const alphaVal = (_shadowFlg ? `80` : ``);
+	// 矢印の塗りつぶしのみ、透明度を50%にする
+	const alphaVal = (_shadowFlg && _objType !== `frz`) ? `80` : ``;
+
 	let convertColorStr;
 	const tmpColorStr = _colorStr.split(`@`);
 	const colorArray = tmpColorStr[0].split(`:`);
@@ -2676,6 +2678,7 @@ function headerConvert(_dosObj) {
 				setColorList(tmpFrzColors[j], new Array(obj.setColorInit.length).fill(obj[`${_name}Str`][j]), {
 					defaultColorgrd: obj.defaultColorgrd,
 					colorCdPaddingUse: obj.colorCdPaddingUse,
+					objType: `frz`,
 					shadowFlg: Boolean(k),
 				});
 		}
@@ -2695,6 +2698,7 @@ function headerConvert(_dosObj) {
 
 		const _defaultColorgrd = _options.defaultColorgrd || g_headerObj.defaultColorgrd;
 		const _colorCdPaddingUse = _options.colorCdPaddingUse || false;
+		const _objType = _options.objType || `normal`;
 		const _shadowFlg = _options.shadowFlg || false;
 
 		// グラデーション文字列 #ffff99:#9999ff@linear-gradient
@@ -2734,6 +2738,7 @@ function headerConvert(_dosObj) {
 				colorList[j] = makeColorGradation(colorStr[j] === `` ? _colorInit[j] : colorStr[j], {
 					defaultColorgrd: _defaultColorgrd,
 					colorCdPaddingUse: _colorCdPaddingUse,
+					objType: _objType,
 					shadowFlg: _shadowFlg,
 				});
 			}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2636,6 +2636,15 @@ function headerConvert(_dosObj) {
 		getGaugeSetting(_dosObj, g_gaugeOptionObj.custom[j], obj);
 	}
 
+	// フリーズアローのデフォルト色セットの利用有無 (true: 使用, false: 矢印色を優先してセット)
+	if (_dosObj.defaultFrzUse !== undefined) {
+		obj.defaultFrzUse = setVal(_dosObj.defaultFrzUse, true, C_TYP_BOOLEAN);
+	} else if (typeof g_presetFrzColors === C_TYP_BOOLEAN) {
+		obj.defaultFrzUse = (g_presetFrzColor ? true : false);
+	} else {
+		obj.defaultFrzUse = true;
+	}
+
 	// 初期色情報
 	obj.setColorInit = [`#6666ff`, `#99ffff`, `#ffffff`, `#ffff99`, `#ff9966`];
 	obj.setShadowColorInit = [``, ``, ``, ``, ``];
@@ -2644,6 +2653,8 @@ function headerConvert(_dosObj) {
 	obj.setColorType2 = [`#ffffff`, `#9999ff`, `#ffffff`, `#ffccff`, `#ff9999`];
 
 	// フリーズアロー初期色情報
+	obj.frzColorInit = [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`];
+	obj.frzShadowColorInit = [``, ``, ``, ``];
 	obj.frzColorType1 = [[`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
 	[`#00ffcc`, `#339999`, `#cccc33`, `#999933`],
 	[`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
@@ -2674,8 +2685,15 @@ function headerConvert(_dosObj) {
 		obj[`${_frzName}Org`] = [];
 		const tmpFrzColors = (_dosObj[_frzName] !== undefined ? _dosObj[_frzName].split(`$`) : []);
 		for (let j = 0; j < obj.setColorInit.length; j++) {
+			let defaultFrz;
+			if (obj.defaultFrzUse) {
+				defaultFrz = (j === 0 ? obj[`${_frzName}Init`] : obj[`${_frzName}Org`][0]);
+			} else {
+				defaultFrz = new Array(obj.setColorInit.length).fill(obj[`${_name}Str`][j]);
+			}
+
 			[obj[`${_frzName}`][j], obj[`${_frzName}Str`][j], obj[`${_frzName}Org`][j]] =
-				setColorList(tmpFrzColors[j], new Array(obj.setColorInit.length).fill(obj[`${_name}Str`][j]), {
+				setColorList(tmpFrzColors[j], defaultFrz, {
 					defaultColorgrd: obj.defaultColorgrd,
 					colorCdPaddingUse: obj.colorCdPaddingUse,
 					objType: `frz`,

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -22,6 +22,9 @@ const g_presetGauge = {
 	//	Init: 25,    // 初期値
 };
 
+// フリーズアローのデフォルト色セットの利用有無 (true: 使用, false: 矢印色を優先してセット)
+const g_presetFrzColors = true;
+
 // ゲージ設定（デフォルト以外）
 const g_presetGaugeCustom = {
 	Easy: {


### PR DESCRIPTION
## 変更内容
1. フリーズアロー(矢印)の塗りつぶし部分について、
6桁カラーコードで指定した場合に透明度が0.5⇒1になるように修正しました。
2. 従来の`frzColor`補完がされる設定を追加しました。デフォルトは`true`です。
```
|defaultFrzColorUse=false|
```
danoni_setting.js からも設定できます。
その場合の変数名は `g_presetFrzColors` です。

## 変更理由
1. フリーズアロー(矢印)の塗りつぶし部分は通常、透明度100％のため。
2. 従来のfrzColorの省略形に対応するため。

## その他コメント

