### PR TITLE
[0292/reverse-stepshadow] 矢印塗りつぶし有、ステップゾーンをOFFにした場合の表示問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7309,6 +7309,7 @@ function MainInit() {
 	const dummyFrzCnts = [];
 	let speedCnts = 0;
 	let boostCnts = 0;
+	const stepZoneHideFlg = g_stateObj.d_stepzone === C_FLG_OFF || g_stateObj.scroll === `Flat`;
 
 	for (let j = 0; j < keyNum; j++) {
 
@@ -7329,7 +7330,7 @@ function MainInit() {
 			stepRoot.appendChild(
 				createColorObject2(`stepShadow${j}`, {
 					rotate: g_workObj.stepRtn[j], styleName: `ShadowStep`,
-					opacity: 0.7,
+					opacity: 0.7, display: stepZoneHideFlg ? C_DIS_NONE : C_DIS_INHERIT,
 				}, g_cssObj.main_objStepShadow)
 			);
 		}
@@ -7337,6 +7338,7 @@ function MainInit() {
 		// ステップゾーン本体
 		const step = createColorObject2(`step${j}`, {
 			rotate: g_workObj.stepRtn[j], styleName: `Step`,
+			display: stepZoneHideFlg ? C_DIS_NONE : C_DIS_INHERIT,
 		}, g_cssObj.main_stepDefault);
 		stepRoot.appendChild(step);
 
@@ -7356,27 +7358,18 @@ function MainInit() {
 		stepHit.setAttribute(`cnt`, 0);
 		stepRoot.appendChild(stepHit);
 
-		// ステップゾーンOFF設定
-		if (g_stateObj.d_stepzone === C_FLG_OFF || g_stateObj.scroll === `Flat`) {
-			step.style.display = C_DIS_NONE;
-		}
 	}
 	if (g_stateObj.scroll === `Flat` && g_stateObj.d_stepzone === C_FLG_ON) {
 
 		// ステップゾーンの代わり
-		mainSprite.appendChild(
-			createColorObject2(`stepBar0`, {
-				x: 0, y: C_STEP_Y + g_posObj.reverseStepY * (g_stateObj.reverse === C_FLG_OFF ? 0 : 1),
-				w: g_headerObj.playingWidth - 50, h: 1, styleName: `lifeBar`,
-			}, g_cssObj.life_Failed)
-		);
-
-		mainSprite.appendChild(
-			createColorObject2(`stepBar1`, {
-				x: 0, y: C_STEP_Y + g_posObj.reverseStepY * (g_stateObj.reverse === C_FLG_OFF ? 0 : 1) + C_ARW_WIDTH,
-				w: g_headerObj.playingWidth - 50, h: 1, styleName: `lifeBar`,
-			}, g_cssObj.life_Failed)
-		);
+		[0, C_ARW_WIDTH].forEach((y, j) => {
+			mainSprite.appendChild(
+				createColorObject2(`stepBar${j}`, {
+					x: 0, y: C_STEP_Y + g_posObj.reverseStepY * (g_stateObj.reverse === C_FLG_OFF ? 0 : 1) + y,
+					w: g_headerObj.playingWidth - 50, h: 1, styleName: `lifeBar`,
+				}, g_cssObj.life_Failed)
+			);
+		});
 
 	}
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- 矢印の塗りつぶしをしており、Display設定のStepZoneをOFFにしたとき
下段のステップゾーンが見える問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- 背景グラデーションにより、背景が黒で無い場合やスキンのケースに
ステップゾーンの塗りつぶし部分が対応できていませんでした。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 過去バージョンも修正が必要かもしれません。
