### PR TITLE
[0261/result-format] リザルトデータ用フォーマットの実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3274,8 +3274,8 @@ function headerConvert(_dosObj) {
 
 	// リザルトデータのカスタマイズ
 	const resultFormatDefault = `【#danoni[hashTag]】[musicTitle]([keyLabel]) /[maker] /Rank:[rank]/Score:[score]/Playstyle:[playStyle]/[arrowJdg]/[frzJdg]/[maxCombo] [url]`;
-	obj.resultFormat = setVal(_dosObj.resultFormat, (typeof g_presetResultFormat === C_TYP_STRING ?
-		setVal(g_presetResultFormat, resultFormatDefault, C_TYP_STRING) : resultFormatDefault), C_TYP_STRING);
+	obj.resultFormat = escapeHtmlForEnabledTag(setVal(_dosObj.resultFormat, (typeof g_presetResultFormat === C_TYP_STRING ?
+		setVal(g_presetResultFormat, resultFormatDefault, C_TYP_STRING) : resultFormatDefault), C_TYP_STRING));
 
 	return obj;
 }

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3272,6 +3272,11 @@ function headerConvert(_dosObj) {
 	// ジャストフレームの設定 (ローカル: 0フレーム, リモートサーバ上: 1フレーム以内)
 	obj.justFrames = (location.href.match(`^file`) || location.href.indexOf(`localhost`) !== -1) ? 0 : 1;
 
+	// リザルトデータのカスタマイズ
+	const resultFormatDefault = `【#danoni[hashTag]】[musicTitle]([keyLabel]) /[maker] /Rank:[rank]/Score:[score]/Playstyle:[playStyle]/[arrowJdg]/[frzJdg]/[maxCombo] [url]`;
+	obj.resultFormat = setVal(_dosObj.resultFormat, (typeof g_presetResultFormat === C_TYP_STRING ?
+		setVal(g_presetResultFormat, resultFormatDefault, C_TYP_STRING) : resultFormatDefault), C_TYP_STRING);
+
 	return obj;
 }
 
@@ -9780,6 +9785,27 @@ function resultInit() {
 		lblAutoView.style.fontSize = `24px`;
 	}
 
