### PR TITLE
[0208/fast-slow-cnt2] countFastSlowの引数忘れを修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8812,7 +8812,7 @@ function judgeArrow(_j) {
 				judgeShobon(difFrame);
 				stepDivHit.classList.add(g_cssObj.main_stepShobon);
 			}
-			countFastSlow(difFrame);
+			countFastSlow(difFrame, g_headerObj.justFrames);
 			stepDivHit.setAttribute(`cnt`, C_FRM_HITMOTION);
 
 			arrowSprite.removeChild(judgArrow);
@@ -8840,7 +8840,7 @@ function judgeArrow(_j) {
 				} else {
 					judgeShobon(difFrame);
 				}
-				countFastSlow(difFrame);
+				countFastSlow(difFrame, g_headerObj.justFrames);
 				g_workObj.judgFrzHitCnt[_j] = fcurrentNo + 1;
 			}
 			changeHitFrz(_j, fcurrentNo, `frz`);


### PR DESCRIPTION
## 変更内容
1. countFastSlowの引数忘れを修正しました。

## 変更理由
1. 上述の通り。
これをしないとサーバ上でのFast/Slow数が0フレーム以外カウントとなってしまう。

## その他コメント

