### PR TITLE
[0174/appearance-filter] Hidden+, Sudden+の実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7178,7 +7178,7 @@ function MainInit() {
 
 	// Appearanceのオプション適用時は一部描画を隠す
 	if (g_stateObj.appearance === `Hidden+` || g_stateObj.appearance === `Sudden+`) {
-		changeAppearanceFilter();
+		changeAppearanceFilter(g_hidSudObj.filterPos);
 
 	} else if (g_stateObj.appearance !== `Visible`) {
 		arrowSprite[0].classList.add(`${g_stateObj.appearance}0`);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7168,6 +7168,10 @@ function MainInit() {
 			g_sWidth - 50, 1, ``, `lifeBar`);
 		filterBar1.classList.add(g_cssObj.life_Failed);
 		mainSprite.appendChild(filterBar1);
+
+		const filterView = createDivCssLabel(`filterView`, g_sWidth - 70, 0, 10, 10, 10, ``);
+		filterView.style.textAlign = C_ALIGN_RIGHT;
+		mainSprite.appendChild(filterView);
 	}
 
 	// 矢印・フリーズアロー描画スプライト（ステップゾーンの上に配置）
@@ -7518,9 +7522,9 @@ function MainInit() {
 			document.onkeyup = _ => { };
 
 		} else if (g_stateObj.appearance === `Hidden+` || g_stateObj.appearance === `Sudden+`) {
-			if (setKey === g_hidSudObj.pgDown[g_stateObj.appearance]) {
+			if (setKey === g_hidSudObj.pgDown[g_stateObj.appearance][g_stateObj.reverse]) {
 				changeAppearanceFilter(g_hidSudObj.filterPos < 100 ? g_hidSudObj.filterPos + 1 : g_hidSudObj.filterPos);
-			} else if (setKey === g_hidSudObj.pgUp[g_stateObj.appearance]) {
+			} else if (setKey === g_hidSudObj.pgUp[g_stateObj.appearance][g_stateObj.reverse]) {
 				changeAppearanceFilter(g_hidSudObj.filterPos > 0 ? g_hidSudObj.filterPos - 1 : g_hidSudObj.filterPos);
 			}
 		}
@@ -8344,6 +8348,8 @@ function changeAppearanceFilter(_num = 10) {
 
 	document.querySelector(`#filterBar0`).style.top = `${g_sHeight * _num / 100}px`;
 	document.querySelector(`#filterBar1`).style.top = `${g_sHeight * (100 - _num) / 100}px`;
+	document.querySelector(`#filterView`).style.top = `${g_sHeight * (100 - _num) / 100 - 10}px`;
+	document.querySelector(`#filterView`).innerHTML = `${_num}%`;
 	g_hidSudObj.filterPos = _num;
 }
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8348,7 +8348,8 @@ function changeAppearanceFilter(_num = 10) {
 
 	document.querySelector(`#filterBar0`).style.top = `${g_sHeight * _num / 100}px`;
 	document.querySelector(`#filterBar1`).style.top = `${g_sHeight * (100 - _num) / 100}px`;
-	document.querySelector(`#filterView`).style.top = `${g_sHeight * (100 - _num) / 100 - 10}px`;
+	document.querySelector(`#filterView`).style.top =
+		document.querySelector(`#filterBar${g_hidSudObj.std[g_stateObj.appearance][g_stateObj.reverse]}`).style.top;
 	document.querySelector(`#filterView`).innerHTML = `${_num}%`;
 	g_hidSudObj.filterPos = _num;
 }

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7156,6 +7156,20 @@ function MainInit() {
 
 	}
 
+	if (g_stateObj.appearance === `Hidden+` || g_stateObj.appearance === `Sudden+`) {
+		const filterBar0 = createColorObject(`filterBar0`, ``,
+			0, 0,
+			g_sWidth - 50, 1, ``, `lifeBar`);
+		filterBar0.classList.add(g_cssObj.life_Failed);
+		mainSprite.appendChild(filterBar0);
+
+		const filterBar1 = createColorObject(`filterBar1`, ``,
+			0, 0,
+			g_sWidth - 50, 1, ``, `lifeBar`);
+		filterBar1.classList.add(g_cssObj.life_Failed);
+		mainSprite.appendChild(filterBar1);
+	}
+
 	// 矢印・フリーズアロー描画スプライト（ステップゾーンの上に配置）
 	const arrowSprite = [
 		createSprite(`mainSprite`, `arrowSprite0`, 0, 0, g_sWidth, g_sHeight),
@@ -7163,7 +7177,10 @@ function MainInit() {
 	];
 
 	// Appearanceのオプション適用時は一部描画を隠す
-	if (g_stateObj.appearance !== `Visible`) {
+	if (g_stateObj.appearance === `Hidden+` || g_stateObj.appearance === `Sudden+`) {
+		changeAppearanceFilter();
+
+	} else if (g_stateObj.appearance !== `Visible`) {
 		arrowSprite[0].classList.add(`${g_stateObj.appearance}0`);
 		arrowSprite[1].classList.add(`${g_stateObj.appearance}1`);
 	}
@@ -7499,6 +7516,13 @@ function MainInit() {
 				titleInit();
 			}
 			document.onkeyup = _ => { };
+
+		} else if (g_stateObj.appearance === `Hidden+` || g_stateObj.appearance === `Sudden+`) {
+			if (setKey === g_hidSudObj.pgDown[g_stateObj.appearance]) {
+				changeAppearanceFilter(g_hidSudObj.filterPos < 90 ? g_hidSudObj.filterPos + 1 : g_hidSudObj.filterPos);
+			} else if (setKey === g_hidSudObj.pgUp[g_stateObj.appearance]) {
+				changeAppearanceFilter(g_hidSudObj.filterPos > 10 ? g_hidSudObj.filterPos - 1 : g_hidSudObj.filterPos);
+			}
 		}
 		return blockCode(setKey);
 	}
@@ -8304,6 +8328,23 @@ function MainInit() {
 		}
 	}
 	g_timeoutEvtId = setTimeout(_ => flowTimeline(), 1000 / g_fps);
+}
+
+/**
+ * アルファマスクの再描画 (Appearance: Hidden+, Sudden+ 用)
+ * @param {number} _num 
+ */
+function changeAppearanceFilter(_num = 10) {
+	const topNum = g_hidSudObj[g_stateObj.appearance];
+	const bottomNum = (g_hidSudObj[g_stateObj.appearance] + 1) % 2;
+	document.querySelector(`#arrowSprite${topNum}`).style.clipPath = `inset(${_num}% 0% 0% 0%)`;
+	document.querySelector(`#arrowSprite${topNum}`).style.webkitClipPath = `inset(${_num}% 0% 0% 0%)`;
+	document.querySelector(`#arrowSprite${bottomNum}`).style.clipPath = `inset(0% 0% ${_num}% 0%)`;
+	document.querySelector(`#arrowSprite${bottomNum}`).style.webkitClipPath = `inset(0% 0% ${_num}% 0%)`;
+
+	document.querySelector(`#filterBar0`).style.top = `${g_sHeight * _num / 100}px`;
+	document.querySelector(`#filterBar1`).style.top = `${g_sHeight * (100 - _num) / 100}px`;
+	g_hidSudObj.filterPos = _num;
 }
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7519,9 +7519,9 @@ function MainInit() {
 
 		} else if (g_stateObj.appearance === `Hidden+` || g_stateObj.appearance === `Sudden+`) {
 			if (setKey === g_hidSudObj.pgDown[g_stateObj.appearance]) {
-				changeAppearanceFilter(g_hidSudObj.filterPos < 90 ? g_hidSudObj.filterPos + 1 : g_hidSudObj.filterPos);
+				changeAppearanceFilter(g_hidSudObj.filterPos < 100 ? g_hidSudObj.filterPos + 1 : g_hidSudObj.filterPos);
 			} else if (setKey === g_hidSudObj.pgUp[g_stateObj.appearance]) {
-				changeAppearanceFilter(g_hidSudObj.filterPos > 10 ? g_hidSudObj.filterPos - 1 : g_hidSudObj.filterPos);
+				changeAppearanceFilter(g_hidSudObj.filterPos > 0 ? g_hidSudObj.filterPos - 1 : g_hidSudObj.filterPos);
 			}
 		}
 		return blockCode(setKey);
