### PR TITLE
[0217/custom-preload] ロード画面の譜面読込前にカスタム関数を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5600,6 +5600,14 @@ function loadingScoreInit2() {
 	const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
 	g_headerObj.blankFrame = g_headerObj.blankFrameDef;
 
+	// ユーザカスタムイベント
+	if (typeof customPreloadingInit === C_TYP_FUNCTION) {
+		customPreloadingInit();
+		if (typeof customPreloadingInit2 === C_TYP_FUNCTION) {
+			customPreloadingInit2();
+		}
+	}
+
 	// 譜面初期情報ロード許可フラグ
 	// (タイトルバック時保存したデータを設定画面にて再読み込みするため、
 	//  ローカルストレージ保存時はフラグを解除しない)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5607,6 +5607,12 @@ function loadingScoreInit2() {
 			customPreloadingInit2();
 		}
 	}
+	if (typeof skinPreloadingInit === C_TYP_FUNCTION) {
+		skinPreloadingInit();
+		if (typeof skinPreloadingInit2 === C_TYP_FUNCTION) {
+			skinPreloadingInit2();
+		}
+	}
 
 	// 譜面初期情報ロード許可フラグ
 	// (タイトルバック時保存したデータを設定画面にて再読み込みするため、


### PR DESCRIPTION
## 変更内容
1. ロード画面の譜面読込前にカスタム関数を追加しました。

## 変更理由
1. 将来的にエディター用スキンを作成することを想定し、
譜面読込前に譜面データを割り込ませることで譜面プレビューできる余地を作ります。

## その他コメント

