### PR TITLE
[0203/twitter-url-query] Twitter投稿用リザルトのURL表示に譜面番号を付加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9462,16 +9462,13 @@ function resultInit() {
 	}
 
 	// Twitter用リザルト
-	let hashTag;
-	if (g_headerObj.hashTag !== undefined) {
-		hashTag = ` ${g_headerObj.hashTag}`;
-	} else {
-		hashTag = ``;
-	}
+	const hashTag = (g_headerObj.hashTag !== undefined ? ` ${g_headerObj.hashTag}` : ``);
 	let tweetDifData = `${g_headerObj.keyLabels[g_stateObj.scoreId]}${transKeyData}k-${g_headerObj.difLabels[g_stateObj.scoreId]}`;
 	if (g_stateObj.shuffle !== `OFF`) {
 		tweetDifData += `:${g_stateObj.shuffle}`;
 	}
+	const twiturl = new URL(g_localStorageUrl);
+	twiturl.searchParams.append(`scoreId`, g_stateObj.scoreId);
 	const tweetResultTmp = `【#danoni${hashTag}】${musicTitle}(${tweetDifData})/
 		${g_headerObj.tuning}/
 		Rank:${rankMark}/
@@ -9480,7 +9477,7 @@ function resultInit() {
 		${g_resultObj.ii}-${g_resultObj.shakin}-${g_resultObj.matari}-${g_resultObj.shobon}-${g_resultObj.uwan}/
 		${g_resultObj.kita}-${g_resultObj.iknai}/
 		${g_resultObj.maxCombo}-${g_resultObj.fmaxCombo} 
-		${g_localStorageUrl}`.replace(/[\t\n]/g, ``);
+		${twiturl.toString()}`.replace(/[\t\n]/g, ``);
 	const tweetResult = `https://twitter.com/intent/tweet?text=${encodeURIComponent(tweetResultTmp)}`;
 
 	// 戻るボタン描画


### PR DESCRIPTION
## 変更内容
1. Twitter投稿用リザルトのURL表示に譜面番号を付加するようにしました。
下記のように、`scoreId=1`のようなクエリを付加します。
```
【#danoni】Combative InstinctⅡ(14k-Normal)/ティックル/Rank:F/Score:0/Playstyle:2.5x/0-0-0-0-0/0-0/0-0 http://localhost/danoniplus/danoni/danoni2.html?scoreId=1
```
- このクエリの付加方法は、URLクラスを利用しています。
すでに他のGETクエリがあった場合でも、その部分を保持しながらscoreIdを付与します。
```javascript
const twiturl = new URL(g_localStorageUrl); // scoreIdを除去したURL
twiturl.searchParams.append(`scoreId`, g_stateObj.scoreId);
// twiturl.toString() がTwitter用のパスに指定される
```

## 変更理由
1. 1作品に譜面が複数入っていた場合に、
どれをプレイしたかをダイレクトパスで指定できるため。
`scoreId=2`（3譜面目）でアクセスしていながら実際には2譜面目をプレイした場合、
`scoreId=1`（2譜面目）をクエリに付加します。

## その他コメント
