### PR TITLE
[0210/default-display-setting] setting.js側で本来不要なdisplay設定を行ったときの挙動を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3039,7 +3039,8 @@ function headerConvert(_dosObj) {
 
 		// displayUse -> ボタンの有効/無効, displaySet -> ボタンの初期値(ON/OFF)
 		obj[`${option}Use`] = setVal(displayUse[0], true, C_TYP_BOOLEAN);
-		obj[`${option}Set`] = setVal(displayUse.length > 1 ? displayUse[1] : C_FLG_OFF, ``, C_TYP_SWITCH);
+		obj[`${option}Set`] = setVal(displayUse.length > 1 ? displayUse[1] :
+			(obj[`${option}Use`] ? C_FLG_ON : C_FLG_OFF), ``, C_TYP_SWITCH);
 
 		g_stateObj[`d_${option.toLowerCase()}`] = (obj[`${option}Set`] !== `` ? obj[`${option}Set`] : C_FLG_ON);
 		obj[`${option}ChainOFF`] = (_dosObj[`${option}ChainOFF`] !== undefined ? _dosObj[`${option}ChainOFF`].split(`,`) : []);


### PR DESCRIPTION
## 変更内容
1. `danoni_setting.js`で`g_presetSettingUse`に対してdisplay設定を有効にした場合、
ボタンの初期値がOFFになってしまう問題を修正しました。
（ボタンは押せる状態）

```javascript
const g_presetSettingUse = {
	fastSlow: `true`,
	filterLine: `true`,
};
```

## 変更理由
1. `g_presetSettingUse`のdisplay設定における2要素目未指定時の値補完ミス。
なお、`true`という指定は指定しない（コメントアウト）状態と同じため、
現行バージョンでもコメントアウトすれば、この問題は発生しません。
```javascript
const g_presetSettingUse = {
	// fastSlow: `true`,
	// filterLine: `true`,
};
```
## その他コメント
- そこまで大きな問題ではないため、次のリリースにて合わせて対応予定です。
- また、実装方法が違うため過去バージョンでは発生しません。