### PR TITLE
[0314/preload-firefox] Firefoxで画像のプリロードを有効にする変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -390,18 +390,28 @@ function preloadFile(_as, _href, _type = ``, _crossOrigin = `anonymous`) {
 	if (preloadFlg === undefined) {
 		g_preloadImgs.push(_href);
 
-		const link = document.createElement(`link`);
-		link.rel = `preload`;
-		link.as = _as;
-		link.href = _href;
-		if (_type !== ``) {
-			link.type = _type;
-		}
-		if (location.href.match(`^file`)) {
+		if (g_userAgent.indexOf(`firefox`) !== -1) {
+			// Firefoxの場合のみpreloadが効かないため、画像読込形式にする
+			g_loadObj[_href] = false;
+			const img = new Image();
+			img.src = _href;
+			img.onload = _ => g_loadObj[_href] = true;
+
 		} else {
-			link.crossOrigin = _crossOrigin;
+			// それ以外のブラウザの場合はrel=preloadを利用
+			const link = document.createElement(`link`);
+			link.rel = `preload`;
+			link.as = _as;
+			link.href = _href;
+			if (_type !== ``) {
+				link.type = _type;
+			}
+			if (location.href.match(`^file`)) {
+			} else {
+				link.crossOrigin = _crossOrigin;
+			}
+			document.head.appendChild(link);
 		}
-		document.head.appendChild(link);
 	}
 }
 
@@ -5792,7 +5802,13 @@ function loadingScoreInit2() {
 		if (g_audio.duration !== undefined) {
 			clearInterval(tempId);
 			clearWindow();
-			MainInit();
+			if (g_userAgent.indexOf(`firefox`) !== -1) {
+				if (g_preloadImgs.every(v => g_loadObj[v] === true)) {
+					MainInit();
+				}
+			} else {
+				MainInit();
+			}
 		}
 	}, 0.5);
 }


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- Firefoxで画像のプリロードができるよう画像の読込処理を追加しました。
※その他のブラウザについてはこれまで通りです。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- Resolves #899 

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 処理影響は無いと思いますが、画像が多い場合、
Firefoxのプレイ開始に若干のラグが出る可能性があります。
