### PR TITLE
[0182/display-judgment] Display:Judgmentを種別ごとに分離

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2970,6 +2970,7 @@ function headerConvert(_dosObj) {
 	// オプション利用可否設定
 	let usingOptions = [`motion`, `scroll`, `shuffle`, `autoPlay`, `gauge`, `appearance`];
 	usingOptions = usingOptions.concat(g_displays);
+	usingOptions = usingOptions.concat(`judgement`);
 
 	usingOptions.forEach(option => {
 		obj[`${option}Use`] = setVal(_dosObj[`${option}Use`],
@@ -2977,6 +2978,12 @@ function headerConvert(_dosObj) {
 				setVal(g_presetSettingUse[option], true, C_TYP_BOOLEAN) : true), C_TYP_BOOLEAN);
 	});
 
+	// 旧バージョン互換（judgementUse=falseを指定した場合は例外的にjudgment, fastSlow, scoreを一律設定）
+	if (!obj.judgementUse) {
+		obj.judgmentUse = false;
+		obj.fastSlowUse = false;
+		obj.scoreUse = false;
+	}
 	g_displays.forEach(option => {
 		g_stateObj[`d_${option.toLowerCase()}`] = (obj[`${option}Use`] ? C_FLG_ON : C_FLG_OFF);
 	});

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4831,7 +4831,7 @@ function createSettingsDisplayWindow(_sprite) {
 	// 設定毎に個別のスプライトを作成し、その中にラベル・ボタン類を配置
 	const displaySprite = createSprite(`optionsprite`, `displaySprite`, childX, childY,
 		optionWidth, C_LEN_SETLBL_HEIGHT * 5);
-	const appearanceSprite = createSprite(`optionsprite`, `appearanceSprite`, childX, 6 * C_LEN_SETLBL_HEIGHT + childY,
+	const appearanceSprite = createSprite(`optionsprite`, `appearanceSprite`, childX, 8 * C_LEN_SETLBL_HEIGHT + childY,
 		optionWidth, C_LEN_SETLBL_HEIGHT);
 
 	const sdDesc = createDivCssLabel(`sdDesc`, 0, 65, g_sWidth, 20, 14,
@@ -4839,7 +4839,7 @@ function createSettingsDisplayWindow(_sprite) {
 	document.querySelector(`#${_sprite}`).appendChild(sdDesc);
 
 	g_displays.forEach((name, j) => {
-		makeDisplayButton(name, j % 5, Math.floor(j / 5));
+		makeDisplayButton(name, j % 7, Math.floor(j / 7));
 	});
 
 	// ---------------------------------------------------
@@ -7414,15 +7414,21 @@ function MainInit() {
 				g_cssObj[`common_${judgeColors[j]}`], j + 1, 0));
 		}
 	});
-	if (g_stateObj.d_judgement === C_FLG_OFF) {
+	if (g_stateObj.d_score === C_FLG_OFF) {
 		jdgObjs.forEach(jdgObj => {
 			if (jdgObj !== ``) {
 				document.querySelector(`#lbl${jdgObj}`).style.display = C_DIS_NONE;
 			}
 		});
+	}
+	if (g_stateObj.d_judgment === C_FLG_OFF) {
 		jdgGroups.forEach(jdg => {
 			document.querySelector(`#chara${jdg}`).style.display = C_DIS_NONE;
 			document.querySelector(`#combo${jdg}`).style.display = C_DIS_NONE;
+		});
+	}
+	if (g_stateObj.d_fastslow === C_FLG_OFF) {
+		jdgGroups.forEach(jdg => {
 			document.querySelector(`#diff${jdg}`).style.display = C_DIS_NONE;
 		});
 	}
@@ -9067,9 +9073,12 @@ function resultInit() {
 
 	let displayData = ``;
 	displayData = withString(displayData, g_stateObj.d_stepzone, `Step`);
-	displayData = withString(displayData, g_stateObj.d_judgement, `Judge`);
+	displayData = withString(displayData, g_stateObj.d_judgment, `Judge`);
+	displayData = withString(displayData, g_stateObj.d_fastslow, `FS`);
 	displayData = withString(displayData, g_stateObj.d_lifegauge, `Life`);
+	displayData = withString(displayData, g_stateObj.d_score, `Score`);
 	displayData = withString(displayData, g_stateObj.d_musicinfo, `MusicInfo`);
+	displayData = withString(displayData, g_stateObj.d_special, `SP`);
 	if (displayData === ``) {
 		displayData = `All Visible`;
 	} else {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -289,9 +289,11 @@ const g_stateObj = {
     scoreDetail: `Speed`,
 
     d_stepzone: C_FLG_ON,
-    d_judgement: C_FLG_ON,
+    d_judgment: C_FLG_ON,
+    d_fastslow: C_FLG_ON,
     d_lifegauge: C_FLG_ON,
     d_musicinfo: C_FLG_ON,
+    d_score: C_FLG_ON,
     d_special: C_FLG_ON,
     d_color: C_FLG_ON,
     d_speed: C_FLG_ON,
@@ -343,7 +345,7 @@ let g_appearanceNum = 0;
 let g_scoreDetails = [`Speed`, `Density`, `ToolDif`];
 let g_scoreDetailNum = 0;
 
-let g_displays = [`stepZone`, `judgement`, `lifeGauge`, `musicInfo`, `special`,
+let g_displays = [`stepZone`, `judgment`, `fastSlow`, `lifeGauge`, `score`, `musicInfo`, `special`,
     `speed`, `color`, `lyrics`, `background`, `arrowEffect`];
 
 // サイズ(後で指定)


### PR DESCRIPTION
## 変更内容
1. Display:Judgementを種別ごとに分離しました。
合わせて、Judgementのスペルをアメリカ式(Judgment)に変更しています。
    - Judgment (判定キャラクタ・コンボ)
    - FastSlow (差分フレーム数表示)
    - Score (現時点の判定数)

![image](https://user-images.githubusercontent.com/44026291/79323360-0e735100-7f49-11ea-8029-c353f953a966.png)


2. 1の変更に伴い、新たにDisplayオプションに応じた以下の設定ができるようになります。
```
|judgmentUse=false|
|fastSlowUse=false|
|scoreUse=false|
```

3. 過去互換として、|judgementUse=false|を指定した場合に限り
Judgment, FastSlow, Score を全て無効化するようにしました。

## 変更理由
1. 判定表示を個別に非表示にするニーズに対応するため。
2. 1の変更に伴って実装。
3. 過去互換のため。

## その他コメント

