### PR TITLE
[0303/storage-display] Display設定周りのローカルストレージ対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1310,6 +1310,11 @@ function loadLocalStorage() {
 			g_localStorage.volume = 100;
 		}
 
+		g_storeSettings.filter(tmpSetting => hasVal(g_localStorage[tmpSetting])).forEach(setting =>
+			g_stateObj[setting] = g_localStorage[setting]);
+		g_appearanceNum = roundZero(g_appearances.findIndex(setting => setting === g_stateObj.appearance));
+		g_opacityNum = roundZero(g_opacitys.findIndex(setting => setting === g_stateObj.opacity));
+
 		// ハイスコア取得準備
 		if (g_localStorage.highscores === undefined) {
 			g_localStorage.highscores = {};
@@ -3135,7 +3140,11 @@ function headerConvert(_dosObj) {
 		obj[`${option}Set`] = setVal(displayUse.length > 1 ? displayUse[1] :
 			(obj[`${option}Use`] ? C_FLG_ON : C_FLG_OFF), ``, C_TYP_SWITCH);
 
-		g_stateObj[`d_${option.toLowerCase()}`] = (obj[`${option}Set`] !== `` ? obj[`${option}Set`] : C_FLG_ON);
+		if (g_localStorage[`d_${option.toLowerCase()}`] !== undefined) {
+			g_stateObj[`d_${option.toLowerCase()}`] = g_localStorage[`d_${option.toLowerCase()}`];
+		} else {
+			g_stateObj[`d_${option.toLowerCase()}`] = (obj[`${option}Set`] !== `` ? obj[`${option}Set`] : C_FLG_ON);
+		}
 		obj[`${option}ChainOFF`] = (_dosObj[`${option}ChainOFF`] !== undefined ? _dosObj[`${option}ChainOFF`].split(`,`) : []);
 
 		// Displayのデフォルト設定で、双方向に設定されている場合は設定をブロック
@@ -7057,6 +7066,8 @@ function getArrowSettings() {
 		// ローカルストレージへAdjustment, Volumeを保存
 		g_localStorage.adjustment = g_stateObj.adjustment;
 		g_localStorage.volume = g_stateObj.volume;
+
+		g_storeSettings.forEach(setting => g_localStorage[setting] = g_stateObj[setting]);
 
 		// ローカルストレージ(キー別)へデータ保存　※特殊キーは除く
 		if (!g_stateObj.extraKeyFlg) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1310,6 +1310,7 @@ function loadLocalStorage() {
 			g_localStorage.volume = 100;
 		}
 
+		// Display関連の初期値設定
 		g_storeSettings.filter(tmpSetting => hasVal(g_localStorage[tmpSetting])).forEach(setting =>
 			g_stateObj[setting] = g_localStorage[setting]);
 		g_appearanceNum = roundZero(g_appearances.findIndex(setting => setting === g_stateObj.appearance));
@@ -7063,10 +7064,9 @@ function getArrowSettings() {
 
 	if (g_stateObj.dataSaveFlg && !hasVal(g_keyObj[`transKey${keyCtrlPtn}`])) {
 
-		// ローカルストレージへAdjustment, Volumeを保存
+		// ローカルストレージへAdjustment, Volume, Display関連設定を保存
 		g_localStorage.adjustment = g_stateObj.adjustment;
 		g_localStorage.volume = g_stateObj.volume;
-
 		g_storeSettings.forEach(setting => g_localStorage[setting] = g_stateObj[setting]);
 
 		// ローカルストレージ(キー別)へデータ保存　※特殊キーは除く

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4624,7 +4624,7 @@ function createGeneralSetting(_obj, _settingName, _options = {}) {
 	if (g_headerObj[`${_settingName}Use`] === undefined || g_headerObj[`${_settingName}Use`]) {
 
 		multiAppend(_obj,
-			makeSettingLblCssButton(`lnk${settingUpper}`, `${g_stateObj[_settingName]}${_unitName}`, 0,
+			makeSettingLblCssButton(`lnk${settingUpper}`, `${g_stateObj[_settingName]}${_unitName}${g_localStorage[_settingName] === g_stateObj[_settingName] ? ' *' : ''}`, 0,
 				_ => setSetting(1, _settingName, _unitName),
 				{ cxtFunc: _ => setSetting(-1, _settingName, _unitName) }),
 
@@ -4678,7 +4678,8 @@ function setSetting(_scrollNum, _settingName, _unitName = ``) {
 	}
 	g_stateObj[_settingName] = settingList[settingNum];
 	eval(`g_${_settingName}Num = settingNum`);
-	document.querySelector(`#lnk${toCapitalize(_settingName)}`).textContent = `${g_stateObj[_settingName]}${_unitName}`;
+	document.querySelector(`#lnk${toCapitalize(_settingName)}`).textContent =
+		`${g_stateObj[_settingName]}${_unitName}${g_localStorage[_settingName] === g_stateObj[_settingName] ? ' *' : ''}`;
 }
 
 /**

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -375,6 +375,9 @@ let g_scoreDetailNum = 0;
 let g_displays = [`stepZone`, `judgment`, `fastSlow`, `lifeGauge`, `score`, `musicInfo`, `filterLine`,
     `speed`, `color`, `lyrics`, `background`, `arrowEffect`, `special`];
 
+let g_storeSettings = [`appearance`, `opacity`, `d_stepzone`, `d_judgment`, `d_fastslow`, `d_lifegauge`,
+    `d_score`, `d_musicinfo`, `d_filterline`];
+
 // サイズ(後で指定)
 let g_sWidth;
 let g_sHeight;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. Display設定周りのローカルストレージ保存に対応しました。作品ごとに保管します。
    - Appearance, Opacity設定及び、
DisplayのStepZone, Judgment, FastSlow, LifeGauge, Score, MusicInfo, FilterLineについて
ローカルストレージに保存する対象に追加しました。
2. Adjustment, Volume, Appearance, Opacityに限り、ローカル保存している設定を選択時に
アスタリスクを付けるように変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. Resolves #881 
2. 保存値がデフォルトかどうかがわからないため。
なお、Reverseはキー毎のローカルストレージに保管されているため、アスタリスクは付きません。
スクロール拡張対応キーであれば、Reverse:ON時に色が付くので、そこまで問題にはならないと思います。
※スキンを考慮する必要があったため、色で分けずにアスタリスク表記にしました。

## :camera: スクリーンショット / Screenshot
<img src="https://user-images.githubusercontent.com/44026291/97851747-1e158400-1d39-11eb-8ba8-6e3fa085a908.png" width="80%">

## :pencil: その他コメント / Other Comments
- Hidden+, Sudden+, Hid&Sud+で設定するフィルター範囲についても保存することを検討しましたが、
こちらはパラメーターが共通のため、対象からは外しています。
