### PR TITLE
[0195/appearance-filter-posdif] 上下非対称時のAppearanceの挙動変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2906,8 +2906,10 @@ function headerConvert(_dosObj) {
 	// ステップゾーン位置
 	g_stepY = (isNaN(parseFloat(_dosObj.stepY)) ? C_STEP_Y : parseFloat(_dosObj.stepY));
 	g_stepYR = (isNaN(parseFloat(_dosObj.stepYR)) ? C_STEP_YR : parseFloat(_dosObj.stepYR));
-	g_distY = g_sHeight - g_stepY + g_stepYR;
-	g_reverseStepY = g_distY - g_stepY - C_ARW_WIDTH;
+	g_stepDiffY = g_stepY - C_STEP_Y;
+	g_distY = g_sHeight - C_STEP_Y + g_stepYR;
+	g_reverseStepY = g_distY - g_stepY - g_stepDiffY - C_ARW_WIDTH;
+	g_arrowHeight = g_sHeight + g_stepYR - g_stepDiffY * 2;
 	obj.bottomWordSetFlg = setVal(_dosObj.bottomWordSet, false, C_TYP_BOOLEAN);
 
 	// 矢印・フリーズアロー判定位置補正
@@ -7196,7 +7198,7 @@ function MainInit() {
 	}
 
 	// ステップゾーン、矢印のメインスプライトを作成
-	const mainSprite = createSprite(`divRoot`, `mainSprite`, 0, 0, g_sWidth, g_sHeight);
+	const mainSprite = createSprite(`divRoot`, `mainSprite`, 0, g_stepY - C_STEP_Y, g_sWidth, g_sHeight);
 	mainSprite.style.transform = `scale(${g_keyObj.scale})`;
 
 	// 曲情報・判定カウント用スプライトを作成（メインスプライトより上位）
@@ -7243,7 +7245,7 @@ function MainInit() {
 		// ステップゾーンルート
 		const stepRoot = createSprite(`mainSprite`, `stepRoot${j}`,
 			g_workObj.stepX[j],
-			g_stepY + g_reverseStepY * g_workObj.dividePos[j],
+			C_STEP_Y + g_reverseStepY * g_workObj.dividePos[j],
 			C_ARW_WIDTH, C_ARW_WIDTH);
 
 		// 矢印の内側を塗りつぶすか否か
@@ -7290,13 +7292,13 @@ function MainInit() {
 
 		// ステップゾーンの代わり
 		const stepBar0 = createColorObject(`stepBar`, ``,
-			0, g_stepY + g_reverseStepY * (g_stateObj.reverse === C_FLG_OFF ? 0 : 1),
+			0, C_STEP_Y + g_reverseStepY * (g_stateObj.reverse === C_FLG_OFF ? 0 : 1),
 			g_sWidth - 50, 1, ``, `lifeBar`);
 		stepBar0.classList.add(g_cssObj.life_Failed);
 		mainSprite.appendChild(stepBar0);
 
 		const stepBar1 = createColorObject(`stepBar`, ``,
-			0, g_stepY + g_reverseStepY * (g_stateObj.reverse === C_FLG_OFF ? 0 : 1) + C_ARW_WIDTH,
+			0, C_STEP_Y + g_reverseStepY * (g_stateObj.reverse === C_FLG_OFF ? 0 : 1) + C_ARW_WIDTH,
 			g_sWidth - 50, 1, ``, `lifeBar`);
 		stepBar1.classList.add(g_cssObj.life_Failed);
 		mainSprite.appendChild(stepBar1);
@@ -7332,15 +7334,16 @@ function MainInit() {
 
 	// 矢印・フリーズアロー描画スプライト（ステップゾーンの上に配置）
 	const arrowSprite = [
-		createSprite(`mainSprite`, `arrowSprite0`, 0, 0, g_sWidth, g_sHeight),
-		createSprite(`mainSprite`, `arrowSprite1`, 0, 0, g_sWidth, g_sHeight)
+		createSprite(`mainSprite`, `arrowSprite0`, 0, 0, g_sWidth, g_arrowHeight),
+		createSprite(`mainSprite`, `arrowSprite1`, 0, 0, g_sWidth, g_arrowHeight)
 	];
 
 	// Appearanceのオプション適用時は一部描画を隠す
 	if (g_appearanceRanges.includes(g_stateObj.appearance)) {
 		changeAppearanceFilter(g_stateObj.appearance, g_hidSudObj.filterPos);
-
-	} else if (g_stateObj.appearance !== `Visible`) {
+	} else if (g_stateObj.appearance === `Visible`) {
+		changeAppearanceFilter(g_stateObj.appearance, 0);
+	} else {
 		arrowSprite[0].classList.add(`${g_stateObj.appearance}0`);
 		arrowSprite[1].classList.add(`${g_stateObj.appearance}1`);
 	}
@@ -7349,7 +7352,7 @@ function MainInit() {
 
 		// フリーズアローヒット部分
 		const frzHit = createSprite(`mainSprite`, `frzHit${j}`,
-			g_workObj.stepX[j], g_stepY + g_reverseStepY * g_workObj.dividePos[j],
+			g_workObj.stepX[j], C_STEP_Y + g_reverseStepY * g_workObj.dividePos[j],
 			C_ARW_WIDTH, C_ARW_WIDTH);
 		frzHit.style.opacity = 0;
 		if (isNaN(Number(g_workObj.arrowRtn[j]))) {
@@ -8000,7 +8003,7 @@ function MainInit() {
 
 		const stepRoot = createSprite(`arrowSprite${dividePos}`, `${_name}${_j}_${_arrowCnt}`,
 			g_workObj.stepX[_j],
-			g_stepY + g_reverseStepY * dividePos + g_workObj.initY[g_scoreObj.frameNum] * boostSpdDir,
+			C_STEP_Y + g_reverseStepY * dividePos + g_workObj.initY[g_scoreObj.frameNum] * boostSpdDir,
 			C_ARW_WIDTH, C_ARW_WIDTH);
 		stepRoot.setAttribute(`cnt`, g_workObj.arrivalFrame[g_scoreObj.frameNum] + 1);
 		stepRoot.setAttribute(`boostCnt`, g_workObj.motionFrame[g_scoreObj.frameNum]);
@@ -8085,7 +8088,7 @@ function MainInit() {
 
 		const frzRoot = createSprite(`arrowSprite${dividePos}`, `${_name}${_j}_${_arrowCnt}`,
 			g_workObj.stepX[_j],
-			g_stepY + g_reverseStepY * dividePos + g_workObj.initY[g_scoreObj.frameNum] * boostSpdDir,
+			C_STEP_Y + g_reverseStepY * dividePos + g_workObj.initY[g_scoreObj.frameNum] * boostSpdDir,
 			C_ARW_WIDTH, C_ARW_WIDTH + frzLength);
 		frzRoot.setAttribute(`cnt`, g_workObj.arrivalFrame[g_scoreObj.frameNum] + 1);
 		frzRoot.setAttribute(`boostCnt`, g_workObj.motionFrame[g_scoreObj.frameNum]);
@@ -8522,16 +8525,18 @@ function changeAppearanceFilter(_appearance, _num = 10) {
 	document.querySelector(`#arrowSprite${bottomNum}`).style.clipPath = bottomShape;
 	document.querySelector(`#arrowSprite${bottomNum}`).style.webkitClipPath = bottomShape;
 
-	document.querySelector(`#filterBar0`).style.top = `${g_sHeight * _num / 100}px`;
-	document.querySelector(`#filterBar1`).style.top = `${g_sHeight * (100 - _num) / 100}px`;
-	document.querySelector(`#filterView`).style.top =
-		document.querySelector(`#filterBar${g_hidSudObj.std[g_stateObj.appearance][g_stateObj.reverse]}`).style.top;
-	document.querySelector(`#filterView`).innerHTML = `${_num}%`;
+	if (document.querySelector(`#filterBar0`) !== null) {
+		document.querySelector(`#filterBar0`).style.top = `${g_arrowHeight * _num / 100}px`;
+		document.querySelector(`#filterBar1`).style.top = `${g_arrowHeight * (100 - _num) / 100}px`;
+		document.querySelector(`#filterView`).style.top =
+			document.querySelector(`#filterBar${g_hidSudObj.std[g_stateObj.appearance][g_stateObj.reverse]}`).style.top;
+		document.querySelector(`#filterView`).innerHTML = `${_num}%`;
 
-	if (_appearance !== `Hid&Sud+` && g_workObj.dividePos.every(v => v === g_workObj.dividePos[0])) {
-		document.querySelector(`#filterBar${(g_hidSudObj.std[g_stateObj.appearance][g_stateObj.reverse] + 1) % 2}`).style.display = C_DIS_NONE;
+		if (_appearance !== `Hid&Sud+` && g_workObj.dividePos.every(v => v === g_workObj.dividePos[0])) {
+			document.querySelector(`#filterBar${(g_hidSudObj.std[g_stateObj.appearance][g_stateObj.reverse] + 1) % 2}`).style.display = C_DIS_NONE;
+		}
+		g_hidSudObj.filterPos = _num;
 	}
-	g_hidSudObj.filterPos = _num;
 }
 
 /**
@@ -9222,9 +9227,6 @@ function resultInit() {
 	}
 	if (g_stateObj.appearance !== `Visible`) {
 		playStyleData += `, ${g_stateObj.appearance}`;
-		if (g_appearanceRanges.includes(g_stateObj.appearance)) {
-			playStyleData += `(${g_hidSudObj.filterPos}%)`;
-		}
 	}
 	if (g_stateObj.gauge !== g_gauges[0]) {
 		playStyleData += `, ${g_stateObj.gauge}`;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2904,13 +2904,19 @@ function headerConvert(_dosObj) {
 	}
 
 	// ステップゾーン位置
-	g_stepY = (isNaN(parseFloat(_dosObj.stepY)) ? C_STEP_Y : parseFloat(_dosObj.stepY));
-	g_stepYR = (isNaN(parseFloat(_dosObj.stepYR)) ? C_STEP_YR : parseFloat(_dosObj.stepYR));
-	g_stepDiffY = g_stepY - C_STEP_Y;
-	g_distY = g_sHeight - C_STEP_Y + g_stepYR;
-	g_reverseStepY = g_distY - g_stepY - g_stepDiffY - C_ARW_WIDTH;
-	g_arrowHeight = g_sHeight + g_stepYR - g_stepDiffY * 2;
+	g_posObj.stepY = (isNaN(parseFloat(_dosObj.stepY)) ? C_STEP_Y : parseFloat(_dosObj.stepY));
+	g_posObj.stepYR = (isNaN(parseFloat(_dosObj.stepYR)) ? C_STEP_YR : parseFloat(_dosObj.stepYR));
+	g_posObj.stepDiffY = g_posObj.stepY - C_STEP_Y;
+	g_posObj.distY = g_sHeight - C_STEP_Y + g_posObj.stepYR;
+	g_posObj.reverseStepY = g_posObj.distY - g_posObj.stepY - g_posObj.stepDiffY - C_ARW_WIDTH;
+	g_posObj.arrowHeight = g_sHeight + g_posObj.stepYR - g_posObj.stepDiffY * 2;
 	obj.bottomWordSetFlg = setVal(_dosObj.bottomWordSet, false, C_TYP_BOOLEAN);
+
+	// ステップゾーン位置 (旧変数)
+	g_stepY = g_posObj.stepY;
+	g_stepYR = g_posObj.stepYR;
+	g_distY = g_posObj.distY;
+	g_reverseStepY = g_posObj.reverseStepY;
 
 	// 矢印・フリーズアロー判定位置補正
 	g_diffObj.arrowJdgY = (isNaN(parseFloat(_dosObj.arrowJdgY)) ? 0 : parseFloat(_dosObj.arrowJdgY));
@@ -6393,7 +6399,7 @@ function getFirstArrivalFrame(_startFrame, _speedOnFrame, _motionOnFrame) {
 	let frm = _startFrame;
 	let motionFrm = C_MOTION_STD_POS;
 
-	while (g_distY - startY > 0) {
+	while (g_posObj.distY - startY > 0) {
 		startY += _speedOnFrame[frm];
 
 		if (_speedOnFrame[frm] !== 0) {
@@ -6802,7 +6808,7 @@ function getArrowStartFrame(_frame, _speedOnFrame, _motionOnFrame) {
 		motionFrm: C_MOTION_STD_POS
 	};
 
-	while (g_distY - obj.startY > 0) {
+	while (g_posObj.distY - obj.startY > 0) {
 		obj.startY += _speedOnFrame[obj.frm];
 
 		if (_speedOnFrame[obj.frm] !== 0) {
@@ -7198,7 +7204,7 @@ function MainInit() {
 	}
 
 	// ステップゾーン、矢印のメインスプライトを作成
-	const mainSprite = createSprite(`divRoot`, `mainSprite`, 0, g_stepY - C_STEP_Y, g_sWidth, g_sHeight);
+	const mainSprite = createSprite(`divRoot`, `mainSprite`, 0, g_posObj.stepY - C_STEP_Y, g_sWidth, g_sHeight);
 	mainSprite.style.transform = `scale(${g_keyObj.scale})`;
 
 	// 曲情報・判定カウント用スプライトを作成（メインスプライトより上位）
@@ -7245,7 +7251,7 @@ function MainInit() {
 		// ステップゾーンルート
 		const stepRoot = createSprite(`mainSprite`, `stepRoot${j}`,
 			g_workObj.stepX[j],
-			C_STEP_Y + g_reverseStepY * g_workObj.dividePos[j],
+			C_STEP_Y + g_posObj.reverseStepY * g_workObj.dividePos[j],
 			C_ARW_WIDTH, C_ARW_WIDTH);
 
 		// 矢印の内側を塗りつぶすか否か
@@ -7292,13 +7298,13 @@ function MainInit() {
 
 		// ステップゾーンの代わり
 		const stepBar0 = createColorObject(`stepBar`, ``,
-			0, C_STEP_Y + g_reverseStepY * (g_stateObj.reverse === C_FLG_OFF ? 0 : 1),
+			0, C_STEP_Y + g_posObj.reverseStepY * (g_stateObj.reverse === C_FLG_OFF ? 0 : 1),
 			g_sWidth - 50, 1, ``, `lifeBar`);
 		stepBar0.classList.add(g_cssObj.life_Failed);
 		mainSprite.appendChild(stepBar0);
 
 		const stepBar1 = createColorObject(`stepBar`, ``,
-			0, C_STEP_Y + g_reverseStepY * (g_stateObj.reverse === C_FLG_OFF ? 0 : 1) + C_ARW_WIDTH,
+			0, C_STEP_Y + g_posObj.reverseStepY * (g_stateObj.reverse === C_FLG_OFF ? 0 : 1) + C_ARW_WIDTH,
 			g_sWidth - 50, 1, ``, `lifeBar`);
 		stepBar1.classList.add(g_cssObj.life_Failed);
 		mainSprite.appendChild(stepBar1);
@@ -7334,8 +7340,8 @@ function MainInit() {
 
 	// 矢印・フリーズアロー描画スプライト（ステップゾーンの上に配置）
 	const arrowSprite = [
-		createSprite(`mainSprite`, `arrowSprite0`, 0, 0, g_sWidth, g_arrowHeight),
-		createSprite(`mainSprite`, `arrowSprite1`, 0, 0, g_sWidth, g_arrowHeight)
+		createSprite(`mainSprite`, `arrowSprite0`, 0, 0, g_sWidth, g_posObj.arrowHeight),
+		createSprite(`mainSprite`, `arrowSprite1`, 0, 0, g_sWidth, g_posObj.arrowHeight)
 	];
 
 	// Appearanceのオプション適用時は一部描画を隠す
@@ -7352,7 +7358,7 @@ function MainInit() {
 
 		// フリーズアローヒット部分
 		const frzHit = createSprite(`mainSprite`, `frzHit${j}`,
-			g_workObj.stepX[j], C_STEP_Y + g_reverseStepY * g_workObj.dividePos[j],
+			g_workObj.stepX[j], C_STEP_Y + g_posObj.reverseStepY * g_workObj.dividePos[j],
 			C_ARW_WIDTH, C_ARW_WIDTH);
 		frzHit.style.opacity = 0;
 		if (isNaN(Number(g_workObj.arrowRtn[j]))) {
@@ -7495,7 +7501,7 @@ function MainInit() {
 	// 歌詞表示
 	createSprite(`judgeSprite`, `wordSprite`, 0, 0, g_sWidth, g_sHeight);
 	for (let j = 0; j <= g_scoreObj.wordMaxDepth; j++) {
-		const wordY = (j % 2 === 0 ? 10 : (g_headerObj.bottomWordSetFlg ? g_distY + 10 : g_sHeight - 60));
+		const wordY = (j % 2 === 0 ? 10 : (g_headerObj.bottomWordSetFlg ? g_posObj.distY + 10 : g_sHeight - 60));
 		const lblWord = createSprite(`wordSprite`, `lblword${j}`, 100, wordY, g_sWidth - 200, 50);
 
 		lblWord.style.fontSize = `14px`;
@@ -7529,7 +7535,7 @@ function MainInit() {
 
 	const jdgGroups = [`J`, `FJ`];
 	const jdgX = [g_sWidth / 2 - 200, g_sWidth / 2 - 100];
-	const jdgY = [(g_sHeight + g_stepYR) / 2 - 60 + g_diffObj.arrowJdgY, (g_sHeight + g_stepYR) / 2 + 10 + g_diffObj.frzJdgY];
+	const jdgY = [(g_sHeight + g_posObj.stepYR) / 2 - 60 + g_diffObj.arrowJdgY, (g_sHeight + g_posObj.stepYR) / 2 + 10 + g_diffObj.frzJdgY];
 	const jdgCombos = [`kita`, `ii`];
 
 	jdgGroups.forEach((jdg, j) => {
@@ -7624,7 +7630,7 @@ function MainInit() {
 
 	// Ready?表示
 	if (!g_headerObj.customReadyUse) {
-		const lblReady = createDivCssLabel(`lblReady`, g_sWidth / 2 - 100, (g_sHeight + g_stepYR) / 2 - 75,
+		const lblReady = createDivCssLabel(`lblReady`, g_sWidth / 2 - 100, (g_sHeight + g_posObj.stepYR) / 2 - 75,
 			200, 50, 40,
 			`<span style='color:` + g_headerObj.setColorOrg[0] + `;font-size:60px;'>R</span>EADY<span style='font-size:50px;'>?</span>`);
 		lblReady.style.animationDuration = `2.5s`;
@@ -8003,7 +8009,7 @@ function MainInit() {
 
 		const stepRoot = createSprite(`arrowSprite${dividePos}`, `${_name}${_j}_${_arrowCnt}`,
 			g_workObj.stepX[_j],
-			C_STEP_Y + g_reverseStepY * dividePos + g_workObj.initY[g_scoreObj.frameNum] * boostSpdDir,
+			C_STEP_Y + g_posObj.reverseStepY * dividePos + g_workObj.initY[g_scoreObj.frameNum] * boostSpdDir,
 			C_ARW_WIDTH, C_ARW_WIDTH);
 		stepRoot.setAttribute(`cnt`, g_workObj.arrivalFrame[g_scoreObj.frameNum] + 1);
 		stepRoot.setAttribute(`boostCnt`, g_workObj.motionFrame[g_scoreObj.frameNum]);
@@ -8088,7 +8094,7 @@ function MainInit() {
 
 		const frzRoot = createSprite(`arrowSprite${dividePos}`, `${_name}${_j}_${_arrowCnt}`,
 			g_workObj.stepX[_j],
-			C_STEP_Y + g_reverseStepY * dividePos + g_workObj.initY[g_scoreObj.frameNum] * boostSpdDir,
+			C_STEP_Y + g_posObj.reverseStepY * dividePos + g_workObj.initY[g_scoreObj.frameNum] * boostSpdDir,
 			C_ARW_WIDTH, C_ARW_WIDTH + frzLength);
 		frzRoot.setAttribute(`cnt`, g_workObj.arrivalFrame[g_scoreObj.frameNum] + 1);
 		frzRoot.setAttribute(`boostCnt`, g_workObj.motionFrame[g_scoreObj.frameNum]);
@@ -8526,8 +8532,8 @@ function changeAppearanceFilter(_appearance, _num = 10) {
 	document.querySelector(`#arrowSprite${bottomNum}`).style.webkitClipPath = bottomShape;
 
 	if (document.querySelector(`#filterBar0`) !== null) {
-		document.querySelector(`#filterBar0`).style.top = `${g_arrowHeight * _num / 100}px`;
-		document.querySelector(`#filterBar1`).style.top = `${g_arrowHeight * (100 - _num) / 100}px`;
+		document.querySelector(`#filterBar0`).style.top = `${g_posObj.arrowHeight * _num / 100}px`;
+		document.querySelector(`#filterBar1`).style.top = `${g_posObj.arrowHeight * (100 - _num) / 100}px`;
 		document.querySelector(`#filterView`).style.top =
 			document.querySelector(`#filterBar${g_hidSudObj.std[g_stateObj.appearance][g_stateObj.reverse]}`).style.top;
 		document.querySelector(`#filterView`).innerHTML = `${_num}%`;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -418,6 +418,15 @@ let g_stepYR;
 let g_stepDiffY;
 let g_arrowHeight;
 
+const g_posObj = {
+    stepY: 70,
+    distY: 0,
+    reverseStepY: 0,
+    stepYR: 0,
+    stepDiffY: 0,
+    arrowHeight: 0,
+}
+
 const g_diffObj = {
     arrowJdgY: 0,
     frzJdgY: 0,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -367,6 +367,7 @@ const g_hidSudObj = {
     pgUp: {},
     std: {},
 };
+g_hidSudObj[`Visible`] = 1;
 g_hidSudObj[`Hidden+`] = 0;
 g_hidSudObj[`Sudden+`] = 1;
 g_hidSudObj[`Hid&Sud+`] = 1;
@@ -414,6 +415,8 @@ let g_stepY;
 let g_distY;
 let g_reverseStepY;
 let g_stepYR;
+let g_stepDiffY;
+let g_arrowHeight;
 
 const g_diffObj = {
     arrowJdgY: 0,


### PR DESCRIPTION
## 変更内容
1. 上下非対称時のAppearance設定の挙動を変更しました。
stepYRが指定され上下スクロールで距離が異なる場合に、
上スクロール距離が下スクロール距離と同一になるように
可視範囲のフィルターを入れています。(stepYが大きい場合にも同様)

2. ステップゾーン位置関連の変数を`g_posObj`へ集約しました。
当面、既存変数は残します。

|旧変数|新変数|意味|
|----|----|----|
|g_stepY|g_posObj.stepY|ステップゾーン位置(上段)|
|g_distY|g_posObj.distY|矢印出現からステップゾーンまでの距離|
|g_stepYR|g_posObj.stepYR|ステップゾーン位置(下段)の補正値|
|g_reverseStepY|g_posObj.reverseStepY|ステップゾーン位置間(上段・下段)の距離|

## 変更理由
1. stepYRが指定されると、上下のスクロール量に開きが出て
上スクロールが有利となってしまうため。
また、Hidden/Sudden時の位置が想定しない位置になってしまう。
2. コード整理、分類のため。

## その他コメント
- 17keyの場合、フィルターの都合で横幅が最低800px必要になります。
- 今回の変更で、stepYが70以外を指定した場合、mainSpriteのサイズが変わります。
あまりないケースだと思いますが、このときmainSpriteの座標操作をしていると
位置ズレが起きる可能性があります。