### PR TITLE
[0320/customjs-duplicated] customjsを二重読込している問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5591,7 +5591,7 @@ function removeClassList(_j, _k) {
  */
 function loadingScoreInit() {
 	// 譜面データの読み込み
-	loadDos(_ => loadCustomjs(_ => loadingScoreInit2()));
+	loadDos(_ => loadingScoreInit2());
 }
 
 function setScoreIdHeader(_scoreId = 0, _scoreLockFlg = false) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5591,7 +5591,220 @@ function removeClassList(_j, _k) {
  */
 function loadingScoreInit() {
 	// 譜面データの読み込み
-	loadDos(_ => loadingScoreInit2());
+	loadDos(_ => {
+		const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
+		const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
+		g_headerObj.blankFrame = g_headerObj.blankFrameDef;
+
+		// ユーザカスタムイベント
+		if (typeof customPreloadingInit === C_TYP_FUNCTION) {
+			customPreloadingInit();
+			if (typeof customPreloadingInit2 === C_TYP_FUNCTION) {
+				customPreloadingInit2();
+			}
+		}
+		if (typeof skinPreloadingInit === C_TYP_FUNCTION) {
+			skinPreloadingInit();
+			if (typeof skinPreloadingInit2 === C_TYP_FUNCTION) {
+				skinPreloadingInit2();
+			}
+		}
+
+		// 譜面初期情報ロード許可フラグ
+		// (タイトルバック時保存したデータを設定画面にて再読み込みするため、
+		//  ローカルストレージ保存時はフラグを解除しない)
+		if (!g_stateObj.dataSaveFlg || hasVal(g_keyObj[`transKey${keyCtrlPtn}`])) {
+			g_canLoadDifInfoFlg = false;
+		}
+
+		let dummyIdHeader = ``;
+		if (g_stateObj.dummyId !== ``) {
+			if (g_stateObj.dummyId === 0 || g_stateObj.dummyId === 1) {
+				dummyIdHeader = ``;
+			} else {
+				dummyIdHeader = g_stateObj.dummyId;
+			}
+		}
+		g_scoreObj = scoreConvert(g_rootObj, g_stateObj.scoreId, 0, dummyIdHeader);
+
+		// 最終フレーム数の取得
+		let lastFrame = getLastFrame(g_scoreObj) + g_headerObj.blankFrame;
+
+		// 最初の矢印データがあるフレーム数を取得
+		let firstArrowFrame = getFirstArrowFrame(g_scoreObj);
+
+		// 開始フレーム数の取得(フェードイン加味)
+		g_scoreObj.frameNum = getStartFrame(lastFrame, g_stateObj.fadein);
+		g_scoreObj.baseFrame;
+
+		// フレームごとの速度を取得（配列形式）
+		let speedOnFrame = setSpeedOnFrame(g_scoreObj.speedData, lastFrame);
+
+		// Motionオプション適用時の矢印別の速度を取得（配列形式）
+		const motionOnFrame = setMotionOnFrame();
+		g_workObj.motionOnFrames = JSON.parse(JSON.stringify(motionOnFrame));
+
+		// 最初のフレームで出現する矢印が、ステップゾーンに到達するまでのフレーム数を取得
+		const firstFrame = (g_scoreObj.frameNum === 0 ? 0 : g_scoreObj.frameNum + g_headerObj.blankFrame);
+		let arrivalFrame = getFirstArrivalFrame(firstFrame, speedOnFrame, motionOnFrame);
+
+		// キーパターン(デフォルト)に対応する矢印番号を格納
+		convertreplaceNums();
+
+		const setData = (_data, _minLength = 1) => {
+			return (_data !== undefined && _data.length >= _minLength ? _data.concat() : []);
+		}
+
+		// フレーム・曲開始位置調整
+		let preblankFrame = 0;
+		if (g_scoreObj.frameNum === 0) {
+			if (firstArrowFrame - C_MAX_ADJUSTMENT < arrivalFrame) {
+				preblankFrame = arrivalFrame - firstArrowFrame + C_MAX_ADJUSTMENT;
+
+				// 譜面データの再読み込み
+				const tmpObj = scoreConvert(g_rootObj, g_stateObj.scoreId, preblankFrame, dummyIdHeader);
+				for (let j = 0; j < keyNum; j++) {
+					if (tmpObj.arrowData[j] !== undefined) {
+						g_scoreObj.arrowData[j] = JSON.parse(JSON.stringify(tmpObj.arrowData[j]));
+					}
+					if (tmpObj.frzData[j] !== undefined) {
+						g_scoreObj.frzData[j] = JSON.parse(JSON.stringify(tmpObj.frzData[j]));
+					}
+					if (tmpObj.dummyArrowData[j] !== undefined && g_stateObj.shuffle === C_FLG_OFF) {
+						g_scoreObj.dummyArrowData[j] = JSON.parse(JSON.stringify(tmpObj.dummyArrowData[j]));
+					}
+					if (tmpObj.dummyFrzData[j] !== undefined && g_stateObj.shuffle === C_FLG_OFF) {
+						g_scoreObj.dummyFrzData[j] = JSON.parse(JSON.stringify(tmpObj.dummyFrzData[j]));
+					}
+				}
+
+				/**
+				 * データ種, 最小データ長のセット
+				 */
+				const dataTypes = [
+					[`speed`, 2],
+					[`boost`, 2],
+					[`color`, 3],
+					[`acolor`, 3],
+					[`shadowcolor`, 3],
+					[`ashadowcolor`, 3],
+					[`arrowCssMotion`, 3],
+					[`frzCssMotion`, 3],
+					[`dummyArrowCssMotion`, 3],
+					[`dummyFrzCssMotion`, 3],
+					[`object`, 4],
+					[`word`, 3],
+					[`mask`, 1],
+					[`back`, 1],
+				];
+				dataTypes.forEach(dataType => {
+					g_scoreObj[`${dataType[0]}Data`] = setData(tmpObj[`${dataType[0]}Data`], dataType[1]);
+				});
+
+				lastFrame += preblankFrame;
+				firstArrowFrame += preblankFrame;
+				speedOnFrame = setSpeedOnFrame(g_scoreObj.speedData, lastFrame);
+				arrivalFrame = getFirstArrivalFrame(firstFrame, speedOnFrame, motionOnFrame);
+				g_headerObj.blankFrame += preblankFrame;
+			}
+		}
+
+		// シャッフルグループ未定義の場合
+		if (g_keyObj[`shuffle${keyCtrlPtn}`] === undefined) {
+			g_keyObj[`shuffle${keyCtrlPtn}`] = [...Array(keyNum)].fill(0);
+		}
+
+		// シャッフルグループを扱いやすくする
+		// [0, 0, 0, 1, 0, 0, 0] -> [[0, 1, 2, 4, 5, 6], [3]]
+		const shuffleGroupMap = {};
+		g_keyObj[`shuffle${keyCtrlPtn}`].forEach((_val, _i) => {
+			if (shuffleGroupMap[_val] === undefined) {
+				shuffleGroupMap[_val] = [];
+			};
+			shuffleGroupMap[_val].push(_i);
+		});
+		const shuffleGroup = Object.values(shuffleGroupMap);
+
+		// Mirror,Random,S-Randomの適用
+		if (g_stateObj.shuffle === `Mirror`) {
+			applyMirror(keyNum, shuffleGroup);
+		} else if (g_stateObj.shuffle === `Random`) {
+			applyRandom(keyNum, shuffleGroup);
+		} else if (g_stateObj.shuffle === `Random+`) {
+			applyRandom(keyNum, [[...Array(keyNum).keys()]]);
+		} else if (g_stateObj.shuffle === `S-Random`) {
+			applySRandom(keyNum, shuffleGroup, `arrow`, `frz`);
+			applySRandom(keyNum, shuffleGroup, `dummyArrow`, `dummyFrz`);
+		} else if (g_stateObj.shuffle === `S-Random+`) {
+			applySRandom(keyNum, [[...Array(keyNum).keys()]], `arrow`, `frz`);
+			applySRandom(keyNum, [[...Array(keyNum).keys()]], `dummyArrow`, `dummyFrz`);
+		}
+
+		// アシスト用の配列があれば、ダミーデータで上書き
+		if (typeof g_keyObj[`assistPos${keyCtrlPtn}`] === C_TYP_OBJECT &&
+			!g_autoPlaysBase.includes(g_stateObj.autoPlay)) {
+			const assistArray = g_keyObj[`assistPos${keyCtrlPtn}`][g_stateObj.autoPlay];
+			for (let j = 0; j < keyNum; j++) {
+				if (assistArray[j] === 1) {
+					g_scoreObj.dummyArrowData[j] = g_scoreObj.arrowData[j].concat();
+					g_scoreObj.arrowData[j] = [];
+					g_scoreObj.dummyFrzData[j] = g_scoreObj.frzData[j].concat();
+					g_scoreObj.frzData[j] = [];
+				} else {
+					g_scoreObj.dummyArrowData[j] = [];
+					g_scoreObj.dummyFrzData[j] = [];
+				}
+			}
+		}
+
+		// 矢印・フリーズアロー数をカウント
+		g_allArrow = 0;
+		g_allFrz = 0;
+		for (let j = 0; j < keyNum; j++) {
+			g_allArrow += (isNaN(parseFloat(g_scoreObj.arrowData[j][0])) ? 0 : g_scoreObj.arrowData[j].length);
+			g_allFrz += (isNaN(parseFloat(g_scoreObj.frzData[j][0])) ? 0 : g_scoreObj.frzData[j].length);
+		}
+
+		// ライフ回復・ダメージ量の計算
+		// フリーズ始点でも通常判定させる場合は総矢印数を水増しする
+		if (g_headerObj.frzStartjdgUse) {
+			g_allArrow += g_allFrz / 2;
+		}
+		g_fullArrows = g_allArrow + g_allFrz / 2;
+
+		calcLifeVals(g_fullArrows);
+
+		// 矢印・フリーズアロー・速度/色変化格納処理
+		pushArrows(g_scoreObj, speedOnFrame, motionOnFrame, arrivalFrame);
+
+		// メインに入る前の最終初期化処理
+		getArrowSettings();
+
+		// ユーザカスタムイベント
+		if (typeof customLoadingInit === C_TYP_FUNCTION) {
+			customLoadingInit();
+			if (typeof customLoadingInit2 === C_TYP_FUNCTION) {
+				customLoadingInit2();
+			}
+		}
+
+		const tempId = setInterval(() => {
+			const executeMain = _ => {
+				clearInterval(tempId);
+				clearWindow();
+				MainInit();
+			}
+			if (g_audio.duration !== undefined) {
+				if (g_userAgent.indexOf(`firefox`) !== -1) {
+					if (g_preloadImgs.every(v => g_loadObj[v] === true)) {
+						executeMain();
+					}
+				} else {
+					executeMain();
+				}
+			}
+		}, 100);
+	});
 }
 
 function setScoreIdHeader(_scoreId = 0, _scoreLockFlg = false) {
@@ -5599,221 +5812,6 @@ function setScoreIdHeader(_scoreId = 0, _scoreLockFlg = false) {
 		return Number(_scoreId) + 1;
 	}
 	return ``;
-}
-
-function loadingScoreInit2() {
-	const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
-	const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
-	g_headerObj.blankFrame = g_headerObj.blankFrameDef;
-
-	// ユーザカスタムイベント
-	if (typeof customPreloadingInit === C_TYP_FUNCTION) {
-		customPreloadingInit();
-		if (typeof customPreloadingInit2 === C_TYP_FUNCTION) {
-			customPreloadingInit2();
-		}
-	}
-	if (typeof skinPreloadingInit === C_TYP_FUNCTION) {
-		skinPreloadingInit();
-		if (typeof skinPreloadingInit2 === C_TYP_FUNCTION) {
-			skinPreloadingInit2();
-		}
-	}
-
-	// 譜面初期情報ロード許可フラグ
-	// (タイトルバック時保存したデータを設定画面にて再読み込みするため、
-	//  ローカルストレージ保存時はフラグを解除しない)
-	if (!g_stateObj.dataSaveFlg || hasVal(g_keyObj[`transKey${keyCtrlPtn}`])) {
-		g_canLoadDifInfoFlg = false;
-	}
-
-	let dummyIdHeader = ``;
-	if (g_stateObj.dummyId !== ``) {
-		if (g_stateObj.dummyId === 0 || g_stateObj.dummyId === 1) {
-			dummyIdHeader = ``;
-		} else {
-			dummyIdHeader = g_stateObj.dummyId;
-		}
-	}
-	g_scoreObj = scoreConvert(g_rootObj, g_stateObj.scoreId, 0, dummyIdHeader);
-
-	// 最終フレーム数の取得
-	let lastFrame = getLastFrame(g_scoreObj) + g_headerObj.blankFrame;
-
-	// 最初の矢印データがあるフレーム数を取得
-	let firstArrowFrame = getFirstArrowFrame(g_scoreObj);
-
-	// 開始フレーム数の取得(フェードイン加味)
-	g_scoreObj.frameNum = getStartFrame(lastFrame, g_stateObj.fadein);
-	g_scoreObj.baseFrame;
-
-	// フレームごとの速度を取得（配列形式）
-	let speedOnFrame = setSpeedOnFrame(g_scoreObj.speedData, lastFrame);
-
-	// Motionオプション適用時の矢印別の速度を取得（配列形式）
-	const motionOnFrame = setMotionOnFrame();
-	g_workObj.motionOnFrames = JSON.parse(JSON.stringify(motionOnFrame));
-
-	// 最初のフレームで出現する矢印が、ステップゾーンに到達するまでのフレーム数を取得
-	const firstFrame = (g_scoreObj.frameNum === 0 ? 0 : g_scoreObj.frameNum + g_headerObj.blankFrame);
-	let arrivalFrame = getFirstArrivalFrame(firstFrame, speedOnFrame, motionOnFrame);
-
-	// キーパターン(デフォルト)に対応する矢印番号を格納
-	convertreplaceNums();
-
-	const setData = (_data, _minLength = 1) => {
-		return (_data !== undefined && _data.length >= _minLength ? _data.concat() : []);
-	}
-
-	// フレーム・曲開始位置調整
-	let preblankFrame = 0;
-	if (g_scoreObj.frameNum === 0) {
-		if (firstArrowFrame - C_MAX_ADJUSTMENT < arrivalFrame) {
-			preblankFrame = arrivalFrame - firstArrowFrame + C_MAX_ADJUSTMENT;
-
-			// 譜面データの再読み込み
-			const tmpObj = scoreConvert(g_rootObj, g_stateObj.scoreId, preblankFrame, dummyIdHeader);
-			for (let j = 0; j < keyNum; j++) {
-				if (tmpObj.arrowData[j] !== undefined) {
-					g_scoreObj.arrowData[j] = JSON.parse(JSON.stringify(tmpObj.arrowData[j]));
-				}
-				if (tmpObj.frzData[j] !== undefined) {
-					g_scoreObj.frzData[j] = JSON.parse(JSON.stringify(tmpObj.frzData[j]));
-				}
-				if (tmpObj.dummyArrowData[j] !== undefined && g_stateObj.shuffle === C_FLG_OFF) {
-					g_scoreObj.dummyArrowData[j] = JSON.parse(JSON.stringify(tmpObj.dummyArrowData[j]));
-				}
-				if (tmpObj.dummyFrzData[j] !== undefined && g_stateObj.shuffle === C_FLG_OFF) {
-					g_scoreObj.dummyFrzData[j] = JSON.parse(JSON.stringify(tmpObj.dummyFrzData[j]));
-				}
-			}
-
-			/**
-			 * データ種, 最小データ長のセット
-			 */
-			const dataTypes = [
-				[`speed`, 2],
-				[`boost`, 2],
-				[`color`, 3],
-				[`acolor`, 3],
-				[`shadowcolor`, 3],
-				[`ashadowcolor`, 3],
-				[`arrowCssMotion`, 3],
-				[`frzCssMotion`, 3],
-				[`dummyArrowCssMotion`, 3],
-				[`dummyFrzCssMotion`, 3],
-				[`object`, 4],
-				[`word`, 3],
-				[`mask`, 1],
-				[`back`, 1],
-			];
-			dataTypes.forEach(dataType => {
-				g_scoreObj[`${dataType[0]}Data`] = setData(tmpObj[`${dataType[0]}Data`], dataType[1]);
-			});
-
-			lastFrame += preblankFrame;
-			firstArrowFrame += preblankFrame;
-			speedOnFrame = setSpeedOnFrame(g_scoreObj.speedData, lastFrame);
-			arrivalFrame = getFirstArrivalFrame(firstFrame, speedOnFrame, motionOnFrame);
-			g_headerObj.blankFrame += preblankFrame;
-		}
-	}
-
-	// シャッフルグループ未定義の場合
-	if (g_keyObj[`shuffle${keyCtrlPtn}`] === undefined) {
-		g_keyObj[`shuffle${keyCtrlPtn}`] = [...Array(keyNum)].fill(0);
-	}
-
-	// シャッフルグループを扱いやすくする
-	// [0, 0, 0, 1, 0, 0, 0] -> [[0, 1, 2, 4, 5, 6], [3]]
-	const shuffleGroupMap = {};
-	g_keyObj[`shuffle${keyCtrlPtn}`].forEach((_val, _i) => {
-		if (shuffleGroupMap[_val] === undefined) {
-			shuffleGroupMap[_val] = [];
-		};
-		shuffleGroupMap[_val].push(_i);
-	});
-	const shuffleGroup = Object.values(shuffleGroupMap);
-
-	// Mirror,Random,S-Randomの適用
-	if (g_stateObj.shuffle === `Mirror`) {
-		applyMirror(keyNum, shuffleGroup);
-	} else if (g_stateObj.shuffle === `Random`) {
-		applyRandom(keyNum, shuffleGroup);
-	} else if (g_stateObj.shuffle === `Random+`) {
-		applyRandom(keyNum, [[...Array(keyNum).keys()]]);
-	} else if (g_stateObj.shuffle === `S-Random`) {
-		applySRandom(keyNum, shuffleGroup, `arrow`, `frz`);
-		applySRandom(keyNum, shuffleGroup, `dummyArrow`, `dummyFrz`);
-	} else if (g_stateObj.shuffle === `S-Random+`) {
-		applySRandom(keyNum, [[...Array(keyNum).keys()]], `arrow`, `frz`);
-		applySRandom(keyNum, [[...Array(keyNum).keys()]], `dummyArrow`, `dummyFrz`);
-	}
-
-	// アシスト用の配列があれば、ダミーデータで上書き
-	if (typeof g_keyObj[`assistPos${keyCtrlPtn}`] === C_TYP_OBJECT &&
-		!g_autoPlaysBase.includes(g_stateObj.autoPlay)) {
-		const assistArray = g_keyObj[`assistPos${keyCtrlPtn}`][g_stateObj.autoPlay];
-		for (let j = 0; j < keyNum; j++) {
-			if (assistArray[j] === 1) {
-				g_scoreObj.dummyArrowData[j] = g_scoreObj.arrowData[j].concat();
-				g_scoreObj.arrowData[j] = [];
-				g_scoreObj.dummyFrzData[j] = g_scoreObj.frzData[j].concat();
-				g_scoreObj.frzData[j] = [];
-			} else {
-				g_scoreObj.dummyArrowData[j] = [];
-				g_scoreObj.dummyFrzData[j] = [];
-			}
-		}
-	}
-
-	// 矢印・フリーズアロー数をカウント
-	g_allArrow = 0;
-	g_allFrz = 0;
-	for (let j = 0; j < keyNum; j++) {
-		g_allArrow += (isNaN(parseFloat(g_scoreObj.arrowData[j][0])) ? 0 : g_scoreObj.arrowData[j].length);
-		g_allFrz += (isNaN(parseFloat(g_scoreObj.frzData[j][0])) ? 0 : g_scoreObj.frzData[j].length);
-	}
-
-	// ライフ回復・ダメージ量の計算
-	// フリーズ始点でも通常判定させる場合は総矢印数を水増しする
-	if (g_headerObj.frzStartjdgUse) {
-		g_allArrow += g_allFrz / 2;
-	}
-	g_fullArrows = g_allArrow + g_allFrz / 2;
-
-	calcLifeVals(g_fullArrows);
-
-	// 矢印・フリーズアロー・速度/色変化格納処理
-	pushArrows(g_scoreObj, speedOnFrame, motionOnFrame, arrivalFrame);
-
-	// メインに入る前の最終初期化処理
-	getArrowSettings();
-
-	// ユーザカスタムイベント
-	if (typeof customLoadingInit === C_TYP_FUNCTION) {
-		customLoadingInit();
-		if (typeof customLoadingInit2 === C_TYP_FUNCTION) {
-			customLoadingInit2();
-		}
-	}
-
-	const tempId = setInterval(() => {
-		const executeMain = _ => {
-			clearInterval(tempId);
-			clearWindow();
-			MainInit();
-		}
-		if (g_audio.duration !== undefined) {
-			if (g_userAgent.indexOf(`firefox`) !== -1) {
-				if (g_preloadImgs.every(v => g_loadObj[v] === true)) {
-					executeMain();
-				}
-			} else {
-				executeMain();
-			}
-		}
-	}, 100);
 }
 
 /**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. カスタムjs、スキンjsが二重読込されている問題を修正しました。
    - 現状、初期（initAfterDosLoaded処理後）と楽曲ロード時（loadingScoreInit処理後）の
2回読み込んでいます。
後者はリトライごとに呼び出されるため、場合によっては何度も読込します。
2. loadingScoreInitとloadingScoreInit2を統合しました。
3. #915 の修正箇所と重なるため、マージしたものをPull Requestします。詳細は #915 を参照してください。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 上記が二重読込されることにより、
ファイル内でconstやletで定義している変数群がエラーになることを抑止します。
2. 1.に伴う、不要コードの整理のため。
3. 詳細は #915 を参照。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
### 初期表示時での読込
- ここの`g_loadObj.main`は、譜面ロードに失敗したときのみ`false`となるため、問題なし。
<img src="https://user-images.githubusercontent.com/44026291/103115120-bb8b9500-46a4-11eb-841b-006d08cf19e8.png" width="70%">

### 楽曲ロード時の読込（毎回実行されるため不要）
<img src="https://user-images.githubusercontent.com/44026291/103115146-d2ca8280-46a4-11eb-982d-6237fc2c44ea.png" width="70%">


## :pencil: その他コメント / Other Comments
- ファイルが動的に変わるわけではないので、二重読込させる意味は無いと考えています。
- コード見直し時に混入した可能性があります。過去バージョンも要確認。
