### PR TITLE
[0229/maxcombo] MaxComboが初期化されない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7280,7 +7280,7 @@ function getArrowSettings() {
 	}
 
 	[
-		`ii`, `shakin`, `matari`, `shobon`, `uwan`, `combo`, `maxcombo`,
+		`ii`, `shakin`, `matari`, `shobon`, `uwan`, `combo`, `maxCombo`,
 		`kita`, `sfsf`, `iknai`, `fCombo`, `fmaxCombo`, `fast`, `slow`
 	].forEach(judgeCnt => g_resultObj[judgeCnt] = 0);
 


### PR DESCRIPTION
## 変更内容
1. MaxComboが初期化されない問題を修正しました。

## 変更理由
1. PR #715 で、コード整理を行った際のコードミスの修正です。

## その他コメント
- v15.1.0に対する修正です。他のバージョンには影響しません。
