### PR TITLE
[0196/display-musicinfo] Display:musicInfo時の挙動変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7590,7 +7590,10 @@ function MainInit() {
 
 	// 曲情報OFF
 	if (g_stateObj.d_musicinfo === C_FLG_OFF) {
-		document.querySelector(`#lblCredit`).style.left = `20px`;
+		lblCredit.style.left = `20px`;
+		lblCredit.style.animationDuration = `4.0s`;
+		lblCredit.style.animationName = `leftToRightFade`;
+		lblCredit.style.animationFillMode = `both`;
 		document.querySelector(`#lblTime1`).style.display = C_DIS_NONE;
 		document.querySelector(`#lblTime2`).style.display = C_DIS_NONE;
 	}

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1283,7 +1283,7 @@ const g_msgObj = {
     d_fastslow: `Fast/Slow表示`,
     d_lifegauge: `ライフゲージの表示`,
     d_score: `現時点の判定数を表示`,
-    d_musicinfo: `音楽情報（現状は時間表示のみ）`,
+    d_musicinfo: `音楽情報（時間表示含む）`,
     d_filterline: `Hidden+, Sudden+使用時のフィルターの境界線表示`,
     d_speed: `途中変速、個別加速の有効化設定`,
     d_color: `色変化の有効化設定`,


### PR DESCRIPTION
## 変更内容
1. Display: MusicInfo適用時、最初の4秒のみ表示する形式に変更しました。

## 変更理由
1. 元々は上下でスクロール表示量に開きが出ないよう調整するためのオプションだったが、
クレジット表記を残したことで問題がそのままになっていたため。
その代わり、cssアニメーションを利用し、最初の4秒ほどクレジットを表記することで、
何の曲か/誰の曲かがわかるように留意する。

## その他コメント

