### PR TITLE
[0330/reset-window] 画面初期表示と画面消去を統一

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3516,8 +3516,7 @@ function optionInit() {
 		// Display設定へ移動
 		createCss2Button(`btnDisplay`, `>`, _ => settingsDisplayInit(), {
 			x: g_sWidth / 2 + 175 - C_LEN_SETMINI_WIDTH / 2, y: 25,
-			w: C_LEN_SETMINI_WIDTH, h: 40,
-			title: g_msgObj.toDisplay,
+			w: C_LEN_SETMINI_WIDTH, h: 40, title: g_msgObj.toDisplay,
 		}, g_cssObj.button_Mini),
 
 		// データセーブフラグの切替
@@ -4764,8 +4763,7 @@ function settingsDisplayInit() {
 		// メイン設定へ戻る
 		createCss2Button(`btnSettings`, `<`, _ => optionInit(), {
 			x: g_sWidth / 2 - 175 - C_LEN_SETMINI_WIDTH / 2, y: 25,
-			w: C_LEN_SETMINI_WIDTH, h: 40,
-			title: g_msgObj.toSettings,
+			w: C_LEN_SETMINI_WIDTH, h: 40, title: g_msgObj.toSettings,
 		}, g_cssObj.button_Mini)
 
 	);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1676,6 +1676,8 @@ function loadSettingJs() {
 }
 
 function loadMusic() {
+
+	clearWindow();
 	document.onkeydown = evt => blockCode(transCode(evt.code));
 
 	const musicUrl = g_headerObj.musicUrls[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.musicUrls[0];
@@ -2021,6 +2023,8 @@ function drawTitleResultMotion(_spriteName) {
  *  タイトル画面初期化
  */
 function titleInit() {
+
+	clearWindow();
 	drawDefaultBackImage(``);
 
 	// タイトル用フレーム初期化
@@ -2182,7 +2186,6 @@ function titleInit() {
 		// Click Here
 		createCss2Button(`btnStart`, `Click Here!!`, _ => {
 			clearTimeout(g_timeoutEvtTitleId);
-			clearWindow();
 			optionInit();
 		}, {
 			w: g_sWidth, siz: C_LBL_TITLESIZE,
@@ -2329,7 +2332,6 @@ function titleInit() {
 
 		if (setCode === `Enter`) {
 			clearTimeout(g_timeoutEvtTitleId);
-			clearWindow();
 			optionInit();
 		}
 		return blockCode(setCode);
@@ -3475,6 +3477,7 @@ function keysConvert(_dosObj) {
  */
 function optionInit() {
 
+	clearWindow();
 	drawDefaultBackImage(``);
 	const divRoot = document.querySelector(`#divRoot`);
 	g_baseDisp = `Settings`;
@@ -3498,7 +3501,6 @@ function optionInit() {
 
 		// タイトル画面へ戻る
 		createCss2Button(`btnBack`, `Back`, _ => {
-			clearWindow();
 			titleInit();
 		}, {
 			animationName: (g_initialFlg ? `` : `smallToNormalY`),
@@ -3508,7 +3510,6 @@ function optionInit() {
 		createCss2Button(`btnKeyConfig`, `KeyConfig`, _ => {
 			// キーコンフィグ画面へ遷移
 			g_kcType = `Main`;
-			clearWindow();
 			keyConfigInit();
 		}, {
 			x: g_sWidth / 3,
@@ -3517,13 +3518,11 @@ function optionInit() {
 
 		// プレイ開始
 		makePlayButton(_ => {
-			clearWindow();
 			loadMusic();
 		}),
 
 		// Display設定へ移動
 		createCss2Button(`btnDisplay`, `>`, _ => {
-			clearWindow();
 			settingsDisplayInit();
 		}, {
 			x: g_sWidth / 2 + 175 - C_LEN_SETMINI_WIDTH / 2, y: 25,
@@ -3554,7 +3553,6 @@ function optionInit() {
 		}
 
 		if (setCode === `Enter`) {
-			clearWindow();
 			loadMusic();
 		}
 		return blockCode(setCode);
@@ -4730,6 +4728,7 @@ function makeMiniCssButton(_id, _directionFlg, _heightPos, _func, { dx = 0, dy =
 
 function settingsDisplayInit() {
 
+	clearWindow();
 	drawDefaultBackImage(``);
 	const divRoot = document.querySelector(`#divRoot`);
 	g_baseDisp = `Display`;
@@ -4763,14 +4762,12 @@ function settingsDisplayInit() {
 
 		// タイトル画面へ戻る
 		createCss2Button(`btnBack`, `Back`, _ => {
-			clearWindow();
 			titleInit();
 		}, {}, g_cssObj.button_Back),
 
 		// キーコンフィグ画面へ移動
 		createCss2Button(`btnKeyConfig`, `KeyConfig`, _ => {
 			g_kcType = `Main`;
-			clearWindow();
 			keyConfigInit();
 		}, {
 			x: g_sWidth / 3,
@@ -4778,13 +4775,11 @@ function settingsDisplayInit() {
 
 		// プレイ開始
 		makePlayButton(_ => {
-			clearWindow();
 			loadMusic();
 		}),
 
 		// メイン設定へ戻る
 		createCss2Button(`btnSettings`, `<`, _ => {
-			clearWindow();
 			optionInit();
 		}, {
 			x: g_sWidth / 2 - 175 - C_LEN_SETMINI_WIDTH / 2, y: 25,
@@ -4803,7 +4798,6 @@ function settingsDisplayInit() {
 		}
 
 		if (setCode === `Enter`) {
-			clearWindow();
 			loadMusic();
 		}
 		return blockCode(setCode);
@@ -4963,6 +4957,7 @@ function interlockingButton(_headerObj, _name, _current, _next, _buttonFlg = fal
  */
 function keyConfigInit() {
 
+	clearWindow();
 	drawDefaultBackImage(``);
 	const divRoot = document.querySelector(`#divRoot`);
 
@@ -5188,7 +5183,6 @@ function keyConfigInit() {
 			g_currentj = 0;
 			g_currentk = 0;
 			g_prevKey = 0;
-			clearWindow();
 
 			if (g_baseDisp === `Settings`) {
 				optionInit();
@@ -5211,7 +5205,6 @@ function keyConfigInit() {
 			g_keyObj.currentPtn = (g_keyObj[`keyCtrl${g_keyObj.currentKey}_${tempPtn}`] !== undefined ?
 				tempPtn : (g_keyObj[`keyCtrl${g_keyObj.currentKey}_-1`] !== undefined ? -1 : 0));
 
-			clearWindow();
 			keyConfigInit();
 			const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
 			const divideCnt = g_keyObj[`div${keyCtrlPtn}`] - 1;
@@ -5227,7 +5220,6 @@ function keyConfigInit() {
 			g_keyObj.currentPtn = (g_keyObj[`keyCtrl${g_keyObj.currentKey}_${tempPtn}`] !== undefined ?
 				tempPtn : searchPattern(searchPattern(0, 1) - 1, -1, g_headerObj.transKeyUse, `transKey`));
 
-			clearWindow();
 			keyConfigInit();
 			const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
 			const divideCnt = g_keyObj[`div${keyCtrlPtn}`] - 1;
@@ -5680,7 +5672,6 @@ function loadingScoreInit() {
 		const tempId = setInterval(() => {
 			const executeMain = _ => {
 				clearInterval(tempId);
-				clearWindow();
 				MainInit();
 			}
 			if (g_audio.duration !== undefined) {
@@ -7067,6 +7058,7 @@ function setKeyCtrl(_localStorage, _keyNum, _keyCtrlPtn) {
  * メイン画面初期化
  */
 function MainInit() {
+	clearWindow();
 	drawDefaultBackImage(`Main`);
 	const divRoot = document.querySelector(`#divRoot`);
 	document.oncontextmenu = _ => false;
@@ -7540,7 +7532,6 @@ function MainInit() {
 		} else if (setCode === g_kCdN[g_headerObj.keyTitleBack]) {
 			g_audio.pause();
 			clearTimeout(g_timeoutEvtId);
-			clearWindow();
 			if (keyIsDown(`ShiftLeft`)) {
 				g_gameOverFlg = true;
 				g_finishFlg = false;
@@ -8283,7 +8274,6 @@ function MainInit() {
 
 			clearTimeout(g_timeoutEvtId);
 			setTimeout(_ => {
-				clearWindow();
 				resultInit();
 			}, 100);
 
@@ -8292,7 +8282,6 @@ function MainInit() {
 			// ライフ制＆ライフ０の場合は途中終了
 			g_audio.pause();
 			clearTimeout(g_timeoutEvtId);
-			clearWindow();
 			g_gameOverFlg = true;
 			g_finishFlg = false;
 			resultInit();
@@ -8876,6 +8865,7 @@ function finishViewing() {
  */
 function resultInit() {
 
+	clearWindow();
 	drawDefaultBackImage(``);
 
 	// 結果画面用フレーム初期化
@@ -9253,7 +9243,6 @@ function resultInit() {
 			}
 			clearTimeout(g_timeoutEvtId);
 			clearTimeout(g_timeoutEvtResultId);
-			clearWindow();
 			titleInit();
 		}, {
 			w: g_sWidth / 4, h: C_BTN_HEIGHT * 5 / 4,
@@ -9292,7 +9281,6 @@ function resultInit() {
 			}
 			clearTimeout(g_timeoutEvtId);
 			clearTimeout(g_timeoutEvtResultId);
-			clearWindow();
 			loadMusic();
 		}, {
 			x: g_sWidth / 4 * 3,

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3500,31 +3500,21 @@ function optionInit() {
 	multiAppend(divRoot,
 
 		// タイトル画面へ戻る
-		createCss2Button(`btnBack`, `Back`, _ => {
-			titleInit();
-		}, {
+		createCss2Button(`btnBack`, `Back`, _ => titleInit(), {
 			animationName: (g_initialFlg ? `` : `smallToNormalY`),
 		}, g_cssObj.button_Back),
 
 		// キーコンフィグ画面へ移動
-		createCss2Button(`btnKeyConfig`, `KeyConfig`, _ => {
-			// キーコンフィグ画面へ遷移
-			g_kcType = `Main`;
-			keyConfigInit();
-		}, {
+		createCss2Button(`btnKeyConfig`, `KeyConfig`, _ => keyConfigInit(`Main`), {
 			x: g_sWidth / 3,
 			animationName: (g_initialFlg ? `` : `smallToNormalY`),
 		}, g_cssObj.button_Setting),
 
 		// プレイ開始
-		makePlayButton(_ => {
-			loadMusic();
-		}),
+		makePlayButton(_ => loadMusic()),
 
 		// Display設定へ移動
-		createCss2Button(`btnDisplay`, `>`, _ => {
-			settingsDisplayInit();
-		}, {
+		createCss2Button(`btnDisplay`, `>`, _ => settingsDisplayInit(), {
 			x: g_sWidth / 2 + 175 - C_LEN_SETMINI_WIDTH / 2, y: 25,
 			w: C_LEN_SETMINI_WIDTH, h: 40,
 			title: g_msgObj.toDisplay,
@@ -4761,27 +4751,18 @@ function settingsDisplayInit() {
 	multiAppend(divRoot,
 
 		// タイトル画面へ戻る
-		createCss2Button(`btnBack`, `Back`, _ => {
-			titleInit();
-		}, {}, g_cssObj.button_Back),
+		createCss2Button(`btnBack`, `Back`, _ => titleInit(), {}, g_cssObj.button_Back),
 
 		// キーコンフィグ画面へ移動
-		createCss2Button(`btnKeyConfig`, `KeyConfig`, _ => {
-			g_kcType = `Main`;
-			keyConfigInit();
-		}, {
+		createCss2Button(`btnKeyConfig`, `KeyConfig`, _ => keyConfigInit(`Main`), {
 			x: g_sWidth / 3,
 		}, g_cssObj.button_Setting),
 
 		// プレイ開始
-		makePlayButton(_ => {
-			loadMusic();
-		}),
+		makePlayButton(_ => loadMusic()),
 
 		// メイン設定へ戻る
-		createCss2Button(`btnSettings`, `<`, _ => {
-			optionInit();
-		}, {
+		createCss2Button(`btnSettings`, `<`, _ => optionInit(), {
 			x: g_sWidth / 2 - 175 - C_LEN_SETMINI_WIDTH / 2, y: 25,
 			w: C_LEN_SETMINI_WIDTH, h: 40,
 			title: g_msgObj.toSettings,
@@ -4955,11 +4936,12 @@ function interlockingButton(_headerObj, _name, _current, _next, _buttonFlg = fal
 /**
  * キーコンフィグ画面初期化
  */
-function keyConfigInit() {
+function keyConfigInit(_kcType = g_kcType) {
 
 	clearWindow();
 	drawDefaultBackImage(``);
 	const divRoot = document.querySelector(`#divRoot`);
+	g_kcType = _kcType;
 
 	// 譜面初期情報ロード許可フラグ
 	g_canLoadDifInfoFlg = false;
@@ -8273,9 +8255,7 @@ function MainInit() {
 			document.onkeyup = evt => { }
 
 			clearTimeout(g_timeoutEvtId);
-			setTimeout(_ => {
-				resultInit();
-			}, 100);
+			setTimeout(_ => resultInit(), 100);
 
 		} else if (g_workObj.lifeVal === 0 && g_workObj.lifeBorder === 0) {
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- 画面初期表示と画面消去を統一しました。
titleInit / optionInit / settingsDisplayInit / loadMusic / MainInit / resultInit の処理の先頭に
clearWindow() 処理を追加しています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- 処理の単純化のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- ボタン処理をコピーしてカスタムしている場合、clearWindowが二重に動く可能性があります。
（二重に動かしても問題はありません）