### PR TITLE
[ver15.0.1] [ver15.0.1] フリーズアロー始点判定有効時の矢印分がライフ増減値に反映されない問題を修正

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,23 +13,23 @@ v13の対応終了時期はv16リリース開始時を予定しています。�
 :x: サポート終了 /   
 :anchor: サポート終了しているが安定
 
-| Version | Supported          | Latest Version | End of Support |
-| ------- | ------------------ |----------------|----------------|
-| v15     | :white_check_mark: |[v15.0.0](../../releases/tag/v15.0.0)          |-|
-| v14     | :white_check_mark: |[v14.5.2](../../releases/tag/v14.5.2)          |-|
-| v13     | :warning:          |[v13.6.3](../../releases/tag/v13.6.3)          |(At Release v16)|
-| v12     | :x:                |[v12.3.6 (final)](../../releases/tag/v12.3.6)  |2020-05-13|
-| v11     | :x:                |[v11.4.5 (final)](../../releases/tag/v11.4.5)  |2020-04-18|
-| v10     | :x:                |[v10.5.5 (final)](../../releases/tag/v10.5.5)  |2020-02-10|
-| v9      | :white_check_mark: |[v9.4.12](../../releases/tag/v9.4.12)          |-|
-| v8      | :x:                |[v8.7.10 (final)](../../releases/tag/v8.7.10)  |2019-12-14|
-| v7      | :x:                |[v7.9.13 (final)](../../releases/tag/v7.9.13)  |2019-11-04|
-| v6      | :x:                |[v6.6.13 (final)](../../releases/tag/v6.6.13)  |2019-11-04|
-| v5      | :x::anchor:        |[v5.12.17 (final)](../../releases/tag/v5.12.17)|2019-12-14|
-| v4      | :x:                |[v4.10.22 (final)](../../releases/tag/v4.10.22)|2019-10-08|
-| v3      | :x:                |[v3.13.9 (final)](../../releases/tag/v3.13.9)  |2019-06-18|
-| v2      | :x:                |[v2.9.11 (final)](../../releases/tag/v2.9.11)  |2019-06-18|
-| v1      | :x::anchor:        |[v1.15.17 (final)](../../releases/tag/v1.15.17)|2019-10-08|
+| Version | Supported          | Latest Version | First Release | End of Support |
+| ------- | ------------------ |----------------|---------------|----------------|
+| v15     | :white_check_mark: |[v15.0.0](../../releases/tag/v15.0.0)          |2020-05-13|-|
+| v14     | :white_check_mark: |[v14.5.2](../../releases/tag/v14.5.2)          |2020-04-29|-|
+| v13     | :warning:          |[v13.6.3](../../releases/tag/v13.6.3)          |2020-03-29|(At Release v16)|
+| v12     | :x:                |[v12.3.6 (final)](../../releases/tag/v12.3.6)  |2020-02-09|2020-05-13|
+| v11     | :x:                |[v11.4.5 (final)](../../releases/tag/v11.4.5)  |2019-12-14|2020-04-18|
+| v10     | :x:                |[v10.5.5 (final)](../../releases/tag/v10.5.5)  |2019-11-04|2020-02-10|
+| v9      | :white_check_mark: |[v9.4.12](../../releases/tag/v9.4.12)          |2019-10-08|-|
+| v8      | :x:                |[v8.7.10 (final)](../../releases/tag/v8.7.10)  |2019-09-08|2019-12-14|
+| v7      | :x:                |[v7.9.13 (final)](../../releases/tag/v7.9.13)  |2019-07-08|2019-11-04|
+| v6      | :x:                |[v6.6.13 (final)](../../releases/tag/v6.6.13)  |2019-06-22|2019-11-04|
+| v5      | :x::anchor:        |[v5.12.17 (final)](../../releases/tag/v5.12.17)|2019-05-16|2019-12-14|
+| v4      | :x:                |[v4.10.22 (final)](../../releases/tag/v4.10.22)|2019-04-25|2019-10-08|
+| v3      | :x:                |[v3.13.9 (final)](../../releases/tag/v3.13.9)  |2019-02-25|2019-06-18|
+| v2      | :x:                |[v2.9.11 (final)](../../releases/tag/v2.9.11)  |2019-01-18|2019-06-18|
+| v1      | :x::anchor:        |[v1.15.17 (final)](../../releases/tag/v1.15.17)|2018-11-25|2019-10-08|
 
 ## Reporting a Vulnerability / 脆弱性・不具合情報
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ v13の対応終了時期はv16リリース開始時を予定しています。�
 
 | Version | Supported          | Latest Version | First Release | End of Support |
 | ------- | ------------------ |----------------|---------------|----------------|
-| v15     | :white_check_mark: |[v15.0.0](../../releases/tag/v15.0.0)          |2020-05-13|-|
+| v15     | :white_check_mark: |[v15.0.1](../../releases/tag/v15.0.1)          |2020-05-13|-|
 | v14     | :white_check_mark: |[v14.5.2](../../releases/tag/v14.5.2)          |2020-04-29|-|
 | v13     | :warning:          |[v13.6.3](../../releases/tag/v13.6.3)          |2020-03-29|(At Release v16)|
 | v12     | :x:                |[v12.3.6 (final)](../../releases/tag/v12.3.6)  |2020-02-09|2020-05-13|

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2020/05/13
+ * Revised : 2020/05/17
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 15.0.0`;
-const g_revisedDate = `2020/05/13`;
+const g_version = `Ver 15.0.1`;
+const g_revisedDate = `2020/05/17`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)


### PR DESCRIPTION
## 変更内容
- Pull Request #716 を参照。

## 変更理由


## その他コメント

