### PR TITLE
曲終了直後にリトライキーを押すとALL0のリザルトが表示される問題の修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8387,6 +8387,10 @@ function MainInit() {
 			if (g_stateObj.lifeMode === C_LFE_BORDER && g_workObj.lifeVal < g_workObj.lifeBorder) {
 				g_gameOverFlg = true;
 			}
+
+			document.onkeydown = evt => blockCode(transCode(evt.code));
+			document.onkeyup = evt => { }
+
 			clearTimeout(g_timeoutEvtId);
 			setTimeout(_ => {
 				clearWindow();


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- 曲終了判定時にキーイベントを初期化するようにしました

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- 曲終了後、setTimeoutでリザルトに移行するまでの間、リトライキーを押すとリザルトの判定が全て0になります
- [izkdicさんの配信](https://twitter.com/vdos2643/status/1340684397381468166)
- [関連ツイート](https://twitter.com/vdos2643/status/1340689775565533184)

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- setTimeoutの待ち時間を1000(ms)などにすると簡単に再現できます
- 超処理落ちや急加速は私は再現できず、原因も分かりませんでした
