### PR TITLE
[0331/custom-gauge-list] danoni_setting.jsにカスタムゲージリストを追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2680,6 +2680,11 @@ function headerConvert(_dosObj) {
 			g_gaugeOptionObj.custom[j] = customGaugeSets[0];
 			g_gaugeOptionObj.varCustom[j] = (customGaugeSets[1] !== `V` ? C_FLG_OFF : C_FLG_ON);
 		}
+	} else if (typeof g_presetGaugeList === C_TYP_OBJECT) {
+		Object.keys(g_presetGaugeList).forEach(key => {
+			g_gaugeOptionObj.custom.push(key);
+			g_gaugeOptionObj.varCustom.push((g_presetGaugeList[key] !== `V` ? C_FLG_OFF : C_FLG_ON));
+		});
 	}
 
 	// ライフ設定のカスタム部分取得（譜面ヘッダー加味）

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -60,6 +60,17 @@ const g_presetGaugeCustom = {
 	}
 };
 
+// カスタムゲージ設定(デフォルト)
+// 'ゲージ名': `回復・ダメージ量設定`　の形式で指定します。
+// (F : 矢印数によらず固定, V: 矢印数により変動)
+/*
+const g_presetGaugeList = {
+	'Original': `F`,
+	'Normal': `V`,
+	'Hard': `V`,
+};
+*/
+
 // デフォルトのデザインを使用せず、独自のデザインを使用するかを指定
 // カスタムデザインにする場合は `true` を指定
 const g_presetCustomDesignUse = {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- danoni_setting.jsにカスタムゲージリストを追加しました。
- 譜面ヘッダー：customGaugeと使い方はほぼ同じです。
customGaugeの指定がある場合は、customGaugeが優先されます。

```javascript
// カスタムゲージ設定(デフォルト)
// 'ゲージ名': `回復・ダメージ量設定`　の形式で指定します。
// (F : 矢印数によらず固定, V: 矢印数により変動)
const g_presetGaugeList = {
	'Original': `F`,
	'Normal': `V`,
	'Hard': `V`,
};
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- 常時カスタムゲージを設定するケースがあるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- danoni_setting.jsに記載するカスタムゲージリストは指定した順に変わります
（上記の場合は、Original -> Normal -> Hard）。
- 合作など、通常のサイトの設定と異なる場合はsettingTypeを別途指定し、分けて管理することもできます。