### PR TITLE
同一レーン上に通常矢印とフリーズアローが短い間隔で存在するとき、通常矢印の判定が優先されてしまう現象を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8666,14 +8666,15 @@ function judgeArrow(_j) {
 	const arrowName = `arrow${_j}_${currentNo}`;
 	const judgArrow = document.getElementById(arrowName);
 
-	if (judgArrow !== null) {
-		const difFrame = g_attrObj[arrowName].cnt;
-		const difCnt = Math.abs(difFrame);
+	const fcurrentNo = g_workObj.judgFrzCnt[_j];
+	const frzName = `frz${_j}_${fcurrentNo}`;
+	const judgFrz = document.getElementById(frzName);
 
-		if (difCnt <= g_judgObj.arrowJ[C_JDG_UWAN]) {
-			const [resultFunc, resultJdg] = checkJudgment(difCnt);
-			resultFunc(difFrame);
-			countFastSlow(difFrame, g_headerObj.justFrames);
+	function judgeTargetArrow(_difCnt, _difFrame) {
+		if (_difCnt <= g_judgObj.arrowJ[C_JDG_UWAN]) {
+			const [resultFunc, resultJdg] = checkJudgment(_difCnt);
+			resultFunc(_difFrame);
+			countFastSlow(_difFrame, g_headerObj.justFrames);
 
 			const stepDivHit = document.querySelector(`#stepHit${_j}`);
 			stepDivHit.style.top = `${g_attrObj[arrowName].prevY - parseFloat($id(`stepRoot${_j}`).top) - 15}px`;
@@ -8684,30 +8685,52 @@ function judgeArrow(_j) {
 
 			document.querySelector(`#arrowSprite${g_attrObj[arrowName].dividePos}`).removeChild(judgArrow);
 			g_workObj.judgArrowCnt[_j]++;
-			return;
 		}
 	}
 
-	const fcurrentNo = g_workObj.judgFrzCnt[_j];
-	const frzName = `frz${_j}_${fcurrentNo}`;
-	const judgFrz = document.getElementById(frzName);
+	function judgeTargetFrzArrow(_difCnt, _difFrame) {
+		if (_difCnt <= g_judgObj.frzJ[C_JDG_SFSF] && !g_attrObj[frzName].judgEndFlg) {
+			if (g_headerObj.frzStartjdgUse &&
+				(g_workObj.judgFrzHitCnt[_j] === undefined || g_workObj.judgFrzHitCnt[_j] <= fcurrentNo)) {
+				const [resultFunc] = checkJudgment(_difCnt);
+				resultFunc(_difFrame);
+				countFastSlow(_difFrame, g_headerObj.justFrames);
+				g_workObj.judgFrzHitCnt[_j] = fcurrentNo + 1;
+			}
+			changeHitFrz(_j, fcurrentNo, `frz`);
+		}
+	}
+
+	if (judgArrow !== null && judgFrz !== null) {
+		const difFrame = g_attrObj[arrowName].cnt;
+		const difCnt = Math.abs(difFrame);
+		const frzDifFrame = g_attrObj[frzName].cnt;
+		const frzDifCnt = Math.abs(frzDifFrame);
+
+		if (difCnt < frzDifCnt) {
+			judgeTargetArrow(difCnt, difFrame);
+		} else {
+			judgeTargetFrzArrow(frzDifCnt, frzDifFrame);
+		}
+		return;
+	}
+
+	if (judgArrow !== null) {
+		const difFrame = g_attrObj[arrowName].cnt;
+		const difCnt = Math.abs(difFrame);
+
+		judgeTargetArrow(difCnt, difFrame);
+		return;
+	}
 
 	if (judgFrz !== null) {
 		const difFrame = g_attrObj[frzName].cnt;
 		const difCnt = Math.abs(difFrame);
 
-		if (difCnt <= g_judgObj.frzJ[C_JDG_SFSF] && !g_attrObj[frzName].judgEndFlg) {
-			if (g_headerObj.frzStartjdgUse &&
-				(g_workObj.judgFrzHitCnt[_j] === undefined || g_workObj.judgFrzHitCnt[_j] <= fcurrentNo)) {
-				const [resultFunc] = checkJudgment(difCnt);
-				resultFunc(difFrame);
-				countFastSlow(difFrame, g_headerObj.justFrames);
-				g_workObj.judgFrzHitCnt[_j] = fcurrentNo + 1;
-			}
-			changeHitFrz(_j, fcurrentNo, `frz`);
-			return;
-		}
+		judgeTargetFrzArrow(difCnt, difFrame);
+		return;
 	}
+
 	$id(`stepDiv${_j}`).display = C_DIS_INHERIT;
 }
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- 通常矢印とフリーズアローの矢印番号が別で管理されている関係で、通常矢印のショボーン判定以内にフリーズアローが存在する場合に、通常矢印の判定が優先されてしまう現象が発生するためこれを修正しました

例)
```
left_data=205
frzLeft_data=200,202
```
となっている場合、200F地点でキーを押下するとフリーズアローのキター判定が出ることが期待されますが、
実際には通常矢印のマターリ判定が出てしまっていました

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
正確にキーを押下しても想定したプレイができないため
- +ERABY+E CONNEC+10N [Death] http://ngtkd.starfree.jp/danoni/177_tera.html
- Vast Universe [S２６] http://www.ricetask68934.shop/ricetask68934.shop/danoni/DS357.html?scoreId=4

などで発生します

## :pencil: その他コメント / Other Comments
- 特になし
