### PR TITLE
[0204/pipe-escape] パイプ、アンパサンド等の特殊文字の置き換え

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2397,7 +2397,14 @@ function dosConvert(_dos) {
 		const pos = params[j].indexOf(`=`);
 		if (pos > 0) {
 			const pKey = params[j].substring(0, pos);
-			const pValue = params[j].substring(pos + 1);
+			let pValue = params[j].substring(pos + 1);
+
+			// アンパサンド、パイプ文字のエスケープ指定
+			pValue = pValue.split(`*amp*`).join(`&`);
+			pValue = pValue.split(`*pipe*`).join(`|`);
+			pValue = pValue.split(`*rsquo*`).join(`'`);
+			pValue = pValue.split(`*quot*`).join(`"`);
+
 			if (pKey !== undefined) {
 				obj[pKey] = g_enableDecodeURI ? decodeURIComponent(pValue) : pValue;
 			}


### PR DESCRIPTION
## 変更内容
1. パイプ、アンパサンド等の特殊文字へ置き換えるための代替文字を準備しました。

|指定文字|代替先|
|----|----|
|\*pipe\*|\||
|\*amp\*|&amp;|
|\*rsquo\*|&rsquo;|
|\*quot\*|&quot;|

## 変更理由
- 区切り文字等で使用しており、値に使用できなかったため。

## その他コメント

