### PR TITLE
word_data でフォントサイズの変更を可能にする

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8696,6 +8696,12 @@ function MainInit() {
 					// 歌詞位置変更
 					g_wordSprite.style.textAlign = g_wordObj.wordDat.slice(1, -1);
 
+				} else if (/\[fontSize=\d+\]/.test(g_wordObj.wordDat)) {
+
+					// フォントサイズ変更
+					const fontSize = setVal(g_wordObj.wordDat.match(/\d+/)[0], 14, C_TYP_NUMBER);
+					g_wordSprite.style.fontSize = `${fontSize}px`;
+
 				} else {
 
 					// フェードイン・アウト処理後、表示する歌詞を表示


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- word_data で使用するフォントのサイズを変更できる設定を追加しました
- `[fadein]`や`[center]`等と同様に`[fontSize=XX]`として指定します

例
```
400,0,[fontSize=20]
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
歌詞表示全体をデフォルトサイズ(14px)以外で統一したい場合、
全ての歌詞に対してHTMLタグの付与が必要であることから記述簡略化のため

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 理論的には`[fontSize=XX]`という歌詞を持つ作品が存在すれば影響を与えますが、考慮しなくていいでしょう
