### PR TITLE
[0302/speed-blank] 速度データが空の場合、データがあると判断されてしまう問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5952,10 +5952,10 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 
 	// 速度変化データの分解 (2つで1セット)
 	let speedFooter = ``;
-	if (_dosObj[`speed${scoreIdHeader}_data`] !== undefined) {
+	if (hasVal(_dosObj[`speed${scoreIdHeader}_data`])) {
 		speedFooter = `_data`;
 	}
-	if (_dosObj[`speed${scoreIdHeader}_change`] !== undefined) {
+	if (hasVal(_dosObj[`speed${scoreIdHeader}_change`])) {
 		speedFooter = `_change`;
 	}
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- 速度データが空の場合、データがあると判断されてしまう問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- 下記の場合に`speed_change`が優先されていました。
`g_rootObj`はデータの置き換えではなく上書き（マージ）を行うため、
譜面番号固定時に下記の事象が発生する場合がありました。
```
|speed_data=200,0.5,3000,1|
|speed_change=|
```

## :camera: スクリーンショット / Screenshot

## :pencil: その他コメント / Other Comments
- 過去バージョンにも同様の記述があるため、見直しが必要です。
