### PR TITLE
[0321/gitter-link] 結果画面にGitterへのリンクを追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9350,7 +9350,7 @@ function resultInit() {
 			clearWindow();
 			titleInit();
 		}, {
-			h: C_BTN_HEIGHT * 5 / 4,
+			w: g_sWidth / 4, h: C_BTN_HEIGHT * 5 / 4,
 			animationName: `smallToNormalY`,
 		}, g_cssObj.button_Back),
 
@@ -9359,17 +9359,25 @@ function resultInit() {
 			copyTextToClipboard(resultText);
 			makeInfoWindow(C_MSG_I_0001, `leftToRightFade`);
 		}, {
-			x: g_sWidth / 3,
+			x: g_sWidth / 4,
+			w: g_sWidth / 2,
 			h: C_BTN_HEIGHT * 5 / 8, siz: 24,
 			animationName: `smallToNormalY`,
 		}, g_cssObj.button_Setting),
 
 		// リザルトデータをTwitterへ転送
 		createCss2Button(`btnTweet`, `Tweet`, _ => openLink(tweetResult), {
-			x: g_sWidth / 3, y: g_sHeight - 100 + C_BTN_HEIGHT * 5 / 8,
-			h: C_BTN_HEIGHT * 5 / 8, siz: 24,
+			x: g_sWidth / 4, y: g_sHeight - 100 + C_BTN_HEIGHT * 5 / 8,
+			w: g_sWidth / 4, h: C_BTN_HEIGHT * 5 / 8, siz: 24,
 			animationName: `smallToNormalY`,
 		}, g_cssObj.button_Tweet),
+
+		// Gitterへのリンク
+		createCss2Button(`btnGitter`, `To Gitter`, _ => openLink(`https://gitter.im/danonicw/freeboard`), {
+			x: g_sWidth / 2, y: g_sHeight - 100 + C_BTN_HEIGHT * 5 / 8,
+			w: g_sWidth / 4, h: C_BTN_HEIGHT * 5 / 8, siz: 24,
+			animationName: `smallToNormalY`,
+		}, g_cssObj.button_Default),
 
 		// リトライ
 		createCss2Button(`btnRetry`, `Retry`, _ => {
@@ -9381,8 +9389,8 @@ function resultInit() {
 			clearWindow();
 			loadMusic();
 		}, {
-			x: g_sWidth / 3 * 2,
-			h: C_BTN_HEIGHT * 5 / 4,
+			x: g_sWidth / 4 * 3,
+			w: g_sWidth / 4, h: C_BTN_HEIGHT * 5 / 4,
 			animationName: `smallToNormalY`,
 		}, g_cssObj.button_Reset),
 	)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2330,6 +2330,13 @@ function titleInit() {
 			title: g_msgObj.reload,
 		}, g_cssObj.button_Start),
 
+		// ヘルプ
+		createCss2Button(`btnHelp`, `?`, _ => openLink(`https://github.com/cwtickle/danoniplus/wiki/AboutGameSystem`), {
+			x: 0, y: g_sHeight - 150,
+			w: 40, h: 40, siz: 30,
+			title: g_msgObj.howto,
+		}, g_cssObj.button_Setting),
+
 		// 製作者表示
 		createCss2Button(`lnkMaker`, `Maker: ${g_headerObj.tuningInit}`, _ => {
 			openLink(g_headerObj.creatorUrl);
@@ -9373,7 +9380,7 @@ function resultInit() {
 		}, g_cssObj.button_Tweet),
 
 		// Gitterへのリンク
-		createCss2Button(`btnGitter`, `To Gitter`, _ => openLink(`https://gitter.im/danonicw/freeboard`), {
+		createCss2Button(`btnGitter`, `Gitter`, _ => openLink(`https://gitter.im/danonicw/freeboard`), {
 			x: g_sWidth / 2, y: g_sHeight - 100 + C_BTN_HEIGHT * 5 / 8,
 			w: g_sWidth / 4, h: C_BTN_HEIGHT * 5 / 8, siz: 24,
 			animationName: `smallToNormalY`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1673,6 +1673,7 @@ const C_MSG_I_0002 = `入力したキーは割り当てできません。他の�
 const g_msgObj = {
 
     reload: `ページを再読込します。`,
+    howto: `ゲーム画面の見方や設定の詳細についてのページへ移動します（GitHub Wiki）。`,
     dataReset: `この作品で保存されているハイスコアや\nAdjustment情報等をリセットします。`,
     github: `Dancing☆Onigiri (CW Edition)のGitHubページへ移動します。`,
     security: `Dancing☆Onigiri (CW Edition)のサポート情報ページへ移動します。`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- 結果画面にGitterへのリンクを追加しました。
- タイトル画面にゲーム画面説明リンクを追加しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- Issue #919 関連。

## :camera: スクリーンショット / Screenshot
- 結果画面
<img src="https://user-images.githubusercontent.com/44026291/103171216-b0478d80-488d-11eb-8a68-cfbcbfc2597d.png" width="50%">

- タイトル画面
<img src="https://user-images.githubusercontent.com/44026291/103171201-9148fb80-488d-11eb-848a-9b5697860e1b.png" width="50%">

## :pencil: その他コメント / Other Comments
- 技術系リンクは後回し。一旦結果画面を優先して対応します。
