### PR TITLE
[0222/animation-frame-calc] 譜面効果データでフレーム・深度等に数式が使えるよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -231,6 +231,9 @@ function setVal(_checkStr, _default, _type) {
 		isNaNflg = isNaN(parseInt(_checkStr));
 		convertStr = (isNaNflg ? _default : parseInt(_checkStr));
 
+	} else if (_type === C_TYP_CALC) {
+		convertStr = new Function(`return ${_checkStr}`)();
+
 	} else if (_type === C_TYP_BOOLEAN) {
 		// 真偽値の場合
 		const lowerCase = _checkStr.toString().toLowerCase();
@@ -943,12 +946,12 @@ function makeSpriteData(_data, _calcFrame = _frame => _frame) {
 				if (setVal(tmpSpriteData[0], 200, C_TYP_NUMBER) === 0) {
 					tmpFrame = 0;
 				} else {
-					tmpFrame = _calcFrame(setVal(tmpSpriteData[0], 200, C_TYP_NUMBER));
+					tmpFrame = _calcFrame(setVal(tmpSpriteData[0], 200, C_TYP_CALC));
 					if (tmpFrame < 0) {
 						tmpFrame = 0;
 					}
 				}
-				const tmpDepth = (tmpSpriteData[1] === C_FLG_ALL ? C_FLG_ALL : setVal(tmpSpriteData[1], 0, C_TYP_NUMBER));
+				const tmpDepth = (tmpSpriteData[1] === C_FLG_ALL ? C_FLG_ALL : setVal(tmpSpriteData[1], 0, C_TYP_CALC));
 				if (tmpDepth !== C_FLG_ALL && tmpDepth > maxDepth) {
 					maxDepth = tmpDepth;
 				}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -243,7 +243,11 @@ function setVal(_checkStr, _default, _type) {
 			_checkStr.toString().toUpperCase() : _default;
 
 	} else if (_type === C_TYP_CALC) {
-		convertStr = new Function(`return ${_checkStr}`)();
+		try {
+			convertStr = new Function(`return ${_checkStr}`)();
+		} catch (err) {
+			convertStr = _default;
+		}
 	}
 
 	// 文字列型の場合 (最初でチェック済みのためそのまま値を返却)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -205,7 +205,8 @@ const blockCode = setKey => C_BLOCK_KEYS.includes(setKey) ? false : true;
 
 /**
  * 文字列を想定された型に変換
- * - _type は `float`(小数)、`number`(整数)、`boolean`(真偽値)、`switch`(ON/OFF), `string`(文字列)から選択
+ * - _type は `float`(小数)、`number`(整数)、`boolean`(真偽値)、
+ *   `switch`(ON/OFF), `calc`(数式), `string`(文字列)から選択
  * - 型に合わない場合は _default を返却するが、_default自体の型チェック・変換は行わない
  * @param {string} _checkStr 
  * @param {string} _default 
@@ -231,9 +232,6 @@ function setVal(_checkStr, _default, _type) {
 		isNaNflg = isNaN(parseInt(_checkStr));
 		convertStr = (isNaNflg ? _default : parseInt(_checkStr));
 
-	} else if (_type === C_TYP_CALC) {
-		convertStr = new Function(`return ${_checkStr}`)();
-
 	} else if (_type === C_TYP_BOOLEAN) {
 		// 真偽値の場合
 		const lowerCase = _checkStr.toString().toLowerCase();
@@ -243,6 +241,11 @@ function setVal(_checkStr, _default, _type) {
 		// ON/OFFスイッチの場合
 		convertStr = [C_FLG_OFF, C_FLG_ON].includes(_checkStr.toString().toUpperCase()) ?
 			_checkStr.toString().toUpperCase() : _default;
+
+	} else if (_type === C_TYP_CALC) {
+		convertStr = new Function(`return ${_checkStr}`)();
+		isNaNflg = isNaN(parseInt(convertStr));
+		convertStr = (isNaNflg ? _default : convertStr);
 	}
 
 	// 文字列型の場合 (最初でチェック済みのためそのまま値を返却)
@@ -6176,13 +6179,14 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 				if (tmpData !== undefined && tmpData !== ``) {
 					const tmpSpeedData = tmpData.split(`,`);
 					for (let k = 0; k < tmpSpeedData.length; k += 2) {
-						if (isNaN(parseInt(tmpSpeedData[k]))) {
+						const tmpFrame = setVal(tmpSpeedData[k], ``, C_TYP_CALC);
+						if (tmpFrame === ``) {
 							continue;
 						} else if (tmpSpeedData[k + 1] === `-`) {
 							break;
 						}
-						speedData[speedIdx] = calcFrame(tmpSpeedData[k]);
-						speedData[speedIdx + 1] = parseFloat(tmpSpeedData[k + 1]);
+						speedData[speedIdx] = calcFrame(tmpFrame);
+						speedData[speedIdx + 1] = setVal(tmpSpeedData[k + 1], 1, C_TYP_CALC);
 						speedIdx += 2;
 					}
 				}
@@ -6209,13 +6213,14 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 				if (tmpData !== undefined && tmpData !== ``) {
 					const tmpColorData = tmpData.split(`,`);
 					for (let k = 0; k < tmpColorData.length; k += 3) {
-						if (isNaN(parseInt(tmpColorData[k]))) {
+						const tmpFrame = setVal(tmpColorData[k], ``, C_TYP_CALC);
+						if (tmpFrame === ``) {
 							continue;
 						} else if (tmpColorData[k + 1] === `-`) {
 							break;
 						}
-						colorData[colorIdx] = calcFrame(tmpColorData[k]);
-						colorData[colorIdx + 1] = parseFloat(tmpColorData[k + 1]);
+						colorData[colorIdx] = calcFrame(tmpFrame);
+						colorData[colorIdx + 1] = setVal(tmpColorData[k + 1], 0, C_TYP_CALC);
 						colorData[colorIdx + 2] = tmpColorData[k + 2];
 						colorIdx += 3;
 					}
@@ -6294,13 +6299,14 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 			if (tmpData !== undefined && tmpData !== ``) {
 				const tmpWordData = tmpData.split(`,`);
 				for (let k = 0; k < tmpWordData.length; k += 3) {
-					if (isNaN(parseInt(tmpWordData[k]))) {
+					const tmpFrame = setVal(tmpWordData[k], ``, C_TYP_CALC);
+					if (tmpFrame === ``) {
 						continue;
 					} else if (tmpWordData[k + 1] === `-`) {
 						break;
 					}
-					tmpWordData[k] = calcFrame(tmpWordData[k]);
-					tmpWordData[k + 1] = parseFloat(tmpWordData[k + 1]);
+					tmpWordData[k] = calcFrame(tmpFrame);
+					tmpWordData[k + 1] = setVal(tmpWordData[k + 1], 0, C_TYP_CALC);
 
 					if (tmpWordData[k + 1] > wordMaxDepth) {
 						wordMaxDepth = tmpWordData[k + 1];

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -244,8 +244,6 @@ function setVal(_checkStr, _default, _type) {
 
 	} else if (_type === C_TYP_CALC) {
 		convertStr = new Function(`return ${_checkStr}`)();
-		isNaNflg = isNaN(parseInt(convertStr));
-		convertStr = (isNaNflg ? _default : convertStr);
 	}
 
 	// 文字列型の場合 (最初でチェック済みのためそのまま値を返却)
@@ -6179,13 +6177,12 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 				if (tmpData !== undefined && tmpData !== ``) {
 					const tmpSpeedData = tmpData.split(`,`);
 					for (let k = 0; k < tmpSpeedData.length; k += 2) {
-						const tmpFrame = setVal(tmpSpeedData[k], ``, C_TYP_CALC);
-						if (tmpFrame === ``) {
+						if (setVal(tmpSpeedData[k], ``, C_TYP_STRING) === ``) {
 							continue;
 						} else if (tmpSpeedData[k + 1] === `-`) {
 							break;
 						}
-						speedData[speedIdx] = calcFrame(tmpFrame);
+						speedData[speedIdx] = calcFrame(setVal(tmpSpeedData[k], ``, C_TYP_CALC));
 						speedData[speedIdx + 1] = setVal(tmpSpeedData[k + 1], 1, C_TYP_CALC);
 						speedIdx += 2;
 					}
@@ -6213,13 +6210,12 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 				if (tmpData !== undefined && tmpData !== ``) {
 					const tmpColorData = tmpData.split(`,`);
 					for (let k = 0; k < tmpColorData.length; k += 3) {
-						const tmpFrame = setVal(tmpColorData[k], ``, C_TYP_CALC);
-						if (tmpFrame === ``) {
+						if (setVal(tmpColorData[k], ``, C_TYP_STRING) === ``) {
 							continue;
 						} else if (tmpColorData[k + 1] === `-`) {
 							break;
 						}
-						colorData[colorIdx] = calcFrame(tmpFrame);
+						colorData[colorIdx] = calcFrame(setVal(tmpColorData[k], ``, C_TYP_CALC));
 						colorData[colorIdx + 1] = setVal(tmpColorData[k + 1], 0, C_TYP_CALC);
 						colorData[colorIdx + 2] = tmpColorData[k + 2];
 						colorIdx += 3;
@@ -6299,13 +6295,12 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 			if (tmpData !== undefined && tmpData !== ``) {
 				const tmpWordData = tmpData.split(`,`);
 				for (let k = 0; k < tmpWordData.length; k += 3) {
-					const tmpFrame = setVal(tmpWordData[k], ``, C_TYP_CALC);
-					if (tmpFrame === ``) {
+					if (setVal(tmpWordData[k], ``, C_TYP_STRING) === ``) {
 						continue;
 					} else if (tmpWordData[k + 1] === `-`) {
 						break;
 					}
-					tmpWordData[k] = calcFrame(tmpFrame);
+					tmpWordData[k] = calcFrame(setVal(tmpWordData[k], ``, C_TYP_CALC));
 					tmpWordData[k + 1] = setVal(tmpWordData[k + 1], 0, C_TYP_CALC);
 
 					if (tmpWordData[k + 1] > wordMaxDepth) {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -40,6 +40,7 @@ const C_TYP_FLOAT = `float`;
 const C_TYP_OBJECT = `object`;
 const C_TYP_FUNCTION = `function`;
 const C_TYP_SWITCH = `switch`;
+const C_TYP_CALC = `calc`;
 
 // 画像ファイル
 let C_IMG_ARROW = `../img/arrow.png`;


### PR DESCRIPTION
## 変更内容
1. 以下の譜面データでフレーム・深度等に数式が使えるよう変更しました。

### 対象
- speed_data(change), boost_data のフレーム数、速度
- color_data, acolor_data のフレーム数、矢印種別
- word_data のフレーム数、深度
- back_data, mask_data のフレーム数、深度
※タイトル・リザルトモーション及びリバース・Alt系の対応を含みます。

### 使用例
```
|back_data=
200,0,（省略）
200+40,0,（省略）
200+60,0,（省略）
|
```

2. setVal関数に数式に変換するオプションを追加しました。
typeに`C_TYP_CALC`と指定します。
setVal関数内で、数式に変換後計算した値を返却します。
    - undefined, null, 空値をチェックします。
    - 数式が間違っている場合はデフォルト値を適用します。

## 変更理由
1. FrameNumが変わった場合に一括置換しやすくするため。
後で見返した場合に同じ系統の表示かどうかの判別がつきやすくなるため。
2. 1.の対応に伴い追加しました。

## その他コメント