### PR TITLE
[0235/keyconfig-iniset] キーコンフィグ保存時の問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7356,11 +7356,11 @@ function getArrowSettings() {
 		// ローカルストレージ(キー別)へデータ保存　※特殊キーは除く
 		if (!g_stateObj.extraKeyFlg) {
 			g_localKeyStorage.reverse = g_stateObj.reverse;
+			g_localKeyStorage.keyCtrl = setKeyCtrl(g_localKeyStorage, keyNum, keyCtrlPtn);
 			if (g_keyObj.currentPtn !== -1) {
 				g_localKeyStorage.keyCtrlPtn = g_keyObj.currentPtn;
 				g_keyObj[`keyCtrl${keyCtrlPtn}`] = JSON.parse(JSON.stringify(g_keyObj[`keyCtrl${keyCtrlPtn}d`]));
 			}
-			g_localKeyStorage.keyCtrl = setKeyCtrl(g_localKeyStorage, keyNum, keyCtrlPtn);
 			localStorage.setItem(`danonicw-${g_keyObj.currentKey}k`, JSON.stringify(g_localKeyStorage));
 
 		} else {


### PR DESCRIPTION
## 変更内容
1. 通常キーであらかじめデフォルトセットされているキーコンフィグパターンと
異なるキーを割り当てた際、初回保存時のみそのキーがリセットされる問題を修正しました。

## 変更理由
1. 上述の通りです。
なお、独自キーの場合はこの事象は発生しません。

## その他コメント
- 影響範囲、起因となったバージョンは調査中です。
