### PR TITLE
[0287/copy-time] ツール値出力時、時間表示がおかしくなることがある問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6519,7 +6519,7 @@ function getFirstArrowFrame(_dataObj, _keyCtrlPtn = `${g_keyObj.currentKey}_${g_
 			}
 		});
 	}
-	return tmpFirstNum;
+	return (tmpFirstNum === Infinity ? 0 : tmpFirstNum);
 }
 
 /**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- ツール値出力時、時間表示がおかしくなることがある問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- 最初の矢印を取得する処理で、初期値にInfinityが入っているため
データが無い場合に、時間表示を再計算する際にInfinityが入ってしまっていました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 過去バージョンも修正が必要です。（ver12以降）
