### PR TITLE
[0329/gauge-initial] gaugeXの設定補完に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3213,44 +3213,39 @@ function getGaugeSetting(_dosObj, _name, _headerObj) {
 
 	const difLength = _headerObj.keyLabels.length;
 
+	const obj = {
+		lifeBorders: [],
+		lifeRecoverys: [],
+		lifeDamages: [],
+		lifeInits: []
+	};
+
+	const setGaugeDetails = gaugeData => {
+		const gaugeDetails = gaugeData.split(`,`);
+		if (gaugeDetails[0] === `x`) {
+			obj.lifeBorders.push(`x`);
+		} else {
+			obj.lifeBorders.push(setVal(gaugeDetails[0], ``, C_TYP_FLOAT));
+		}
+		obj.lifeRecoverys.push(setVal(gaugeDetails[1], ``, C_TYP_FLOAT));
+		obj.lifeDamages.push(setVal(gaugeDetails[2], ``, C_TYP_FLOAT));
+		obj.lifeInits.push(setVal(gaugeDetails[3], ``, C_TYP_FLOAT));
+	};
+
 	if (hasVal(_dosObj[`gauge${_name}`])) {
 		const gauges = _dosObj[`gauge${_name}`].split(`$`);
 
-		const obj = {
-			lifeBorders: [],
-			lifeRecoverys: [],
-			lifeDamages: [],
-			lifeInits: []
-		};
-
 		for (let j = 0; j < gauges.length; j++) {
-			const gaugeDetails = gauges[j].split(`,`);
-			if (gaugeDetails[0] === `x`) {
-				obj.lifeBorders.push(`x`);
-			} else {
-				obj.lifeBorders.push(setVal(gaugeDetails[0], ``, C_TYP_FLOAT));
-			}
-			obj.lifeRecoverys.push(setVal(gaugeDetails[1], ``, C_TYP_FLOAT));
-			obj.lifeDamages.push(setVal(gaugeDetails[2], ``, C_TYP_FLOAT));
-			obj.lifeInits.push(setVal(gaugeDetails[3], ``, C_TYP_FLOAT));
+			setGaugeDetails(gauges[j]);
 		}
 		if (gauges.length < difLength) {
 			for (let j = gauges.length; j < difLength; j++) {
-				obj.lifeBorders.push(``);
-				obj.lifeRecoverys.push(``);
-				obj.lifeDamages.push(``);
-				obj.lifeInits.push(``);
+				setGaugeDetails(gauges[0]);
 			}
 		}
 		g_gaugeOptionObj[`gauge${_name}s`] = Object.assign({}, obj);
 
 	} else if (typeof g_presetGaugeCustom === C_TYP_OBJECT && g_presetGaugeCustom[_name]) {
-		const obj = {
-			lifeBorders: [],
-			lifeRecoverys: [],
-			lifeDamages: [],
-			lifeInits: []
-		};
 		for (let j = 0; j < difLength; j++) {
 			if (g_presetGaugeCustom[_name].Border === `x`) {
 				obj.lifeBorders.push(`x`);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- gaugeX において、2譜面目以降の指定を省略した場合に1譜面目の設定を補完するよう変更しました。

```
|gaugeHeavy=x,1,20,100|
-> |gaugeHeavy=x,1,20,100$x,1,20,100$...$x,1,20,100|
|gaugeEasy=70,2,5,40$80,2,7,40|
-> |gaugeEasy=70,2,5,40$80,2,7,40$70,2,5,40$...$70,2,5,40|
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- 現状は全譜面に対して設定が必要であり、数が多くなると手間になるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 中途半端な設定（3譜面のうち最初の2譜面のみ設定）にしていると
ゲージ設定がこれまでのバージョンと変わる可能性があります。