### PR TITLE
[0225/preload-revision] preload後に透明画像を表示するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -340,6 +340,13 @@ function preloadFile(_as, _href, _type = ``, _crossOrigin = `anonymous`) {
 		} else {
 			link.crossOrigin = _crossOrigin;
 		}
+		link.onload = _ => {
+			const tmpImg = document.createElement(`img`);
+			tmpImg.src = _href;
+			tmpImg.style.opacity = 0;
+			document.querySelector(`#divRoot`).appendChild(tmpImg);
+			document.head.removeChild(link);
+		}
 		document.head.appendChild(link);
 	}
 }


### PR DESCRIPTION
## 変更内容
1. 画像のプリロード後に、透明画像を表示するよう変更しました。

`function preloadFile`に、以下の文言を追加しています。
```javascript
function preloadFile(_as, _href, _type = ``, _crossOrigin = `anonymous`) {
		// 省略
		if (location.href.match(`^file`)) {
		} else {
			link.crossOrigin = _crossOrigin;
		}
		// ↓　追加部分　↓
		link.onload = _ => {
			const tmpImg = document.createElement(`img`);
			tmpImg.src = _href;
			tmpImg.style.opacity = 0;
			document.querySelector(`#divRoot`).appendChild(tmpImg);
			document.head.removeChild(link);
		}
		// ↑　追加部分　↑
		document.head.appendChild(link);
```

## 変更理由
1. 画像をpreloadしても、imgタグで実体化しないと画像が表示されるのにラグが生じるため。

## その他コメント
- これで改善するかどうかは未検証です。
