### PR TITLE
[0275/button-expansion] ボタン処理の割り込み制御の実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -782,6 +782,36 @@ function createCss2Button(_id, _text, _func, { x = 0, y = g_sHeight - 100, w = g
 }
 
 /**
+ * オブジェクトのスタイル一括変更
+ * @param {string} _id 
+ * @param {object} _obj (x, y, w, h, siz, align, title, ...rest) 
+ */
+function changeStyle(_id, { x, y, w, h, siz, align, title, ...rest } = {}) {
+	const div = document.querySelector(`#${_id}`);
+	const style = div.style;
+
+	const obj = {
+		left: x,
+		top: y,
+		width: w,
+		height: h,
+		fontSize: siz,
+	};
+	Object.keys(obj).forEach((property) => {
+		if (setVal(obj[property], ``, C_TYP_FLOAT !== ``)) {
+			style[property] = `${obj[property]}px`;
+		}
+	})
+	if (align !== undefined) {
+		style.textAlign = `${align}`;
+	}
+	if (title !== undefined) {
+		div.title = title;
+	}
+	Object.keys(rest).forEach(property => style[property] = rest[property]);
+}
+
+/**
  * ラベル文字作成（レイヤー直書き。htmlタグは使用できない）
  * @param {string} _ctx ラベルを作成する場所のコンテキスト名
  * @param {string} _text 表示するテキスト

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -100,6 +100,8 @@ const g_userAgent = window.navigator.userAgent.toLowerCase(); // msie, edge, chr
 let g_rootObj = {};
 let g_headerObj = {};
 let g_scoreObj = {};
+let g_btnAddFunc = {};
+let g_btnDeleteFlg = {};
 
 const g_detailObj = {
 	arrowCnt: [],
@@ -764,7 +766,14 @@ function createCss2Button(_id, _text, _func, { x = 0, y = g_sHeight - 100, w = g
 	Object.keys(rest).forEach(property => style[property] = rest[property]);
 
 	// ボタンを押したときの動作
-	const lsnrkey = g_handler.addListener(div, `click`, _ => _func());
+	const lsnrkey = g_handler.addListener(div, `click`, _ => {
+		if (!setVal(g_btnDeleteFlg[_id], false, C_TYP_BOOLEAN)) {
+			_func();
+		}
+		if (typeof g_btnAddFunc[_id] === C_TYP_FUNCTION) {
+			g_btnAddFunc[_id]();
+		}
+	});
 
 	// イベントリスナー用のキーをセット
 	div.setAttribute(`lsnrkey`, lsnrkey);
@@ -1911,6 +1920,9 @@ function setAudio(_url) {
  * @param {string} _key メイン画面かどうか。Main:メイン画面、(空白):それ以外
  */
 function drawDefaultBackImage(_key) {
+
+	g_btnAddFunc = {};
+	g_btnDeleteFlg = {};
 
 	// レイヤー情報取得
 	if (document.querySelector(`#layer0`) !== null) {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 既存のボタンの処理に対して追加カスタム処理を挿入できる機能を実装しました。
customjsのそれぞれの画面別関数にて設定します。
```javascript
function customTitleInit() {
    g_btnDeleteFlg.btnStart = true;  // g_btnDeleteFlg.(ボタンID) = true でボタンIDが行っている処理をやめる
    g_btnAddFunc.btnStart = _ => {
        commentInit(); // g_btnAddFunc.(ボタンID) に関数を定義することでその処理を後から挿入
    };
}
```

2. ボタン及びラベルのスタイル一括変更関数を実装しました。
ボタンやラベルのIDを指定し、それに対して一括でスタイルを指定します。
中括弧部分の仕様は`createCss2Button`や`createDivCss2Label`の`_obj`と同じにしています。
なお、こちらは変更する前提のため初期値はありません。変更があった箇所のみ変更します。
```javascript
changeStyle(`btnSave`, {x: 20, y: 30, w:170, h:45, siz:14, align:C_ALIGN_RIGHT`});
```
参考：
https://github.com/cwtickle/danoniplus/wiki/fnc-c0002-createDivCss2Label

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. ボタン処理に対する割込み制御できる本来の方法が無かったため。
2. ボタンやラベルのスタイル変更をまとめて管理できるようにするため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- ボタン処理を上書き（`g_btnDeleteFlg`を有効）にする場合、本来の処理が無くなるため
その代替処理はcustomjs側で制御する必要があります。
