### PR TITLE
[0260/color-upper20] 20個以上のキーに対する色変化対応（単発矢印・個別）

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7281,14 +7281,14 @@ function pushColors(_header, _frame, _val, _colorCd) {
 	const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
 	const colorCd = makeColorGradation(_colorCd);
 
-	if (_val < 30) {
+	if (_val < 30 || _val >= 1000) {
 		// 矢印の色変化
 		if (g_workObj[`mk${_header}Color`][_frame] === undefined) {
 			g_workObj[`mk${_header}Color`][_frame] = [];
 			g_workObj[`mk${_header}ColorCd`][_frame] = [];
 		}
-		if (_val < 20) {
-			const realVal = g_workObj.replaceNums[_val];
+		if (_val < 20 || _val >= 1000) {
+			const realVal = g_workObj.replaceNums[_val % 1000];
 			g_workObj[`mk${_header}Color`][_frame].push(realVal);
 			g_workObj[`mk${_header}ColorCd`][_frame].push(colorCd);
 		} else if (_val >= 20) {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- 20個以上のキーに対して、単発矢印・個別の色変化ができない問題を解消しました。
矢印番号に1000を足します。
グループ指定についてはこれまで通りです。

```
|color_data=200,2,#ff9966| <- 単発矢印の3番目の要素の色を変更します。
|color_data=200,1002,#ff9966| <- 単発矢印の3番目の要素の色を変更します。

|color_data=200,22,#ff9966| <- 矢印グループ2（斜め矢印すべて）の色を変更します。
|color_data=200,1022,#ff9966| <- 単発矢印の23番目の要素の色を変更します。
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- Resolves #807 

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- グループ指定については据え置き、そのままとします。
