### PR TITLE
矢印色の明暗設定の実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5324,7 +5324,58 @@ function keyConfigInit() {
 	}
 	posj = g_keyObj[`pos${keyCtrlPtn}`][0];
 
-	// カーソルの作成
+	// TODO arrowBrightness slider implementation
+	// ! these are almost copied from SETTINGS window "Fadein slider".
+	// 矢印の明るさ ( arrowBrightness )
+	//arrowBrightnessSprite.appendChild(createLblSetting(`Fadein`));
+
+	//位置指定は11Lkey設定画面の上下キーの間にしてみた
+	//const arrowBrightnessSprite = createSprite(`divRoot`, `arrowBrightnessSprite`, 0, 100 + (g_sHeight - 500) / 2, g_sWidth, 50);
+	const arrowBrightnessSprite = createSprite(`divRoot`, `arrowBrightnessSprite`, 0, 200, g_sWidth, 50);
+
+	const lnkArrowBrightness = createDivCssLabel(`lnkArrowBrightness`, C_LEN_SETLBL_LEFT, 0,
+		C_LEN_SETLBL_WIDTH, C_LEN_SETLBL_HEIGHT, C_SIZ_SETLBL, `${g_stateObj.fadein}%`, g_cssObj.settings_FadeinBar); // TODO fix arguments
+	arrowBrightnessSprite.appendChild(lnkArrowBrightness);
+
+	// 右回し・左回しボタン
+	arrowBrightnessSprite.appendChild(makeMiniCssButton(`lnkArrowBrightness`, `R`, 0, _ => {
+	/* //TODO fix
+		g_stateObj.fadein = (g_stateObj.fadein === 99 ? 0 : g_stateObj.fadein + 1);
+		fadeinSlider.value = g_stateObj.fadein;
+		lnkFadein.innerHTML = `${g_stateObj.fadein}%`; */
+	}));
+	arrowBrightnessSprite.appendChild(makeMiniCssButton(`lnkArrowBrightness`, `L`, 0, _ => {
+	/* //TODO fix
+		g_stateObj.fadein = (g_stateObj.fadein === 0 ? 99 : g_stateObj.fadein - 1);
+		fadeinSlider.value = g_stateObj.fadein;
+		lnkFadein.innerHTML = `${g_stateObj.fadein}%`; */
+	}));
+
+	// フェードインのスライダー処理
+	let addXPos = 0;
+	let addYPos = 0;
+	if (g_userAgent.indexOf(`firefox`) !== -1) {
+		addXPos = -8;
+		addYPos = 1;
+	}
+	const lblArrowBrightnessSlider = createDivCssLabel(`lblArrowBrightnessBar`, 160 + addXPos, addYPos, ``, ``, ``,
+		`<input id=arrowBrightnessSlider type=range value=0 min=0 max=99 step=1>`);
+	arrowBrightnessSprite.appendChild(lblArrowBrightnessSlider);
+
+	const arrowBrightnessSlider = document.querySelector(`#arrowBrightnessSlider`);
+	arrowBrightnessSlider.value = 0;//g_stateObj.fadein; //TODO not to use g_ consts.
+
+	arrowBrightnessSlider.addEventListener(`input`, _ => {
+		/* g_stateObj.fadein = parseInt(arrowBrightnessSlider.value);
+		lnkArrowBrightness.innerHTML = `${g_stateObj.fadein}%`; */
+	}, false);
+
+	arrowBrightnessSlider.addEventListener(`change`, _ => {
+		/* g_stateObj.fadein = parseInt(arrowBrightnessSlider.value);
+		lnkArrowBrightness.innerHTML = `${g_stateObj.fadein}%`; */
+	}, false);
+
+// カーソルの作成
 	const cursor = keyconSprite.appendChild(createImg(`cursor`, g_imgObj.cursor,
 		(kWidth - C_ARW_WIDTH) / 2 + g_keyObj.blank * (posj - divideCnt / 2) - 10, 45, 15, 30));
 	cursor.style.transitionDuration = `0.125s`;
@@ -5727,6 +5778,16 @@ function removeClassList(_j, _k) {
 	if (obj.classList.contains(g_cssObj.title_base)) {
 		obj.classList.remove(g_cssObj.title_base);
 	}
+}
+
+/**
+ * 矢印色の明暗の変更
+ * 
+ */
+function changeArrowBrightness() {
+	// TODO implementation with window.getComputedStyle().getPropertyValue()
+	const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
+
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- Scene : KEYCONFIG に明暗設定の実装の大枠(見た目の部品だけ)を入れてみました。ほとんど、フェードインの部品をコピーして名前をarrowBrightnessに変えたものです。
- 明暗設定の関数changeArrowBrightnessを形だけ入れてみました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- ticket #745 に関連してdraft PRを出します。
- グローバル定数や矢印への参照方法に難しさを感じたため、早速相談することにしました。
- スライダーを動かすのに対応して明暗が変わるといいと思い、KEYCONFIGに配置します。

## :camera: スクリーンショット / Screenshot
![見た目部品を設置した画像](https://user-images.githubusercontent.com/41767316/86528464-f6292780-bee2-11ea-95b0-a010a306d64d.png)

## :pencil: その他コメント / Other Comments
- 見た目部品の位置に関しては、keyPatternの直上にスライダーを置いた方がいいかとも思っています。

## draft TODOs
以下、主にコードを見ていても分からなかった点と今後の予定です。相談しつつ着実に実装していきたいです。
- 明暗設定用の定数の実装(globalかどうかも含め)
- 定数の実装後、スライダーとの対応を実装
- すべての矢印を参照するための配列、もしくはテンプレートリテラルによる参照の方法を実装し、実際に明暗を変える
- 明暗が変わる&スライダー対応実装後、それらの対応の実装
- スライダーの機能の微調整(どのような計算式で色とスライダーを関連付けるか)
- 見た目部品の位置の調整