### PR TITLE
AppearanceとOpacityの初期値設定処理を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1319,9 +1319,17 @@ function loadLocalStorage() {
 			g_localStorage.volume = 100;
 		}
 
-		// Display関連の初期値設定
-		g_appearanceNum = roundZero(g_appearances.findIndex(setting => setting === g_stateObj.appearance));
-		g_opacityNum = roundZero(g_opacitys.findIndex(setting => setting === g_stateObj.opacity));
+		// Appearance初期値設定
+		if (g_localStorage.appearance !== undefined) {
+			g_stateObj.appearance = g_localStorage.appearance;
+			g_appearanceNum = roundZero(g_appearances.findIndex(setting => setting === g_stateObj.appearance));
+		}
+
+		// Opacity初期値設定
+		if (g_localStorage.opacity !== undefined) {
+			g_stateObj.opacity = g_localStorage.opacity;
+			g_opacityNum = roundZero(g_opacitys.findIndex(setting => setting === g_stateObj.opacity));
+		}
 
 		// ハイスコア取得準備
 		if (g_localStorage.highscores === undefined) {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- `g_appearanceNum`と`g_opacityNum`をLocalStorageの値をもとに初期化するように修正しました

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- [gitterより](https://gitter.im/danonicw/community?at=5ff5e496e578cf1e95cfe0b2)

## :camera: スクリーンショット / Screenshot
## :pencil: その他コメント / Other Comments
