### PR TITLE
[0239/reverse-lyrics-setting] Reverse時の歌詞の自動反転制御設定を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3200,6 +3200,10 @@ function headerConvert(_dosObj) {
 	// コメントの外部化設定
 	obj.commentExternal = setVal(_dosObj.commentExternal, false, C_TYP_BOOLEAN);
 
+	// Reverse時の歌詞の自動反転制御
+	obj.wordAutoReverse = setVal(_dosObj.wordAutoReverse,
+		(typeof g_presetWordAutoReverse === C_TYP_STRING ? setVal(g_presetWordAutoReverse, `auto`, C_TYP_SWITCH) : false), C_TYP_SWITCH);
+
 	// ジャストフレームの設定 (ローカル: 0フレーム, リモートサーバ上: 1フレーム以内)
 	obj.justFrames = (location.href.match(`^file`) || location.href.indexOf(`localhost`) !== -1) ? 0 : 1;
 
@@ -6341,8 +6345,16 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 			wordDataList = [_dosObj[`wordAlt${_scoreNo}_data`], _dosObj.wordAlt_data];
 		} else if (g_stateObj.reverse === C_FLG_ON) {
 			wordDataList = [_dosObj[`wordRev${_scoreNo}_data`], _dosObj.wordRev_data];
-			if (keyNum === divideCnt + 1 && wordDataList.find((v) => v !== undefined) === undefined) {
-				wordReverseFlg = true;
+
+			// wordRev_dataが指定されている場合はそのままの位置を採用
+			// word_dataのみ指定されている場合、下記ルールに従って設定
+			if (wordDataList.find((v) => v !== undefined) === undefined) {
+				// Reverse時の歌詞の自動反転制御設定
+				if (g_headerObj.wordAutoReverse !== `auto`) {
+					wordReverseFlg = (g_headerObj.wordAutoReverse === C_FLG_ON ? true : false);
+				} else if (keyNum === divideCnt + 1) {
+					wordReverseFlg = true;
+				}
 			}
 		}
 		wordDataList.push(_dosObj[`word${_scoreNo}_data`], _dosObj.word_data);
@@ -6364,13 +6376,15 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 		let tmpArrayData = _data.split(`\r`).join(`\n`);
 		tmpArrayData = tmpArrayData.split(`\n`);
 
-		tmpArrayData.forEach(tmpData => {
-			if (tmpData !== undefined && tmpData !== ``) {
-				if (tmpData.indexOf(`<br>`) !== -1) {
-					wordReverseFlg = false;
+		if (g_headerObj.wordAutoReverse === `auto`) {
+			tmpArrayData.forEach(tmpData => {
+				if (tmpData !== undefined && tmpData !== ``) {
+					if (tmpData.indexOf(`<br>`) !== -1) {
+						wordReverseFlg = false;
+					}
 				}
-			}
-		});
+			});
+		}
 
 		tmpArrayData.forEach(tmpData => {
 			if (tmpData !== undefined && tmpData !== ``) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3202,7 +3202,7 @@ function headerConvert(_dosObj) {
 
 	// Reverse時の歌詞の自動反転制御
 	obj.wordAutoReverse = setVal(_dosObj.wordAutoReverse,
-		(typeof g_presetWordAutoReverse === C_TYP_STRING ? setVal(g_presetWordAutoReverse, `auto`, C_TYP_SWITCH) : false), C_TYP_SWITCH);
+		(typeof g_presetWordAutoReverse === C_TYP_STRING ? setVal(g_presetWordAutoReverse, `auto`, C_TYP_STRING) : `auto`), C_TYP_STRING);
 
 	// ジャストフレームの設定 (ローカル: 0フレーム, リモートサーバ上: 1フレーム以内)
 	obj.justFrames = (location.href.match(`^file`) || location.href.indexOf(`localhost`) !== -1) ? 0 : 1;

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -104,3 +104,18 @@ const g_presetFrzStartjdgUse = `false`;
 // `svg`: デフォルト(svg形式)、`png`: 従来画像(png形式)
 
 // const g_presetOverrideExtension = `svg`;
+
+
+// Reverse時の歌詞の自動反転制御設定
+// 
+// 通常は以下の条件でReverseが指定された場合、歌詞表示を反転します。
+// この設定をどのように制御するか設定します。
+// ・上下スクロールを挟まないキーに限定（5key, 7key, 7ikey, 9A/9Bkeyなど）
+// ・リバース・スクロール拡張用の歌詞表示（wordRev_data / wordAlt_data）が設定されていない作品
+// ・SETTINGS 画面で Reverse：ON、Scroll：--- (指定なし) を指定してプレイ開始した場合
+// ・歌詞表示がすべて1段表示の場合
+//
+// ＜設定可能の値＞
+// `auto`(既定)：上記ルールに従い設定 / `OFF`: 上記ルールに関わらず反転しない / `ON`: 上記ルールに関わらず反転する
+
+// const g_presetWordAutoReverse = `auto`;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- Issue #747 にて、Reverse時に歌詞表示を条件付きで反転する機能を実装しましたが（ver15.3.0）、
back/mask_dataとの兼ね合いや、word_dataの歌詞以外の使われ方により
意図せず反転されてしまうケースがあるため、個別/全体にこの自動制御ができるようにします。

### 設定仕様
- 譜面ヘッダー仕様（作品個別用）：wordAutoReverse
- danoni_setting.js（作品全体）：g_presetWordAutoReverse

|値|既定|内容|
|----|----|----|
|auto|*|Reverse時に歌詞表示を条件付きで反転する|
|OFF||Reverse時に歌詞表示を反転しない|
|ON||Reverse時に条件を満たさなくても歌詞を反転する　※|

※スクロール拡張（Cross, Splitなど）を設定している場合や、
　wordRev_dataが含まれている場合は反転しません。
　11keyなど本来適用しないキーや、歌詞が2段になっているケースが反転可能です。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- Resolves #754 

## :pencil: その他コメント / Other Comments
- 特にありません。
