### PR TITLE
[0221/calc-lifeval] フリーズアロー始点判定時の矢印分がライフ増減値に反映されない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5850,13 +5850,13 @@ function loadingScoreInit2() {
 		g_allFrz += (isNaN(parseFloat(g_scoreObj.frzData[j][0])) ? 0 : g_scoreObj.frzData[j].length);
 	}
 
-	calcLifeVals(g_allArrow + g_allFrz / 2);
-
 	// ライフ回復・ダメージ量の計算
 	// フリーズ始点でも通常判定させる場合は総矢印数を水増しする
 	if (g_headerObj.frzStartjdgUse) {
 		g_allArrow += g_allFrz / 2;
 	}
+
+	calcLifeVals(g_allArrow + g_allFrz / 2);
 
 	// 矢印・フリーズアロー・速度/色変化格納処理
 	pushArrows(g_scoreObj, speedOnFrame, motionOnFrame, arrivalFrame);


### PR DESCRIPTION
## 変更内容
1. フリーズアロー始点判定時の矢印分がライフ増減値に反映されない問題を修正しました。

## 変更理由
1. 上述の通り。

## その他コメント
- 影響範囲は ver15.0.0 のみです。