+	// Twitter用リザルト
+	const hashTag = (g_headerObj.hashTag !== undefined ? ` ${g_headerObj.hashTag}` : ``);
+	let tweetDifData = `${g_headerObj.keyLabels[g_stateObj.scoreId]}${transKeyData}k-${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}`;
+	if (g_stateObj.shuffle !== `OFF`) {
+		tweetDifData += `:${g_stateObj.shuffle}`;
+	}
+	const twiturl = new URL(g_localStorageUrl);
+	twiturl.searchParams.append(`scoreId`, g_stateObj.scoreId);
+
+	let tweetResultTmp = g_headerObj.resultFormat.split(`[hashTag]`).join(`${hashTag}`)
+		.split(`[musicTitle]`).join(`${musicTitle}`)
+		.split(`[keyLabel]`).join(`${tweetDifData}`)
+		.split(`[maker]`).join(`${g_headerObj.tuning}`)
+		.split(`[rank]`).join(`${rankMark}`)
+		.split(`[score]`).join(`${g_resultObj.score}`)
+		.split(`[playStyle]`).join(`${playStyleData}`)
+		.split(`[arrowJdg]`).join(`${g_resultObj.ii}-${g_resultObj.shakin}-${g_resultObj.matari}-${g_resultObj.shobon}-${g_resultObj.uwan}`)
+		.split(`[frzJdg]`).join(`${g_resultObj.kita}-${g_resultObj.iknai}`)
+		.split(`[maxCombo]`).join(`${g_resultObj.maxCombo}-${g_resultObj.fmaxCombo}`)
+		.split(`[url]`).join(`${twiturl.toString()}`.replace(/[\t\n]/g, ``));
+
 	// ユーザカスタムイベント(初期)
 	if (typeof customResultInit === C_TYP_FUNCTION) {
 		customResultInit();
@@ -9830,23 +9856,11 @@ function resultInit() {
 
 	}
 
-	// Twitter用リザルト
-	const hashTag = (g_headerObj.hashTag !== undefined ? ` ${g_headerObj.hashTag}` : ``);
-	let tweetDifData = `${g_headerObj.keyLabels[g_stateObj.scoreId]}${transKeyData}k-${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}`;
-	if (g_stateObj.shuffle !== `OFF`) {
-		tweetDifData += `:${g_stateObj.shuffle}`;
+	if (typeof g_presetResultVals === C_TYP_OBJECT) {
+		Object.keys(g_presetResultVals).forEach(key => {
+			tweetResultTmp = tweetResultTmp.split(`[${key}]`).join(g_resultObj[g_presetResultVals[key]]);
+		});
 	}
-	const twiturl = new URL(g_localStorageUrl);
-	twiturl.searchParams.append(`scoreId`, g_stateObj.scoreId);
-	const tweetResultTmp = `【#danoni${hashTag}】${musicTitle}(${tweetDifData}) /
-		${g_headerObj.tuning} /
-		Rank:${rankMark}/
-		Score:${g_resultObj.score}/
-		Playstyle:${playStyleData}/
-		${g_resultObj.ii}-${g_resultObj.shakin}-${g_resultObj.matari}-${g_resultObj.shobon}-${g_resultObj.uwan}/
-		${g_resultObj.kita}-${g_resultObj.iknai}/
-		${g_resultObj.maxCombo}-${g_resultObj.fmaxCombo} 
-		${twiturl.toString()}`.replace(/[\t\n]/g, ``);
 	const resultText = `${unEscapeHtml(tweetResultTmp)}`;
 	const tweetResult = `https://twitter.com/intent/tweet?text=${encodeURIComponent(resultText)}`;
 

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -105,17 +105,48 @@ const g_presetFrzStartjdgUse = `false`;
 
 // const g_presetOverrideExtension = `svg`;
 
+/*
+	Reverse時の歌詞の自動反転制御設定
 
-// Reverse時の歌詞の自動反転制御設定
-// 
-// 通常は以下の条件でReverseが指定された場合、歌詞表示を反転します。
-// この設定をどのように制御するか設定します。
-// ・上下スクロールを挟まないキーに限定（5key, 7key, 7ikey, 9A/9Bkeyなど）
-// ・リバース・スクロール拡張用の歌詞表示（wordRev_data / wordAlt_data）が設定されていない作品
-// ・SETTINGS 画面で Reverse：ON、Scroll：--- (指定なし) を指定してプレイ開始した場合
-// ・歌詞表示がすべて1段表示の場合
-//
-// ＜設定可能の値＞
-// `auto`(既定)：上記ルールに従い設定 / `OFF`: 上記ルールに関わらず反転しない / `ON`: 上記ルールに関わらず反転する
+	通常は以下の条件でReverseが指定された場合、歌詞表示を反転します。
+	この設定をどのように制御するか設定します。
+	・上下スクロールを挟まないキーに限定（5key, 7key, 7ikey, 9A/9Bkeyなど）
+	・リバース・スクロール拡張用の歌詞表示（wordRev_data / wordAlt_data）が設定されていない作品
+	・SETTINGS 画面で Reverse：ON、Scroll：--- (指定なし) を指定してプレイ開始した場合
+	・歌詞表示がすべて1段表示の場合
 
+	＜設定可能の値＞
+	`auto`(既定)：上記ルールに従い設定 / `OFF`: 上記ルールに関わらず反転しない / `ON`: 上記ルールに関わらず反転する
+*/
 // const g_presetWordAutoReverse = `auto`;
+
+/*
+	リザルトデータのフォーマット設定
+	   以下のタグは下記で置き換えられます。
+	   [hashTag]   ハッシュタグ
+	   [rank]      ランク
+	   [score]     スコア
+	   [playStyle] オプション設定
+	   [arrowJdg]  矢印判定数
+	   [frzJdg]    フリーズアロー判定数
+	   [maxCombo]  マックスコンボ、フリーズコンボ
+	   [url]       scoreId付きURL
+*/
+// デフォルトフォーマット
+// const g_presetResultFormat = `【#danoni[hashTag]】[musicTitle]([keyLabel]) /[maker] /Rank:[rank]/Score:[score]/Playstyle:[playStyle]/[arrowJdg]/[frzJdg]/[maxCombo] [url]`;
+
+// MFV2さんフォーマット（オプション設定なし・参考）
+// const g_presetResultFormat = `【#danoni[hashTag]】[musicTitle]/[keyLabel] /[maker] /[rank]/[arrowJdg]/[frzJdg]/Mc[maxCombo]/Sco[score]-[exScore] [url]`;
+
+/*
+	リザルトデータ用のカスタム変数群
+
+	   プロパティを定義するとそれに応じた変数に置換されます。
+	   右側に定義する値は、g_resultObj配下に定義する必要があります。
+
+	   例) exScore: `exScores`,
+	       [exScore] -> g_resultObj.exScores
+ */
+const g_presetResultVals = {
+	// exScore: `exScore`,
+};


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- リザルトデータ用フォーマットを実装しました。

### 1. 譜面ヘッダー
```
|resultFormat=【#danoni[hashTag]】[musicTitle]([keyLabel]) /[maker] /Rank:[rank]/Score:[score]/Playstyle:[playStyle]/[arrowJdg]/[frzJdg]/[combo] [url]|
```

### 2. 共通設定 (danoni_setting.js)
```javascript
const g_presetResultFormat = `【#danoni[hashTag]】[musicTitle]([keyLabel]) /[maker] /Rank:[rank]/Score:[score]-[exScore]/Playstyle:[playStyle]/[arrowJdg]/[frzJdg]/[maxCombo] [url]`;
```

- カスタム変数もリザルトデータに追加することができます。
共通設定 (danoni_setting.js)の`g_presetResultVals`のプロパティに追加します。
追加したプロパティは、`g_resultObj`配下に定義する必要があります。
（下記の場合、[exScore] とフォーマットに入れた場合、`g_resultObj.exScores`に置き換えられます。）
```javascript
const g_presetResultVals = {
	exScore: `exScores`,
};
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- Resolves #809 

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- リザルトデータ用フォーマットでパイプなど特殊文字を使用する際は、
下記ページのルールに従います。
https://github.com/cwtickle/danoniplus/wiki/SpecialCharacters
