### PR TITLE
[0223/preset-animation] 静止画像表示で数フレーム前に透明画像を配置する設定を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -980,9 +980,9 @@ function makeSpriteData(_data, _calcFrame = _frame => _frame) {
 				setSpriteData(tmpObj, tmpFrame, tmpDepth);
 
 				// opacityが"preload"を指定された場合は一定フレーム手前に同じ画像をopacity:0で描画して準備
-				if (tmpSpriteData[8] === `preload` && tmpFrame - 1 >= 0) {
+				if (tmpSpriteData[8] === `preload` && tmpFrame - 10 >= 0) {
 					tmpObj.opacity = 0;
-					setSpriteData(tmpObj, tmpFrame - 1, tmpDepth);
+					setSpriteData(tmpObj, tmpFrame - 10, tmpDepth);
 				}
 			}
 		}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -926,6 +926,19 @@ function checkDuplicatedObjects(_obj) {
 	return [_obj, addFrame];
 }
 
+function checkDepthZeroPos(_obj) {
+	let pos = -1;
+	if (_obj !== undefined) {
+		_obj.forEach((tmpObj, j) => {
+			console.log(tmpObj.depth);
+			if (tmpObj.depth === 0) {
+				pos = j;
+			}
+		});
+	}
+	return pos;
+}
+
 /**
  * 多層スプライトデータの作成処理
  * @param {array} _data 
@@ -980,9 +993,18 @@ function makeSpriteData(_data, _calcFrame = _frame => _frame) {
 				setSpriteData(tmpObj, tmpFrame, tmpDepth);
 
 				// opacityが"preload"を指定された場合は一定フレーム手前に同じ画像をopacity:0で描画して準備
-				if (tmpSpriteData[8] === `preload` && tmpFrame - 10 >= 0) {
+				const preFrame = tmpFrame - 10;
+				if (tmpSpriteData[8] === `preload` && preFrame >= 0) {
 					tmpObj.opacity = 0;
-					setSpriteData(tmpObj, tmpFrame - 10, 0);
+					const zeroPos = checkDepthZeroPos(spriteData[preFrame]);
+
+					if (zeroPos === -1) {
+						setSpriteData(tmpObj, preFrame, 0);
+						console.log(spriteData[preFrame]);
+					} else {
+						spriteData[preFrame][zeroPos].htmlText += (checkImage(tmpObj.path) ? makeSpriteImage(tmpObj) : makeSpriteText(tmpObj));
+						console.log(spriteData[preFrame][zeroPos].htmlText);
+					}
 				}
 			}
 		}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -956,7 +956,7 @@ function makeSpriteData(_data, _calcFrame = _frame => _frame) {
 						tmpFrame = 0;
 					}
 				}
-				const tmpDepth = (tmpSpriteData[1] === C_FLG_ALL ? C_FLG_ALL : setVal(tmpSpriteData[1], 0, C_TYP_CALC));
+				const tmpDepth = (tmpSpriteData[1] === C_FLG_ALL ? C_FLG_ALL : setVal(tmpSpriteData[1], 0, C_TYP_CALC) + 1);
 				if (tmpDepth !== C_FLG_ALL && tmpDepth > maxDepth) {
 					maxDepth = tmpDepth;
 				}
@@ -982,7 +982,7 @@ function makeSpriteData(_data, _calcFrame = _frame => _frame) {
 				// opacityが"preload"を指定された場合は一定フレーム手前に同じ画像をopacity:0で描画して準備
 				if (tmpSpriteData[8] === `preload` && tmpFrame - 10 >= 0) {
 					tmpObj.opacity = 0;
-					setSpriteData(tmpObj, tmpFrame - 10, tmpDepth);
+					setSpriteData(tmpObj, tmpFrame - 10, 0);
 				}
 			}
 		}


### PR DESCRIPTION
## 変更内容
1. 静止画像表示で10フレーム前に透明画像を配置する設定を追加しました。
back/mask_dataでopacity項目に数字指定の代わりに`preload`を指定することで、
数フレーム手前に非透明度0の画像を事前に配置します。

## 変更理由
1. 読込遅延防止のため。

## その他コメント
- 何フレーム手前にすべきかは調整中です。
- 非透明度が強制的に1になるので、非透明度が1以外にしたい場合は仕様の見直しが必要です。
