### PR TITLE
[0232/jdgY-reset] Background:OFF時にjdgYを初期化する処理を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3138,6 +3138,9 @@ function headerConvert(_dosObj) {
 	// 譜面明細の使用可否
 	obj.scoreDetailUse = setVal(_dosObj.scoreDetailUse, true, C_TYP_BOOLEAN);
 
+	// 判定位置をBackgroundのON/OFFと連動してリセットする設定
+	obj.jdgPosReset = setVal(_dosObj.jdgPosReset, true, C_TYP_BOOLEAN);
+
 	// ジャストフレームの設定 (ローカル: 0フレーム, リモートサーバ上: 1フレーム以内)
 	obj.justFrames = (location.href.match(`^file`) || location.href.indexOf(`localhost`) !== -1) ? 0 : 1;
 
@@ -7697,7 +7700,8 @@ function MainInit() {
 	const jdgGroups = [`J`, `FJ`];
 	const jdgX = [g_sWidth / 2 - 200, g_sWidth / 2 - 100];
 	const jdgY = [(g_sHeight + g_posObj.stepYR) / 2 - 60, (g_sHeight + g_posObj.stepYR) / 2 + 10];
-	if (g_stateObj.d_background === C_FLG_ON) {
+	if (g_stateObj.d_background === C_FLG_OFF && g_headerObj.jdgPosReset) {
+	} else {
 		jdgY[0] += g_diffObj.arrowJdgY;
 		jdgY[1] += g_diffObj.frzJdgY;
 	}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7696,7 +7696,11 @@ function MainInit() {
 
 	const jdgGroups = [`J`, `FJ`];
 	const jdgX = [g_sWidth / 2 - 200, g_sWidth / 2 - 100];
-	const jdgY = [(g_sHeight + g_posObj.stepYR) / 2 - 60 + g_diffObj.arrowJdgY, (g_sHeight + g_posObj.stepYR) / 2 + 10 + g_diffObj.frzJdgY];
+	const jdgY = [(g_sHeight + g_posObj.stepYR) / 2 - 60, (g_sHeight + g_posObj.stepYR) / 2 + 10];
+	if (g_stateObj.d_background === C_FLG_ON) {
+		jdgY[0] += g_diffObj.arrowJdgY;
+		jdgY[1] += g_diffObj.frzJdgY;
+	}
 	const jdgCombos = [`kita`, `ii`];
 
 	jdgGroups.forEach((jdg, j) => {


### PR DESCRIPTION
## 変更内容
1. Background:OFF時にjdgYを初期化する処理を追加しました。

## 変更理由
1. Issue #714 より。
背景・マスク表示による判定キャラクタ位置を調整するため、
arrowJdgY / frzJdgY という判定・コンボ位置の調整機能があるが
Background: OFF時は元に戻した方がいいことが多いため。

## その他コメント

