### PR TITLE
[0322/image-extensions] 画像拡張子指定時に画像読込チェックに失敗する問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1983,7 +1983,7 @@ function drawDefaultBackImage(_key) {
  */
 function checkImage(_str) {
 	return (
-		g_imgObj.imgExtensions.findIndex(value => _str.toLowerCase().match(new RegExp(String.raw`.${value}$`, 'i'))) !== -1 ? true : false
+		g_imgExtensions.findIndex(value => _str.toLowerCase().match(new RegExp(String.raw`.${value}$`, 'i'))) !== -1 ? true : false
 	);
 }
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -117,9 +117,10 @@ const g_imgObj = {
     frzBar: C_IMG_FRZBAR,
     lifeBar: C_IMG_LIFEBAR,
     lifeBorder: C_IMG_LIFEBORDER,
-
-    imgExtensions: [`png`, `gif`, `bmp`, `jpg`, `jpeg`, `svg`],
 };
+
+// 読込対象の画像拡張子
+let g_imgExtensions = [`png`, `gif`, `bmp`, `jpg`, `jpeg`, `svg`];
 
 // Motionオプション配列の基準位置
 const C_MOTION_STD_POS = 15;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- `danoni_setting.js`で定義する`g_presetOverrideExtension`(画像拡張子指定)が有効のとき、
checkImage（画像読込チェック）に失敗する問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- 下記、Gitterからの指摘より。
https://gitter.im/danonicw/community?at=5fe8ae4fdbb17f28c5a284ff

- g_imgObj の各プロパティ（ファイル名）に対して拡張子を付与しているが、
`g_imgObj.imgExtensions` のみファイル名ではなく配列であるため、
配列が文字列として扱われ、以後の処理で`g_imgObj.imgExtensions`が機能しなくなる。
```javascript
        // 画像拡張子の設定 (サーバ上のみ)
	if (typeof g_presetOverrideExtension === C_TYP_STRING && !location.href.match(`^file`)) {
		let key;
		for (key in g_imgObj) {
			g_imgObj[key] = `${g_imgObj[key].slice(0, -3)}${g_presetOverrideExtension}`;
		}
	}
```

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 修正の方向性としては、imgExtensionsプロパティを`g_imgObj`から外して独立変数にする。
- 変数名を変更するため、この変数を上書き設定している場合は注意が必要。