### PR TITLE
[0333/color-to-rgba] 色名をカラーコードに変換する処理を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2021,7 +2021,6 @@ function makeColorGradation(_colorStr, { _defaultColorgrd = g_headerObj.defaultC
 			colorArray[j] += alphaVal;
 		}
 	}
-	console.log(colorArray);
 
 	const gradationType = (tmpColorStr.length > 1 ? tmpColorStr[1] : `linear-gradient`);
 	const defaultDir = (_objType === `titleArrow` ? `to left` : `to right`);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1970,17 +1970,18 @@ const byteToHex = _num => (`${('0' + _num.toString(16)).slice(-2)}`);
  * @param {string} _color 色名
  */
 const colorToHex = (_color) => {
-	if (_color.substring(0, 1) === `#`) {
+	if (_color.substring(0, 1) === `#` || !isNaN(parseFloat(_color))) {
 		return _color;
 	}
 
 	// red;255 の形式が指定された場合は透明度情報を上書きして変換
 	const tmpColor = _color.split(`;`);
+	const colorSet = tmpColor[0].split(` `);
 	let alphaVal = ``;
 	if (tmpColor.length > 1) {
 		alphaVal = byteToHex(setVal(tmpColor[1], 255, C_TYP_NUMBER));
 	}
-	return `${colorNameToCode(tmpColor[0])}${alphaVal}`;
+	return `${colorNameToCode(colorSet[0])}${alphaVal}${colorSet[1] !== undefined ? ` ${colorSet[1]}` : ''}`;
 }
 
 /**
@@ -2020,6 +2021,7 @@ function makeColorGradation(_colorStr, { _defaultColorgrd = g_headerObj.defaultC
 			colorArray[j] += alphaVal;
 		}
 	}
+	console.log(colorArray);
 
 	const gradationType = (tmpColorStr.length > 1 ? tmpColorStr[1] : `linear-gradient`);
 	const defaultDir = (_objType === `titleArrow` ? `to left` : `to right`);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1950,17 +1950,13 @@ function drawMainSpriteData(_frame, _depthName) {
 }
 
 /**
- * 色名をカラーコード配列(RGBA)に変換
+ * 色名をカラーコードに変換
  * @param {string} _color 
  */
-const colorToRGBA = _color => {
-	const cvs = document.createElement(`canvas`);
-	cvs.height = 1;
-	cvs.width = 1;
-	const cxt = cvs.getContext(`2d`);
+const colorNameToCode = _color => {
+	const cxt = document.createElement(`canvas`).getContext(`2d`);
 	cxt.fillStyle = _color;
-	cxt.fillRect(0, 0, 1, 1);
-	return cxt.getImageData(0, 0, 1, 1).data;
+	return cxt.fillStyle;
 }
 
 /**
@@ -1972,22 +1968,19 @@ const byteToHex = _num => (`${('0' + _num.toString(16)).slice(-2)}`);
 /**
  * 色名をカラーコードへ変換 (元々カラーコードの場合は除外)
  * @param {string} _color 色名
- * @param {number} _length カラーコード種類を指定 (3 -> RGB, 4 -> RGBA)
  */
-const colorToHex = (_color, _length = 3) => {
+const colorToHex = (_color) => {
 	if (_color.substring(0, 1) === `#`) {
 		return _color;
 	}
-	const tmpColor = _color.split(`;`);
-	const rgba = colorToRGBA(tmpColor[0]);
-	let rgbaLength = _length;
 
 	// red;255 の形式が指定された場合は透明度情報を上書きして変換
+	const tmpColor = _color.split(`;`);
+	let alphaVal = ``;
 	if (tmpColor.length > 1) {
-		rgba[3] = setVal(tmpColor[1], rgba[3], C_TYP_NUMBER);
-		rgbaLength = rgba.length;
+		alphaVal = byteToHex(setVal(tmpColor[1], 255, C_TYP_NUMBER));
 	}
-	return `#${[...Array(rgbaLength).keys()].map(idx => byteToHex(rgba[idx])).join('')}`;
+	return `${colorNameToCode(tmpColor[0])}${alphaVal}`;
 }
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1972,9 +1972,9 @@ const byteToHex = _num => (`${('0' + _num.toString(16)).slice(-2)}`);
 const colorToHex = (_color) => {
 
 	// すでにカラーコードのものやパーセント表記、位置表記系を除外
-	// 'to'のみ、'to left'や'to right'のように方向が入るため、半角スペースまで込みで判断
-	const exceptHeader = [`at`, `to `, `from`, `circle`, `ellipse`, `closest-side`, `farthest-corner`, `transparent`];
-	const exceptFooter = [`deg`];
+	// 'at', 'to'のみ、'to left'や'to right'のように方向が入るため、半角スペースまで込みで判断
+	const exceptHeader = [`at `, `to `, `from`, `circle`, `ellipse`, `closest-`, `farthest-`, `transparent`];
+	const exceptFooter = [`deg`, `rad`, `grad`, `turn`, `repeat`];
 	if (_color.substring(0, 1) === `#` || !isNaN(parseFloat(_color)) ||
 		exceptHeader.findIndex(value => _color.toLowerCase().match(new RegExp(String.raw`^${value}`, 'i'))) !== -1 ||
 		exceptFooter.findIndex(value => _color.toLowerCase().match(new RegExp(String.raw`${value}$`, 'i'))) !== -1) {
@@ -2041,8 +2041,9 @@ function makeColorGradation(_colorStr, { _defaultColorgrd = g_headerObj.defaultC
 			convertColorStr = `${defaultDir}, ${colorArray[0]}, ${colorArray[0]}`;
 		}
 	} else if (gradationType === `linear-gradient` && (colorArray[0].slice(0, 1) === `#` ||
-		(!colorArray[0].startsWith(`to `) && !colorArray[0].endsWith(`deg`)))) {
-		// "to XXXX" もしくは "XXXdeg"のパターン以外は方向を補完する
+		(!colorArray[0].startsWith(`to `) && !colorArray[0].endsWith(`deg`)
+			&& !colorArray[0].endsWith(`rad`) && !colorArray[0].endsWith(`turn`)))) {
+		// "to XXXX" もしくは "XXXdeg(rad, grad, turn)"のパターン以外は方向を補完する
 		convertColorStr = `${defaultDir}, ${colorArray.join(', ')}`;
 	} else {
 		convertColorStr = `${colorArray.join(', ')}`;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1970,18 +1970,26 @@ const byteToHex = _num => (`${('0' + _num.toString(16)).slice(-2)}`);
  * @param {string} _color 色名
  */
 const colorToHex = (_color) => {
-	if (_color.substring(0, 1) === `#` || !isNaN(parseFloat(_color))) {
+
+	// すでにカラーコードのものやパーセント表記、位置表記系を除外
+	// 'to'のみ、'to left'や'to right'のように方向が入るため、半角スペースまで込みで判断
+	const exceptHeader = [`at`, `to `, `from`, `circle`, `ellipse`, `closest-side`, `farthest-corner`, `transparent`];
+	const exceptFooter = [`deg`];
+	if (_color.substring(0, 1) === `#` || !isNaN(parseFloat(_color)) ||
+		exceptHeader.findIndex(value => _color.toLowerCase().match(new RegExp(String.raw`^${value}`, 'i'))) !== -1 ||
+		exceptFooter.findIndex(value => _color.toLowerCase().match(new RegExp(String.raw`${value}$`, 'i'))) !== -1) {
 		return _color;
 	}
 
-	// red;255 の形式が指定された場合は透明度情報を上書きして変換
+	// 色_位置;透明度 (Ex: red 20%;255) の形式で取り込み
+	// 透明度はカラーコード形式に変換してRGBの後ろに設定
 	const tmpColor = _color.split(`;`);
 	const colorSet = tmpColor[0].split(` `);
 	let alphaVal = ``;
 	if (tmpColor.length > 1) {
 		alphaVal = byteToHex(setVal(tmpColor[1], 255, C_TYP_NUMBER));
 	}
-	return `${colorNameToCode(colorSet[0])}${alphaVal}${colorSet[1] !== undefined ? ` ${colorSet[1]}` : ''}`;
+	return `${colorNameToCode(colorSet[0])}${alphaVal}${colorSet[1] !== undefined ? ` ${colorSet.slice(1).join(' ')}` : ''}`;
 }
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1950,6 +1950,39 @@ function drawMainSpriteData(_frame, _depthName) {
 }
 
 /**
+ * 色名をカラーコード配列(RGBA)に変換
+ * @param {string} _color 
+ */
+const colorToRGBA = _color => {
+	const cvs = document.createElement(`canvas`);
+	cvs.height = 1;
+	cvs.width = 1;
+	const cxt = cvs.getContext(`2d`);
+	cxt.fillStyle = _color;
+	cxt.fillRect(0, 0, 1, 1);
+	return cxt.getImageData(0, 0, 1, 1).data;
+}
+
+/**
+ * 10進 -> 16進数変換 (カラーコード形式になるよう0埋め)
+ * @param {number} _num 
+ */
+const byteToHex = _num => (`${('0' + _num.toString(16)).slice(-2)}`);
+
+/**
+ * 色名をカラーコードへ変換 (元々カラーコードの場合は除外)
+ * @param {string} _color 色名
+ * @param {number} _length カラーコード種類を指定 (3 -> RGB, 4 -> RGBA)
+ */
+const colorToHex = (_color, _length = 3) => {
+	if (_color.substring(0, 1) === `#`) {
+		return _color;
+	}
+	const rgba = colorToRGBA(_color);
+	return `#${[...Array(_length).keys()].map(idx => byteToHex(rgba[idx])).join('')}`;
+}
+
+/**
  * グラデーション用のカラーフォーマットを作成
  * @param {string} _colorStr 
  * @param {object} _options
@@ -1977,7 +2010,7 @@ function makeColorGradation(_colorStr, { _defaultColorgrd = g_headerObj.defaultC
 	const tmpColorStr = _colorStr.split(`@`);
 	const colorArray = tmpColorStr[0].split(`:`);
 	for (let j = 0; j < colorArray.length; j++) {
-		colorArray[j] = colorArray[j].replace(/0x/g, `#`);
+		colorArray[j] = colorToHex(colorArray[j].replace(/0x/g, `#`));
 		if (_colorCdPaddingUse) {
 			colorArray[j] = `#${paddingLeft(colorArray[j].slice(1), 6, `0`)}`;
 		}
@@ -2083,7 +2116,7 @@ function titleInit() {
 
 		// グラデーションの指定がない場合、
 		// 矢印色の1番目と3番目を使ってタイトルをグラデーション
-		const titlegrd1 = g_headerObj.titlegrds[0] || `${g_headerObj.setColorOrg[0]},${g_headerObj.setColorOrg[2]}`;
+		const titlegrd1 = g_headerObj.titlegrds[0] || `${g_headerObj.setColorOrg[0]}:${g_headerObj.setColorOrg[2]}`;
 		const titlegrd2 = g_headerObj.titlegrds[1] || titlegrd1;
 
 		const titlegrds = [];

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2041,8 +2041,8 @@ function makeColorGradation(_colorStr, { _defaultColorgrd = g_headerObj.defaultC
 			convertColorStr = `${defaultDir}, ${colorArray[0]}, ${colorArray[0]}`;
 		}
 	} else if (gradationType === `linear-gradient` && (colorArray[0].slice(0, 1) === `#` ||
-		(!colorArray[0].startsWith(`to `) && !colorArray[0].endsWith(`deg`)
-			&& !colorArray[0].endsWith(`rad`) && !colorArray[0].endsWith(`turn`)))) {
+		(!colorArray[0].startsWith(`to `) &&
+			[`deg`, `rad`, `turn`].findIndex(value => colorArray[0].toLowerCase().match(new RegExp(String.raw`${value}$`, 'i'))) === -1))) {
 		// "to XXXX" もしくは "XXXdeg(rad, grad, turn)"のパターン以外は方向を補完する
 		convertColorStr = `${defaultDir}, ${colorArray.join(', ')}`;
 	} else {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1875,7 +1875,7 @@ function drawDefaultBackImage(_key) {
  * @param {string} _str 
  */
 function checkImage(_str) {
-	return listMatching(_str, g_imgExtensions, { suffix: `$` });
+	return listMatching(_str, g_imgExtensions, { prefix: `[.]`, suffix: `$` });
 }
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1978,8 +1978,16 @@ const colorToHex = (_color, _length = 3) => {
 	if (_color.substring(0, 1) === `#`) {
 		return _color;
 	}
-	const rgba = colorToRGBA(_color);
-	return `#${[...Array(_length).keys()].map(idx => byteToHex(rgba[idx])).join('')}`;
+	const tmpColor = _color.split(`;`);
+	const rgba = colorToRGBA(tmpColor[0]);
+	let rgbaLength = _length;
+
+	// red;255 の形式が指定された場合は透明度情報を上書きして変換
+	if (tmpColor.length > 1) {
+		rgba[3] = setVal(tmpColor[1], rgba[3], C_TYP_NUMBER);
+		rgbaLength = rgba.length;
+	}
+	return `#${[...Array(rgbaLength).keys()].map(idx => byteToHex(rgba[idx])).join('')}`;
 }
 
 /**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 色名をカラーコードに変換する処理を追加しました。
2. `色名;透明度(0～255)`の形式で、色名と透明度を同時に指定できるようにしました。
```
|titlearrowgrd=midnightblue:tan|
|titlearrowgrd=midnightblue;255:tan;255|
```
3. linear-gradientの方向自動補完で rad, grad, turn についても検知するようにしました。
4. リストのいずれかに部分一致検索（大小文字問わず）する処理を統一しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. PR #942 により、色名をtitlearrowgrdに指定した場合に
デフォルトの透明度が掛からない問題が発生していました。
2. 色名指定であっても、カラーコードと同等の設定が行えるようにするため。
3. rad, grad, turn を指定した場合に余計な補完が入らないようにするため。
4. 下記その他コメントに記載の除外条件が、画像かどうかのチェックと類似しているため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/105106662-a82fe600-5af9-11eb-8691-83a115add066.png" width="60%">

## :pencil: その他コメント / Other Comments
- 上記は背景矢印の例ですが、グラデーション処理全般に対して修正しているため
グラデーションが使えるところであれば、同じ記述が使えます。（タイトル文字、矢印色など）
- グラデーションの方向名を色名として判断しないよう、除外条件を付けています。
```javascript
// すでにカラーコードのものやパーセント表記、位置表記系を除外
// 'to'のみ、'to left'や'to right'のように方向が入るため、半角スペースまで込みで判断
const exceptHeader = [`at`, `to `, `from`, `circle`, `ellipse`, `closest-side`, `farthest-corner`, `transparent`];
const exceptFooter = [`deg`];
if (_color.substring(0, 1) === `#` || !isNaN(parseFloat(_color)) ||
	exceptHeader.findIndex(value => _color.toLowerCase().match(new RegExp(String.raw`^${value}`, 'i'))) !== -1 ||
	exceptFooter.findIndex(value => _color.toLowerCase().match(new RegExp(String.raw`${value}$`, 'i'))) !== -1) {
	return _color;
}
```