### PR TITLE
[0324/ttile-expansion] タイトルアニメーションの設定を拡張（クラス設定他）

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2225,7 +2225,8 @@ function titleInit() {
 			for (let j = 0; j < txtAnimations.length; j++) {
 				txtAnimations[j] = `animation-name:${g_headerObj.titleAnimationName[j]};
 				animation-duration:${g_headerObj.titleAnimationDuration[j]}s;
-				animation-delay:${g_headerObj.titleAnimationDelay[j]}s;`;
+				animation-delay:${g_headerObj.titleAnimationDelay[j]}s;
+				animation-timing-function:${g_headerObj.titleAnimationTimingFunction[j]};`;
 			}
 		}
 		const lblmusicTitle = createDivCss2Label(`lblmusicTitle`,
@@ -2236,7 +2237,7 @@ function titleInit() {
 				-webkit-background-clip: text;
 				-webkit-text-fill-color: rgba(255,255,255,0.0);
 				${txtAnimations[0]}
-			">
+			" class="${g_headerObj.titleAnimationClass[0]}">
 				${g_headerObj.musicTitleForView[0]}
 			</div>
 			<div id="lblmusicTitle2" style="
@@ -2249,7 +2250,7 @@ function titleInit() {
 				-webkit-background-clip: text;
 				-webkit-text-fill-color: rgba(255,255,255,0.0);
 				${txtAnimations[1]}
-			">
+			" class="${g_headerObj.titleAnimationClass[1]}">
 				${setVal(g_headerObj.musicTitleForView[1], ``, C_TYP_STRING)}
 			</div>
 			`,
@@ -3141,18 +3142,29 @@ function headerConvert(_dosObj) {
 	obj.titleAnimationName = [`leftToRight`];
 	obj.titleAnimationDuration = [1.5];
 	obj.titleAnimationDelay = [0];
+	obj.titleAnimationTimingFunction = [`ease`];
+	obj.titleAnimationClass = [``];
 	if (hasVal(_dosObj.titleanimation)) {
 		_dosObj.titleanimation.split(`$`).forEach((pos, j) => {
 			const titleAnimation = pos.split(`,`);
 			obj.titleAnimationName[j] = setVal(titleAnimation[0], obj.titleAnimationName[0], C_TYP_STRING);
 			obj.titleAnimationDuration[j] = setVal(titleAnimation[1] / g_fps, obj.titleAnimationDuration[0], C_TYP_FLOAT);
 			obj.titleAnimationDelay[j] = setVal(titleAnimation[2] / g_fps, obj.titleAnimationDelay[0], C_TYP_FLOAT);
+			obj.titleAnimationTimingFunction[j] = setVal(titleAnimation[3], obj.titleAnimationName[3], C_TYP_STRING);
+		});
+	}
+	if (hasVal(_dosObj.titleanimationclass)) {
+		_dosObj.titleanimationclass.split(`$`).forEach((animationClass, j) => {
+			obj.titleAnimationClass[j] = setVal(animationClass, ``, C_TYP_STRING);
 		});
 	}
 	if (obj.titleAnimationName.length === 1) {
-		[`Name`, `Duration`, `Delay`].forEach(pattern => {
+		[`Name`, `Duration`, `Delay`, `TimingFunction`].forEach(pattern => {
 			obj[`titleAnimation${pattern}`][1] = obj[`titleAnimation${pattern}`][0];
 		});
+	}
+	if (obj.titleAnimationClass.length === 1) {
+		obj.titleAnimationClass[1] = obj.titleAnimationClass[0];
 	}
 
 	// デフォルト曲名表示の複数行時の縦間隔


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 譜面ヘッダー：titleanimationを拡張しました（4番目の要素にアニメーション方法を追加）。
※CSSで言うところの`animaton-timing-function`に相当
2. 譜面ヘッダー：titleanimationclassを追加しました。titleanimationで設定しきれないcss設定をまとめて設定するために使用することを想定しています。
```
|titleanimation=leftToRight,120,0,linear|
|titleanimationclass=title|
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 現状の設定ではアニメーションをlinearにするといった設定ができないため。
2. 上記以外の項目にも対応できる余地を作るため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments