### PR TITLE
[0315/gauge-heavy] ライフ制ゲージ設定にHeavyを追加、ゲージ設定順序の見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2759,23 +2759,23 @@ function headerConvert(_dosObj) {
 
 	// ゲージ設定詳細（初期値）
 	g_gaugeOptionObj = {
-		survival: [`Original`, `Light`, `NoRecovery`, `SuddenDeath`, `Practice`],
-		border: [`Normal`, `Easy`, `Hard`, `SuddenDeath`],
+		survival: [`Original`, `Heavy`, `NoRecovery`, `SuddenDeath`, `Practice`, `Light`],
+		border: [`Normal`, `Hard`, `SuddenDeath`, `Easy`],
 		custom: [],
 
-		initSurvival: [25, 25, 100, 100, 50],
-		rcvSurvival: [6, 6, 0, 0, 0],
-		dmgSurvival: [40, 20, 50, obj.maxLifeVal, 0],
-		typeSurvival: [C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL],
-		varSurvival: [C_FLG_OFF, C_FLG_OFF, C_FLG_OFF, C_FLG_OFF, C_FLG_OFF],
-		clearSurvival: [0, 0, 0, 0, 0],
+		initSurvival: [25, 50, 100, 100, 50, 25],
+		rcvSurvival: [6, 1, 0, 0, 0, 12],
+		dmgSurvival: [40, 50, 50, obj.maxLifeVal, 0, 40],
+		typeSurvival: [C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL],
+		varSurvival: [C_FLG_OFF, C_FLG_OFF, C_FLG_OFF, C_FLG_OFF, C_FLG_OFF, C_FLG_OFF],
+		clearSurvival: [0, 0, 0, 0, 0, 0],
 
-		initBorder: [25, 25, 100, 100],
-		rcvBorder: [2, 2, 1, 0],
-		dmgBorder: [7, 4, 50, obj.maxLifeVal],
-		typeBorder: [C_LFE_BORDER, C_LFE_BORDER, C_LFE_BORDER, C_LFE_SURVIVAL],
-		varBorder: [C_FLG_ON, C_FLG_ON, C_FLG_ON, C_FLG_OFF],
-		clearBorder: [70, 70, 0, 0],
+		initBorder: [25, 100, 100, 25],
+		rcvBorder: [2, 1, 0, 4],
+		dmgBorder: [7, 50, obj.maxLifeVal, 7],
+		typeBorder: [C_LFE_BORDER, C_LFE_BORDER, C_LFE_SURVIVAL, C_LFE_BORDER],
+		varBorder: [C_FLG_ON, C_FLG_ON, C_FLG_OFF, C_FLG_ON],
+		clearBorder: [70, 0, 0, 70],
 
 		varCustom: [],
 	};

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2764,7 +2764,7 @@ function headerConvert(_dosObj) {
 		custom: [],
 
 		initSurvival: [25, 50, 100, 100, 50, 25],
-		rcvSurvival: [6, 1, 0, 0, 0, 12],
+		rcvSurvival: [6, 2, 0, 0, 0, 12],
 		dmgSurvival: [40, 50, 50, obj.maxLifeVal, 0, 40],
 		typeSurvival: [C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL],
 		varSurvival: [C_FLG_OFF, C_FLG_OFF, C_FLG_OFF, C_FLG_OFF, C_FLG_OFF, C_FLG_OFF],


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. ライフ制ゲージ設定にHeavyを追加しました。
  - 初期値: 50%、回復: 2、ダメージ: 50に設定しています。
  - 譜面ヘッダー：gaugeHeavyにて詳細の変更が可能です（他と同様）。
2. ゲージ設定順序を見直しました（ゲージが簡単な順にソート）。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- Resolves #909 

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- Light, Easyゲージの初期値について、既定値と異なっていたため見直しています。
（基本は他の箇所で自動設定され、この設定値は採用されないので影響はありません）