### PR TITLE
[0228/musictitle-pos] タイトル文字のサイズを見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2126,8 +2126,8 @@ function titleInit() {
 		}
 
 		const lblmusicTitle = createDivCssLabel(`lblmusicTitle`,
-			g_sWidth * -1 + Number(titlefontpos[0]), 0 + Number(titlefontpos[1]),
-			g_sWidth * 3, g_sHeight - 40,
+			Number(titlefontpos[0]), Number(titlefontpos[1]),
+			g_sWidth, g_sHeight - 40,
 			titlefontsize,
 			`<span style="
 				align:${C_ALIGN_CENTER};


### PR DESCRIPTION
## 変更内容
1. タイトル文字(#lblmusicTitle)のサイズを見直しました。

## 変更理由
1. タイトル文字(#lblmusicTitle)位置について、
過去の経緯で横幅が枠の3倍に設定されており、テーブルタグが使いにくい状況のため。

## その他コメント

