### PR TITLE
[0286/reset-border] カスタムゲージで一部未指定がある場合にボーダー値が反映されない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1,4 +1,4 @@
-'use strict';
+﻿'use strict';
 /**
  * Dancing☆Onigiri (CW Edition)
  * 
@@ -4394,7 +4394,9 @@ function createOptionWindow(_sprite) {
 		// 譜面ヘッダー：gaugeXXX で設定した値がここで適用される
 		if (g_gaugeOptionObj[`gauge${g_stateObj.gauge}s`] !== undefined) {
 			const tmpGaugeObj = g_gaugeOptionObj[`gauge${g_stateObj.gauge}s`];
-			changeLifeMode(tmpGaugeObj);
+			if (setVal(tmpGaugeObj.lifeBorders[tmpScoreId], ``, C_TYP_STRING) !== ``) {
+				changeLifeMode(tmpGaugeObj);
+			}
 			setLifeCategory(tmpGaugeObj);
 		}
 	}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- カスタムゲージで一部未指定がある場合にボーダー値が反映されない問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- gaugeXXXでボーダー値が未指定の譜面があった場合、ボーダーが0%になっていました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- ver17.3.0のみに影響します。
