### PR TITLE
[0263/abbreviate-frz] リザルトデータでフリーズアローが無い時の表記を変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9845,6 +9845,13 @@ function resultInit() {
 	const twiturl = new URL(g_localStorageUrl);
 	twiturl.searchParams.append(`scoreId`, g_stateObj.scoreId);
 
+	let tweetMaxCombo = `${g_resultObj.maxCombo}`;
+	let tweetFrzJdg = ``;
+	if (g_allFrz > 0) {
+		tweetMaxCombo += `-${g_resultObj.fmaxCombo}`;
+		tweetFrzJdg = `${g_resultObj.kita}-${g_resultObj.iknai}`;
+	}
+
 	let tweetResultTmp = g_headerObj.resultFormat.split(`[hashTag]`).join(`${hashTag}`)
 		.split(`[musicTitle]`).join(`${musicTitle}`)
 		.split(`[keyLabel]`).join(`${tweetDifData}`)
@@ -9853,8 +9860,8 @@ function resultInit() {
 		.split(`[score]`).join(`${g_resultObj.score}`)
 		.split(`[playStyle]`).join(`${playStyleData}`)
 		.split(`[arrowJdg]`).join(`${g_resultObj.ii}-${g_resultObj.shakin}-${g_resultObj.matari}-${g_resultObj.shobon}-${g_resultObj.uwan}`)
-		.split(`[frzJdg]`).join(`${g_resultObj.kita}-${g_resultObj.iknai}`)
-		.split(`[maxCombo]`).join(`${g_resultObj.maxCombo}-${g_resultObj.fmaxCombo}`)
+		.split(`[frzJdg]`).join(tweetFrzJdg)
+		.split(`[maxCombo]`).join(tweetMaxCombo)
 		.split(`[url]`).join(`${twiturl.toString()}`.replace(/[\t\n]/g, ``));
 
 	if (typeof g_presetResultVals === C_TYP_OBJECT) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9845,11 +9845,11 @@ function resultInit() {
 	const twiturl = new URL(g_localStorageUrl);
 	twiturl.searchParams.append(`scoreId`, g_stateObj.scoreId);
 
-	let tweetMaxCombo = `${g_resultObj.maxCombo}`;
 	let tweetFrzJdg = ``;
+	let tweetMaxCombo = `${g_resultObj.maxCombo}`;
 	if (g_allFrz > 0) {
-		tweetMaxCombo += `-${g_resultObj.fmaxCombo}`;
 		tweetFrzJdg = `${g_resultObj.kita}-${g_resultObj.iknai}`;
+		tweetMaxCombo += `-${g_resultObj.fmaxCombo}`;
 	}
 
 	let tweetResultTmp = g_headerObj.resultFormat.split(`[hashTag]`).join(`${hashTag}`)


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- フリーズアローが無い場合、スコア貼り付け用の書式を一部省略するよう変更しました。
```
Before: .../350-30-7-2-9/0-0/140-0/...
After : .../350-30-7-2-9//140/...
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- Resolves #817 

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 結果画面本体に手を入れるかどうかは一旦保留します。
