### PR TITLE
[0319/onigiri-color-type2] ColorType: 2のおにぎりの初期色を白から薄青に変更

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1592,7 +1592,7 @@ const g_dfColorObj = {
     setShadowColorInit: [``, ``, ``, ``, ``],
 
     setColorType1: [`#6666ff`, `#99ffff`, `#ffffff`, `#ffff99`, `#ff9966`],
-    setColorType2: [`#ffffff`, `#9999ff`, `#ffffff`, `#ffccff`, `#ff9999`],
+    setColorType2: [`#ffffff`, `#9999ff`, `#99ccff`, `#ffccff`, `#ff9999`],
 
     // フリーズアロー初期色情報
     frzColorInit: [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- ColorType: 2のおにぎりの初期色を白から薄青に変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- 上下左右の色とおにぎりの色が同じになっており、
色でオブジェクトを判断する方が見づらい状況になっていました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/103113636-00143200-469f-11eb-8f74-0fd33a895b5e.png" width="70%">

## :pencil: その他コメント / Other Comments
- danoni_constants.js のみの変更です。
