### PR TITLE
[0173/frzhit-color-etc] フリーズアロー色（ヒット時）の処理間違いを修正　他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2738,7 +2738,7 @@ function headerConvert(_dosObj) {
 			// 色変化配列が既定長より小さい場合、データ補完する
 			if (colorStr.length < _colorInit.length) {
 				const defaultLength = colorStr.length;
-				if (_defaultFrzColorUse) {
+				if (_objType === `frz` && _defaultFrzColorUse) {
 					for (let j = defaultLength; j < _colorInit.length; j++) {
 						colorStr[j] = _colorInit[j];
 					}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2696,6 +2696,7 @@ function headerConvert(_dosObj) {
 				setColorList(tmpFrzColors[j], defaultFrzColor, {
 					defaultColorgrd: obj.defaultColorgrd,
 					colorCdPaddingUse: obj.colorCdPaddingUse,
+					defaultFrzColorUse: obj.defaultFrzColorUse,
 					objType: `frz`,
 					shadowFlg: Boolean(k),
 				});
@@ -2716,6 +2717,7 @@ function headerConvert(_dosObj) {
 
 		const _defaultColorgrd = _options.defaultColorgrd || g_headerObj.defaultColorgrd;
 		const _colorCdPaddingUse = _options.colorCdPaddingUse || false;
+		const _defaultFrzColorUse = _options.defaultFrzColorUse || true;
 		const _objType = _options.objType || `normal`;
 		const _shadowFlg = _options.shadowFlg || false;
 
@@ -2736,8 +2738,14 @@ function headerConvert(_dosObj) {
 			// 色変化配列が既定長より小さい場合、データ補完する
 			if (colorStr.length < _colorInit.length) {
 				const defaultLength = colorStr.length;
-				for (let j = 0; j < _colorInit.length; j++) {
-					colorStr[j] = colorStr[j % defaultLength];
+				if (_defaultFrzColorUse) {
+					for (let j = defaultLength; j < _colorInit.length; j++) {
+						colorStr[j] = _colorInit[j];
+					}
+				} else {
+					for (let j = 0; j < _colorInit.length; j++) {
+						colorStr[j] = colorStr[j % defaultLength];
+					}
 				}
 				colorList = colorStr.concat();
 			}

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -207,8 +207,8 @@ const C_LEN_JDGCNTS_WIDTH = 100;
 const C_LEN_JDGCNTS_HEIGHT = 20;
 const C_SIZ_JDGCNTS = 16;
 
-const C_FRM_HITMOTION = 4;
-const C_FRM_JDGMOTION = 60;
+let C_FRM_HITMOTION = 4;
+let C_FRM_JDGMOTION = 60;
 
 /** 結果画面用共通オブジェクト */
 const g_resultObj = {


### PR DESCRIPTION
## 変更内容
1. フリーズアロー色（ヒット時）の色補完処理で、`defaultFrzColorUse`が有効のとき、
デフォルトのフリーズアローセットから取得できない問題を修正しました。
2. 一部変数のconstをletに変更しました。
    - C_FRM_HITMOTION, C_FRM_JDGMOTION

## 変更理由
1. 上述の通り。
2. カスタム側の実装緩和のため。

## その他コメント

