### PR TITLE
[0231/frzcolor-changed] フリーズアローヒット色の変化誤りを修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8764,7 +8764,7 @@ function changeFrzColors(_mkColor, _mkColorCd, _colorPatterns, _allFlg = ``) {
 	_mkColor.forEach((targetj, j) => {
 
 		// targetj=0,2,4,6,8 ⇒ Arrow, 1,3,5,7,9 ⇒ Bar
-		const ctype = (targetj > 10 ? `Hit` : `Normal`) + (targetj % 2 === 0 ? `` : `Bar`);
+		const ctype = (targetj >= 10 ? `Hit` : `Normal`) + (targetj % 2 === 0 ? `` : `Bar`);
 		const colorPos = Math.ceil((targetj % 10 - 1) / 2);
 
 		_colorPatterns.forEach((cpattern, k) => {


### PR DESCRIPTION
## 変更内容
1. フリーズアローヒット時の矢印色が変化しない問題を修正しました。

## 変更理由
1. ver15.1.0にてコード整理の一環で`changeFrzColors`関数を整理しましたが、
その際の条件式に誤りがありました。

## その他コメント

