### PR TITLE
[0216/link-hover] 外部リンクに対してオンマウスでURLを表示

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2245,6 +2245,9 @@ function titleInit() {
 			window.open(g_headerObj.creatorUrl, `_blank`);
 		}
 	});
+	if (setVal(g_headerObj.creatorUrl, ``, C_TYP_STRING) !== ``) {
+		lnkMaker.title = g_headerObj.creatorUrl;
+	}
 	divRoot.appendChild(lnkMaker);
 
 	// 作曲者リンク表示
@@ -2263,6 +2266,9 @@ function titleInit() {
 			window.open(g_headerObj.artistUrl, `_blank`);
 		}
 	});
+	if (setVal(g_headerObj.artistUrl, ``, C_TYP_STRING) !== ``) {
+		lnkArtist.title = g_headerObj.artistUrl;
+	}
 	divRoot.appendChild(lnkArtist);
 
 	// バージョン描画


### PR DESCRIPTION
## 変更内容
1. 外部リンクに対してオンマウスでURLを表示するように変更しました。

## 変更理由
1. リンク先がデッドリンクかどうかを判断するための情報が現状無いため。

## その他コメント

