### PR TITLE
[0237/failed-animation] Failed時のリザルトモーションがカスタムゲージで使用できない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6218,9 +6218,9 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 		[g_headerObj.maskResultData, g_headerObj.maskResultMaxDepth] =
 			makeBackgroundResultData(`maskresult`, scoreIdHeader);
 		[g_headerObj.backFailedData, g_headerObj.backFailedMaxDepth] =
-			makeBackgroundResultData(`backfailed${g_gaugeType.slice(0, 1)}`, scoreIdHeader, `backresult`);
+			makeBackgroundResultData(`backfailed${g_stateObj.lifeMode.slice(0, 1)}`, scoreIdHeader, `backresult`);
 		[g_headerObj.maskFailedData, g_headerObj.maskFailedMaxDepth] =
-			makeBackgroundResultData(`maskfailed${g_gaugeType.slice(0, 1)}`, scoreIdHeader, `maskresult`);
+			makeBackgroundResultData(`maskfailed${g_stateObj.lifeMode.slice(0, 1)}`, scoreIdHeader, `maskresult`);
 	}
 
 	/**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- CustomGauge使用時にクリア失敗時のリザルトモーションが使用できない問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- Resolves #749 

## :pencil: その他コメント / Other Comments
- v9, v13, v14にも修正が必要です。
