### PR TITLE
プレイ中に他のキーイベントが呼ばれないようにする

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7899,6 +7899,7 @@ function MainInit() {
 
 	// キー操作イベント
 	document.onkeydown = evt => {
+		evt.preventDefault();
 		const setKey = transCode(evt.keyCode);
 		g_inputKeyBuffer[setKey] = true;
 		mainKeyDownActFunc[g_stateObj.autoAll](setKey);


### PR DESCRIPTION
## 変更内容
プレイ中の画面で `Event.preventDefault()` を呼ぶようにしました。

## 変更理由
プレイ中にブラウザショートカットが発火したりするのを防ぐため。

## その他コメント
一応動作確認は入れていますが、問題あれば取り下げてください。

