### PR TITLE
[0305/grd-setting] 強制グラデーション設定の実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2105,8 +2105,8 @@ function makeColorGradation(_colorStr, { _defaultColorgrd = g_headerObj.defaultC
 	if (colorArray.length === 1) {
 		if (_objType === `titleMusic`) {
 			convertColorStr = `${defaultDir}, ${colorArray[0]} 100%, #eeeeee${alphaVal} 0%`;
-		} else if (_defaultColorgrd || g_colorType === `Type0`) {
-			convertColorStr = `${defaultDir}, ${colorArray[0]}, #eeeeee${alphaVal}, ${colorArray[0]}`;
+		} else if (_defaultColorgrd[0]) {
+			convertColorStr = `${defaultDir}, ${colorArray[0]}, ${_defaultColorgrd[1]}${alphaVal}, ${colorArray[0]}`;
 		} else {
 			convertColorStr = `${defaultDir}, ${colorArray[0]}, ${colorArray[0]}`;
 		}
@@ -2170,7 +2170,7 @@ function titleInit() {
 				x: (g_sWidth - 500) / 2, y: -15 + (g_sHeight - 500) / 2,
 				w: 500, h: 500,
 				background: makeColorGradation(g_headerObj.titlearrowgrds[0] || g_headerObj.setColorOrg[0], {
-					_defaultColorgrd: false,
+					_defaultColorgrd: [false, `#eeeeee`],
 					_objType: `titleArrow`,
 				}), rotate: 180, opacity: 0.25,
 			})
@@ -2729,7 +2729,12 @@ function headerConvert(_dosObj) {
 	g_speedNum = roundZero(g_speeds.findIndex(speed => speed === g_stateObj.speed));
 
 	// 矢印の色変化を常時グラデーションさせる設定
-	obj.defaultColorgrd = setVal(_dosObj.defaultColorgrd, false, C_TYP_BOOLEAN);
+	obj.defaultColorgrd = [false, `#eeeeee`];
+	if (hasVal(_dosObj.defaultColorgrd)) {
+		obj.defaultColorgrd = _dosObj.defaultColorgrd.split(`,`);
+		obj.defaultColorgrd[0] = setVal(obj.defaultColorgrd[0], false, C_TYP_BOOLEAN);
+		obj.defaultColorgrd[1] = setVal(obj.defaultColorgrd[1], `#eeeeee`, C_TYP_STRING);
+	}
 
 	// カラーコードのゼロパディング有無設定
 	obj.colorCdPaddingUse = setVal(_dosObj.colorCdPaddingUse, false, C_TYP_BOOLEAN);
@@ -2808,10 +2813,10 @@ function headerConvert(_dosObj) {
 				_shadowFlg: Boolean(k),
 			});
 
-		if (!obj.defaultColorgrd) {
+		if (!obj.defaultColorgrd[0]) {
 			[obj[`${_name}Type0`], obj[`${_name}StrType0`], obj[`${_name}OrgType0`]] =
 				setColorList(_dosObj[`${_name}`], obj[`${_name}Init`], obj[`${_name}Init`].length, {
-					_defaultColorgrd: true,
+					_defaultColorgrd: [true, obj.defaultColorgrd[1]],
 					_colorCdPaddingUse: obj.colorCdPaddingUse,
 					_shadowFlg: Boolean(k),
 				});
@@ -2847,10 +2852,10 @@ function headerConvert(_dosObj) {
 					_shadowFlg: Boolean(k),
 				});
 
-			if (!obj.defaultColorgrd) {
+			if (!obj.defaultColorgrd[0]) {
 				[obj[`${_frzName}Type0`][j], obj[`${_frzName}StrType0`][j], obj[`${_frzName}OrgType0`][j]] =
 					setColorList(tmpFrzColors[j], currentFrzColors, obj[`${_frzName}Init`].length, {
-						_defaultColorgrd: true,
+						_defaultColorgrd: [true, obj.defaultColorgrd[1]],
 						_colorCdPaddingUse: obj.colorCdPaddingUse,
 						_defaultFrzColorUse: obj.defaultFrzColorUse,
 						_objType: `frz`,
@@ -6883,7 +6888,8 @@ function pushColors(_header, _frame, _val, _colorCd) {
 
 	const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
 	const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
-	const colorCd = makeColorGradation(_colorCd);
+	const grdFlg = (g_colorType === `Type0` ? true : g_headerObj.defaultColorgrd[0])
+	const colorCd = makeColorGradation(_colorCd, { defaultColorgrd: [grdFlg, g_headerObj.defaultColorgrd[1]] });
 
 	if (_val < 30 || _val >= 1000) {
 		// 矢印の色変化

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5139,6 +5139,40 @@ function keyConfigInit() {
 		(kWidth - C_ARW_WIDTH) / 2 + g_keyObj.blank * (posj - divideCnt / 2) - 10, 45, 15, 30));
 	cursor.style.transitionDuration = `0.125s`;
 
+	/**
+	 * ConfigTypeの制御
+	 * @param {event} _evt 
+	 * @param {number} _scrollNum 
+	 */
+	function setConfigType(_evt, _scrollNum = 1) {
+		const typeNum = g_keycons.configTypes.findIndex(value => value === g_kcType);
+		const nextNum = (typeNum + g_keycons.configTypes.length + _scrollNum) % g_keycons.configTypes.length;
+		g_kcType = g_keycons.configTypes[nextNum];
+		g_keycons.configFunc[nextNum](kWidth, divideCnt, keyCtrlPtn, false);
+		_evt.target.textContent = g_kcType;
+	}
+
+	/**
+	 * ColorTypeの制御
+	 * @param {event} _evt 
+	 * @param {number} _scrollNum 
+	 */
+	function setColorType(_evt, _scrollNum = 1) {
+		const typeNum = g_keycons.colorTypes.findIndex(value => value === g_colorType);
+		const nextNum = (typeNum + g_keycons.colorTypes.length + _scrollNum) % g_keycons.colorTypes.length;
+		g_colorType = g_keycons.colorTypes[nextNum];
+		g_stateObj.d_color = g_keycons.colorDefs[nextNum];
+
+		g_headerObj.setColor = JSON.parse(JSON.stringify(g_headerObj[`setColor${g_colorType}`]));
+		for (let j = 0; j < g_headerObj.setColorInit.length; j++) {
+			g_headerObj.frzColor[j] = JSON.parse(JSON.stringify(g_headerObj[`frzColor${g_colorType}`][j]));
+		}
+		for (let j = 0; j < keyNum; j++) {
+			$id(`arrow${j}`).background = getKeyConfigColor(j, g_keyObj[`color${keyCtrlPtn}`][j]);
+		}
+		_evt.target.textContent = g_colorType;
+	}
+
 	multiAppend(divRoot,
 
 		// ショートカットキーメッセージ
@@ -5160,26 +5194,9 @@ function keyConfigInit() {
 			x: 30, y: 10, w: 70,
 		}, g_cssObj.keyconfig_ConfigType),
 
-		makeSettingLblCssButton(`lnkKcType`, g_kcType, 0, evt => {
-			switch (g_kcType) {
-				case `Main`:
-					g_kcType = `Replaced`;
-					resetCursorReplaced(kWidth, divideCnt, keyCtrlPtn, false);
-					break;
-
-				case `Replaced`:
-					g_kcType = C_FLG_ALL;
-					resetCursorALL(kWidth, divideCnt, keyCtrlPtn, false);
-					break;
-
-				case C_FLG_ALL:
-					g_kcType = `Main`;
-					resetCursorMain(kWidth, divideCnt, keyCtrlPtn, false);
-					break;
-			}
-			evt.target.textContent = g_kcType;
-		}, {
+		makeSettingLblCssButton(`lnkKcType`, g_kcType, 0, evt => setConfigType(evt), {
 			x: 30, y: 35, w: 100,
+			cxtFunc: evt => setConfigType(evt, -1),
 		}),
 
 		// キーカラータイプ切替ボタン
@@ -5187,34 +5204,9 @@ function keyConfigInit() {
 			x: g_sWidth - 120, y: 10, w: 70,
 		}, g_cssObj.keyconfig_ColorType),
 
-		makeSettingLblCssButton(`lnkColorType`, g_colorType, 0, evt => {
-			switch (g_colorType) {
-				case `Default`:
-					g_colorType = `Type0`;
-					break;
-				case `Type0`:
-					g_colorType = `Type1`;
-					g_stateObj.d_color = C_FLG_OFF;
-					break;
-				case `Type1`:
-					g_colorType = `Type2`;
-					g_stateObj.d_color = C_FLG_OFF;
-					break;
-				case `Type2`:
-					g_colorType = `Default`;
-					g_stateObj.d_color = C_FLG_ON;
-					break;
-			}
-			g_headerObj.setColor = JSON.parse(JSON.stringify(g_headerObj[`setColor${g_colorType}`]));
-			for (let j = 0; j < g_headerObj.setColorInit.length; j++) {
-				g_headerObj.frzColor[j] = JSON.parse(JSON.stringify(g_headerObj[`frzColor${g_colorType}`][j]));
-			}
-			for (let j = 0; j < keyNum; j++) {
-				$id(`arrow${j}`).background = getKeyConfigColor(j, g_keyObj[`color${keyCtrlPtn}`][j]);
-			}
-			evt.target.textContent = g_colorType;
-		}, {
+		makeSettingLblCssButton(`lnkColorType`, g_colorType, 0, evt => setColorType(evt), {
 			x: g_sWidth - 130, y: 35, w: 100,
+			cxtFunc: evt => setColorType(evt, -1),
 		}),
 
 	);
@@ -6870,7 +6862,7 @@ function pushColors(_header, _frame, _val, _colorCd) {
 	const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
 	const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
 	const grdFlg = (g_colorType === `Type0` ? !g_headerObj.defaultColorgrd[0] : g_headerObj.defaultColorgrd[0])
-	const colorCd = makeColorGradation(_colorCd, { defaultColorgrd: [grdFlg, g_headerObj.defaultColorgrd[1]] });
+	const colorCd = makeColorGradation(_colorCd, { _defaultColorgrd: [grdFlg, g_headerObj.defaultColorgrd[1]] });
 
 	if (_val < 30 || _val >= 1000) {
 		// 矢印の色変化

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2105,7 +2105,7 @@ function makeColorGradation(_colorStr, { _defaultColorgrd = g_headerObj.defaultC
 	if (colorArray.length === 1) {
 		if (_objType === `titleMusic`) {
 			convertColorStr = `${defaultDir}, ${colorArray[0]} 100%, #eeeeee${alphaVal} 0%`;
-		} else if (_defaultColorgrd) {
+		} else if (_defaultColorgrd || g_colorType === `Type0`) {
 			convertColorStr = `${defaultDir}, ${colorArray[0]}, #eeeeee${alphaVal}, ${colorArray[0]}`;
 		} else {
 			convertColorStr = `${defaultDir}, ${colorArray[0]}, ${colorArray[0]}`;
@@ -2808,6 +2808,18 @@ function headerConvert(_dosObj) {
 				_shadowFlg: Boolean(k),
 			});
 
+		if (!obj.defaultColorgrd) {
+			[obj[`${_name}Type0`], obj[`${_name}StrType0`], obj[`${_name}OrgType0`]] =
+				setColorList(_dosObj[`${_name}`], obj[`${_name}Init`], obj[`${_name}Init`].length, {
+					_defaultColorgrd: true,
+					_colorCdPaddingUse: obj.colorCdPaddingUse,
+					_shadowFlg: Boolean(k),
+				});
+			obj[`${_frzName}Type0`] = [];
+			obj[`${_frzName}StrType0`] = [];
+			obj[`${_frzName}OrgType0`] = [];
+		}
+
 		// フリーズアロー色
 		obj[`${_frzName}`] = [];
 		obj[`${_frzName}Str`] = [];
@@ -2822,11 +2834,8 @@ function headerConvert(_dosObj) {
 			const baseLength = firstFrzColors.length === 0 || obj.defaultFrzColorUse ?
 				obj[`${_frzName}Init`].length : firstFrzColors.length;
 			for (let k = 0; k < baseLength; k++) {
-				if (firstFrzColors[k] === undefined || firstFrzColors[k] === ``) {
-					currentFrzColors[k] = obj.defaultFrzColorUse ? obj[`${_frzName}Init`][k] : obj[`${_name}Str`][j];
-				} else {
-					currentFrzColors[k] = firstFrzColors[k];
-				}
+				currentFrzColors[k] = setVal(firstFrzColors[k],
+					obj.defaultFrzColorUse ? obj[`${_frzName}Init`][k] : obj[`${_name}Str`][j], C_TYP_STRING);
 			}
 
 			[obj[`${_frzName}`][j], obj[`${_frzName}Str`][j], obj[`${_frzName}Org`][j]] =
@@ -2837,6 +2846,17 @@ function headerConvert(_dosObj) {
 					_objType: `frz`,
 					_shadowFlg: Boolean(k),
 				});
+
+			if (!obj.defaultColorgrd) {
+				[obj[`${_frzName}Type0`][j], obj[`${_frzName}StrType0`][j], obj[`${_frzName}OrgType0`][j]] =
+					setColorList(tmpFrzColors[j], currentFrzColors, obj[`${_frzName}Init`].length, {
+						_defaultColorgrd: true,
+						_colorCdPaddingUse: obj.colorCdPaddingUse,
+						_defaultFrzColorUse: obj.defaultFrzColorUse,
+						_objType: `frz`,
+						_shadowFlg: Boolean(k),
+					});
+			}
 		}
 		if (k === 0) {
 			obj[`${_name}Default`] = obj[`${_name}`].concat();
@@ -5179,6 +5199,14 @@ function keyConfigInit() {
 		makeSettingLblCssButton(`lnkColorType`, g_colorType, 0, evt => {
 			switch (g_colorType) {
 				case `Default`:
+					if (g_headerObj.setColorType0 !== undefined) {
+						g_colorType = `Type0`;
+					} else {
+						g_colorType = `Type1`;
+						g_stateObj.d_color = C_FLG_OFF;
+					}
+					break;
+				case `Type0`:
 					g_colorType = `Type1`;
 					g_stateObj.d_color = C_FLG_OFF;
 					break;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2800,35 +2800,30 @@ function headerConvert(_dosObj) {
 
 	// ダミー用初期矢印色
 	obj.setDummyColor = [`#777777`, `#444444`, `#777777`, `#444444`, `#777777`];
+	const dfColorgrdSet = {
+		'': obj.defaultColorgrd,
+		'Type0': [!obj.defaultColorgrd[0], obj.defaultColorgrd[1]],
+	};
 
 	[``, `Shadow`].forEach((pattern, k) => {
 		const _name = `set${pattern}Color`;
 		const _frzName = `frz${pattern}Color`;
 
 		// 矢印色
-		[obj[`${_name}`], obj[`${_name}Str`], obj[`${_name}Org`]] =
-			setColorList(_dosObj[`${_name}`], obj[`${_name}Init`], obj[`${_name}Init`].length, {
-				_defaultColorgrd: obj.defaultColorgrd,
-				_colorCdPaddingUse: obj.colorCdPaddingUse,
-				_shadowFlg: Boolean(k),
-			});
-
-		if (!obj.defaultColorgrd[0]) {
-			[obj[`${_name}Type0`], obj[`${_name}StrType0`], obj[`${_name}OrgType0`]] =
+		[``, `Type0`].forEach(type => {
+			[obj[`${_name}${type}`], obj[`${_name}Str${type}`], obj[`${_name}Org${type}`]] =
 				setColorList(_dosObj[`${_name}`], obj[`${_name}Init`], obj[`${_name}Init`].length, {
-					_defaultColorgrd: [true, obj.defaultColorgrd[1]],
+					_defaultColorgrd: dfColorgrdSet[type],
 					_colorCdPaddingUse: obj.colorCdPaddingUse,
 					_shadowFlg: Boolean(k),
 				});
-			obj[`${_frzName}Type0`] = [];
-			obj[`${_frzName}StrType0`] = [];
-			obj[`${_frzName}OrgType0`] = [];
-		}
+
+			obj[`${_frzName}${type}`] = [];
+			obj[`${_frzName}Str${type}`] = [];
+			obj[`${_frzName}Org${type}`] = [];
+		});
 
 		// フリーズアロー色
-		obj[`${_frzName}`] = [];
-		obj[`${_frzName}Str`] = [];
-		obj[`${_frzName}Org`] = [];
 		const tmpFrzColors = (_dosObj[_frzName] !== undefined ? _dosObj[_frzName].split(`$`) : []);
 		const firstFrzColors = (tmpFrzColors[0] !== undefined ? tmpFrzColors[0].split(`,`) : []);
 
@@ -2843,25 +2838,16 @@ function headerConvert(_dosObj) {
 					obj.defaultFrzColorUse ? obj[`${_frzName}Init`][k] : obj[`${_name}Str`][j], C_TYP_STRING);
 			}
 
-			[obj[`${_frzName}`][j], obj[`${_frzName}Str`][j], obj[`${_frzName}Org`][j]] =
-				setColorList(tmpFrzColors[j], currentFrzColors, obj[`${_frzName}Init`].length, {
-					_defaultColorgrd: obj.defaultColorgrd,
-					_colorCdPaddingUse: obj.colorCdPaddingUse,
-					_defaultFrzColorUse: obj.defaultFrzColorUse,
-					_objType: `frz`,
-					_shadowFlg: Boolean(k),
-				});
-
-			if (!obj.defaultColorgrd[0]) {
-				[obj[`${_frzName}Type0`][j], obj[`${_frzName}StrType0`][j], obj[`${_frzName}OrgType0`][j]] =
+			[``, `Type0`].forEach(type => {
+				[obj[`${_frzName}${type}`][j], obj[`${_frzName}Str${type}`][j], obj[`${_frzName}Org${type}`][j]] =
 					setColorList(tmpFrzColors[j], currentFrzColors, obj[`${_frzName}Init`].length, {
-						_defaultColorgrd: [true, obj.defaultColorgrd[1]],
+						_defaultColorgrd: dfColorgrdSet[type],
 						_colorCdPaddingUse: obj.colorCdPaddingUse,
 						_defaultFrzColorUse: obj.defaultFrzColorUse,
 						_objType: `frz`,
 						_shadowFlg: Boolean(k),
 					});
-			}
+			});
 		}
 		if (k === 0) {
 			obj[`${_name}Default`] = obj[`${_name}`].concat();
@@ -5204,12 +5190,7 @@ function keyConfigInit() {
 		makeSettingLblCssButton(`lnkColorType`, g_colorType, 0, evt => {
 			switch (g_colorType) {
 				case `Default`:
-					if (g_headerObj.setColorType0 !== undefined) {
-						g_colorType = `Type0`;
-					} else {
-						g_colorType = `Type1`;
-						g_stateObj.d_color = C_FLG_OFF;
-					}
+					g_colorType = `Type0`;
 					break;
 				case `Type0`:
 					g_colorType = `Type1`;
@@ -6888,7 +6869,7 @@ function pushColors(_header, _frame, _val, _colorCd) {
 
 	const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
 	const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
-	const grdFlg = (g_colorType === `Type0` ? true : g_headerObj.defaultColorgrd[0])
+	const grdFlg = (g_colorType === `Type0` ? !g_headerObj.defaultColorgrd[0] : g_headerObj.defaultColorgrd[0])
 	const colorCd = makeColorGradation(_colorCd, { defaultColorgrd: [grdFlg, g_headerObj.defaultColorgrd[1]] });
 
 	if (_val < 30 || _val >= 1000) {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -372,6 +372,16 @@ let g_opacityNum = g_opacitys.length - 1;
 let g_scoreDetails = [`Speed`, `Density`, `ToolDif`];
 let g_scoreDetailNum = 0;
 
+let g_keycons = {
+    configTypes: [`Main`, `Replaced`, `ALL`],
+    configFunc: [resetCursorMain, resetCursorReplaced, resetCursorALL],
+    configTypeNum: 0,
+
+    colorTypes: [`Default`, `Type0`, `Type1`, `Type2`],
+    colorDefs: [C_FLG_ON, C_FLG_ON, C_FLG_OFF, C_FLG_OFF],
+    colorTypeNum: 0,
+};
+
 let g_displays = [`stepZone`, `judgment`, `fastSlow`, `lifeGauge`, `score`, `musicInfo`, `filterLine`,
     `speed`, `color`, `lyrics`, `background`, `arrowEffect`, `special`];
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 強制的にグラデーションを反転 (defaultColorgrdを反転)にする設定を追加しました。
ColorType: Type0 が該当します。
Type0選択時は、色変化部分を含めて中央が白色のグラデーションが掛かります。
2. defaultColorgrdの2つ目の要素を追加しました。グラデーションで挟む色を指定できます。
この2つ目の要素は省略可能です。
```
|defaultColorgrd=true,#ffffcc|
```
3. ConfigType, Colortypeの逆回し操作に対応しました。右クリックにて逆回し可能です。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. Issue #745 に関連した変更です。
色が見づらい場合の明暗設定の案の1つとして実装しています。
2. 明背景の場合の見づらさに対応するため。
3. パターンが増えた場合に備えるのと、他の設定項目と操作を共通化するため。
左右のボタンを追加するかどうかは一旦保留します。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/98457100-9069e680-21c7-11eb-86f2-30bfd17b859b.png" width="70%">

## :pencil: その他コメント / Other Comments
- 元からグラデーションが掛かっている場合、「Default」と「Type0」が同じになる場合があります。
- Type1, Type2はそのままです。グラデーションしません。
- 明背景に対応するために、defaultColorgrdの引数拡張を予定しています。
