### PR TITLE
[0207/fast-slow-cnt] Fast/Slowカウントの誤りを修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8876,7 +8876,7 @@ function displayDiff(_difFrame, _justFrames = 0) {
 function countFastSlow(_difFrame, _justFrames = 0) {
 	if (_difFrame > _justFrames) {
 		g_resultObj.fast++;
-	} else if (_difFrame < _justFrames) {
+	} else if (_difFrame < _justFrames * (-1)) {
 		g_resultObj.slow++;
 	}
 }


### PR DESCRIPTION
## 変更内容
1. Fast/Slowカウントの誤りを修正しました。

## 変更理由
1. サーバ上でプレイしたときに、Slowが過剰にカウントされるようになっていました。

## その他コメント

