### PR TITLE
リトライ時に稀に早回しになる不具合の修正 +α

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1,4 +1,4 @@
-﻿`use strict`;
+`use strict`;
 /**
  * Dancing☆Onigiri (CW Edition)
  * 
@@ -725,6 +725,8 @@ function getTitleDivLabel(_id, _titlename, _x, _y) {
  * - 再描画時に共通で表示する箇所はここで指定している。
  */
 function clearWindow() {
+	document.onkeyup = _ => {};
+	document.onkeydown = evt => blockCode(transCode(evt.code));
 
 	if (document.querySelector(`#layer0`) !== null) {
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1,4 +1,4 @@
-`use strict`;
+﻿`use strict`;
 /**
  * Dancing☆Onigiri (CW Edition)
  * 
@@ -1659,7 +1659,7 @@ function loadSettingJs() {
 }
 
 function loadMusic() {
-	document.onkeydown = evt => blockCode(evt.code);
+	document.onkeydown = evt => blockCode(transCode(evt.code));
 
 	const musicUrl = g_headerObj.musicUrls[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.musicUrls[0];
 	let url;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1,4 +1,4 @@
-﻿`use strict`;
+`use strict`;
 /**
  * Dancing☆Onigiri (CW Edition)
  * 
@@ -2420,6 +2420,11 @@ function titleInit() {
 	// キー操作イベント（デフォルト）
 	document.onkeydown = evt => {
 		const setCode = transCode(evt.code);
+		
+		if (evt.repeat) {
+			return blockCode(setCode);
+		}
+
 		if (setCode === `Enter`) {
 			clearTimeout(g_timeoutEvtTitleId);
 			clearWindow();
@@ -3629,6 +3634,11 @@ function optionInit() {
 	// キー操作イベント（デフォルト）
 	document.onkeydown = evt => {
 		const setCode = transCode(evt.code);
+
+		if (evt.repeat) {
+			return blockCode(setCode);
+		}
+
 		if (setCode === `Enter`) {
 			clearWindow();
 			loadMusic();
@@ -5078,6 +5088,11 @@ function settingsDisplayInit() {
 	// キー操作イベント（デフォルト）
 	document.onkeydown = evt => {
 		const setCode = transCode(evt.code);
+
+		if (evt.repeat) {
+			return blockCode(setCode);
+		}
+
 		if (setCode === `Enter`) {
 			clearWindow();
 			loadMusic();
@@ -5581,10 +5596,15 @@ function keyConfigInit() {
 
 	// キーボード押下時処理
 	document.onkeydown = evt => {
+		const setCode = transCode(evt.code);
+
+		if (evt.repeat) {
+			return blockCode(setCode);
+		}
+
 		const keyCdObj = document.querySelector(`#keycon${g_currentj}_${g_currentk}`);
 		const cursor = document.querySelector(`#cursor`);
 		const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
-		let setCode = transCode(evt.code);
 		let setKey = g_kCdN.findIndex(kCd => kCd === setCode);
 		g_inputKeyBuffer[setCode] = true;
 
@@ -7986,6 +8006,11 @@ function MainInit() {
 	document.onkeydown = evt => {
 		evt.preventDefault();
 		const setCode = transCode(evt.code);
+
+		if (evt.repeat) {
+			return blockCode(setCode);
+		}
+
 		g_inputKeyBuffer[setCode] = true;
 		mainKeyDownActFunc[g_stateObj.autoAll](setCode);
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. リトライ時に稀に早回しになる不具合を修正しました
2. キーリピートを無効化しました
3. 軽微な不具合を修正しました

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
### 1. リトライ時に稀にゲームが早回し状態になる不具合

原因として、リトライで`musicAfterLoaded`が呼び出されるときプレイ中の`keydown`イベントハンドラが残っており、
条件不明ですがここで`readyState === 4`になっていないと`canplaythrough`待ちが発生します。
そのときbackspaceキーによる`keydown`が発火すると`musicAfterLoaded`が複数呼び出され、
結果としてメインループが多重に走ってしまうようです。

以下のように意図的に遅延させると疑似的に再現できます。
```
function musicAfterLoaded() {
	g_audio.load();
	setTimeout(function () {
		if (g_audio.readyState === 4) {
			// (省略)
		}
	}, 1000);
}
```

上記問題を解決するため、`clearWindow`内で`keydown`イベントを初期化するように変更しました。
通常、画面遷移時はキーイベントを新しく設定すると思われるため、同様の不具合を防ぐ意味でここにしています。

### 2. キーリピート無効化

上記問題の直接の原因ではありませんが、意図しない動作を起こしやすいため無効にしました。

### 3. 軽微な不具合の修正

`loadMusic`内の`keydown`イベントで`transCode`が抜けていたのを修正しています。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
これは私が作ってしまったバグですかね……。
申し訳ないです。