### PR TITLE
[0270/user-select] user-selectのwebkit-を戻し、khtml-を削除

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -461,9 +461,9 @@ function createDiv(_id, _x, _y, _width, _height) {
 	style.position = `absolute`;
 
 	style.userSelect = C_DIS_NONE;
+	style.webkitUserSelect = C_DIS_NONE;
 	style.msUserSelect = C_DIS_NONE;
 	style.mozUserSelect = C_DIS_NONE;
-	style.khtmlUserSelect = C_DIS_NONE;
 	style.webkitTouchCallout = C_DIS_NONE;
 
 	return div;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- CSSの`user-select`について、`webkit-`プレフィックスを戻し、
`khtml-`プレフィックスを削除しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- CSSの`user-select`はSafariでは`webkit-`プレフィックスが必要なため。
非推奨となっているが、互換として残すようにします。
一方、`khtml-`プレフィックスは「Can I Use」でも使っているところが無いため、削除します。
https://caniuse.com/?search=user-select

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 特になし
