### PR TITLE
[0318/interval-time] setIntervalの経過時間誤りを修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5813,7 +5813,7 @@ function loadingScoreInit2() {
 				executeMain();
 			}
 		}
-	}, 0.5);
+	}, 100);
 }
 
 /**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- 本体ソース中に1か所だけある`setInterval`について、
待ち時間が0.5ミリ秒だったものを100ミリ秒に修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- 処理待ち間隔が短すぎるため。（おそらく、秒と勘違い）
なお、10ミリ秒より小さい値が指定された場合は10ミリ秒になるとのことですが、
そこまで短くする必要もないため、今回変更しています。
https://developer.mozilla.org/ja/docs/Web/API/WindowOrWorkerGlobalScope/setInterval

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 過去バージョンにも影響と書いていますが（v9, v14, v16, v17）、
実害はほぼないため修正は後回しにします。
