### PR TITLE
[0205/comma-escape] カンマのエスケープ対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2404,6 +2404,7 @@ function dosConvert(_dos) {
 			pValue = pValue.split(`*pipe*`).join(`|`);
 			pValue = pValue.split(`*rsquo*`).join(`'`);
 			pValue = pValue.split(`*quot*`).join(`"`);
+			pValue = pValue.split(`*comma*`).join(`,`);
 
 			if (pKey !== undefined) {
 				obj[pKey] = g_enableDecodeURI ? decodeURIComponent(pValue) : pValue;


### PR DESCRIPTION
## 変更内容
1. カンマのエスケープ対応を行いました。

|指定文字|代替先|
|----|----|
|\*comma\*|\,|

## 変更理由
1. カンマを曲名に充てるケースがそれなりにあるため。

## その他コメント

