### PR TITLE
[0183/display-replace] Display:filterLine実装、Displayオプションの配置変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4725,7 +4725,7 @@ function settingsDisplayInit() {
 
 	// ショートカットキーメッセージ
 	const scMsg = createDivCssLabel(`scMsg`, 0, g_sHeight - 45, g_sWidth, 20, 14,
-		`Hidden+/Sudden+ 時ショートカット：「pageUp」カバーを上へ / 「pageDown」カバーを下へ`);
+		`Hid+/Sud+時ショートカット：「pageUp」カバーを上へ / 「pageDown」下へ`);
 	scMsg.style.align = C_ALIGN_CENTER;
 	divRoot.appendChild(scMsg);
 
@@ -7179,6 +7179,7 @@ function MainInit() {
 
 	}
 
+	// Hidden+, Sudden+用のライン、パーセント表示
 	if (g_appearanceRanges.includes(g_stateObj.appearance)) {
 		const filterBar0 = createColorObject(`filterBar0`, ``,
 			0, 0,
@@ -7195,6 +7196,11 @@ function MainInit() {
 		const filterView = createDivCssLabel(`filterView`, g_sWidth - 70, 0, 10, 10, 10, ``);
 		filterView.style.textAlign = C_ALIGN_RIGHT;
 		mainSprite.appendChild(filterView);
+
+		if (g_stateObj.d_filterline === C_FLG_OFF) {
+			[`filterBar0`, `filterBar1`].forEach(obj =>
+				document.querySelector(`#${obj}`).style.display = C_DIS_NONE);
+		}
 	}
 
 	// 矢印・フリーズアロー描画スプライト（ステップゾーンの上に配置）
@@ -9106,7 +9112,7 @@ function resultInit() {
 	displayData = withString(displayData, g_stateObj.d_lifegauge, `Life`);
 	displayData = withString(displayData, g_stateObj.d_score, `Score`);
 	displayData = withString(displayData, g_stateObj.d_musicinfo, `MusicInfo`);
-	displayData = withString(displayData, g_stateObj.d_special, `SP`);
+	displayData = withString(displayData, g_stateObj.d_filterline, `Filter`);
 	if (displayData === ``) {
 		displayData = `All Visible`;
 	} else {
@@ -9120,7 +9126,8 @@ function resultInit() {
 	display2Data = withString(display2Data, g_stateObj.d_color, `Color`);
 	display2Data = withString(display2Data, g_stateObj.d_lyrics, `Lyrics`);
 	display2Data = withString(display2Data, g_stateObj.d_background, `Back`);
-	display2Data = withString(display2Data, g_stateObj.d_arroweffect, `ArrowEffect`);
+	display2Data = withString(display2Data, g_stateObj.d_arroweffect, `Effect`);
+	display2Data = withString(display2Data, g_stateObj.d_special, `SP`);
 	if (display2Data !== ``) {
 		display2Data += ` : OFF`;
 	}

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -294,12 +294,14 @@ const g_stateObj = {
     d_lifegauge: C_FLG_ON,
     d_musicinfo: C_FLG_ON,
     d_score: C_FLG_ON,
-    d_special: C_FLG_ON,
+    d_filterline: C_FLG_ON,
+
     d_color: C_FLG_ON,
     d_speed: C_FLG_ON,
     d_arroweffect: C_FLG_ON,
     d_lyrics: C_FLG_ON,
     d_background: C_FLG_ON,
+    d_special: C_FLG_ON,
     appearance: `Visible`,
 };
 
@@ -347,8 +349,8 @@ let g_appearanceRanges = [`Hidden+`, `Sudden+`, `Hid&Sud+`];
 let g_scoreDetails = [`Speed`, `Density`, `ToolDif`];
 let g_scoreDetailNum = 0;
 
-let g_displays = [`stepZone`, `judgment`, `fastSlow`, `lifeGauge`, `score`, `musicInfo`, `special`,
-    `speed`, `color`, `lyrics`, `background`, `arrowEffect`];
+let g_displays = [`stepZone`, `judgment`, `fastSlow`, `lifeGauge`, `score`, `musicInfo`, `filterLine`,
+    `speed`, `color`, `lyrics`, `background`, `arrowEffect`, `special`];
 
 // サイズ(後で指定)
 let g_sWidth;


### PR DESCRIPTION
## 変更内容
1. Displayオプションに「filterLine」を追加しました。
「Hidden+」「Sudden+」「Hid&Sud+」設定時に表示するフィルターの境界線が消せるようになります。
2. 「pageUp」「pageDown」の説明文を簡略化しました。

## 変更理由
1. フィルターの境界線が無くても、パーセント表記があれば判別がつく場合があるため。
2. 横幅が500pxのとき、説明文が2段になってしまうため。

## その他コメント

