### PR TITLE
[0180/enabled-delete] キーコンフィグ画面でdeleteキーが使用できない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5234,7 +5234,7 @@ function keyConfigInit() {
 	document.onkeydown = evt => {
 		const keyCdObj = document.querySelector(`#keycon${g_currentj}_${g_currentk}`);
 		const cursor = document.querySelector(`#cursor`);
-		const setKey = transCode(evt.keyCode);
+		let setKey = transCode(evt.keyCode);
 
 		// 全角切替、BackSpace、Deleteキー、Escキーは割り当て禁止
 		// また、直前と同じキーを押した場合(BackSpaceを除く)はキー操作を無効にする


### PR DESCRIPTION
## 変更内容
1. キーコンフィグ画面でdeleteキーが使用できず、キー無効化ができない問題を修正しました。

## 変更理由
1. 上述の通り。

## その他コメント

