### PR TITLE
[0264/ready-pos] Ready表示に関するカスタム設定実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8017,7 +8017,8 @@ function MainInit() {
 		lblReady.style.animationDuration = `${g_headerObj.readyAnimationFrame / g_fps}s`;
 		lblReady.style.animationName = g_headerObj.readyAnimationName;
 		let readyDelayFrame = 0;
-		if (g_headerObj.readyDelayFrame > 0 && g_headerObj.readyDelayFrame + g_stateObj.adjustment > 0) {
+		if (g_stateObj.fadein === 0 && g_headerObj.readyDelayFrame > 0 &&
+			g_headerObj.readyDelayFrame + g_stateObj.adjustment > 0) {
 			readyDelayFrame = g_headerObj.readyDelayFrame + g_stateObj.adjustment;
 		}
 		lblReady.style.animationDelay = `${readyDelayFrame / g_fps}s`;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3131,6 +3131,9 @@ function headerConvert(_dosObj) {
 	// デフォルトReady表示のアニメーション名
 	obj.readyAnimationName = setVal(_dosObj.readyAnimationName, `leftToRightFade`, C_TYP_STRING);
 
+	// デフォルトReady表示の先頭文字色
+	obj.readyColor = setVal(_dosObj.readyColor, ``, C_TYP_STRING);
+
 	// デフォルト曲名表示のフォントサイズ
 	obj.titlesize = setVal(_dosObj.titlesize, ``, C_TYP_STRING);
 
@@ -8011,9 +8014,10 @@ function MainInit() {
 
 	// Ready?表示
 	if (!g_headerObj.customReadyUse) {
+		const readyColor = (g_headerObj.readyColor !== `` ? g_headerObj.readyColor : g_headerObj.setColorOrg[0]);
 		const lblReady = createDivCssLabel(`lblReady`, g_headerObj.playingX + g_headerObj.playingWidth / 2 - 100,
 			(g_sHeight + g_posObj.stepYR) / 2 - 75, 200, 50, 40,
-			`<span style='color:` + g_headerObj.setColorOrg[0] + `;font-size:60px;'>R</span>EADY<span style='font-size:50px;'>?</span>`);
+			`<span style='color:${readyColor};font-size:60px;'>R</span>EADY<span style='font-size:50px;'>?</span>`);
 		lblReady.style.animationDuration = `${g_headerObj.readyAnimationFrame / g_fps}s`;
 		lblReady.style.animationName = g_headerObj.readyAnimationName;
 		let readyDelayFrame = 0;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8003,15 +8003,6 @@ function MainInit() {
 		document.querySelector(`#lblframe`).style.display = C_DIS_NONE;
 	}
 
-	// ユーザカスタムイベント(初期)
-	if (typeof customMainInit === C_TYP_FUNCTION) {
-		g_scoreObj.baseFrame = g_scoreObj.frameNum - g_stateObj.realAdjustment;
-		customMainInit();
-		if (typeof customMainInit2 === C_TYP_FUNCTION) {
-			customMainInit2();
-		}
-	}
-
 	// Ready?表示
 	if (!g_headerObj.customReadyUse) {
 		const lblReady = createDivCssLabel(`lblReady`, g_headerObj.playingX + g_headerObj.playingWidth / 2 - 100,
@@ -8026,6 +8017,15 @@ function MainInit() {
 		lblReady.style.animationDelay = `${readyDelayFrame / g_fps}s`;
 		lblReady.style.opacity = 0;
 		divRoot.appendChild(lblReady);
+	}
+
+	// ユーザカスタムイベント(初期)
+	if (typeof customMainInit === C_TYP_FUNCTION) {
+		g_scoreObj.baseFrame = g_scoreObj.frameNum - g_stateObj.realAdjustment;
+		customMainInit();
+		if (typeof customMainInit2 === C_TYP_FUNCTION) {
+			customMainInit2();
+		}
 	}
 
 	/**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3125,6 +3125,12 @@ function headerConvert(_dosObj) {
 	// デフォルトReady表示の遅延時間設定
 	obj.readyDelayFrame = setVal(_dosObj.readyDelayFrame, 0, C_TYP_NUMBER);
 
+	// デフォルトReady表示のアニメーション時間設定
+	obj.readyAnimationFrame = setVal(_dosObj.readyAnimationFrame, 150, C_TYP_NUMBER);
+
+	// デフォルトReady表示のアニメーション名
+	obj.readyAnimationName = setVal(_dosObj.readyAnimationName, `leftToRightFade`, C_TYP_STRING);
+
 	// デフォルト曲名表示のフォントサイズ
 	obj.titlesize = setVal(_dosObj.titlesize, ``, C_TYP_STRING);
 
@@ -8008,8 +8014,8 @@ function MainInit() {
 		const lblReady = createDivCssLabel(`lblReady`, g_headerObj.playingX + g_headerObj.playingWidth / 2 - 100,
 			(g_sHeight + g_posObj.stepYR) / 2 - 75, 200, 50, 40,
 			`<span style='color:` + g_headerObj.setColorOrg[0] + `;font-size:60px;'>R</span>EADY<span style='font-size:50px;'>?</span>`);
-		lblReady.style.animationDuration = `2.5s`;
-		lblReady.style.animationName = `leftToRightFade`;
+		lblReady.style.animationDuration = `${g_headerObj.readyAnimationFrame / g_fps}s`;
+		lblReady.style.animationName = g_headerObj.readyAnimationName;
 		let readyDelayFrame = 0;
 		if (g_headerObj.readyDelayFrame > 0 && g_headerObj.readyDelayFrame + g_stateObj.adjustment > 0) {
 			readyDelayFrame = g_headerObj.readyDelayFrame + g_stateObj.adjustment;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. Ready表示をカスタムjsの前に配置しました。
2. Ready表示に関するアニメーション設定を実装しました。（譜面ヘッダー）
3. フェードイン有効時はreadyDelayFrameを無効にする設定を追加しました。

|譜面ヘッダー名|用途|
|----|----|
|readyAnimationFrame|Readyをアニメーションするフレーム数（既定：150フレーム）|
|readyAnimationName|Readyのアニメーション名（既定：leftToRightFade）|
|readyColor|Readyの先頭色（既定：1番目の矢印色）|

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1, 2. Ready設定を見直したい場合に見直す手段が無いため。
3. Resolves #819 

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 余力があれば、Readyの表示時間をヘッダーで変更できるようにします。⇒対応しました。
