### PR TITLE
[0301/2nd-title-undefined] 複数曲搭載時に2段目がundefinedになる問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2547,9 +2547,8 @@ function getMusicNameSimple(_musicName) {
  * @param {string} _musicName 
  */
 function getMusicNameMultiLine(_musicName) {
-	let tmpName = _musicName.split(`<nbr>`).join(`<br>`);
-	tmpName = tmpName.split(`<dbr>`).join(`<br>`);
-	return tmpName.split(`<br>`);
+	const tmpName = _musicName.split(`<nbr>`).join(`<br>`).split(`<dbr>`).join(`<br>`).split(`<br>`);
+	return tmpName.length === 1 ? [tmpName[0], ``] : tmpName;
 }
 
 /**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- 複数曲搭載時、結果画面で2段目がundefinedになる問題を修正しました。
※元々2段目がある曲名の場合や、単一曲では発生しません。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- 上述の通り。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/97772885-65134600-1b8e-11eb-8bd0-eadd39cdd648.png" width="80%">

## :pencil: その他コメント / Other Comments
- v17でコード修正した影響のため、v17にも適用する必要があります。
