### PR TITLE
[0188/endframe-expantion] startFrame/fadeFrame/endFrameの疑似タイマー表記に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2827,10 +2827,17 @@ function headerConvert(_dosObj) {
 	// 終了フレーム数
 	if (_dosObj.endFrame !== undefined) {
 		obj.endFrame = _dosObj.endFrame.split(`$`);
+
+		// タイマー表示 |endFrame=1:35.20|
 		for (let j = 0; j < obj.endFrame.length; j++) {
 			if (obj.endFrame[j].indexOf(`:`) !== -1) {
 				const tmpTimes = obj.endFrame[j].split(`:`);
-				obj.endFrame[j] = g_fps * (Number(tmpTimes[0]) * 60 + Number(tmpTimes[1]));
+				if (tmpTimes[1].indexOf(`.`) !== -1) {
+					const tmpSeconds = tmpTimes[1].split(`.`);
+					obj.endFrame[j] = g_fps * (Number(tmpTimes[0]) * 60 + Number(tmpSeconds[0])) + Number(tmpSeconds[1]);
+				} else {
+					obj.endFrame[j] = g_fps * (Number(tmpTimes[0]) * 60 + Number(tmpTimes[1]));
+				}
 			}
 		}
 	}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2827,6 +2827,12 @@ function headerConvert(_dosObj) {
 	// 終了フレーム数
 	if (_dosObj.endFrame !== undefined) {
 		obj.endFrame = _dosObj.endFrame.split(`$`);
+		for (let j = 0; j < obj.endFrame.length; j++) {
+			if (obj.endFrame[j].indexOf(`:`) !== -1) {
+				const tmpTimes = obj.endFrame[j].split(`:`);
+				obj.endFrame[j] = g_fps * (Number(tmpTimes[0]) * 60 + Number(tmpTimes[1]));
+			}
+		}
 	}
 
 	// タイミング調整

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2813,6 +2813,10 @@ function headerConvert(_dosObj) {
 	// 開始フレーム数（0以外の場合はフェードインスタート）
 	if (_dosObj.startFrame !== undefined) {
 		obj.startFrame = _dosObj.startFrame.split(`$`);
+
+		for (let j = 0; j < obj.startFrame.length; j++) {
+			obj.startFrame[j] = transTimerToFrame(obj.startFrame[j]);
+		}
 	}
 
 	// フェードアウトフレーム数(譜面別)
@@ -2821,6 +2825,7 @@ function headerConvert(_dosObj) {
 		obj.fadeFrame = [];
 		fadeFrames.forEach((fadeInfo, j) => {
 			obj.fadeFrame[j] = fadeInfo.split(`,`);
+			obj.fadeFrame[j][0] = transTimerToFrame(obj.fadeFrame[j][0]);
 		});
 	}
 
@@ -2828,17 +2833,8 @@ function headerConvert(_dosObj) {
 	if (_dosObj.endFrame !== undefined) {
 		obj.endFrame = _dosObj.endFrame.split(`$`);
 
-		// タイマー表示 |endFrame=1:35.20|
 		for (let j = 0; j < obj.endFrame.length; j++) {
-			if (obj.endFrame[j].indexOf(`:`) !== -1) {
-				const tmpTimes = obj.endFrame[j].split(`:`);
-				if (tmpTimes[1].indexOf(`.`) !== -1) {
-					const tmpSeconds = tmpTimes[1].split(`.`);
-					obj.endFrame[j] = g_fps * (Number(tmpTimes[0]) * 60 + Number(tmpSeconds[0])) + Number(tmpSeconds[1]);
-				} else {
-					obj.endFrame[j] = g_fps * (Number(tmpTimes[0]) * 60 + Number(tmpTimes[1]));
-				}
-			}
+			obj.endFrame[j] = transTimerToFrame(obj.endFrame[j]);
 		}
 	}
 
@@ -3037,6 +3033,24 @@ function headerConvert(_dosObj) {
 	obj.scoreDetailUse = setVal(_dosObj.scoreDetailUse, true, C_TYP_BOOLEAN);
 
 	return obj;
+}
+
+/**
+ * 疑似タイマー表記をフレーム数へ変換
+ * |endFrame=1:35.20|
+ * @param {string} _str 
+ */
+function transTimerToFrame(_str) {
+	if (_str.indexOf(`:`) !== -1) {
+		const tmpTimes = _str.split(`:`);
+		if (tmpTimes[1].indexOf(`.`) !== -1) {
+			const tmpSeconds = tmpTimes[1].split(`.`);
+			return g_fps * (Number(tmpTimes[0]) * 60 + Number(tmpSeconds[0])) + Number(tmpSeconds[1]);
+		} else {
+			return g_fps * (Number(tmpTimes[0]) * 60 + Number(tmpTimes[1]));
+		}
+	}
+	return _str;
 }
 
 /**


### PR DESCRIPTION
## 変更内容
1. startFrame/fadeFrame/endFrameの疑似タイマー表記に対応しました。
`|endFrame=分:秒.補正フレーム数|` の形式で記述します。
下記の2つの指定は同じ意味です。
```
|endFrame=1:30|
|endFrame=5400|
```

- なお、フレーム数レベルで調整したい場合は以下のように記述します。
(タイマーを入れた後、後ろにドット(.)を入れてその後ろに補正フレーム数を入れます)
```
|endFrame=3:02.30|
```

- もちろん、譜面毎の設定も可能です。
```
|endFrame=1:35.20$3:50.20|
```

## 変更理由
1. 疑似タイマー表記は厳密には最終フレーム数ではないですが、
startFrame, fadeFrame, endFrameを手軽に使用できるようにするため。

## その他コメント
1. 疑似タイマーのため、以下のような記述をしても一応動きます。
（混乱のもとになるので、やむを得ない事情を除いてはやらないことをおススメします）
```
|endFrame=:55| -> 0:55と同じ
|endFrame=0:90| -> 1:30と同じ
```
2. blankFrame, adjustmentは疑似タイマー非対応です。
これらは疑似タイマーよりもフレーム数を使用する傾向が強いため。