### PR TITLE
[0187/display-alpha2] Opacity仕様を一部変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7087,7 +7087,6 @@ function MainInit() {
 
 	// 判定系スプライトを作成（メインスプライトより上位）
 	const judgeSprite = createSprite(`divRoot`, `judgeSprite`, 0, 0, g_sWidth, g_sHeight);
-	judgeSprite.style.opacity = g_stateObj.opacity / 100;
 
 	const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
 	const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
@@ -7420,18 +7419,21 @@ function MainInit() {
 		charaJ.style.textAlign = C_ALIGN_CENTER;
 		charaJ.setAttribute(`cnt`, 0);
 		judgeSprite.appendChild(charaJ);
+		charaJ.style.opacity = g_stateObj.opacity / 100;
 
 		// コンボ表示
 		const comboJ = createDivCssLabel(`combo${jdg}`, jdgX[j] + 150, jdgY[j],
 			C_LEN_JDGCHARA_WIDTH, C_LEN_JDGCHARA_HEIGHT, C_SIZ_JDGCHARA, ``, g_cssObj[`common_${jdgCombos[j]}`]);
 		comboJ.style.textAlign = C_ALIGN_CENTER;
 		judgeSprite.appendChild(comboJ);
+		comboJ.style.opacity = g_stateObj.opacity / 100;
 
 		// Fast/Slow表示
 		const diffJ = createDivCssLabel(`diff${jdg}`, jdgX[j] + 150, jdgY[j] + 25,
 			C_LEN_JDGCHARA_WIDTH, C_LEN_JDGCHARA_HEIGHT, 14, ``, g_cssObj.common_combo);
 		diffJ.style.textAlign = C_ALIGN_CENTER;
 		judgeSprite.appendChild(diffJ);
+		diffJ.style.opacity = g_stateObj.opacity / 100;
 	});
 
 	// 判定カウンタ表示


### PR DESCRIPTION
## 変更内容
1. Opacityオプションの仕様を一部変更しました。
judgeSpriteに対して一律透明度を設定するのではなく、
判定キャラクタ・Fast/Slow・Hidden+/Sudden+の境界線表示に絞って透明度を掛けるように変更しています。

## 変更理由
1. judgeSprite, wordSprite（歌詞表示）は画面全体に透明度が掛かり
動作に影響するため。

## その他コメント

