### PR TITLE
[0181/appearance-filter-plus] Hidden+&Sudden+の実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8354,6 +8354,9 @@ function MainInit() {
 function changeAppearanceFilter(_appearance, _num = 10) {
 	const topNum = g_hidSudObj[g_stateObj.appearance];
 	const bottomNum = (g_hidSudObj[g_stateObj.appearance] + 1) % 2;
+	if (_appearance === `Hid&Sud+` && _num > 50) {
+		_num = 50;
+	}
 
 	const numPlus = (_appearance === `Hid&Sud+` ? _num : `0`);
 	const topShape = `inset(${_num}% 0% ${numPlus}% 0%)`;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7166,7 +7166,7 @@ function MainInit() {
 
 	}
 
-	if (g_stateObj.appearance === `Hidden+` || g_stateObj.appearance === `Sudden+`) {
+	if (g_appearanceRanges.includes(g_stateObj.appearance)) {
 		const filterBar0 = createColorObject(`filterBar0`, ``,
 			0, 0,
 			g_sWidth - 50, 1, ``, `lifeBar`);
@@ -7191,8 +7191,8 @@ function MainInit() {
 	];
 
 	// Appearanceのオプション適用時は一部描画を隠す
-	if (g_stateObj.appearance === `Hidden+` || g_stateObj.appearance === `Sudden+`) {
-		changeAppearanceFilter(g_hidSudObj.filterPos);
+	if (g_appearanceRanges.includes(g_stateObj.appearance)) {
+		changeAppearanceFilter(g_stateObj.appearance, g_hidSudObj.filterPos);
 
 	} else if (g_stateObj.appearance !== `Visible`) {
 		arrowSprite[0].classList.add(`${g_stateObj.appearance}0`);
@@ -7531,11 +7531,13 @@ function MainInit() {
 			}
 			document.onkeyup = _ => { };
 
-		} else if (g_stateObj.appearance === `Hidden+` || g_stateObj.appearance === `Sudden+`) {
+		} else if (g_appearanceRanges.includes(g_stateObj.appearance)) {
 			if (setKey === g_hidSudObj.pgDown[g_stateObj.appearance][g_stateObj.reverse]) {
-				changeAppearanceFilter(g_hidSudObj.filterPos < 100 ? g_hidSudObj.filterPos + 1 : g_hidSudObj.filterPos);
+				changeAppearanceFilter(g_stateObj.appearance, g_hidSudObj.filterPos < 100 ?
+					g_hidSudObj.filterPos + 1 : g_hidSudObj.filterPos);
 			} else if (setKey === g_hidSudObj.pgUp[g_stateObj.appearance][g_stateObj.reverse]) {
-				changeAppearanceFilter(g_hidSudObj.filterPos > 0 ? g_hidSudObj.filterPos - 1 : g_hidSudObj.filterPos);
+				changeAppearanceFilter(g_stateObj.appearance, g_hidSudObj.filterPos > 0 ?
+					g_hidSudObj.filterPos - 1 : g_hidSudObj.filterPos);
 			}
 		}
 		return blockCode(setKey);
@@ -8346,22 +8348,29 @@ function MainInit() {
 
 /**
  * アルファマスクの再描画 (Appearance: Hidden+, Sudden+ 用)
+ * @param {string} _appearance
  * @param {number} _num 
  */
-function changeAppearanceFilter(_num = 10) {
+function changeAppearanceFilter(_appearance, _num = 10) {
 	const topNum = g_hidSudObj[g_stateObj.appearance];
 	const bottomNum = (g_hidSudObj[g_stateObj.appearance] + 1) % 2;
-	document.querySelector(`#arrowSprite${topNum}`).style.clipPath = `inset(${_num}% 0% 0% 0%)`;
-	document.querySelector(`#arrowSprite${topNum}`).style.webkitClipPath = `inset(${_num}% 0% 0% 0%)`;
-	document.querySelector(`#arrowSprite${bottomNum}`).style.clipPath = `inset(0% 0% ${_num}% 0%)`;
-	document.querySelector(`#arrowSprite${bottomNum}`).style.webkitClipPath = `inset(0% 0% ${_num}% 0%)`;
+
+	const numPlus = (_appearance === `Hid/Sud+` ? _num : `0`);
+	const topShape = `inset(${_num}% 0% ${numPlus}% 0%)`;
+	const bottomShape = `inset(${numPlus}% 0% ${_num}% 0%)`;
+
+	document.querySelector(`#arrowSprite${topNum}`).style.clipPath = topShape;
+	document.querySelector(`#arrowSprite${topNum}`).style.webkitClipPath = topShape;
+	document.querySelector(`#arrowSprite${bottomNum}`).style.clipPath = bottomShape;
+	document.querySelector(`#arrowSprite${bottomNum}`).style.webkitClipPath = bottomShape;
 
 	document.querySelector(`#filterBar0`).style.top = `${g_sHeight * _num / 100}px`;
 	document.querySelector(`#filterBar1`).style.top = `${g_sHeight * (100 - _num) / 100}px`;
 	document.querySelector(`#filterView`).style.top =
 		document.querySelector(`#filterBar${g_hidSudObj.std[g_stateObj.appearance][g_stateObj.reverse]}`).style.top;
 	document.querySelector(`#filterView`).innerHTML = `${_num}%`;
-	if (g_workObj.dividePos.every(v => v === g_workObj.dividePos[0])) {
+
+	if (_appearance !== `Hid/Sud+` && g_workObj.dividePos.every(v => v === g_workObj.dividePos[0])) {
 		document.querySelector(`#filterBar${(g_hidSudObj.std[g_stateObj.appearance][g_stateObj.reverse] + 1) % 2}`).style.display = C_DIS_NONE;
 	}
 	g_hidSudObj.filterPos = _num;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4716,6 +4716,12 @@ function settingsDisplayInit() {
 	// オプションボタン用の設置
 	createSettingsDisplayWindow(`divRoot`);
 
+	// ショートカットキーメッセージ
+	const scMsg = createDivCssLabel(`scMsg`, 0, g_sHeight - 45, g_sWidth, 20, 14,
+		`Hidden+/Sudden+ 時ショートカット：「pageUp」カバーを上へ / 「pageDown」カバーを下へ`);
+	scMsg.style.align = C_ALIGN_CENTER;
+	divRoot.appendChild(scMsg);
+
 	// ユーザカスタムイベント(初期)
 	if (typeof customSettingsDisplayInit === C_TYP_FUNCTION) {
 		customSettingsDisplayInit();

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8355,7 +8355,7 @@ function changeAppearanceFilter(_appearance, _num = 10) {
 	const topNum = g_hidSudObj[g_stateObj.appearance];
 	const bottomNum = (g_hidSudObj[g_stateObj.appearance] + 1) % 2;
 
-	const numPlus = (_appearance === `Hid/Sud+` ? _num : `0`);
+	const numPlus = (_appearance === `Hid&Sud+` ? _num : `0`);
 	const topShape = `inset(${_num}% 0% ${numPlus}% 0%)`;
 	const bottomShape = `inset(${numPlus}% 0% ${_num}% 0%)`;
 
@@ -8370,7 +8370,7 @@ function changeAppearanceFilter(_appearance, _num = 10) {
 		document.querySelector(`#filterBar${g_hidSudObj.std[g_stateObj.appearance][g_stateObj.reverse]}`).style.top;
 	document.querySelector(`#filterView`).innerHTML = `${_num}%`;
 
-	if (_appearance !== `Hid/Sud+` && g_workObj.dividePos.every(v => v === g_workObj.dividePos[0])) {
+	if (_appearance !== `Hid&Sud+` && g_workObj.dividePos.every(v => v === g_workObj.dividePos[0])) {
 		document.querySelector(`#filterBar${(g_hidSudObj.std[g_stateObj.appearance][g_stateObj.reverse] + 1) % 2}`).style.display = C_DIS_NONE;
 	}
 	g_hidSudObj.filterPos = _num;
@@ -9064,7 +9064,7 @@ function resultInit() {
 	}
 	if (g_stateObj.appearance !== `Visible`) {
 		playStyleData += `, ${g_stateObj.appearance}`;
-		if (g_stateObj.appearance === `Hidden+` || g_stateObj.appearance === `Sudden+`) {
+		if (g_appearanceRanges.includes(g_stateObj.appearance)) {
 			playStyleData += `(${g_hidSudObj.filterPos}%)`;
 		}
 	}
@@ -9278,7 +9278,7 @@ function resultInit() {
 	}
 	let tweetDifData = `${g_headerObj.keyLabels[g_stateObj.scoreId]}${transKeyData}k-${g_headerObj.difLabels[g_stateObj.scoreId]}`;
 	if (g_stateObj.shuffle !== `OFF`) {
-		tweetDifData += `/${g_stateObj.shuffle}`;
+		tweetDifData += `:${g_stateObj.shuffle}`;
 	}
 	const tweetResultTmp = `【#danoni${hashTag}】${musicTitle}(${tweetDifData})/
 		${g_headerObj.tuning}/

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8361,6 +8361,9 @@ function changeAppearanceFilter(_num = 10) {
 	document.querySelector(`#filterView`).style.top =
 		document.querySelector(`#filterBar${g_hidSudObj.std[g_stateObj.appearance][g_stateObj.reverse]}`).style.top;
 	document.querySelector(`#filterView`).innerHTML = `${_num}%`;
+	if (g_workObj.dividePos.every(v => v === g_workObj.dividePos[0])) {
+		document.querySelector(`#filterBar${(g_hidSudObj.std[g_stateObj.appearance][g_stateObj.reverse] + 1) % 2}`).style.display = C_DIS_NONE;
+	}
 	g_hidSudObj.filterPos = _num;
 }
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -337,8 +337,10 @@ let g_adjustmentNum = C_MAX_ADJUSTMENT;
 let g_volumes = [0, 0.5, 1, 2, 5, 10, 25, 50, 75, 100];
 let g_volumeNum = g_volumes.length - 1;
 
-let g_appearances = [`Visible`, `Hidden`, `Sudden`, `Hidden+`, `Sudden+`, `Slit`];
+let g_appearances = [`Visible`, `Hidden`, `Sudden`, `Hidden+`, `Sudden+`, `Hid/Sud+`, `Slit`];
 let g_appearanceNum = 0;
+
+let g_appearanceRanges = [`Hidden+`, `Sudden+`, `Hid/Sud+`];
 
 let g_scoreDetails = [`Speed`, `Density`, `ToolDif`];
 let g_scoreDetailNum = 0;
@@ -358,11 +360,16 @@ const g_hidSudObj = {
 };
 g_hidSudObj[`Hidden+`] = 0;
 g_hidSudObj[`Sudden+`] = 1;
+g_hidSudObj[`Hid/Sud+`] = 1;
 g_hidSudObj.pgDown[`Hidden+`] = {
     OFF: 34,
     ON: 33,
 };
 g_hidSudObj.pgDown[`Sudden+`] = {
+    OFF: 33,
+    ON: 34,
+}
+g_hidSudObj.pgDown[`Hid/Sud+`] = {
     OFF: 33,
     ON: 34,
 }
@@ -374,11 +381,19 @@ g_hidSudObj.pgUp[`Sudden+`] = {
     OFF: 34,
     ON: 33,
 }
+g_hidSudObj.pgUp[`Hid/Sud+`] = {
+    OFF: 34,
+    ON: 33,
+}
 g_hidSudObj.std[`Hidden+`] = {
     OFF: 0,
     ON: 1,
 };
 g_hidSudObj.std[`Sudden+`] = {
+    OFF: 1,
+    ON: 0,
+}
+g_hidSudObj.std[`Hid/Sud+`] = {
     OFF: 1,
     ON: 0,
 }

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -337,10 +337,10 @@ let g_adjustmentNum = C_MAX_ADJUSTMENT;
 let g_volumes = [0, 0.5, 1, 2, 5, 10, 25, 50, 75, 100];
 let g_volumeNum = g_volumes.length - 1;
 
-let g_appearances = [`Visible`, `Hidden`, `Sudden`, `Hidden+`, `Sudden+`, `Hid/Sud+`, `Slit`];
+let g_appearances = [`Visible`, `Hidden`, `Hidden+`, `Sudden`, `Sudden+`, `Hid&Sud+`, `Slit`];
 let g_appearanceNum = 0;
 
-let g_appearanceRanges = [`Hidden+`, `Sudden+`, `Hid/Sud+`];
+let g_appearanceRanges = [`Hidden+`, `Sudden+`, `Hid&Sud+`];
 
 let g_scoreDetails = [`Speed`, `Density`, `ToolDif`];
 let g_scoreDetailNum = 0;
@@ -360,7 +360,7 @@ const g_hidSudObj = {
 };
 g_hidSudObj[`Hidden+`] = 0;
 g_hidSudObj[`Sudden+`] = 1;
-g_hidSudObj[`Hid/Sud+`] = 1;
+g_hidSudObj[`Hid&Sud+`] = 1;
 g_hidSudObj.pgDown[`Hidden+`] = {
     OFF: 34,
     ON: 33,
@@ -369,7 +369,7 @@ g_hidSudObj.pgDown[`Sudden+`] = {
     OFF: 33,
     ON: 34,
 }
-g_hidSudObj.pgDown[`Hid/Sud+`] = {
+g_hidSudObj.pgDown[`Hid&Sud+`] = {
     OFF: 33,
     ON: 34,
 }
@@ -381,7 +381,7 @@ g_hidSudObj.pgUp[`Sudden+`] = {
     OFF: 34,
     ON: 33,
 }
-g_hidSudObj.pgUp[`Hid/Sud+`] = {
+g_hidSudObj.pgUp[`Hid&Sud+`] = {
     OFF: 34,
     ON: 33,
 }
@@ -393,7 +393,7 @@ g_hidSudObj.std[`Sudden+`] = {
     OFF: 1,
     ON: 0,
 }
-g_hidSudObj.std[`Hid/Sud+`] = {
+g_hidSudObj.std[`Hid&Sud+`] = {
     OFF: 1,
     ON: 0,
 }


### PR DESCRIPTION
## 変更内容
1. Hidden+とSudden+を同時適用する「Hid&Sud+」を実装しました。
「pageUp」「pageDown」キーにて上下のフィルターを同時に操作します。
※上下のフィルターを個別に変えることはできません。
<img src="https://user-images.githubusercontent.com/44026291/79317500-b9cbd800-7f40-11ea-9d52-8546cc3b3987.png" width="300">

2. Hidden+, Sudden+適用時、適用するフィルターが片方しかない場合は
もう片方のフィルターの境界線を非表示にするよう変更しました。
<img src="https://user-images.githubusercontent.com/44026291/79317537-c5b79a00-7f40-11ea-8efb-4e7ae2a3d874.png" width="300">

3. Hidden+, Sudden+のショートカットをDisplay画面に表示するようにしました。
<img src="https://user-images.githubusercontent.com/44026291/79317613-db2cc400-7f40-11ea-8c0e-2d3f92641436.png" width="300">

4. Appearance設定の順序を変更しました。
Visible -> Hidden -> Hidden+ -> Sudden -> Sudden+ -> Hid&Sud+ -> Slit

## 変更理由
1. Hidden+とSudden+を同時に使用する需要を考慮。
2. 関係のないフィルターの境界線により、画面が見づらい可能性があるため。
3. ショートカットキーがわかりにくいため。
4. 関連性のある順番にするため。

## その他コメント
- Hid&Sud+の可動域は0～50%です。
前回プレイでHidden+, Sudden+を選択しており、その際に51～100%にしていた場合、
強制的に50%に修正されます。
