### PR TITLE
[0266/reload] location.reloadの引数をカット

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2237,7 +2237,7 @@ function titleInit() {
 				highscores: {},
 			};
 			localStorage.setItem(g_localStorageUrl, JSON.stringify(g_localStorage));
-			location.reload(true);
+			location.reload();
 		}
 	});
 	btnReset.title = g_msgObj.dataReset;
@@ -2254,7 +2254,7 @@ function titleInit() {
 		fontsize: 20,
 		align: C_ALIGN_CENTER,
 		class: g_cssObj.button_Start,
-	}, _ => location.reload(true));
+	}, _ => location.reload());
 	btnReload.title = g_msgObj.reload;
 	divRoot.appendChild(btnReload);
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- `location.reload`の引数をカットしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- `location.reload`の引数が現状のブラウザでは無効になっているため、外します。
- 現状、リロードボタン・ローカルデータ削除時に使用しています。

## :camera: スクリーンショット / Screenshot

## :pencil: その他コメント / Other Comments
- 特にありません。
