### PR TITLE
[0310/escape-bracket] タグ用括弧のエスケープ文字を追加

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1618,6 +1618,7 @@ const g_escapeStr = {
     escapeTag: [
         [`*amp*`, `&amp;`], [`*pipe*`, `|`], [`*dollar*`, `$`], [`*rsquo*`, `&rsquo;`],
         [`*quot*`, `&quot;`], [`*comma*`, `&sbquo;`], [`*squo*`, `&#39;`], [`*bkquo*`, `&#96;`],
+        [`*lt*`, `&lt;`], [`*gt*`, `&gt;`],
     ],
     unEscapeTag: [
         [`&amp;`, `&`], [`&rsquo;`, `’`], [`&quot;`, `"`], [`&sbquo;`, `,`],


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- タグ用括弧のエスケープ文字を追加しました。
`*lt*`⇒`<`, `*gt*`⇒`>`に置き換えます。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- #895 の実装に伴い、タグ以外の意味で`<`や`>`を使う場合に支障が出るため、
代替文字を用意しました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
