### PR TITLE
一部のキーを押すと全押し状態になる問題の修正

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -485,7 +485,10 @@ for (let j = 0; j < 255; j++) {
     g_kCd[j] = ``;
     g_kCdN[j] = ``;
 }
+
+// キー表示用
 g_kCd[0] = `- - -`;
+g_kCd[1] = `Unknown`;
 g_kCd[8] = `BackSpace`;
 g_kCd[9] = `Tab`;
 g_kCd[12] = `Clear`;
@@ -597,7 +600,9 @@ g_kCd[226] = `\\ _`;
 g_kCd[229] = `IME`;
 g_kCd[240] = `CapsLk`;
 
-g_kCdN[0] = ``;
+// 従来のキーコードとの変換用
+g_kCdN[0] = `- - -`; // 無効値
+g_kCdN[1] = ``; // 特殊キー(PR #924 参照)
 g_kCdN[8] = `Backspace`;
 g_kCdN[9] = `Tab`;
 g_kCdN[12] = `Clear`;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- プレイ中のキー押下処理で`_keyCode === ''`のとき処理を行わないようにします

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- 無変換など一部の特殊キーを押したとき全押し状態になってしまいます
- キーコードが空文字で、無効化された代替キーに反応してしまうようです

## :camera: スクリーンショット / Screenshot

## :pencil: その他コメント / Other Comments
- 環境依存かもしれません