### PR TITLE
[0213/auto-difselector] 譜面数が5を超える場合、自動で譜面セレクターを使用するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2489,9 +2489,6 @@ function headerConvert(_dosObj) {
 		obj.artistUrl = location.href;
 	}
 
-	// 譜面変更セレクターの利用有無
-	obj.difSelectorUse = setVal(_dosObj.difSelectorUse, false, C_TYP_BOOLEAN);
-
 	// 最小・最大速度の設定
 	obj.minSpeed = Math.round(setVal(_dosObj.minSpeed, C_MIN_SPEED, C_TYP_FLOAT) * 4) / 4;
 	obj.maxSpeed = Math.round(setVal(_dosObj.maxSpeed, C_MAX_SPEED, C_TYP_FLOAT) * 4) / 4;
@@ -2602,6 +2599,9 @@ function headerConvert(_dosObj) {
 		return self.indexOf(x) === j;
 	});
 	obj.keyLists = keyLists.sort((a, b) => parseInt(a) - parseInt(b));
+
+	// 譜面変更セレクターの利用有無
+	obj.difSelectorUse = (setVal(_dosObj.difSelectorUse, (obj.keyLabels.length > 5 ? true : false), C_TYP_BOOLEAN));
 
 	// 初期速度の設定
 	g_stateObj.speed = obj.initSpeeds[g_stateObj.scoreId];


### PR DESCRIPTION
## 変更内容
1. 譜面数が5を超える場合、自動で譜面セレクターを使用するよう変更しました。
譜面数が5を超える場合で譜面セレクターを使用したくない場合は、
譜面ヘッダーにて以下の設定が必要となります。
```
|difSelectorUse=false|
```

## 変更理由
1. 譜面数が多い場合、譜面セレクターを使用した方が利便性が高いため。

## その他コメント

