### PR TITLE
[0215/lyrics-replace] 歌詞表示の一部でエスケープが利いていない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6280,11 +6280,13 @@ function escapeHtmlForEnabledTag(_str) {
  */
 function unEscapeHtml(_str) {
 	let newstr = _str.split(`&amp;`).join(`&`);
-	newstr = newstr.split(`&rsquo;`).join(`'`);
+	newstr = newstr.split(`&rsquo;`).join(`’`);
 	newstr = newstr.split(`&quot;`).join(`"`);
 	newstr = newstr.split(`&sbquo;`).join(`,`);
 	newstr = newstr.split(`&lt;`).join(`<`);
 	newstr = newstr.split(`&gt;`).join(`>`);
+	newstr = newstr.split(`&#39;`).join(`'`);
+	newstr = newstr.split(`&#96;`).join(`\``);
 
 	return newstr;
 }

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6193,7 +6193,8 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 
 					if (tmpWordData.length > 3 && tmpWordData.length < 6) {
 						tmpWordData[3] = setVal(tmpWordData[3], C_WOD_FRAME, C_TYP_NUMBER);
-						wordData[tmpWordData[0]][addFrame].push(tmpWordData[1], tmpWordData[2], tmpWordData[3]);
+						wordData[tmpWordData[0]][addFrame].push(tmpWordData[1],
+							escapeHtmlForEnabledTag(tmpWordData[2]), tmpWordData[3]);
 						break;
 					} else {
 						wordData[tmpWordData[k]][addFrame].push(tmpWordData[k + 1],

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2511,14 +2511,14 @@ function headerConvert(_dosObj) {
 	// 製作者表示
 	if (_dosObj.tuning !== undefined && _dosObj.tuning !== ``) {
 		const tunings = _dosObj.tuning.split(`,`);
-		obj.tuning = tunings[0];
+		obj.tuning = escapeHtmlForEnabledTag(tunings[0]);
 		if (tunings.length > 1) {
 			obj.creatorUrl = tunings[1];
 		} else {
 			obj.creatorUrl = location.href;
 		}
 	} else {
-		obj.tuning = (g_presetTuning) ? g_presetTuning : `name`;
+		obj.tuning = (g_presetTuning) ? escapeHtmlForEnabledTag(g_presetTuning) : `name`;
 		obj.creatorUrl = (g_presetTuningUrl) ? g_presetTuningUrl : location.href;
 	}
 	obj.tuningInit = obj.tuning;
@@ -6268,6 +6268,8 @@ function escapeHtmlForEnabledTag(_str) {
 	newstr = newstr.split(`*rsquo*`).join(`&rsquo;`);
 	newstr = newstr.split(`*quot*`).join(`&quot;`);
 	newstr = newstr.split(`*comma*`).join(`&sbquo;`);
+	newstr = newstr.split(`*squo*`).join(`&#39;`);
+	newstr = newstr.split(`*bkquo*`).join(`&#96;`);
 
 	return newstr;
 }


### PR DESCRIPTION
## 変更内容
1. 歌詞表示の一部でエスケープ処理が利いていない問題を修正しました。
1行当たりの歌詞項目数が4～5のときに発生します。

2. tuningに対してエスケープ処理を追加しました。
3. 以下の文字に対して新たに特殊文字として追加しました。

|指定文字|変換先|読み方や意味|
|----|----|----|
|\*rsquo\*|’|アポストロフィ　※分離|
|\*squo\*|'|シングルクォート|
|\*bkquo\*|`|バッククォート|

## 変更理由
1. 上述の通り。エスケープ処理の入れ忘れです。
2. tuningに対してエスケープ処理が無かったため。
3. アポストロフィ、シングルクォートが厳密には異なる文字だったため。

## その他コメント
