### PR TITLE
[0306/image-group] 背景・マスクの画像ファイル対象にsvgを追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1975,12 +1975,7 @@ function drawDefaultBackImage(_key) {
  */
 function checkImage(_str) {
 	return (
-		(
-			_str.indexOf(`.png`) !== -1 ||
-			_str.indexOf(`.gif`) !== -1 ||
-			_str.indexOf(`.bmp`) !== -1 ||
-			_str.indexOf(`.jpg`) !== -1
-		) ? true : false
+		g_imgObj.imgExtensions.findIndex(value => _str.toLowerCase().indexOf(`.${value}`) !== -1) !== -1 ? true : false
 	);
 }
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1975,7 +1975,7 @@ function drawDefaultBackImage(_key) {
  */
 function checkImage(_str) {
 	return (
-		g_imgObj.imgExtensions.findIndex(value => _str.toLowerCase().indexOf(`.${value}`) !== -1) !== -1 ? true : false
+		g_imgObj.imgExtensions.findIndex(value => _str.toLowerCase().match(new RegExp(String.raw`.${value}$`, 'i'))) !== -1 ? true : false
 	);
 }
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -117,6 +117,8 @@ const g_imgObj = {
     frzBar: C_IMG_FRZBAR,
     lifeBar: C_IMG_LIFEBAR,
     lifeBorder: C_IMG_LIFEBORDER,
+
+    imgExtensions: [`png`, `gif`, `bmp`, `jpg`, `jpeg`, `svg`],
 };
 
 // Motionオプション配列の基準位置


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 背景・マスクモーションの画像形式にsvg形式を追加しました。
2. 背景・マスクモーションの画像形式にjpg形式の他、jpeg形式にも対応しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. ベクタ形式への対応のため。Gitter要望より。
2. jpg形式についてはたまにjpeg拡張子が存在するため。
これについては大文字のケース（例：BMP, JPG等）にも対応しました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- danoni_constants.js に変更を加えています。
g_imgObj.imgExtensions に対象の拡張子名を設定することで対象を増やせるように改良しました。
