### PR TITLE
[0238/reverse-lyrics] Reverse時に歌詞を上下逆の位置に表示するよう変更（条件あり）

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6335,14 +6335,13 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 		let wordDataList = [];
 		let wordReverseFlg = false;
 		const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
-		const posMax = (g_keyObj[`divMax${keyCtrlPtn}`] !== undefined ? g_keyObj[`divMax${keyCtrlPtn}`] : g_keyObj[`pos${keyCtrlPtn}`][keyNum - 1] + 1);
 		const divideCnt = g_keyObj[`div${keyCtrlPtn}`] - 1;
 
 		if (g_stateObj.scroll !== `---`) {
 			wordDataList = [_dosObj[`wordAlt${_scoreNo}_data`], _dosObj.wordAlt_data];
 		} else if (g_stateObj.reverse === C_FLG_ON) {
 			wordDataList = [_dosObj[`wordRev${_scoreNo}_data`], _dosObj.wordRev_data];
-			if (posMax === divideCnt && wordDataList.find((v) => v !== undefined) === undefined) {
+			if (keyNum === divideCnt + 1 && wordDataList.find((v) => v !== undefined) === undefined) {
 				wordReverseFlg = true;
 			}
 		}
@@ -6360,9 +6359,18 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	function makeSpriteWordData(_data, _reverseFlg = false) {
 		const wordData = [];
 		let wordMaxDepth = -1;
+		let wordReverseFlg = _reverseFlg;
 
 		let tmpArrayData = _data.split(`\r`).join(`\n`);
 		tmpArrayData = tmpArrayData.split(`\n`);
+
+		tmpArrayData.forEach(tmpData => {
+			if (tmpData !== undefined && tmpData !== ``) {
+				if (tmpData.indexOf(`<br>`) !== -1) {
+					wordReverseFlg = false;
+				}
+			}
+		});
 
 		tmpArrayData.forEach(tmpData => {
 			if (tmpData !== undefined && tmpData !== ``) {
@@ -6376,7 +6384,7 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 					tmpWordData[k] = calcFrame(setVal(tmpWordData[k], ``, C_TYP_CALC));
 					tmpWordData[k + 1] = setVal(tmpWordData[k + 1], 0, C_TYP_CALC);
 					tmpWordData[k + 1] = Math.floor(tmpWordData[k + 1] / 2) * 2 +
-						(tmpWordData[k + 1] + Number(_reverseFlg)) % 2;
+						(tmpWordData[k + 1] + Number(wordReverseFlg)) % 2;
 
 					if (tmpWordData[k + 1] > wordMaxDepth) {
 						wordMaxDepth = tmpWordData[k + 1];

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6333,22 +6333,31 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 */
 	function makeWordData(_scoreNo) {
 		let wordDataList = [];
+		let wordReverseFlg = false;
+		const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
+		const posMax = (g_keyObj[`divMax${keyCtrlPtn}`] !== undefined ? g_keyObj[`divMax${keyCtrlPtn}`] : g_keyObj[`pos${keyCtrlPtn}`][keyNum - 1] + 1);
+		const divideCnt = g_keyObj[`div${keyCtrlPtn}`] - 1;
+
 		if (g_stateObj.scroll !== `---`) {
 			wordDataList = [_dosObj[`wordAlt${_scoreNo}_data`], _dosObj.wordAlt_data];
 		} else if (g_stateObj.reverse === C_FLG_ON) {
 			wordDataList = [_dosObj[`wordRev${_scoreNo}_data`], _dosObj.wordRev_data];
+			if (posMax === divideCnt && wordDataList.find((v) => v !== undefined) === undefined) {
+				wordReverseFlg = true;
+			}
 		}
 		wordDataList.push(_dosObj[`word${_scoreNo}_data`], _dosObj.word_data);
 
 		const inputWordData = wordDataList.find((v) => v !== undefined);
-		return (inputWordData !== undefined ? makeSpriteWordData(inputWordData) : [[], -1]);
+		return (inputWordData !== undefined ? makeSpriteWordData(inputWordData, wordReverseFlg) : [[], -1]);
 	}
 
 	/**
 	 * 多層歌詞データの格納処理
 	 * @param {object} _data 
+	 * @param {boolean} _reverseFlg
 	 */
-	function makeSpriteWordData(_data) {
+	function makeSpriteWordData(_data, _reverseFlg = false) {
 		const wordData = [];
 		let wordMaxDepth = -1;
 
@@ -6366,6 +6375,8 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 					}
 					tmpWordData[k] = calcFrame(setVal(tmpWordData[k], ``, C_TYP_CALC));
 					tmpWordData[k + 1] = setVal(tmpWordData[k + 1], 0, C_TYP_CALC);
+					tmpWordData[k + 1] = Math.floor(tmpWordData[k + 1] / 2) * 2 +
+						(tmpWordData[k + 1] + Number(_reverseFlg)) % 2;
 
 					if (tmpWordData[k + 1] > wordMaxDepth) {
 						wordMaxDepth = tmpWordData[k + 1];


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- 歌詞表示について、次の条件を全て満たした場合のみ、歌詞表示の上下を反転します。
    - 上下スクロールを挟まないキーに限定（5key, 7key, 7ikey, 9A/9Bkeyなど）
    - リバース・スクロール拡張用の歌詞表示（wordRev_data / wordAlt_data）が設定されていない作品
    - SETTINGS 画面で Reverse：ON、Scroll：`---` (指定なし) を指定してプレイ開始した場合
    - 歌詞表示がすべて1段表示の場合（2段の場合、反転すると文字が重なる場合があるため）

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- Resolves #747 

## :pencil: その他コメント / Other Comments
- 歌詞表示＆2段の場合の取り扱いを考慮する必要があります。
