### PR TITLE
[0183/display-settings] Displayオプションのテンプレートを更新

### DIFF
--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -1,7 +1,7 @@
 ﻿`use strict`;
 /**
  * Dancing☆Onigiri 設定用jsファイル
- * Template Update: 2020/03/30
+ * Template Update: 2020/04/15
  * 
  * このファイルでは、作品全体に対しての初期設定を行うことができます。
  * 譜面データ側で個別に同様の項目が設定されている場合は、譜面データ側の設定が優先されます。
@@ -79,6 +79,19 @@ const g_presetSettingUse = {
 	autoPlay: `true`,
 	gauge: `true`,
 	appearance: `true`,
+
+	//	stepZone: `true`,
+	//	judgment: `true`,
+	//	fastSlow: `true`,
+	//	lifeGauge: `true`,
+	//	score: `true`,
+	//	musicInfo: `true`,
+	//	special: `true`,
+	//	speed: `true`,
+	//	color: `true`,
+	//	lyrics: `true`,
+	//	background: `true`,
+	//	arrowEffect: `true`,
 };
 
 // フリーズアローの始点で通常矢印の判定を行うか(dotさんソース方式)


### PR DESCRIPTION
## 変更内容
- Displayオプションを一律無効化する設定について、
danoni_setting.jsのテンプレートを更新しました。

## 変更理由
- Displayオプションを一律無効化するテンプレートが無かったため。

## その他コメント
- danoni_setting.jsのみの変更です。

