### PR TITLE
[0186/display-alpha] Opacity設定を実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4846,6 +4846,8 @@ function createSettingsDisplayWindow(_sprite) {
 		optionWidth, C_LEN_SETLBL_HEIGHT * 5);
 	const appearanceSprite = createSprite(`optionsprite`, `appearanceSprite`, childX, 8 * C_LEN_SETLBL_HEIGHT + childY,
 		optionWidth, C_LEN_SETLBL_HEIGHT);
+	const opacitySprite = createSprite(`optionsprite`, `opacitySprite`, childX, 9 * C_LEN_SETLBL_HEIGHT + childY,
+		optionWidth, C_LEN_SETLBL_HEIGHT);
 
 	const sdDesc = createDivCssLabel(`sdDesc`, 0, 65, g_sWidth, 20, 14,
 		`[クリックでON/OFFを切替、灰色でOFF]`);
@@ -4857,8 +4859,13 @@ function createSettingsDisplayWindow(_sprite) {
 
 	// ---------------------------------------------------
 	// 矢印の見え方 (Appearance)
-	// 縦位置: 6
+	// 縦位置: 8
 	createGeneralSetting(appearanceSprite, `appearance`);
+
+	// ---------------------------------------------------
+	// 判定表示系の不透明度 (Opacity)
+	// 縦位置: 9
+	createGeneralSetting(opacitySprite, `opacity`, `%`);
 
 	/**
 	 * Display表示/非表示ボタン
@@ -4869,15 +4876,15 @@ function createSettingsDisplayWindow(_sprite) {
 	function makeDisplayButton(_name, _heightPos, _widthPos) {
 
 		const flg = g_stateObj[`d_${_name.toLowerCase()}`];
+		const list = [C_FLG_OFF, C_FLG_ON];
 
 		if (g_headerObj[`${_name}Use`]) {
 			const lnk = makeSettingLblCssButton(`lnk${_name}`, `${toCapitalize(_name)}`, _heightPos, _ => {
-				g_stateObj[`d_${_name.toLowerCase()}`] = (g_stateObj[`d_${_name.toLowerCase()}`] === C_FLG_OFF ? C_FLG_ON : C_FLG_OFF);
-				if (g_stateObj[`d_${_name.toLowerCase()}`] === C_FLG_OFF) {
-					lnk.classList.replace(g_cssObj.button_ON, g_cssObj.button_OFF);
-				} else {
-					lnk.classList.replace(g_cssObj.button_OFF, g_cssObj.button_ON);
-				}
+				const displayFlg = g_stateObj[`d_${_name.toLowerCase()}`];
+				const displayNum = list.findIndex(flg => flg === displayFlg);
+				const nextDisplayFlg = list[(displayNum + 1) % list.length];
+				g_stateObj[`d_${_name.toLowerCase()}`] = nextDisplayFlg;
+				lnk.classList.replace(g_cssObj[`button_${displayFlg}`], g_cssObj[`button_${nextDisplayFlg}`]);
 			});
 			lnk.style.width = `170px`;
 			lnk.style.left = `calc(30px + 180px * ${_widthPos})`;
@@ -7080,6 +7087,7 @@ function MainInit() {
 
 	// 判定系スプライトを作成（メインスプライトより上位）
 	const judgeSprite = createSprite(`divRoot`, `judgeSprite`, 0, 0, g_sWidth, g_sHeight);
+	judgeSprite.style.opacity = g_stateObj.opacity / 100;
 
 	const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
 	const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
@@ -7200,6 +7208,9 @@ function MainInit() {
 		if (g_stateObj.d_filterline === C_FLG_OFF) {
 			[`filterBar0`, `filterBar1`].forEach(obj =>
 				document.querySelector(`#${obj}`).style.display = C_DIS_NONE);
+		} else {
+			[`filterBar0`, `filterBar1`, `filterView`].forEach(obj =>
+				document.querySelector(`#${obj}`).style.opacity = g_stateObj.opacity / 100);
 		}
 	}
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -303,6 +303,7 @@ const g_stateObj = {
     d_background: C_FLG_ON,
     d_special: C_FLG_ON,
     appearance: `Visible`,
+    opacity: 100,
 };
 
 const C_VAL_MAXLIFE = 1000;
@@ -345,6 +346,9 @@ let g_appearances = [`Visible`, `Hidden`, `Hidden+`, `Sudden`, `Sudden+`, `Hid&S
 let g_appearanceNum = 0;
 
 let g_appearanceRanges = [`Hidden+`, `Sudden+`, `Hid&Sud+`];
+
+let g_opacitys = [10, 25, 50, 75, 100];
+let g_opacityNum = g_opacitys.length - 1;
 
 let g_scoreDetails = [`Speed`, `Density`, `ToolDif`];
 let g_scoreDetailNum = 0;

--- a/skin/danoni_skin_default.css
+++ b/skin/danoni_skin_default.css
@@ -62,6 +62,9 @@
 .settings_Appearance::first-letter {
 	color:#cc99ff;
 }
+.settings_Opacity::first-letter {
+	color:#999999;
+}
 
 .settings_DifSelector {
 	background-color: #111111;

--- a/skin/danoni_skin_light.css
+++ b/skin/danoni_skin_light.css
@@ -62,6 +62,9 @@
 .settings_Appearance::first-letter {
 	color:#9900ff;
 }
+.settings_Opacity::first-letter {
+	color:#666666;
+}
 
 .settings_DifSelector {
 	background-color:#eeeeee;

--- a/skin/danoni_skin_skyblue.css
+++ b/skin/danoni_skin_skyblue.css
@@ -62,6 +62,9 @@
 .settings_Appearance::first-letter {
 	color:#9900ff;
 }
+.settings_Opacity::first-letter {
+	color:#666666;
+}
 
 .settings_DifSelector {
 	background-color:#ccddee;


### PR DESCRIPTION
## 変更内容
1. 判定表示、歌詞表示、Hidden+/Sudden+用の境界線表示、
フィニッシュ演出の透明度を全体的に変更できる設定「Opacity」を追加しました。
Display画面から変更可能で、「10%」「25%」「50%」「75％」「100%(デフォルト)」
から選択できます。

<img src="https://user-images.githubusercontent.com/44026291/79460153-5ec4de80-802f-11ea-9c39-ea97166faf24.png" width="500">

2. Displayボタンを作成するコードを見直しました。

## 変更理由
1. 矢印やフリーズアローを目立たせる手段の拡充のため。
2. 今後、ON/OFF以外のパターンを作成する場合に備えるため。

## その他コメント
- 設定追加のため、skinデータの更新が入ります。
```css
.settings_Opacity::first-letter {
	color:#999999;
}
```
