### PR TITLE
[0199/filter-line-re] Appearance設定で矢印が画面上に残る事象を修正

### DIFF
--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -258,32 +258,6 @@ input[type=range]:focus {
 	animation-name: spinY;
 }
 
-/* Appearance用 クリッピングマスク */
-.Hidden0 {
-	clip-path: inset(50% 0% 0% 0%);
-	-webkit-clip-path: inset(50% 0% 0% 0%);
-}
-.Hidden1 {
-	clip-path: inset(0% 0% 50% 0%);
-	-webkit-clip-path: inset(0% 0% 50% 0%);
-}
-.Sudden0 {
-	clip-path: inset(0% 0% 40% 0%);
-	-webkit-clip-path: inset(0% 0% 40% 0%);
-}
-.Sudden1 {
-	clip-path: inset(40% 0% 0% 0%);
-	-webkit-clip-path: inset(40% 0% 0% 0%);
-}
-.Slit0 {
-	clip-path: polygon(5% 0%, 100% 0%, 100% 30%, 5% 30%, 5% 45%, 100% 45%, 100% 55%, 5% 55%, 5% 70%, 100% 70%, 100% 100%, 5% 100%);
-	-webkit-clip-path: polygon(5% 0%, 100% 0%, 100% 30%, 5% 30%, 5% 45%, 100% 45%, 100% 55%, 5% 55%, 5% 70%, 100% 70%, 100% 100%, 5% 100%);
-}
-.Slit1 {
-	clip-path: polygon(5% 0%, 100% 0%, 100% 30%, 5% 30%, 5% 45%, 100% 45%, 100% 55%, 5% 55%, 5% 70%, 100% 70%, 100% 100%, 5% 100%);
-	-webkit-clip-path: polygon(5% 0%, 100% 0%, 100% 30%, 5% 30%, 5% 45%, 100% 45%, 100% 55%, 5% 55%, 5% 70%, 100% 70%, 100% 100%, 5% 100%);
-}
-
 /* 設定画面：ゲージ設定詳細 */
 .settings_gaugeVal {
 	font-size:12px;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -76,6 +76,7 @@ const C_ARW_WIDTH = 50;
 const C_FLG_ON = `ON`;
 const C_FLG_OFF = `OFF`;
 const C_DIS_NONE = `none`;
+const C_DIS_INHERIT = `inherit`;
 
 // 初期化フラグ（ボタンアニメーション制御）
 let g_initialFlg = false;
@@ -7325,29 +7326,28 @@ function MainInit() {
 	}
 
 	// Hidden+, Sudden+用のライン、パーセント表示
-	if (g_appearanceRanges.includes(g_stateObj.appearance)) {
-		const filterBar0 = createColorObject(`filterBar0`, ``,
+	[`filterBar0`, `filterBar1`, `borderBar0`, `borderBar1`].forEach(obj => {
+		const filterBar = createColorObject(`${obj}`, ``,
 			0, 0,
 			g_sWidth - 50, 1, ``, `lifeBar`);
-		filterBar0.classList.add(g_cssObj.life_Failed);
-		mainSprite.appendChild(filterBar0);
+		filterBar.classList.add(g_cssObj.life_Failed);
+		filterBar.style.opacity = 0.0625;
+		mainSprite.appendChild(filterBar);
+	});
+	document.querySelector(`#borderBar0`).style.top = `${g_posObj.stepDiffY}px`;
+	document.querySelector(`#borderBar1`).style.top = `${g_posObj.stepDiffY + g_posObj.arrowHeight}px`;
 
-		const filterBar1 = createColorObject(`filterBar1`, ``,
-			0, 0,
-			g_sWidth - 50, 1, ``, `lifeBar`);
-		filterBar1.classList.add(g_cssObj.life_Failed);
-		mainSprite.appendChild(filterBar1);
+	if (g_appearanceRanges.includes(g_stateObj.appearance)) {
 
 		const filterView = createDivCssLabel(`filterView`, g_sWidth - 70, 0, 10, 10, 10, ``);
 		filterView.style.textAlign = C_ALIGN_RIGHT;
 		mainSprite.appendChild(filterView);
 
 		if (g_stateObj.d_filterline === C_FLG_OFF) {
-			[`filterBar0`, `filterBar1`].forEach(obj =>
-				document.querySelector(`#${obj}`).style.display = C_DIS_NONE);
 		} else {
-			[`filterBar0`, `filterBar1`, `filterView`].forEach(obj =>
-				document.querySelector(`#${obj}`).style.opacity = g_stateObj.opacity / 100);
+			[`filterBar0`, `filterBar1`, `filterView`].forEach(obj => {
+				document.querySelector(`#${obj}`).style.opacity = g_stateObj.opacity / 100;
+			});
 		}
 	}
 
@@ -7360,11 +7360,8 @@ function MainInit() {
 	// Appearanceのオプション適用時は一部描画を隠す
 	if (g_appearanceRanges.includes(g_stateObj.appearance)) {
 		changeAppearanceFilter(g_stateObj.appearance, g_hidSudObj.filterPos);
-	} else if (g_stateObj.appearance === `Visible`) {
-		changeAppearanceFilter(g_stateObj.appearance, 0);
 	} else {
-		arrowSprite[0].classList.add(`${g_stateObj.appearance}0`);
-		arrowSprite[1].classList.add(`${g_stateObj.appearance}1`);
+		changeAppearanceFilter(g_stateObj.appearance, g_hidSudObj.filterPosDefault[g_stateObj.appearance]);
 	}
 
 	for (let j = 0; j < keyNum; j++) {
@@ -8547,9 +8544,10 @@ function changeAppearanceFilter(_appearance, _num = 10) {
 	document.querySelector(`#arrowSprite${bottomNum}`).style.clipPath = bottomShape;
 	document.querySelector(`#arrowSprite${bottomNum}`).style.webkitClipPath = bottomShape;
 
-	if (document.querySelector(`#filterBar0`) !== null) {
-		document.querySelector(`#filterBar0`).style.top = `${g_posObj.arrowHeight * _num / 100}px`;
-		document.querySelector(`#filterBar1`).style.top = `${g_posObj.arrowHeight * (100 - _num) / 100}px`;
+	document.querySelector(`#filterBar0`).style.top = `${g_posObj.arrowHeight * _num / 100}px`;
+	document.querySelector(`#filterBar1`).style.top = `${g_posObj.arrowHeight * (100 - _num) / 100}px`;
+
+	if (g_appearanceRanges.includes(_appearance)) {
 		document.querySelector(`#filterView`).style.top =
 			document.querySelector(`#filterBar${g_hidSudObj.std[g_stateObj.appearance][g_stateObj.reverse]}`).style.top;
 		document.querySelector(`#filterView`).innerHTML = `${_num}%`;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -343,7 +343,7 @@ let g_adjustmentNum = C_MAX_ADJUSTMENT;
 let g_volumes = [0, 0.5, 1, 2, 5, 10, 25, 50, 75, 100];
 let g_volumeNum = g_volumes.length - 1;
 
-let g_appearances = [`Visible`, `Hidden`, `Hidden+`, `Sudden`, `Sudden+`, `Hid&Sud+`, `Slit`];
+let g_appearances = [`Visible`, `Hidden`, `Hidden+`, `Sudden`, `Sudden+`, `Hid&Sud+`];
 let g_appearanceNum = 0;
 
 let g_appearanceRanges = [`Hidden+`, `Sudden+`, `Hid&Sud+`];
@@ -366,11 +366,18 @@ const g_hidSudObj = {
     pgDown: {},
     pgUp: {},
     std: {},
+    filterPosDefault: {},
 };
 g_hidSudObj[`Visible`] = 1;
+g_hidSudObj[`Hidden`] = 0;
 g_hidSudObj[`Hidden+`] = 0;
+g_hidSudObj[`Sudden`] = 1;
 g_hidSudObj[`Sudden+`] = 1;
 g_hidSudObj[`Hid&Sud+`] = 1;
+
+g_hidSudObj.filterPosDefault[`Visible`] = 0;
+g_hidSudObj.filterPosDefault[`Hidden`] = 50;
+g_hidSudObj.filterPosDefault[`Sudden`] = 40;
 g_hidSudObj.pgDown[`Hidden+`] = {
     OFF: 34,
     ON: 33,


### PR DESCRIPTION
## 変更内容
1. 高速(5x以上)で矢印を見逃したとき、画面上に矢印が残ることがある事象を修正しました（再）。
フィルターの境界線を6.25%の透明度で表示するようにしました。
2. Appearance「Slit」を削除しました。

## 変更理由
1. 上述の通り。
ChromeやFirefoxの場合、opacity=0やdisplay=noneでは解消されないことを確認済み。
2. 1.の変更でHidden+/Sudden+の仕様に寄せたため、
フィルター仕様が複雑なSlitは一旦実装を見送ります。

## その他コメント
- danoni_main.css にて下記の記述が不要になります。
```css
.Hidden0 {
	clip-path: inset(50% 0% 0% 0%);
	-webkit-clip-path: inset(50% 0% 0% 0%);
}
.Hidden1 {
	clip-path: inset(0% 0% 50% 0%);
	-webkit-clip-path: inset(0% 0% 50% 0%);
}
.Sudden0 {
	clip-path: inset(0% 0% 40% 0%);
	-webkit-clip-path: inset(0% 0% 40% 0%);
}
.Sudden1 {
	clip-path: inset(40% 0% 0% 0%);
	-webkit-clip-path: inset(40% 0% 0% 0%);
}
.Slit0 {
	clip-path: polygon(5% 0%, 100% 0%, 100% 30%, 5% 30%, 5% 45%, 100% 45%, 100% 55%, 5% 55%, 5% 70%, 100% 70%, 100% 100%, 5% 100%);
	-webkit-clip-path: polygon(5% 0%, 100% 0%, 100% 30%, 5% 30%, 5% 45%, 100% 45%, 100% 55%, 5% 55%, 5% 70%, 100% 70%, 100% 100%, 5% 100%);
}
.Slit1 {
	clip-path: polygon(5% 0%, 100% 0%, 100% 30%, 5% 30%, 5% 45%, 100% 45%, 100% 55%, 5% 55%, 5% 70%, 100% 70%, 100% 100%, 5% 100%);
	-webkit-clip-path: polygon(5% 0%, 100% 0%, 100% 30%, 5% 30%, 5% 45%, 100% 45%, 100% 55%, 5% 55%, 5% 70%, 100% 70%, 100% 100%, 5% 100%);
}
```

