### PR TITLE
[0233/title-comment] コメント文をタイトルに表示する機能を実装

### DIFF
--- a/danoni/danoni0.html
+++ b/danoni/danoni0.html
@@ -77,6 +77,56 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 
 |tuning=ティックル,http://cw7.sakura.ne.jp/|
 
+|commentExternal=true|
+|commentAutoBr=false|
+|commentVal=
+		<p>
+			<span style="color:#66ffff;">＜楽曲・譜面について＞</span><br>
+		</p>
+		<p>
+		　秘密さんの企画「<a href="http://sercretroom.qp.land.to/thrust/thrust.html">製作者は秘密です？</a>」の派生作品です。<br>
+		　※HTML5移行を機に、当時の5key譜面も足しました。<br>
+		</p>
+		<hr>
+		<p>
+		<span style="color:#ffff99">[ 5key / Thrust ]</span> (Tool : 10.07, Arrow : 463+22)<br>
+		</p>
+		<p>
+		　2007年時点の合作譜面そのままです。色変化があるのはその名残。<br>
+		　当時は押しにくいフリーズアローが個人的な流行り(？)だったので<br>
+		　妙にフリーズアローが多いです。今(2018年時点)だったら違うところに使ってそうですね。<br>
+		</p>
+		
+		<hr>
+		<p>
+		<span style="color:#ffff99">[ 7key / Hard ]</span> (Tool : 15.99, Arrow : 666+6)<br>
+		</p>
+		<p>
+		　秘密さんの企画「<a href="http://sercretroom.qp.land.to/thrust/thrust.html">製作者は秘密です？</a>」にて多くの5key譜面が作られたこの曲。<br>
+		　あれから時期も経ったので、7keyで作ることに。<br>
+		　製作は思いのほかスムーズに進みました。それだけ印象も強かったんだなあと改めて。<br>
+		　密度的に前より上がっていますが、階段も多いので密度並の難度は感じないと思います。<br>
+		</p>		
+		<hr>
+		<p>
+		<span style="color:#ffff99">[ 11Lkey / Upper ]</span> (Tool : 14.62, Arrow : 644+6)<br>
+		</p>
+		<p>
+		　移動譜にしたら楽しそうだという理由でスタートした追加譜面。<br>
+		　「Thrust up」で突き出す的なニュアンスがあるようなので、これはやるしかないだろうと(ry<br>
+		　7key譜面がすんなりと行き過ぎた感があったので、それを補う譜面が欲しいなとも思ってました。<br>
+		</p>
+		<p>
+		　実はもともと11keyで作る予定でしたが、移動間隔を考慮していろいろと融通の利く11Lkeyに。<br>
+		　久々だったので、ちょうどいい機会かなと。<br>
+		</p>
+		<p>
+		　譜面については、密度は7key譜面より少し抑え目なものの、全体的に二次元同時・交互が多く、<br>
+		　終盤は16分を含めたラッシュが飛んできます。後半・終盤難です。<br>
+		</p>
+		<hr>
+|
+
 '>
 <div id="canvas-frame" style="width:600px;margin:auto;">
 	<p>ゲームを準備しています...</p>
@@ -84,8 +134,7 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 		Google ChromeやFirefox等、HTML5に対応したブラウザをご利用ください。</p>
 </div>
 <hr>
-<p style="text-align:center;">
-	コメント
+<p id="commentArea">
 </p>
 </td></tr></table>
 </body>

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2321,37 +2321,42 @@ function titleInit() {
 
 	// コメントエリア作成
 	if (g_headerObj.commentVal !== ``) {
-		let tmpComment = g_headerObj.commentVal.split(`\r\n`).join(`\n`);
-		tmpComment = escapeHtmlForEnabledTag(tmpComment.split(`\n`).join(`<br>`));
-
-		const lblComment = createDivCssLabel(`lblComment`, 0, 70, g_sWidth, g_sHeight - 180, 14, tmpComment);
-		lblComment.style.textAlign = C_ALIGN_LEFT;
-		lblComment.style.overflow = `auto`;
-		lblComment.style.background = `#222222`;
-		lblComment.style.color = `#cccccc`;
-		lblComment.style.display = C_DIS_NONE;
-		divRoot.appendChild(lblComment);
-
-		const btnComment = createCssButton({
-			id: `btnComment`,
-			name: `Comment`,
-			x: g_sWidth - 180,
-			y: (g_sHeight / 2) + 150,
-			width: 150,
-			height: 50,
-			fontsize: 20,
-			align: C_ALIGN_CENTER,
-			class: `button_Default`,
-		}, _ => {
-			const lblCommentDef = document.querySelector(`#lblComment`);
-			if (lblCommentDef.style.display !== C_DIS_NONE) {
-				lblCommentDef.style.display = C_DIS_NONE;
-			} else {
-				lblCommentDef.style.display = C_DIS_INHERIT;
+		if (g_headerObj.commentExternal) {
+			if (document.querySelector(`#commentArea`) !== null) {
+				document.querySelector(`#commentArea`).innerHTML = g_headerObj.commentVal;
 			}
-		});
-		btnComment.style.border = `solid 1px #999999`;
-		divRoot.appendChild(btnComment);
+		} else {
+			let tmpComment = g_headerObj.commentVal;
+
+			const lblComment = createDivCssLabel(`lblComment`, 0, 70, g_sWidth, g_sHeight - 180, 14, tmpComment);
+			lblComment.style.textAlign = C_ALIGN_LEFT;
+			lblComment.style.overflow = `auto`;
+			lblComment.style.background = `#222222`;
+			lblComment.style.color = `#cccccc`;
+			lblComment.style.display = C_DIS_NONE;
+			divRoot.appendChild(lblComment);
+
+			const btnComment = createCssButton({
+				id: `btnComment`,
+				name: `Comment`,
+				x: g_sWidth - 180,
+				y: (g_sHeight / 2) + 150,
+				width: 150,
+				height: 50,
+				fontsize: 20,
+				align: C_ALIGN_CENTER,
+				class: `button_Default`,
+			}, _ => {
+				const lblCommentDef = document.querySelector(`#lblComment`);
+				if (lblCommentDef.style.display !== C_DIS_NONE) {
+					lblCommentDef.style.display = C_DIS_NONE;
+				} else {
+					lblCommentDef.style.display = C_DIS_INHERIT;
+				}
+			});
+			btnComment.style.border = `solid 1px #999999`;
+			divRoot.appendChild(btnComment);
+		}
 	}
 
 	// マスクスプライトを作成
@@ -3177,7 +3182,13 @@ function headerConvert(_dosObj) {
 	obj.jdgPosReset = setVal(_dosObj.jdgPosReset, true, C_TYP_BOOLEAN);
 
 	// タイトル表示用コメント
-	obj.commentVal = setVal(_dosObj.commentVal, ``, C_TYP_STRING);
+	const newlineTag = setVal(_dosObj.commentAutoBr, true, C_TYP_BOOLEAN) ? `<br>` : ``;
+	let tmpComment = setVal(_dosObj.commentVal, ``, C_TYP_STRING);
+	tmpComment = tmpComment.split(`\r\n`).join(`\n`);
+	obj.commentVal = escapeHtmlForEnabledTag(tmpComment.split(`\n`).join(newlineTag));
+
+	// コメントの外部化設定
+	obj.commentExternal = setVal(_dosObj.commentExternal, false, C_TYP_BOOLEAN);
 
 	// ジャストフレームの設定 (ローカル: 0フレーム, リモートサーバ上: 1フレーム以内)
 	obj.justFrames = (location.href.match(`^file`) || location.href.indexOf(`localhost`) !== -1) ? 0 : 1;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2319,6 +2319,41 @@ function titleInit() {
 	}, _ => window.open(`https://github.com/cwtickle/danoniplus/compare/v${g_version.slice(4)}...master`, `_blank`));
 	divRoot.appendChild(lnkComparison);
 
+	// コメントエリア作成
+	if (g_headerObj.commentVal !== ``) {
+		let tmpComment = g_headerObj.commentVal.split(`\r\n`).join(`\n`);
+		tmpComment = escapeHtmlForEnabledTag(tmpComment.split(`\n`).join(`<br>`));
+
+		const lblComment = createDivCssLabel(`lblComment`, 0, 70, g_sWidth, g_sHeight - 180, 14, tmpComment);
+		lblComment.style.textAlign = C_ALIGN_LEFT;
+		lblComment.style.overflow = `auto`;
+		lblComment.style.background = `#222222`;
+		lblComment.style.color = `#cccccc`;
+		lblComment.style.display = C_DIS_NONE;
+		divRoot.appendChild(lblComment);
+
+		const btnComment = createCssButton({
+			id: `btnComment`,
+			name: `Comment`,
+			x: g_sWidth - 180,
+			y: (g_sHeight / 2) + 150,
+			width: 150,
+			height: 50,
+			fontsize: 20,
+			align: C_ALIGN_CENTER,
+			class: `button_Default`,
+		}, _ => {
+			const lblCommentDef = document.querySelector(`#lblComment`);
+			if (lblCommentDef.style.display !== C_DIS_NONE) {
+				lblCommentDef.style.display = C_DIS_NONE;
+			} else {
+				lblCommentDef.style.display = C_DIS_INHERIT;
+			}
+		});
+		btnComment.style.border = `solid 1px #999999`;
+		divRoot.appendChild(btnComment);
+	}
+
 	// マスクスプライトを作成
 	createSprite(`divRoot`, `maskTitleSprite`, 0, 0, g_sWidth, g_sHeight);
 	for (let j = 0; j <= g_headerObj.maskTitleMaxDepth; j++) {
@@ -3140,6 +3175,9 @@ function headerConvert(_dosObj) {
 
 	// 判定位置をBackgroundのON/OFFと連動してリセットする設定
 	obj.jdgPosReset = setVal(_dosObj.jdgPosReset, true, C_TYP_BOOLEAN);
+
+	// タイトル表示用コメント
+	obj.commentVal = setVal(_dosObj.commentVal, ``, C_TYP_STRING);
 
 	// ジャストフレームの設定 (ローカル: 0フレーム, リモートサーバ上: 1フレーム以内)
 	obj.justFrames = (location.href.match(`^file`) || location.href.indexOf(`localhost`) !== -1) ? 0 : 1;

--- a/js/sample/danoni_custom-003.js
+++ b/js/sample/danoni_custom-003.js
@@ -31,7 +31,7 @@ function customTitleInit() {
 	// Tweetボタン描画
 	var btnTweet = createButton({
 		id: "btnTweet",
-		name: "Comment",
+		name: "Info",
 		x: g_sWidth / 4 * 3,
 		y: 340,
 		width: g_sWidth / 4,
@@ -54,7 +54,7 @@ function customCommentInit() {
 
 	// タイトル文字描画
 	var lblTitle = getTitleDivLabel("lblTitle",
-		"<span style='color:#6666ff;font-size:40px;'>C</span>OMMENT", 0, 15);
+		"<span style='color:#6666ff;font-size:40px;'>I</span>NFO", 0, 15);
 	divRoot.appendChild(lblTitle);
 
 	var comment = "これはカスタムページのテストです。<br>" +


### PR DESCRIPTION
## 変更内容
1. コメント文をタイトルに表示する機能を実装しました。
譜面内に下記のように記載することでコメントエリアがタイトル画面に表示され、
その中にコメントが表示されます。
改行すると`<br>`タグが自動で付加される仕様です。タグも使用可能にしています。
```
|commentVal=
このような形で
コメントを入れます。
<img src="image.png" alt="画像タグや"><a href="index.html">リンクも可能です。</a>
|
```

2. 自動で`<br>`を入れたくない場合は下記のように指定できるようにしました。
※デフォルトは`true`(自動改行タグ挿入が有効)です。
```
|commentAutoBr=false|
```

3. コメントをタイトル画面からのボタンではなく、
ダンおに本体の外部に置きたい場合は下記の譜面ヘッダーを指定します。
※デフォルトは`false`(コメントをタイトル画面内に配置する)です。
```
|commentExternal=true|
```
外部化する場合、html側で次の指定を行います。
指定した箇所が、コメント部に置き換えられます。
```html
<span id="commentArea"></span>　※divタグでも問題ありません。
```

## 変更理由
1. コメント表示を手軽に載せる需要より。
2. 移植等で、すでに`<br>`を入れている可能性があるため。
3. html本体を簡素化し、譜面本体で制御できるようにするため。

## その他コメント
- 特殊文字は[Wiki](../wiki/SpecialCharacters)を参考にエスケープが必要です。
（特にシングルクォート、バッククォートには要注意）
ダブルクォートは譜面データの区切り文字には使用されていないため、必須ではありません。