### PR TITLE
[0332/title-arrow-opacity] タイトルの背景矢印の透明度設定を有効化

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1969,8 +1969,9 @@ function makeColorGradation(_colorStr, { _defaultColorgrd = g_headerObj.defaultC
 		return `Default`;
 	}
 
-	// 矢印の塗りつぶしのみ、透明度を50%にする
-	const alphaVal = (_shadowFlg && _objType !== `frz`) ? `80` : ``;
+	// 矢印の塗りつぶしの場合：透明度を50%にする
+	// 背景矢印の場合　　　　：透明度を25%にする
+	const alphaVal = (_shadowFlg && _objType !== `frz`) ? `80` : (_objType === `titleArrow` ? `40` : ``);
 
 	let convertColorStr;
 	const tmpColorStr = _colorStr.split(`@`);
@@ -2060,7 +2061,7 @@ function titleInit() {
 				background: makeColorGradation(g_headerObj.titlearrowgrds[0] || g_headerObj.setColorOrg[0], {
 					_defaultColorgrd: [false, `#eeeeee`],
 					_objType: `titleArrow`,
-				}), rotate: 180, opacity: 0.25,
+				}), rotate: 180,
 			})
 		);
 	}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- タイトルの背景矢印の透明度設定を有効化しました。（titlearrowgrdに対してRGBA指定を可能に）
下記のような指定が可能になります。
```
|titlearrowgrd=#9999ff20:#9999ffff|
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- Gitter要望より。
https://gitter.im/danonicw/community?at=60058b1d5562a61e9ab284a6
- これまで、影矢印など一部矢印はRGBAのカラーコードに対応していましたが、
タイトルの背景矢印についてはOpacityが強制的に25％になっていました。
背景矢印についても同様の指定ができるように変更します。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/105011153-f0122700-5a7f-11eb-9462-201fc3d3609d.png" width="60%">

## :pencil: その他コメント / Other Comments
- 特になし