@@ -9035,6 +9035,9 @@ function resultInit() {
 	}
 	if (g_stateObj.appearance !== `Visible`) {
 		playStyleData += `, ${g_stateObj.appearance}`;
+		if (g_stateObj.appearance === `Hidden+` || g_stateObj.appearance === `Sudden+`) {
+			playStyleData += `(${g_hidSudObj.filterPos}%)`;
+		}
 	}
 	if (g_stateObj.gauge !== g_gauges[0]) {
 		playStyleData += `, ${g_stateObj.gauge}`;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -354,6 +354,7 @@ const g_hidSudObj = {
     filterPos: 10,
     pgDown: {},
     pgUp: {},
+    std: {},
 };
 g_hidSudObj[`Hidden+`] = 0;
 g_hidSudObj[`Sudden+`] = 1;
@@ -372,6 +373,14 @@ g_hidSudObj.pgUp[`Hidden+`] = {
 g_hidSudObj.pgUp[`Sudden+`] = {
     OFF: 34,
     ON: 33,
+}
+g_hidSudObj.std[`Hidden+`] = {
+    OFF: 0,
+    ON: 1,
+};
+g_hidSudObj.std[`Sudden+`] = {
+    OFF: 1,
+    ON: 0,
 }
 
 // ステップゾーン位置、到達距離(後で指定)

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -337,7 +337,7 @@ let g_adjustmentNum = C_MAX_ADJUSTMENT;
 let g_volumes = [0, 0.5, 1, 2, 5, 10, 25, 50, 75, 100];
 let g_volumeNum = g_volumes.length - 1;
 
-let g_appearances = [`Visible`, `Hidden`, `Sudden`, `Slit`];
+let g_appearances = [`Visible`, `Hidden`, `Sudden`, `Hidden+`, `Sudden+`, `Slit`];
 let g_appearanceNum = 0;
 
 let g_scoreDetails = [`Speed`, `Density`, `ToolDif`];
@@ -349,6 +349,18 @@ let g_displays = [`stepZone`, `judgement`, `lifeGauge`, `musicInfo`, `special`,
 // サイズ(後で指定)
 let g_sWidth;
 let g_sHeight;
+
+const g_hidSudObj = {
+    filterPos: 10,
+    pgDown: {},
+    pgUp: {},
+};
+g_hidSudObj[`Hidden+`] = 0;
+g_hidSudObj[`Sudden+`] = 1;
+g_hidSudObj.pgDown[`Hidden+`] = 34;
+g_hidSudObj.pgDown[`Sudden+`] = 33;
+g_hidSudObj.pgUp[`Hidden+`] = 33;
+g_hidSudObj.pgUp[`Sudden+`] = 34;
 
 // ステップゾーン位置、到達距離(後で指定)
 const C_STEP_Y = 70;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -357,10 +357,22 @@ const g_hidSudObj = {
 };
 g_hidSudObj[`Hidden+`] = 0;
 g_hidSudObj[`Sudden+`] = 1;
-g_hidSudObj.pgDown[`Hidden+`] = 34;
-g_hidSudObj.pgDown[`Sudden+`] = 33;
-g_hidSudObj.pgUp[`Hidden+`] = 33;
-g_hidSudObj.pgUp[`Sudden+`] = 34;
+g_hidSudObj.pgDown[`Hidden+`] = {
+    OFF: 34,
+    ON: 33,
+};
+g_hidSudObj.pgDown[`Sudden+`] = {
+    OFF: 33,
+    ON: 34,
+}
+g_hidSudObj.pgUp[`Hidden+`] = {
+    OFF: 33,
+    ON: 34,
+}
+g_hidSudObj.pgUp[`Sudden+`] = {
+    OFF: 34,
+    ON: 33,
+}
 
 // ステップゾーン位置、到達距離(後で指定)
 const C_STEP_Y = 70;


### PR DESCRIPTION
## 変更内容
1. Appearance設定に「Hidden+」「Sudden+」を追加しました。
隠れる箇所が可動フィルターとなっており、「pageUp」「pageDown」を押すことで
フィルターが上下に1%ずつ移動します。

### 仕様
- 初期値は10%(通常50px)です。可動域は0～100%の間で移動可能となっています。
- 「pageUp」「pageDown」はバーの横にパーセント表示がついている側を基準に上下させます。
（逆側は、それに合わせて反転して動きます。）
- リロードする間、フィルター範囲は保存されます。
- なお、Hidden+/Sudden+でフィルター範囲は共通となっています。
Hidden+のフィルター範囲を変えれば、Sudden+も連動して変わるようになっています。
- リザルトのTweetに、どのくらいフィルターを掛けたかをパーセント表示で表示します。

## 変更理由
1. apoiさん要望より。

## その他コメント
- プレイ中にpageUp, pageDownを押しっぱなしにすると動作が重くなることがあります。
ある程度フィルター位置を調整してから、
リトライを掛けて再プレイすることをおススメします。
