### PR TITLE
[0202/fastslow-setting] Fast/Slowのカウンタ追加、1フレーム誤差のFast/Slow表示

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9337,10 +9337,12 @@ function resultInit() {
 			resultWindow.appendChild(makeCssResultSymbol(`lbl${id}S`, 50, g_cssObj.common_score, j, g_resultObj[judgeScores[j]], C_ALIGN_RIGHT));
 		}
 	});
-	resultWindow.appendChild(makeCssResultSymbol(`lblFast`, 350, g_cssObj.common_matari, 0, `Fast`, C_ALIGN_LEFT));
-	resultWindow.appendChild(makeCssResultSymbol(`lblSlow`, 350, g_cssObj.common_shobon, 2, `Slow`, C_ALIGN_LEFT));
-	resultWindow.appendChild(makeCssResultSymbol(`lblFastS`, 260, g_cssObj.score, 1, g_resultObj.fast, C_ALIGN_RIGHT));
-	resultWindow.appendChild(makeCssResultSymbol(`lblSlowS`, 260, g_cssObj.score, 3, g_resultObj.slow, C_ALIGN_RIGHT));
+	if (g_stateObj.autoPlay === C_FLG_OFF) {
+		resultWindow.appendChild(makeCssResultSymbol(`lblFast`, 350, g_cssObj.common_matari, 0, `Fast`, C_ALIGN_LEFT));
+		resultWindow.appendChild(makeCssResultSymbol(`lblSlow`, 350, g_cssObj.common_shobon, 2, `Slow`, C_ALIGN_LEFT));
+		resultWindow.appendChild(makeCssResultSymbol(`lblFastS`, 260, g_cssObj.score, 1, g_resultObj.fast, C_ALIGN_RIGHT));
+		resultWindow.appendChild(makeCssResultSymbol(`lblSlowS`, 260, g_cssObj.score, 3, g_resultObj.slow, C_ALIGN_RIGHT));
+	}
 
 	// ランク描画
 	const lblRank = createDivCustomLabel(`lblRank`, 340, 160, 70, 20, 50, `#ffffff`,

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7849,7 +7849,6 @@ function MainInit() {
 		arrowOFF: (_j, _arrow, _cnt) => {
 			if (_cnt < (-1) * g_judgObj.arrowJ[C_JDG_UWAN]) {
 				judgeUwan(_cnt);
-				countFastSlow(_cnt);
 				judgeObjDelete.arrow(_j, _arrow);
 			}
 		},
@@ -7916,7 +7915,6 @@ function MainInit() {
 				changeFailedFrz(_j, _k);
 				if (g_headerObj.frzStartjdgUse) {
 					judgeUwan(_cnt);
-					countFastSlow(_cnt);
 				}
 			}
 		},

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7134,6 +7134,9 @@ function getArrowSettings() {
 	g_resultObj.fCombo = 0;
 	g_resultObj.fmaxCombo = 0;
 
+	g_resultObj.fast = 0;
+	g_resultObj.slow = 0;
+
 	g_workObj.lifeVal = Math.round(g_workObj.lifeInit);
 	g_gameOverFlg = false;
 	g_finishFlg = true;
@@ -7843,6 +7846,7 @@ function MainInit() {
 		arrowOFF: (_j, _arrow, _cnt) => {
 			if (_cnt < (-1) * g_judgObj.arrowJ[C_JDG_UWAN]) {
 				judgeUwan(_cnt);
+				countFastSlow(_cnt);
 				judgeObjDelete.arrow(_j, _arrow);
 			}
 		},
@@ -7909,6 +7913,7 @@ function MainInit() {
 				changeFailedFrz(_j, _k);
 				if (g_headerObj.frzStartjdgUse) {
 					judgeUwan(_cnt);
+					countFastSlow(_cnt);
 				}
 			}
 		},
@@ -8795,6 +8800,7 @@ function judgeArrow(_j) {
 				judgeShobon(difFrame);
 				stepDivHit.classList.add(g_cssObj.main_stepShobon);
 			}
+			countFastSlow(difFrame);
 			stepDivHit.setAttribute(`cnt`, C_FRM_HITMOTION);
 
 			arrowSprite.removeChild(judgArrow);
@@ -8822,6 +8828,7 @@ function judgeArrow(_j) {
 				} else {
 					judgeShobon(difCnt);
 				}
+				countFastSlow(difFrame);
 				g_workObj.judgFrzHitCnt[_j] = fcurrentNo + 1;
 			}
 			changeHitFrz(_j, fcurrentNo, `frz`);
@@ -8838,8 +8845,19 @@ function judgeArrow(_j) {
  * @param {number} _difCnt 
  */
 function displayDiff(_difFrame, _difCnt) {
-	document.querySelector(`#diffJ`).innerHTML = `<span class="common_${_difCnt <= 1 ? 'combo' : (_difFrame > 0 ? 'matari' : 'shobon')}">
-		${_difCnt <= 1 ? 'Just!!' : ((_difFrame > 1 ? `Fast` : `Slow`)) + ` ${_difCnt} Frames`}</span>`;
+	if (_difFrame > 0) {
+		document.querySelector(`#diffJ`).innerHTML = `<span class="common_matari">Fast ${_difCnt} Frames</span>`;
+	} else if (_difFrame < 0) {
+		document.querySelector(`#diffJ`).innerHTML = `<span class="common_shobon">Slow ${_difCnt} Frames</span>`;
+	}
+}
+
+function countFastSlow(_difFrame) {
+	if (_difFrame > 0) {
+		g_resultObj.fast++;
+	} else if (_difFrame < 0) {
+		g_resultObj.slow++;
+	}
 }
 
 /**
@@ -9150,7 +9168,7 @@ function resultInit() {
 
 	const playDataWindow = createSprite(`divRoot`, `playDataWindow`, g_sWidth / 2 - 225, 70 + (g_sHeight - 500) / 2, 450, 110);
 	playDataWindow.classList.add(g_cssObj.result_PlayDataWindow);
-	const resultWindow = createSprite(`divRoot`, `resultWindow`, g_sWidth / 2 - 180, 185 + (g_sHeight - 500) / 2, 360, 210);
+	const resultWindow = createSprite(`divRoot`, `resultWindow`, g_sWidth / 2 - 200, 185 + (g_sHeight - 500) / 2, 400, 210);
 
 	const playingArrows = g_resultObj.ii + g_resultObj.shakin +
 		g_resultObj.matari + g_resultObj.shobon + g_resultObj.uwan +
@@ -9319,6 +9337,10 @@ function resultInit() {
 			resultWindow.appendChild(makeCssResultSymbol(`lbl${id}S`, 50, g_cssObj.common_score, j, g_resultObj[judgeScores[j]], C_ALIGN_RIGHT));
 		}
 	});
+	resultWindow.appendChild(makeCssResultSymbol(`lblFast`, 350, g_cssObj.common_matari, 0, `Fast`, C_ALIGN_LEFT));
+	resultWindow.appendChild(makeCssResultSymbol(`lblSlow`, 350, g_cssObj.common_shobon, 2, `Slow`, C_ALIGN_LEFT));
+	resultWindow.appendChild(makeCssResultSymbol(`lblFastS`, 260, g_cssObj.score, 1, g_resultObj.fast, C_ALIGN_RIGHT));
+	resultWindow.appendChild(makeCssResultSymbol(`lblSlowS`, 260, g_cssObj.score, 3, g_resultObj.slow, C_ALIGN_RIGHT));
 
 	// ランク描画
 	const lblRank = createDivCustomLabel(`lblRank`, 340, 160, 70, 20, 50, `#ffffff`,

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8845,11 +8845,13 @@ function judgeArrow(_j) {
  * @param {number} _difCnt 
  */
 function displayDiff(_difFrame, _difCnt) {
+	let diffJDisp = ``;
 	if (_difFrame > 0) {
-		document.querySelector(`#diffJ`).innerHTML = `<span class="common_matari">Fast ${_difCnt} Frames</span>`;
+		diffJDisp = `<span class="common_matari">Fast ${_difCnt} Frames</span>`;
 	} else if (_difFrame < 0) {
-		document.querySelector(`#diffJ`).innerHTML = `<span class="common_shobon">Slow ${_difCnt} Frames</span>`;
+		diffJDisp = `<span class="common_shobon">Slow ${_difCnt} Frames</span>`;
 	}
+	document.querySelector(`#diffJ`).innerHTML = diffJDisp;
 }
 
 function countFastSlow(_difFrame) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3103,6 +3103,9 @@ function headerConvert(_dosObj) {
 	// 譜面明細の使用可否
 	obj.scoreDetailUse = setVal(_dosObj.scoreDetailUse, true, C_TYP_BOOLEAN);
 
+	// ジャストフレームの設定 (ローカル: 0フレーム, リモートサーバ上: 1フレーム以内)
+	obj.justFrames = (location.href.match(`^file`) || location.href.indexOf(`localhost`) !== -1) ? 0 : 1;
+
 	return obj;
 }
 
@@ -8842,22 +8845,28 @@ function judgeArrow(_j) {
 /**
  * タイミングズレを表示
  * @param {number} _difFrame 
- * @param {number} _difCnt 
+ * @param {number} _justFrames
  */
-function displayDiff(_difFrame, _difCnt) {
+function displayDiff(_difFrame, _justFrames = 0) {
 	let diffJDisp = ``;
-	if (_difFrame > 0) {
-		diffJDisp = `<span class="common_matari">Fast ${_difCnt} Frames</span>`;
-	} else if (_difFrame < 0) {
-		diffJDisp = `<span class="common_shobon">Slow ${_difCnt} Frames</span>`;
+	let difCnt = Math.abs(_difFrame);
+	if (_difFrame > _justFrames) {
+		diffJDisp = `<span class="common_matari">Fast ${difCnt} Frames</span>`;
+	} else if (_difFrame < _justFrames * (-1)) {
+		diffJDisp = `<span class="common_shobon">Slow ${difCnt} Frames</span>`;
 	}
 	document.querySelector(`#diffJ`).innerHTML = diffJDisp;
 }
 
-function countFastSlow(_difFrame) {
-	if (_difFrame > 0) {
+/**
+ * Fast/Slowカウンタ
+ * @param {number} _difFrame 
+ * @param {number} _justFrames 
+ */
+function countFastSlow(_difFrame, _justFrames = 0) {
+	if (_difFrame > _justFrames) {
 		g_resultObj.fast++;
-	} else if (_difFrame < 0) {
+	} else if (_difFrame < _justFrames) {
 		g_resultObj.slow++;
 	}
 }
@@ -8941,7 +8950,7 @@ function judgeIi(difFrame) {
 	changeJudgeCharacter(`ii`, C_JCR_II);
 
 	updateCombo();
-	displayDiff(difFrame, Math.abs(difFrame));
+	displayDiff(difFrame, g_headerObj.justFrames);
 
 	lifeRecovery();
 	finishViewing();
@@ -8962,7 +8971,7 @@ function judgeShakin(difFrame) {
 	changeJudgeCharacter(`shakin`, C_JCR_SHAKIN);
 
 	updateCombo();
-	displayDiff(difFrame, Math.abs(difFrame));
+	displayDiff(difFrame, g_headerObj.justFrames);
 
 	lifeRecovery();
 	finishViewing();
@@ -8983,7 +8992,7 @@ function judgeMatari(difFrame) {
 	changeJudgeCharacter(`matari`, C_JCR_MATARI);
 	document.querySelector(`#comboJ`).innerHTML = ``;
 
-	displayDiff(difFrame, Math.abs(difFrame));
+	displayDiff(difFrame, g_headerObj.justFrames);
 	finishViewing();
 
 	if (typeof customJudgeMatari === C_TYP_FUNCTION) {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -225,7 +225,10 @@ const g_resultObj = {
     maxCombo: 0,
     fCombo: 0,
     fmaxCombo: 0,
-    score: 0
+    score: 0,
+
+    fast: 0,
+    slow: 0,
 };
 
 const C_RLT_BRACKET_L = 210;


### PR DESCRIPTION
## 変更内容
1. 誤差1フレームでもFast/Slowを表示するように変更しました。
※現状ローカル時のみ。サーバ上はこれまで通り2フレーム以上の誤差があった場合に
　Fast/Slowを表示します。
　誤差の表示幅については、変更できる余地を残しています。
<img src="https://user-images.githubusercontent.com/44026291/80935062-ebc8af80-8e05-11ea-91ba-7a6dcbf546c4.png" width="70%" alt="fastslow">

2. ±1フレーム以内で表示するJust表記を廃止しました。
3. Fast/Slowをカウントし、リザルトへ表示するようにしました。
<img src="https://user-images.githubusercontent.com/44026291/80934962-7361ee80-8e05-11ea-8818-cac8540a8614.png" width="70%" alt="fastslow">


## 変更理由
1. Adjustmentの調整に必要という意見があるため。
2. Justだけ文字情報が他と違う等の理由で見づらいという意見があるため。
3. Fast/Slowを表示しているのに、どれだけ早いか遅いかを示す情報が無かったため。

## その他コメント
### 要検討事項
- オート時はFast/Slowの表示は不要　⇒　対応済
- Fast/Slow非表示のときでも表示は行うか？　⇒　行う
- プレイ中でもFast/Slowの表示は必要？　⇒　現状は表示しない
（⇒既存作品のデザインに影響を与える可能性があり、当面は実装しない方が良さそう）
- Fast/Slowを表示幅をローカルとサーバ上で変える必要があるか？
⇒　ローカルは0フレーム、サーバ上は1フレーム以内で設定

### 留意事項
- リザルトのFast/Slow表示により判定数の横幅が足りなくなるため、
`resultWindow`の横幅を360px⇒400pxへ変更します。
- また、Fast/Slow用に以下のラベルが増えます。
`lblFast`, `lblFastS`, `lblSlow`, `lblSlowS`
- 見逃しウワァンはカウントしません（変更しました）。
フリーズアローはFast/Slowの対象外です。
※フリーズアローの押し始めを判定する場合はFast/Slowのカウント対象です。

### その他
- `g_headerObj.justFrames` にて、Fast/Slowの**非表示フレーム幅**を指定できます。
- この設定値について、danoni_setting.js や 作品別の譜面ヘッダーで指定するなど
制作者側で指定する案も考えましたが、
どうしても必要な場合は設定やクエリで変えられるようにすべきと考え
制作者側で指定する案は見送りました。
- `g_headerObj.justFrames` の設定幅を指定するオプションを追加するかは未定です。