### PR TITLE
[0230/extra-key-after] 特殊キーの後に通常キーの譜面があると譜面選択できない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4508,12 +4508,6 @@ function createOptionWindow(_sprite) {
 				g_speedNum = 0;
 			}
 			g_gaugeNum = 0;
-			if (!g_stateObj.extraKeyFlg) {
-				g_localKeyStorage.reverse = C_FLG_OFF;
-			} else {
-				g_stateObj.reverse = C_FLG_OFF;
-				g_reverseNum = 0;
-			}
 			g_scrollNum = 0;
 			if (!g_autoPlays.includes(g_stateObj.autoPlay)) {
 				g_autoPlayNum = 0;
@@ -4568,6 +4562,9 @@ function createOptionWindow(_sprite) {
 					if (g_reverseNum < 0) {
 						g_reverseNum = 0;
 					}
+				} else {
+					g_stateObj.reverse = C_FLG_OFF;
+					g_reverseNum = 0;
 				}
 
 				// キーコンフィグ初期値設定


### PR DESCRIPTION
## 変更内容
1. 特殊キーの後に通常キーの譜面があると譜面選択できない問題を修正しました。

## 変更理由
1. g_localKeyStorageが未定義のタイミングで`g_localKeyStorage.reverse`に値を格納しているため。
1譜面目の場合、setDifficultyの_initFlgが`false`であり、
通常/特殊キーによらずこの格納処理が素通りされるため問題は発生しない。

## その他コメント
- 過去バージョンでも再現あり。修正が必要です。