### PR TITLE
[0317/preload-firefox] 追加した画像ファイルがある場合、Firefoxでプレイできない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5799,15 +5799,18 @@ function loadingScoreInit2() {
 	}
 
 	const tempId = setInterval(() => {
-		if (g_audio.duration !== undefined) {
+		const executeMain = _ => {
 			clearInterval(tempId);
 			clearWindow();
+			MainInit();
+		}
+		if (g_audio.duration !== undefined) {
 			if (g_userAgent.indexOf(`firefox`) !== -1) {
 				if (g_preloadImgs.every(v => g_loadObj[v] === true)) {
-					MainInit();
+					executeMain();
 				}
 			} else {
-				MainInit();
+				executeMain();
 			}
 		}
 	}, 0.5);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- 追加した画像ファイルがある場合、Firefoxでプレイできない問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- 画像ファイルを読込確認するためのループ処理の前にループをやめる処理があったため、
処理が止まる問題が発生していました。
Firefoxブラウザのみ発生します。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 特になし。
