### PR TITLE
[0179/frz-color-complement] 矢印色を優先してセットした場合のフリーズアロー色適用ルールを一部変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2673,7 +2673,7 @@ function headerConvert(_dosObj) {
 
 		// 矢印色
 		[obj[`${_name}`], obj[`${_name}Str`], obj[`${_name}Org`]] =
-			setColorList(_dosObj[`${_name}`], obj[`${_name}Init`], {
+			setColorList(_dosObj[`${_name}`], obj[`${_name}Init`], obj[`${_name}Init`].length, {
 				defaultColorgrd: obj.defaultColorgrd,
 				colorCdPaddingUse: obj.colorCdPaddingUse,
 				shadowFlg: Boolean(k),
@@ -2690,7 +2690,9 @@ function headerConvert(_dosObj) {
 
 			// デフォルト配列の作成（1番目の要素をベースに、フリーズアロー初期セット or 矢印色からデータを補完）
 			let currentFrzColors = [];
-			for (let k = 0; k < obj[`${_frzName}Init`].length; k++) {
+			const baseLength = firstFrzColors.length === 0 || obj.defaultFrzColorUse ?
+				obj[`${_frzName}Init`].length : firstFrzColors.length;
+			for (let k = 0; k < baseLength; k++) {
 				if (firstFrzColors[k] === undefined || firstFrzColors[k] === ``) {
 					currentFrzColors[k] = obj.defaultFrzColorUse ? obj[`${_frzName}Init`][k] : obj[`${_name}Str`][j];
 				} else {
@@ -2699,7 +2701,7 @@ function headerConvert(_dosObj) {
 			}
 
 			[obj[`${_frzName}`][j], obj[`${_frzName}Str`][j], obj[`${_frzName}Org`][j]] =
-				setColorList(tmpFrzColors[j], currentFrzColors, {
+				setColorList(tmpFrzColors[j], currentFrzColors, obj[`${_frzName}Init`].length, {
 					defaultColorgrd: obj.defaultColorgrd,
 					colorCdPaddingUse: obj.colorCdPaddingUse,
 					defaultFrzColorUse: obj.defaultFrzColorUse,
@@ -2719,11 +2721,11 @@ function headerConvert(_dosObj) {
 	 * @param {array} _colorInit 
 	 * @param {object} _options 
 	 */
-	function setColorList(_data, _colorInit, _options = {}) {
+	function setColorList(_data, _colorInit, _colorInitLength, _options = {}) {
 
 		const _defaultColorgrd = _options.defaultColorgrd || g_headerObj.defaultColorgrd;
 		const _colorCdPaddingUse = _options.colorCdPaddingUse || false;
-		const _defaultFrzColorUse = _options.defaultFrzColorUse || true;
+		const _defaultFrzColorUse = (_options.defaultFrzColorUse === undefined ? true : _options.defaultFrzColorUse);
 		const _objType = _options.objType || `normal`;
 		const _shadowFlg = _options.shadowFlg || false;
 
@@ -2744,13 +2746,15 @@ function headerConvert(_dosObj) {
 			// データ補完処理
 			const defaultLength = colorStr.length;
 			if (_objType === `frz` && _defaultFrzColorUse) {
-				for (let j = 0; j < _colorInit.length; j++) {
+				// デフォルト配列に満たない・足りない部分はデフォルト配列で穴埋め
+				for (let j = 0; j < _colorInitLength; j++) {
 					if (colorStr[j] === undefined || colorStr[j] === ``) {
 						colorStr[j] = _colorInit[j];
 					}
 				}
 			} else {
-				for (let j = 0; j < _colorInit.length; j++) {
+				// デフォルト配列長をループさせて格納
+				for (let j = 0; j < _colorInitLength; j++) {
 					colorStr[j] = colorStr[j % defaultLength];
 				}
 			}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2687,9 +2687,11 @@ function headerConvert(_dosObj) {
 		for (let j = 0; j < obj.setColorInit.length; j++) {
 			let defaultFrzColor;
 			if (obj.defaultFrzColorUse) {
-				defaultFrzColor = (j === 0 ? obj[`${_frzName}Init`] : obj[`${_frzName}Org`][0]);
+				defaultFrzColor = (j > 0 ?
+					obj[`${_frzName}Org`][0] : obj[`${_frzName}Init`]);
 			} else {
-				defaultFrzColor = new Array(obj.setColorInit.length).fill(obj[`${_name}Str`][j]);
+				defaultFrzColor = (j > 0 && tmpFrzColors.length > 0 ?
+					obj[`${_frzName}Org`][0] : new Array(obj.setColorInit.length).fill(obj[`${_name}Str`][j]));
 			}
 
 			[obj[`${_frzName}`][j], obj[`${_frzName}Str`][j], obj[`${_frzName}Org`][j]] =

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2684,18 +2684,22 @@ function headerConvert(_dosObj) {
 		obj[`${_frzName}Str`] = [];
 		obj[`${_frzName}Org`] = [];
 		const tmpFrzColors = (_dosObj[_frzName] !== undefined ? _dosObj[_frzName].split(`$`) : []);
+		const firstFrzColors = (tmpFrzColors[0] !== undefined ? tmpFrzColors[0].split(`,`) : []);
+
 		for (let j = 0; j < obj.setColorInit.length; j++) {
-			let defaultFrzColor;
-			if (obj.defaultFrzColorUse) {
-				defaultFrzColor = (j > 0 ?
-					obj[`${_frzName}Org`][0] : obj[`${_frzName}Init`]);
-			} else {
-				defaultFrzColor = (j > 0 && tmpFrzColors.length > 0 ?
-					obj[`${_frzName}Org`][0] : new Array(obj.setColorInit.length).fill(obj[`${_name}Str`][j]));
+
+			// デフォルト配列の作成（1番目の要素をベースに、フリーズアロー初期セット or 矢印色からデータを補完）
+			let currentFrzColors = [];
+			for (let k = 0; k < obj[`${_frzName}Init`].length; k++) {
+				if (firstFrzColors[k] === undefined || firstFrzColors[k] === ``) {
+					currentFrzColors[k] = obj.defaultFrzColorUse ? obj[`${_frzName}Init`][k] : obj[`${_name}Str`][j];
+				} else {
+					currentFrzColors[k] = firstFrzColors[k];
+				}
 			}
 
 			[obj[`${_frzName}`][j], obj[`${_frzName}Str`][j], obj[`${_frzName}Org`][j]] =
-				setColorList(tmpFrzColors[j], defaultFrzColor, {
+				setColorList(tmpFrzColors[j], currentFrzColors, {
 					defaultColorgrd: obj.defaultColorgrd,
 					colorCdPaddingUse: obj.colorCdPaddingUse,
 					defaultFrzColorUse: obj.defaultFrzColorUse,
@@ -2737,20 +2741,20 @@ function headerConvert(_dosObj) {
 			colorList = _data.split(`,`);
 			colorStr = colorList.concat();
 
-			// 色変化配列が既定長より小さい場合、データ補完する
-			if (colorStr.length < _colorInit.length) {
-				const defaultLength = colorStr.length;
-				if (_objType === `frz` && _defaultFrzColorUse) {
-					for (let j = defaultLength; j < _colorInit.length; j++) {
+			// データ補完処理
+			const defaultLength = colorStr.length;
+			if (_objType === `frz` && _defaultFrzColorUse) {
+				for (let j = 0; j < _colorInit.length; j++) {
+					if (colorStr[j] === undefined || colorStr[j] === ``) {
 						colorStr[j] = _colorInit[j];
 					}
-				} else {
-					for (let j = 0; j < _colorInit.length; j++) {
-						colorStr[j] = colorStr[j % defaultLength];
-					}
 				}
-				colorList = colorStr.concat();
+			} else {
+				for (let j = 0; j < _colorInit.length; j++) {
+					colorStr[j] = colorStr[j % defaultLength];
+				}
 			}
+			colorList = colorStr.concat();
 
 			for (let j = 0; j < colorList.length; j++) {
 				const tmpSetColorOrg = colorStr[j].replace(/0x/g, `#`).split(`:`);


### PR DESCRIPTION
## 変更内容
1. 矢印色を優先してセットした場合のフリーズアロー色適用ルールを一部変更しました。
`danoni_setting.js`で定義された`g_presetFrzColors`が`false`、
もしくは譜面ヘッダー`defaultFrzColorUse=false`のとき、
frzColorが1要素でも定義されていれば、そのfrzColorの値を使用するよう変更しています。

```
|setColor=a,b,c,d,e|
|frzColor=A,B,C,D|
-> |frzColor=A,B,C,D$A,B,C,D$A,B,C,D$A,B,C,D$A,B,C,D|

|setColor=a,b,c,d,e|
|frzColor=A,B|
-> |frzColor=A,B,A,B$A,B,A,B$A,B,A,B$A,B,A,B$A,B,A,B|

|setColor=a,b,c,d,e|
|frzColor=,,A,B|
-> |frzColor=a,a,A,B$b,b,A,B$c,c,A,B$d,d,A,B$e,e,A,B|

|setColor=a,b,c,d,e|
-> |frzColor=a,a,a,a$b,b,b,b$c,c,c,c$d,d,d,d$e,e,e,e|
```

## 変更理由
1. ParaFla作品からの移植の場合、frzColorが1要素だけ定義されているケースが多いため。

## その他コメント

