### PR TITLE
[0240/security-link] SecurityPolicyへのリンクを追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2308,10 +2308,10 @@ function titleInit() {
 	}, _ => window.open(`https://github.com/cwtickle/danoniplus`, `_blank`));
 	divRoot.appendChild(lnkVersion);
 
-	// バージョン比較用リンク
-	const lnkComparison = createCssButton({
-		id: `lnkComparison`,
-		name: `&#x2194;`,
+	// セキュリティリンク
+	const lnkSecurity = createCssButton({
+		id: `lnkSecurity`,
+		name: `&#x1f6e1;`,
 		x: g_sWidth - 30,
 		y: g_sHeight - 20,
 		width: 20,
@@ -2319,8 +2319,8 @@ function titleInit() {
 		fontsize: 12,
 		align: C_ALIGN_CENTER,
 		class: g_cssObj.button_Tweet,
-	}, _ => window.open(`https://github.com/cwtickle/danoniplus/compare/v${g_version.slice(4)}...master`, `_blank`));
-	divRoot.appendChild(lnkComparison);
+	}, _ => window.open(`https://github.com/cwtickle/danoniplus/security/policy`, `_blank`));
+	divRoot.appendChild(lnkSecurity);
 
 	// コメントエリア作成
 	if (g_headerObj.commentVal !== ``) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2309,8 +2309,8 @@ function titleInit() {
 	divRoot.appendChild(lnkVersion);
 
 	// セキュリティリンク
-	const lnkSecurity = createCssButton({
-		id: `lnkSecurity`,
+	const lnkComparison = createCssButton({
+		id: `lnkComparison`,
 		name: `&#x1f6e1;`,
 		x: g_sWidth - 30,
 		y: g_sHeight - 20,
@@ -2320,7 +2320,7 @@ function titleInit() {
 		align: C_ALIGN_CENTER,
 		class: g_cssObj.button_Tweet,
 	}, _ => window.open(`https://github.com/cwtickle/danoniplus/security/policy`, `_blank`));
-	divRoot.appendChild(lnkSecurity);
+	divRoot.appendChild(lnkComparison);
 
 	// コメントエリア作成
 	if (g_headerObj.commentVal !== ``) {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- バージョン比較リンクの代わりに、Security Policyへリンクするよう変更しました。
- アイコンについても、&#x2194;`&#x2194;`から&#x1f6e1;`&#x1f6e1;`へ変更しています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- Resolves #759 

## :camera: スクリーンショット / Screenshot
<img src="https://user-images.githubusercontent.com/44026291/86017607-301ba900-ba5f-11ea-8e45-c2a9e5cd27a4.png" width="70%">

## :pencil: その他コメント / Other Comments
- 過去バージョンへも反映が必要です。
