### PR TITLE
[0206/filter-cover] Appearanceで使っているフィルターの仕様をv14.2.0に戻す

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7349,7 +7349,7 @@ function MainInit() {
 			0, 0,
 			g_sWidth - 50, 1, ``, `lifeBar`);
 		filterBar.classList.add(g_cssObj.life_Failed);
-		filterBar.style.visibility = `hidden`;
+		filterBar.style.opacity = 0.0625;
 		mainSprite.appendChild(filterBar);
 	});
 	document.querySelector(`#borderBar0`).style.top = `${g_posObj.stepDiffY}px`;
@@ -7364,7 +7364,6 @@ function MainInit() {
 		if (g_stateObj.d_filterline === C_FLG_OFF) {
 		} else {
 			[`filterBar0`, `filterBar1`, `filterView`].forEach(obj => {
-				document.querySelector(`#${obj}`).style.visibility = `visible`;
 				document.querySelector(`#${obj}`).style.opacity = g_stateObj.opacity / 100;
 			});
 		}


### PR DESCRIPTION
## 変更内容
1. Appearanceで使っているフィルターの仕様をv14.2.0に戻しました。

## 変更理由
1. v14.3.xで、一旦枠の上下の境界線を`visibility:hidden`に変更しましたが、
v14.1.0の問題が再発したため、元に戻します。

## その他コメント

