### PR TITLE
[0334/constants] 定数系配列をdanoni_constants.jsへ移動　他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4077,7 +4077,7 @@ function createOptionWindow(_sprite) {
 		} else {
 			dataDouji.textContent = g_detailObj.toolDif[_scoreId].douji;
 			dataTate.textContent = g_detailObj.toolDif[_scoreId].tate;
-			lblArrowInfo2.innerHTML = g_msgObj.difInfoCnt.split(`{0}`).join(g_detailObj.toolDif[_scoreId].push3cnt);
+			lblArrowInfo2.innerHTML = g_lblNameObj.s_linecnts.split(`{0}`).join(g_detailObj.toolDif[_scoreId].push3cnt);
 			dataArrowInfo.innerHTML = ArrowInfo;
 			dataArrowInfo2.innerHTML = ArrowInfo2;
 		}
@@ -6909,33 +6909,27 @@ function getArrowSettings() {
 		}
 	}
 
-	g_workObj.judgArrowCnt = [];
-	g_workObj.judgFrzCnt = [];
-	g_workObj.judgFrzHitCnt = [];
-	g_judgObj.lockFlgs = [];
-
-	g_workObj.judgDummyArrowCnt = [];
-	g_workObj.judgDummyFrzCnt = [];
+	g_typeLists.arrow.forEach(type => g_workObj[`judg${toCapitalize(type)}Cnt`] = [...Array(keyNum)].fill(1));
+	g_workObj.judgFrzHitCnt = [...Array(keyNum)].fill(1);
+	g_judgObj.lockFlgs = [...Array(keyNum)].fill(false);
 
 	// TODO: この部分を矢印塗りつぶし部分についても適用できるように変数を作成
 
 	// 矢印色管理 (個別・全体)
-	[``, `All`].forEach(type => {
+	const eachOrAll = [``, `All`];
+	eachOrAll.forEach(type => {
 		g_workObj[`arrowColors${type}`] = [];
 		g_workObj[`dummyArrowColors${type}`] = [];
 
 		[`frz`, `dummyFrz`].forEach(arrowType => {
-			[`Normal`, `NormalBar`, `Hit`, `HitBar`].forEach(frzType => {
+			g_typeLists.frzColor.forEach(frzType => {
 				g_workObj[`${arrowType}${frzType}Colors${type}`] = [];
 			});
 		});
 	});
 
 	// モーション管理
-	g_workObj.arrowCssMotions = [];
-	g_workObj.frzCssMotions = [];
-	g_workObj.dummyArrowCssMotions = [];
-	g_workObj.dummyFrzCssMotions = [];
+	g_typeLists.arrow.forEach(type => g_workObj[`${type}CssMotions`] = [...Array(keyNum)].fill(``));
 
 	const scrollDirOptions = (g_keyObj[`scrollDir${keyCtrlPtn}`] !== undefined ?
 		g_keyObj[`scrollDir${keyCtrlPtn}`][g_stateObj.scroll] : [...Array(keyNum)].fill(1));
@@ -6952,42 +6946,21 @@ function getArrowSettings() {
 		g_workObj.dividePos[j] = ((posj <= divideCnt ? 0 : 1) + (scrollDirOptions[j] === 1 ? 0 : 1) + (g_stateObj.reverse === C_FLG_OFF ? 0 : 1)) % 2;
 		g_workObj.scrollDir[j] = (posj <= divideCnt ? 1 : -1) * scrollDirOptions[j] * (g_stateObj.reverse === C_FLG_OFF ? 1 : -1);
 
-		g_workObj.judgArrowCnt[j] = 1;
-		g_workObj.judgFrzCnt[j] = 1;
-		g_workObj.judgFrzHitCnt[j] = 1;
-		g_judgObj.lockFlgs[j] = false;
-
-		g_workObj.judgDummyArrowCnt[j] = 1;
-		g_workObj.judgDummyFrzCnt[j] = 1;
-
 		// TODO: この部分を矢印塗りつぶし部分についても適用できるように変数を作成
 
-		[``, `All`].forEach(type => {
+		eachOrAll.forEach(type => {
 			g_workObj[`arrowColors${type}`][j] = g_headerObj.setColor[colorj];
-
-			g_workObj[`frzNormalColors${type}`][j] = g_headerObj.frzColor[colorj][0];
-			g_workObj[`frzNormalBarColors${type}`][j] = g_headerObj.frzColor[colorj][1];
-			g_workObj[`frzHitColors${type}`][j] = g_headerObj.frzColor[colorj][2];
-			g_workObj[`frzHitBarColors${type}`][j] = g_headerObj.frzColor[colorj][3];
-
 			g_workObj[`dummyArrowColors${type}`][j] = g_headerObj.setDummyColor[colorj];
 
-			g_workObj[`dummyFrzNormalColors${type}`][j] = g_headerObj.setDummyColor[colorj];
-			g_workObj[`dummyFrzNormalBarColors${type}`][j] = g_headerObj.setDummyColor[colorj];
-			g_workObj[`dummyFrzHitColors${type}`][j] = g_headerObj.setDummyColor[colorj];
-			g_workObj[`dummyFrzHitBarColors${type}`][j] = g_headerObj.setDummyColor[colorj];
+			g_typeLists.frzColor.forEach((frzType, k) => {
+				g_workObj[`frz${frzType}Colors${type}`][j] = g_headerObj.frzColor[colorj][k];
+				g_workObj[`dummyFrz${frzType}Colors${type}`][j] = g_headerObj.setDummyColor[colorj];
+			});
 		});
-
-		g_workObj.arrowCssMotions[j] = ``;
-		g_workObj.frzCssMotions[j] = ``;
-		g_workObj.dummyArrowCssMotions[j] = ``;
-		g_workObj.dummyFrzCssMotions[j] = ``;
 	}
 
-	[
-		`ii`, `shakin`, `matari`, `shobon`, `uwan`, `combo`, `maxCombo`,
-		`kita`, `sfsf`, `iknai`, `fCombo`, `fmaxCombo`, `fast`, `slow`
-	].forEach(judgeCnt => g_resultObj[judgeCnt] = 0);
+	Object.keys(g_resultObj).forEach(judgeCnt => g_resultObj[judgeCnt] = 0);
+	g_resultObj.spState = ``;
 
 	g_displays.forEach(_disp => {
 		const lowerDisp = _disp.toLowerCase();
@@ -6997,7 +6970,6 @@ function getArrowSettings() {
 	g_workObj.lifeVal = Math.floor(g_workObj.lifeInit * 100) / 100;
 	g_gameOverFlg = false;
 	g_finishFlg = true;
-	g_resultObj.spState = ``;
 
 	if (g_stateObj.dataSaveFlg && !hasVal(g_keyObj[`transKey${keyCtrlPtn}`])) {
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4143,7 +4143,7 @@ function createOptionWindow(_sprite) {
 		];
 
 		spriteList.scroll.appendChild(
-			createCss2Button(`btnReverse`, `Reverse:${g_stateObj.reverse}`, evt => setReverse(evt.target), {
+			createCss2Button(`btnReverse`, `${g_lblNameObj.Reverse}:${g_stateObj.reverse}`, evt => setReverse(evt.target), {
 				x: 160, y: 0,
 				w: 90, h: 21, siz: C_SIZ_DIFSELECTOR,
 				borderStyle: `solid`,
@@ -4162,7 +4162,7 @@ function createOptionWindow(_sprite) {
 	function setReverseView(_btn) {
 		_btn.classList.replace(g_cssObj[`button_Rev${g_reverses[(g_reverseNum + 1) % 2]}`],
 			g_cssObj[`button_Rev${g_reverses[g_reverseNum]}`]);
-		_btn.textContent = `Reverse:${g_stateObj.reverse}`;
+		_btn.textContent = `${g_lblNameObj.Reverse}:${g_stateObj.reverse}`;
 	}
 
 	// ---------------------------------------------------
@@ -4325,16 +4325,16 @@ function createOptionWindow(_sprite) {
 		return `<div id="gaugeDivCover" class="settings_gaugeDivCover">
 					<div id="lblGaugeDivTable" class="settings_gaugeDivTable">
 						<div id="lblGaugeStart" class="settings_gaugeDivTableCol settings_gaugeStart">
-							Start
+							${g_lblNameObj.g_start}
 						</div>
 						<div id="lblGaugeBorder" class="settings_gaugeDivTableCol settings_gaugeEtc">
-							Border
+							${g_lblNameObj.g_border}
 						</div>
 						<div id="lblGaugeRecovery" class="settings_gaugeDivTableCol settings_gaugeEtc">
-							Recovery
+							${g_lblNameObj.g_recovery}
 						</div>
 						<div id="lblGaugeDamage" class="settings_gaugeDivTableCol settings_gaugeEtc">
-							Damage
+							${g_lblNameObj.g_damage}
 						</div>
 					</div>
 					<div id="dataGaugeDivTable" class="settings_gaugeDivTable">

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2324,7 +2324,7 @@ function titleInit() {
 					overflow: `auto`, background: `#222222`, color: `#cccccc`, display: C_DIS_NONE,
 				}),
 
-				createCss2Button(`btnComment`, `Comment`, _ => {
+				createCss2Button(`btnComment`, g_lblNameObj.comment, _ => {
 					const lblCommentDef = lblComment.style.display;
 					lblComment.style.display = (lblCommentDef === C_DIS_NONE ? C_DIS_INHERIT : C_DIS_NONE);
 				}, {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3922,7 +3922,7 @@ function createOptionWindow(_sprite) {
 			context.font = `${C_SIZ_DIFSELECTOR}px ${getBasicFont()}`;
 			context.fillText(speedType, lineX + 35, 218);
 
-			makeScoreDetailLabel(`Speed`, `${speedType.slice(0, 1).toUpperCase()}${speedType.slice(1)}`, speedObj[speedType].cnt, j);
+			makeScoreDetailLabel(`Speed`, g_lblNameObj[`s_${speedType}`], speedObj[speedType].cnt, j);
 		});
 	}
 
@@ -3948,13 +3948,13 @@ function createOptionWindow(_sprite) {
 		}
 
 		const apm = Math.round((arrowCnts + frzCnts) / (g_detailObj.playingFrame[_scoreId] / g_fps / 60));
-		makeScoreDetailLabel(`Density`, `APM`, apm, 0);
+		makeScoreDetailLabel(`Density`, g_lblNameObj.s_apm, apm, 0);
 		const minutes = Math.floor(g_detailObj.playingFrameWithBlank[_scoreId] / g_fps / 60);
 		const seconds = `00${Math.floor((g_detailObj.playingFrameWithBlank[_scoreId] / g_fps) % 60)}`.slice(-2);
 		const playingTime = `${minutes}:${seconds}`;
-		makeScoreDetailLabel(`Density`, `Time`, playingTime, 1);
-		makeScoreDetailLabel(`Density`, `Arrow`, arrowCnts, 3);
-		makeScoreDetailLabel(`Density`, `Frz`, frzCnts, 4);
+		makeScoreDetailLabel(`Density`, g_lblNameObj.s_time, playingTime, 1);
+		makeScoreDetailLabel(`Density`, g_lblNameObj.s_arrow, arrowCnts, 3);
+		makeScoreDetailLabel(`Density`, g_lblNameObj.s_frz, frzCnts, 4);
 	}
 
 	/**
@@ -4051,7 +4051,7 @@ function createOptionWindow(_sprite) {
 		}
 
 		if (document.querySelector(`#lblTooldif`) === null) {
-			makeDifInfoLabel(`lblTooldif`, `Level`, { y: 5, w: 250, siz: C_SIZ_JDGCNTS });
+			makeDifInfoLabel(`lblTooldif`, g_lblNameObj.s_level, { y: 5, w: 250, siz: C_SIZ_JDGCNTS });
 			makeDifInfoLabel(`dataTooldif`, g_detailObj.toolDif[_scoreId].tool, { x: 270, y: 3, w: 160, siz: 18 });
 		} else {
 			dataTooldif.textContent = g_detailObj.toolDif[_scoreId].tool;
@@ -4064,13 +4064,13 @@ function createOptionWindow(_sprite) {
 			${push3CntStr}`.split(`,`).join(`/`);
 
 		if (document.querySelector(`#lblDouji`) === null) {
-			makeDifInfoLabel(`lblDouji`, g_msgObj.difInfoDouji);
-			makeDifInfoLabel(`lblTate`, g_msgObj.difInfoTate, { x: 270 });
+			makeDifInfoLabel(`lblDouji`, g_lblNameObj.s_douji);
+			makeDifInfoLabel(`lblTate`, g_lblNameObj.s_tate, { x: 270 });
 			makeDifInfoLabel(`dataDouji`, g_detailObj.toolDif[_scoreId].douji, { x: 200, w: 160 });
 			makeDifInfoLabel(`dataTate`, g_detailObj.toolDif[_scoreId].tate, { x: 345, w: 160 });
-			makeDifInfoLabel(`lblArrowInfo`, `All Arrows`, { x: 130, y: 45, w: 290, siz: C_SIZ_JDGCNTS });
+			makeDifInfoLabel(`lblArrowInfo`, g_lblNameObj.s_cnts, { x: 130, y: 45, w: 290, siz: C_SIZ_JDGCNTS });
 			makeDifInfoLabel(`dataArrowInfo`, ArrowInfo, { x: 270, y: 45, w: 160, siz: C_SIZ_JDGCNTS });
-			makeDifInfoLabel(`lblArrowInfo2`, g_msgObj.difInfoCnt.split(`{0}`).join(g_detailObj.toolDif[_scoreId].push3cnt),
+			makeDifInfoLabel(`lblArrowInfo2`, g_lblNameObj.s_linecnts.split(`{0}`).join(g_detailObj.toolDif[_scoreId].push3cnt),
 				{ x: 130, y: 70, w: 200, h: 90 });
 			makeDifInfoLabel(`dataArrowInfo2`, ArrowInfo2, { x: 140, y: 70, w: 275, h: 150, overflow: `auto` });
 
@@ -4114,10 +4114,10 @@ function createOptionWindow(_sprite) {
 					`${playingTime}\r\n`;
 			}
 			detailToolDif.appendChild(
-				makeSettingLblCssButton(`lnkDifInfo`, g_msgObj.difInfoPrint, 0, _ => {
+				makeSettingLblCssButton(`lnkDifInfo`, g_lblNameObj.s_print, 0, _ => {
 					copyTextToClipboard(
-						`****** ${g_msgObj.difInfoPrintTitle} [${g_version}] ******\r\n\r\n`
-						+ `\t${g_msgObj.difInfoPrintHeader}\r\n\r\n${printData}`
+						`****** ${g_lblNameObj.s_printTitle} [${g_version}] ******\r\n\r\n`
+						+ `\t${g_lblNameObj.s_printHeader}\r\n\r\n${printData}`
 					);
 					makeInfoWindow(g_msgInfoObj.I_0003, `leftToRightFade`);
 				}, {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4776,7 +4776,7 @@ function settingsDisplayInit() {
 
 	// ショートカットキーメッセージ
 	divRoot.appendChild(
-		createDivCss2Label(`scMsg`, `Hid+/Sud+時ショートカット：「pageUp」カバーを上へ / 「pageDown」下へ`, {
+		createDivCss2Label(`scMsg`, g_msgObj.sdShortcutDesc, {
 			x: 0, y: g_sHeight - 45, w: g_sWidth, h: 20, siz: C_SIZ_MAIN,
 		})
 	);
@@ -4859,7 +4859,7 @@ function createSettingsDisplayWindow(_sprite) {
 	const spriteList = setSpriteList(settingList);
 
 	document.querySelector(`#${_sprite}`).appendChild(
-		createDivCss2Label(`sdDesc`, `[クリックでON/OFFを切替、灰色でOFF]`, {
+		createDivCss2Label(`sdDesc`, g_msgObj.sdDesc, {
 			x: 0, y: 65, w: g_sWidth, h: 20, siz: C_SIZ_MAIN,
 		})
 	);
@@ -4994,7 +4994,7 @@ function keyConfigInit(_kcType = g_kcType) {
 			`<div class="settings_Title">KEY</div><div class="settings_Title2">CONFIG</div>`
 				.replace(/[\t\n]/g, ``), 0, 15, g_cssObj.flex_centering),
 
-		createDivCss2Label(`kcDesc`, `[BackSpaceキー:スキップ / Deleteキー:(代替キーのみ)キー無効化]`, {
+		createDivCss2Label(`kcDesc`, g_msgObj.kcDesc, {
 			x: 0, y: 65, w: g_sWidth, h: 20, siz: C_SIZ_MAIN,
 		}),
 
@@ -5121,14 +5121,18 @@ function keyConfigInit(_kcType = g_kcType) {
 	multiAppend(divRoot,
 
 		// ショートカットキーメッセージ
-		createDivCss2Label(`scMsg`, `プレイ中ショートカット：「${g_kCd[g_headerObj.keyTitleBack]}」タイトルバック / 「${g_kCd[g_headerObj.keyRetry]}」リトライ`, {
-			x: 0, y: g_sHeight - 45, w: g_sWidth, h: 20, siz: C_SIZ_MAIN,
-		}),
+		createDivCss2Label(
+			`scMsg`,
+			g_msgObj.kcShortcutDesc.split(`{0}`).join(g_kCd[g_headerObj.keyTitleBack])
+				.split(`{1}`).join(g_kCd[g_headerObj.keyRetry]),
+			{
+				x: 0, y: g_sHeight - 45, w: g_sWidth, h: 20, siz: C_SIZ_MAIN,
+			}),
 
 		// 別キーモード警告メッセージ
 		createDivCss2Label(
 			`kcMsg`,
-			hasVal(g_keyObj[`transKey${keyCtrlPtn}`]) ? `別キーモードではハイスコア、キーコンフィグ等は保存されません` : ``,
+			hasVal(g_keyObj[`transKey${keyCtrlPtn}`]) ? g_msgObj.transKeyDesc : ``,
 			{
 				x: 0, y: g_sHeight - 25, w: g_sWidth, h: 20, siz: C_SIZ_MAIN,
 			}, g_cssObj.keyconfig_warning

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1106,7 +1106,7 @@ function getQueryParamVal(_name) {
  * ローディング文字用ラベルの作成
  */
 function getLoadingLabel() {
-	return createDivCss2Label(`lblLoading`, `Now Loading...`, {
+	return createDivCss2Label(`lblLoading`, g_lblNameObj.nowLoading, {
 		x: 0, y: g_sHeight - 40, w: g_sWidth, h: C_LEN_SETLBL_HEIGHT,
 		siz: C_SIZ_SETLBL, align: C_ALIGN_RIGHT,
 	});
@@ -1717,7 +1717,7 @@ function loadMusic() {
 			const blobUrl = URL.createObjectURL(request.response);
 			const loader = createSprite(`divRoot`, `loader`, 0, g_sHeight - 10, g_sWidth, 10);
 			loader.style.backgroundColor = `#333333`;
-			lblLoading.textContent = `Please Wait...`;
+			lblLoading.textContent = g_lblNameObj.pleaseWait;
 			setAudio(blobUrl);
 		} else {
 			makeWarningWindow(`${g_msgInfoObj.E_0032}<br>(${request.status} ${request.statusText})`);
@@ -1733,9 +1733,9 @@ function loadMusic() {
 			const loader = createSprite(`divRoot`, `loader`, 0, g_sHeight - 10, g_sWidth, 10);
 			loader.style.width = `${g_sWidth * rate}px`;
 			loader.style.backgroundColor = `#eeeeee`;
-			lblLoading.textContent = `Now Loading... ${Math.floor(rate * 100)}%`;
+			lblLoading.textContent = `${g_lblNameObj.nowLoading} ${Math.floor(rate * 100)}%`;
 		} else {
-			lblLoading.textContent = `Now Loading... ${_event.loaded}Bytes`;
+			lblLoading.textContent = `${g_lblNameObj.nowLoading} ${_event.loaded}Bytes`;
 		}
 		// ユーザカスタムイベント
 		if (typeof customLoadingProgress === C_TYP_FUNCTION) {
@@ -4780,7 +4780,7 @@ function settingsDisplayInit() {
 
 	// ショートカットキーメッセージ
 	divRoot.appendChild(
-		createDivCss2Label(`scMsg`, g_msgObj.sdShortcutDesc, {
+		createDivCss2Label(`scMsg`, g_lblNameObj.sdShortcutDesc, {
 			x: 0, y: g_sHeight - 45, w: g_sWidth, h: 20, siz: C_SIZ_MAIN,
 		})
 	);
@@ -4863,7 +4863,7 @@ function createSettingsDisplayWindow(_sprite) {
 	const spriteList = setSpriteList(settingList);
 
 	document.querySelector(`#${_sprite}`).appendChild(
-		createDivCss2Label(`sdDesc`, g_msgObj.sdDesc, {
+		createDivCss2Label(`sdDesc`, g_lblNameObj.sdDesc, {
 			x: 0, y: 65, w: g_sWidth, h: 20, siz: C_SIZ_MAIN,
 		})
 	);
@@ -4998,7 +4998,7 @@ function keyConfigInit(_kcType = g_kcType) {
 			`<div class="settings_Title">${g_lblNameObj.key}</div><div class="settings_Title2">${g_lblNameObj.config}</div>`
 				.replace(/[\t\n]/g, ``), 0, 15, g_cssObj.flex_centering),
 
-		createDivCss2Label(`kcDesc`, g_msgObj.kcDesc, {
+		createDivCss2Label(`kcDesc`, g_lblNameObj.kcDesc, {
 			x: 0, y: 65, w: g_sWidth, h: 20, siz: C_SIZ_MAIN,
 		}),
 
@@ -5127,7 +5127,7 @@ function keyConfigInit(_kcType = g_kcType) {
 		// ショートカットキーメッセージ
 		createDivCss2Label(
 			`scMsg`,
-			g_msgObj.kcShortcutDesc.split(`{0}`).join(g_kCd[g_headerObj.keyTitleBack])
+			g_lblNameObj.kcShortcutDesc.split(`{0}`).join(g_kCd[g_headerObj.keyTitleBack])
 				.split(`{1}`).join(g_kCd[g_headerObj.keyRetry]),
 			{
 				x: 0, y: g_sHeight - 45, w: g_sWidth, h: 20, siz: C_SIZ_MAIN,
@@ -5136,7 +5136,7 @@ function keyConfigInit(_kcType = g_kcType) {
 		// 別キーモード警告メッセージ
 		createDivCss2Label(
 			`kcMsg`,
-			hasVal(g_keyObj[`transKey${keyCtrlPtn}`]) ? g_msgObj.transKeyDesc : ``,
+			hasVal(g_keyObj[`transKey${keyCtrlPtn}`]) ? g_lblNameObj.transKeyDesc : ``,
 			{
 				x: 0, y: g_sHeight - 25, w: g_sWidth, h: 20, siz: C_SIZ_MAIN,
 			}, g_cssObj.keyconfig_warning

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -872,7 +872,7 @@ function loadScript(_url, _callback, _requiredFlg = true, _charset = `UTF-8`) {
 	script.onload = _ => _callback();
 	script.onerror = _ => {
 		if (_requiredFlg) {
-			makeWarningWindow(C_MSG_E_0041.split(`{0}`).join(_url.split(`?`)[0]));
+			makeWarningWindow(g_msgInfoObj.E_0041.split(`{0}`).join(_url.split(`?`)[0]));
 		} else {
 			g_loadObj[_url.split(`?`)[0]] = false;
 			_callback();
@@ -1242,7 +1242,7 @@ function loadDos(_afterFunc, _scoreId = g_stateObj.scoreId, _cyclicFlg = false) 
 		(externalDosInput !== null ? externalDosInput.value : ``);
 
 	if (dosInput === null && queryDos === ``) {
-		makeWarningWindow(C_MSG_E_0023);
+		makeWarningWindow(g_msgInfoObj.E_0023);
 		g_loadObj.main = false;
 		_afterFunc();
 		return;
@@ -1299,7 +1299,7 @@ function loadDos(_afterFunc, _scoreId = g_stateObj.scoreId, _cyclicFlg = false) 
 				}
 
 			} else {
-				makeWarningWindow(C_MSG_E_0022);
+				makeWarningWindow(g_msgInfoObj.E_0022);
 			}
 			_afterFunc();
 			if (_cyclicFlg) {
@@ -1720,7 +1720,7 @@ function loadMusic() {
 			lblLoading.textContent = `Please Wait...`;
 			setAudio(blobUrl);
 		} else {
-			makeWarningWindow(`${C_MSG_E_0032}<br>(${request.status} ${request.statusText})`);
+			makeWarningWindow(`${g_msgInfoObj.E_0032}<br>(${request.status} ${request.statusText})`);
 		}
 	});
 
@@ -1748,11 +1748,11 @@ function loadMusic() {
 
 	// エラー処理
 	request.addEventListener(`timeout`, _ => {
-		makeWarningWindow(`${C_MSG_E_0033}`);
+		makeWarningWindow(`${g_msgInfoObj.E_0033}`);
 	});
 
 	request.addEventListener(`error`, _ => {
-		makeWarningWindow(`${C_MSG_E_0034}`);
+		makeWarningWindow(`${g_msgInfoObj.E_0034}`);
 	});
 
 	request.send();
@@ -1772,7 +1772,7 @@ async function initWebAudioAPI(_url) {
  * @param {function} _func 
  */
 function makePlayButton(_func) {
-	return createCss2Button(`btnPlay`, `PLAY!`, _func, {
+	return createCss2Button(`btnPlay`, g_lblNameObj.b_play, _func, {
 		x: g_sWidth * 2 / 3,
 		animationName: (g_initialFlg ? `` : `smallToNormalY`),
 	}, g_cssObj.button_Next);
@@ -1814,7 +1814,7 @@ function setAudio(_url) {
 					initWebAudioAPI(`data:audio/mp3;base64,${g_musicdata}`);
 				}
 			} else {
-				makeWarningWindow(C_MSG_E_0031);
+				makeWarningWindow(g_msgInfoObj.E_0031);
 				musicAfterLoaded();
 			}
 		});
@@ -2119,9 +2119,9 @@ function titleInit() {
 	// タイトル文字描画
 	divRoot.appendChild(
 		getTitleDivLabel(`lblTitle`,
-			`<div class="settings_Title">DANCING</div>
-		<div class="settings_TitleStar">☆</div>
-		<div class="settings_Title2">ONIGIRI</div>`
+			`<div class="settings_Title">${g_lblNameObj.dancing}</div>
+		<div class="settings_TitleStar">${g_lblNameObj.star}</div>
+		<div class="settings_Title2">${g_lblNameObj.onigiri}</div>`
 				.replace(/[\t\n]/g, ``), 0, 15, g_cssObj.flex_centering)
 	);
 
@@ -2203,11 +2203,11 @@ function titleInit() {
 		g_userAgent.indexOf(`edge`) !== -1 ||
 		(g_userAgent.indexOf(`firefox`) !== -1 && location.href.match(`^file`))) {
 
-		makeWarningWindow(C_MSG_W_0001);
+		makeWarningWindow(g_msgInfoObj.W_0001);
 	}
 
 	if (location.href.match(/^file/)) {
-		makeWarningWindow(C_MSG_W_0011);
+		makeWarningWindow(g_msgInfoObj.W_0011);
 	}
 
 	// ユーザカスタムイベント(初期)
@@ -2232,7 +2232,7 @@ function titleInit() {
 	multiAppend(divRoot,
 
 		// Click Here
-		createCss2Button(`btnStart`, `Click Here!!`, _ => {
+		createCss2Button(`btnStart`, g_lblNameObj.clickHere, _ => {
 			clearTimeout(g_timeoutEvtTitleId);
 			optionInit();
 		}, {
@@ -2240,8 +2240,8 @@ function titleInit() {
 		}, g_cssObj.button_Start),
 
 		// Reset
-		createCss2Button(`btnReset`, `Data Reset`, _ => {
-			if (window.confirm(`この作品のローカル設定をクリアします。よろしいですか？\n(ハイスコアやAdjustment等のデータがクリアされます)`)) {
+		createCss2Button(`btnReset`, g_lblNameObj.dataReset, _ => {
+			if (window.confirm(g_msgObj.dataResetConfirm)) {
 				g_localStorage = {
 					adjustment: 0,
 					volume: 100,
@@ -2271,7 +2271,7 @@ function titleInit() {
 		}, g_cssObj.button_Setting),
 
 		// 製作者表示
-		createCss2Button(`lnkMaker`, `Maker: ${g_headerObj.tuningInit}`, _ => {
+		createCss2Button(`lnkMaker`, `${g_lblNameObj.maker}: ${g_headerObj.tuningInit}`, _ => {
 			openLink(g_headerObj.creatorUrl);
 		}, {
 			x: 20, y: g_sHeight - 45,
@@ -2280,7 +2280,7 @@ function titleInit() {
 		}, g_cssObj.button_Default),
 
 		// アーティスト表示
-		createCss2Button(`lnkArtist`, `Artist: ${g_headerObj.artistName}`, _ => {
+		createCss2Button(`lnkArtist`, `${g_lblNameObj.artist}: ${g_headerObj.artistName}`, _ => {
 			openLink(g_headerObj.artistUrl);
 		}, {
 			x: g_sWidth / 2, y: g_sHeight - 45,
@@ -2555,7 +2555,7 @@ function headerConvert(_dosObj) {
 		obj.musicTitleForView = obj.musicTitlesForView[0];
 		obj.artistName = obj.artistNames[0] || ``;
 		if (obj.artistName === ``) {
-			makeWarningWindow(C_MSG_E_0011);
+			makeWarningWindow(g_msgInfoObj.E_0011);
 			obj.artistName = `artistName`;
 		}
 		obj.artistUrl = musics[2] || ``;
@@ -2565,7 +2565,7 @@ function headerConvert(_dosObj) {
 		}
 
 	} else {
-		makeWarningWindow(C_MSG_E_0012);
+		makeWarningWindow(g_msgInfoObj.E_0012);
 		obj.musicTitle = `musicName`;
 		obj.musicTitleForView = [`musicName`];
 		obj.artistName = `artistName`;
@@ -2656,7 +2656,7 @@ function headerConvert(_dosObj) {
 			obj.initSpeeds.push(setVal(difDetails[difpos.speed], 3.5, C_TYP_FLOAT));
 		}
 	} else {
-		makeWarningWindow(C_MSG_E_0021);
+		makeWarningWindow(g_msgInfoObj.E_0021);
 		obj.keyLabels = [`7`];
 		obj.difLabels = [`Normal`];
 		obj.initSpeeds = [3.5];
@@ -2693,7 +2693,7 @@ function headerConvert(_dosObj) {
 	obj.maxLifeVal = setVal(_dosObj.maxLifeVal, C_VAL_MAXLIFE, C_TYP_FLOAT);
 	if (obj.maxLifeVal <= 0) {
 		obj.maxLifeVal = C_VAL_MAXLIFE;
-		makeWarningWindow(C_MSG_E_0042.split(`{0}`).join(`maxLifeVal`));
+		makeWarningWindow(g_msgInfoObj.E_0042.split(`{0}`).join(`maxLifeVal`));
 	}
 
 	// ゲージ設定詳細（初期値）
@@ -2928,7 +2928,7 @@ function headerConvert(_dosObj) {
 	obj.playbackRate = setVal(_dosObj.playbackRate, 1, C_TYP_FLOAT);
 	if (obj.playbackRate <= 0) {
 		obj.playbackRate = 1;
-		makeWarningWindow(C_MSG_E_0042.split(`{0}`).join(`playbackRate`));
+		makeWarningWindow(g_msgInfoObj.E_0042.split(`{0}`).join(`playbackRate`));
 	}
 
 	// ファイルパスの取得
@@ -2992,7 +2992,7 @@ function headerConvert(_dosObj) {
 	if (hasVal(_dosObj.musicUrl)) {
 		obj.musicUrls = _dosObj.musicUrl.split(`$`);
 	} else {
-		makeWarningWindow(C_MSG_E_0031);
+		makeWarningWindow(g_msgInfoObj.E_0031);
 	}
 
 	// ハッシュタグ
@@ -3037,6 +3037,9 @@ function headerConvert(_dosObj) {
 
 	// デフォルトReady表示の先頭文字色
 	obj.readyColor = setVal(_dosObj.readyColor, ``, C_TYP_STRING);
+
+	// デフォルトReady表示を上書きするテキスト
+	obj.readyHtml = setVal(_dosObj.readyHtml, ``, C_TYP_STRING);
 
 	// デフォルト曲名表示のフォントサイズ
 	obj.titlesize = setVal(_dosObj.titlesize, ``, C_TYP_STRING);
@@ -3139,13 +3142,13 @@ function headerConvert(_dosObj) {
 				if (obj[`${option}ChainOFF`].includes(option2) &&
 					obj[`${option2}ChainOFF`].includes(option)) {
 					interlockingErrorFlg = true;
-					makeWarningWindow(C_MSG_E_0051);
+					makeWarningWindow(g_msgInfoObj.E_0051);
 				}
 			}
 		});
 		if (!interlockingErrorFlg && obj[`${option}ChainOFF`].includes(option)) {
 			interlockingErrorFlg = true;
-			makeWarningWindow(C_MSG_E_0051);
+			makeWarningWindow(g_msgInfoObj.E_0051);
 		}
 	});
 
@@ -3343,7 +3346,7 @@ function keysConvert(_dosObj) {
 				g_keyObj[`color${newKey}_${k}`] = tmpColors[k].split(`,`).map(n => parseInt(n, 10));
 			}
 		} else if (g_keyObj[`color${newKey}_0`] === undefined) {
-			makeWarningWindow(C_MSG_E_0101.split(`{0}`).join(newKey));
+			makeWarningWindow(g_msgInfoObj.E_0101.split(`{0}`).join(newKey));
 		}
 
 		// 読込変数の接頭辞 (charaX_Y)
@@ -3357,7 +3360,7 @@ function keysConvert(_dosObj) {
 				g_keyObj[`chara${newKey}_${k}d`] = g_keyObj[`chara${newKey}_${k}`].concat();
 			}
 		} else if (g_keyObj[`chara${newKey}_0`] === undefined) {
-			makeWarningWindow(C_MSG_E_0102.split(`{0}`).join(newKey));
+			makeWarningWindow(g_msgInfoObj.E_0102.split(`{0}`).join(newKey));
 		}
 
 		// 各キーの区切り位置 (divX_Y)
@@ -3392,7 +3395,7 @@ function keysConvert(_dosObj) {
 				g_keyObj[`stepRtn${newKey}_${k}d`] = g_keyObj[`stepRtn${newKey}_${k}`].concat();
 			}
 		} else if (g_keyObj[`stepRtn${newKey}_0`] === undefined) {
-			makeWarningWindow(C_MSG_E_0103.split(`{0}`).join(newKey));
+			makeWarningWindow(g_msgInfoObj.E_0103.split(`{0}`).join(newKey));
 		}
 
 		// ステップゾーン位置 (posX_Y)
@@ -3436,7 +3439,7 @@ function keysConvert(_dosObj) {
 				}
 			}
 		} else if (g_keyObj[`keyCtrl${newKey}_0`] === undefined) {
-			makeWarningWindow(C_MSG_E_0104.split(`{0}`).join(newKey));
+			makeWarningWindow(g_msgInfoObj.E_0104.split(`{0}`).join(newKey));
 		}
 
 		// ステップゾーン間隔 (blankX_Y)
@@ -3534,7 +3537,7 @@ function optionInit() {
 	g_baseDisp = `Settings`;
 
 	// タイトル文字描画
-	divRoot.appendChild(getTitleDivLabel(`lblTitle`, `SETTINGS`, 0, 15, `settings_Title`));
+	divRoot.appendChild(getTitleDivLabel(`lblTitle`, g_lblNameObj.settings, 0, 15, `settings_Title`));
 
 	// オプションボタン用の設置
 	createOptionWindow(`divRoot`);
@@ -3551,12 +3554,12 @@ function optionInit() {
 	multiAppend(divRoot,
 
 		// タイトル画面へ戻る
-		createCss2Button(`btnBack`, `Back`, _ => titleInit(), {
+		createCss2Button(`btnBack`, g_lblNameObj.b_back, _ => titleInit(), {
 			animationName: (g_initialFlg ? `` : `smallToNormalY`),
 		}, g_cssObj.button_Back),
 
 		// キーコンフィグ画面へ移動
-		createCss2Button(`btnKeyConfig`, `KeyConfig`, _ => keyConfigInit(`Main`), {
+		createCss2Button(`btnKeyConfig`, g_lblNameObj.b_keyConfig, _ => keyConfigInit(`Main`), {
 			x: g_sWidth / 3,
 			animationName: (g_initialFlg ? `` : `smallToNormalY`),
 		}, g_cssObj.button_Setting),
@@ -3571,7 +3574,7 @@ function optionInit() {
 		}, g_cssObj.button_Mini),
 
 		// データセーブフラグの切替
-		createCss2Button(`btnSave`, `Data Save`, evt => {
+		createCss2Button(`btnSave`, g_lblNameObj.dataSave, evt => {
 			g_stateObj.dataSaveFlg = !g_stateObj.dataSaveFlg;
 			const [from, to] = (g_stateObj.dataSaveFlg ? [C_FLG_OFF, C_FLG_ON] : [C_FLG_ON, C_FLG_OFF]);
 			evt.target.classList.replace(g_cssObj[`button_${from}`], g_cssObj[`button_${to}`]);
@@ -3625,7 +3628,7 @@ function musicAfterLoaded() {
 		// エラー時
 		g_audio.addEventListener(`error`, (_ => function f() {
 			g_audio.removeEventListener(`error`, f, false);
-			makeWarningWindow(C_MSG_E_0041.split(`{0}`).join(g_audio.src));
+			makeWarningWindow(g_msgInfoObj.E_0041.split(`{0}`).join(g_audio.src));
 		})(), false);
 	}
 }
@@ -4116,6 +4119,7 @@ function createOptionWindow(_sprite) {
 						`****** ${g_msgObj.difInfoPrintTitle} [${g_version}] ******\r\n\r\n`
 						+ `\t${g_msgObj.difInfoPrintHeader}\r\n\r\n${printData}`
 					);
+					makeInfoWindow(g_msgInfoObj.I_0003, `leftToRightFade`);
 				}, {
 					x: 10, y: 30, w: 100, borderStyle: `solid`
 				}, g_cssObj.button_RevON)
@@ -4624,7 +4628,7 @@ function createGeneralSetting(_obj, _settingName, _options = {}) {
  * @param {string} _settingLabel 
  */
 function createLblSetting(_settingName, _adjY = 0, _settingLabel = _settingName) {
-	return createDivCss2Label(`lbl${_settingName}`, _settingLabel, {
+	return createDivCss2Label(`lbl${_settingName}`, g_lblNameObj[_settingLabel], {
 		x: 0, y: _adjY, w: 100,
 	}, `settings_${_settingName}`);
 }
@@ -4769,7 +4773,7 @@ function settingsDisplayInit() {
 	g_canLoadDifInfoFlg = false;
 
 	// タイトル文字描画
-	divRoot.appendChild(getTitleDivLabel(`lblTitle`, `DISPLAY`, 0, 15, `settings_Display`));
+	divRoot.appendChild(getTitleDivLabel(`lblTitle`, g_lblNameObj.display, 0, 15, `settings_Display`));
 
 	// オプションボタン用の設置
 	createSettingsDisplayWindow(`divRoot`);
@@ -4793,10 +4797,10 @@ function settingsDisplayInit() {
 	multiAppend(divRoot,
 
 		// タイトル画面へ戻る
-		createCss2Button(`btnBack`, `Back`, _ => titleInit(), {}, g_cssObj.button_Back),
+		createCss2Button(`btnBack`, g_lblNameObj.b_back, _ => titleInit(), {}, g_cssObj.button_Back),
 
 		// キーコンフィグ画面へ移動
-		createCss2Button(`btnKeyConfig`, `KeyConfig`, _ => keyConfigInit(`Main`), {
+		createCss2Button(`btnKeyConfig`, g_lblNameObj.b_keyConfig, _ => keyConfigInit(`Main`), {
 			x: g_sWidth / 3,
 		}, g_cssObj.button_Setting),
 
@@ -4891,7 +4895,7 @@ function createSettingsDisplayWindow(_sprite) {
 
 		if (g_headerObj[`${_name}Use`]) {
 			displaySprite.appendChild(
-				makeSettingLblCssButton(`lnk${_name}`, `${toCapitalize(_name)}`, _heightPos, evt => {
+				makeSettingLblCssButton(`lnk${_name}`, g_lblNameObj[`d_${toCapitalize(_name)}`], _heightPos, evt => {
 					const displayFlg = g_stateObj[`d_${_name.toLowerCase()}`];
 					const displayNum = list.findIndex(flg => flg === displayFlg);
 					const nextDisplayFlg = list[(displayNum + 1) % list.length];
@@ -4908,7 +4912,7 @@ function createSettingsDisplayWindow(_sprite) {
 			);
 		} else {
 			displaySprite.appendChild(makeDisabledDisplayLabel(`lnk${_name}`, _heightPos, _widthPos,
-				`${toCapitalize(_name)}:${g_headerObj[`${_name}Set`]}`, g_headerObj[`${_name}Set`]));
+				g_lblNameObj[`d_${toCapitalize(_name)}`] + `:${g_headerObj[`${_name}Set`]}`, g_headerObj[`${_name}Set`]));
 		}
 
 		/**
@@ -4991,7 +4995,7 @@ function keyConfigInit(_kcType = g_kcType) {
 
 		// キーコンフィグ画面タイトル
 		getTitleDivLabel(`lblTitle`,
-			`<div class="settings_Title">KEY</div><div class="settings_Title2">CONFIG</div>`
+			`<div class="settings_Title">${g_lblNameObj.key}</div><div class="settings_Title2">${g_lblNameObj.config}</div>`
 				.replace(/[\t\n]/g, ``), 0, 15, g_cssObj.flex_centering),
 
 		createDivCss2Label(`kcDesc`, g_msgObj.kcDesc, {
@@ -5139,7 +5143,7 @@ function keyConfigInit(_kcType = g_kcType) {
 		),
 
 		// キーコンフィグタイプ切替ボタン
-		createDivCss2Label(`lblKcType`, `ConfigType`, {
+		createDivCss2Label(`lblKcType`, g_lblNameObj.ConfigType, {
 			x: 30, y: 10, w: 70,
 		}, g_cssObj.keyconfig_ConfigType),
 
@@ -5149,7 +5153,7 @@ function keyConfigInit(_kcType = g_kcType) {
 		}),
 
 		// キーカラータイプ切替ボタン
-		createDivCss2Label(`lblcolorType`, `ColorType`, {
+		createDivCss2Label(`lblcolorType`, g_lblNameObj.ColorType, {
 			x: g_sWidth - 120, y: 10, w: 70,
 		}, g_cssObj.keyconfig_ColorType),
 
@@ -5221,7 +5225,7 @@ function keyConfigInit(_kcType = g_kcType) {
 			w: g_sWidth / 3, h: C_BTN_HEIGHT / 2, siz: C_LBL_BTNSIZE * 2 / 3,
 		}, g_cssObj.button_Back),
 
-		createDivCss2Label(`lblPattern`, `KeyPattern: ${g_keyObj.currentPtn === -1 ? 'Self' : g_keyObj.currentPtn + 1}${lblTransKey}`, {
+		createDivCss2Label(`lblPattern`, `${g_lblNameObj.KeyPattern}: ${g_keyObj.currentPtn === -1 ? 'Self' : g_keyObj.currentPtn + 1}${lblTransKey}`, {
 			x: g_sWidth / 5, y: g_sHeight - 100,
 			w: g_sWidth * 3 / 5, h: C_BTN_HEIGHT / 2,
 		}),
@@ -5257,8 +5261,8 @@ function keyConfigInit(_kcType = g_kcType) {
 		}, g_cssObj.button_Setting),
 
 		// キーコンフィグリセットボタン描画
-		createCss2Button(`btnReset`, `Reset`, _ => {
-			if (window.confirm(`キーを初期配置に戻します。よろしいですか？`)) {
+		createCss2Button(`btnReset`, g_lblNameObj.b_reset, _ => {
+			if (window.confirm(g_msgObj.keyResetConfirm)) {
 				g_keyObj.currentKey = g_headerObj.keyLabels[g_stateObj.scoreId];
 				const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
 				const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
@@ -5301,7 +5305,7 @@ function keyConfigInit(_kcType = g_kcType) {
 		// また、直前と同じキーを押した場合(BackSpaceを除く)はキー操作を無効にする
 		const disabledKeys = [229, 240, 242, 243, 244, 91, 29, 28, 27, g_prevKey];
 		if (disabledKeys.includes(setKey) || g_kCdN[setKey] === undefined) {
-			makeInfoWindow(C_MSG_I_0002, `fadeOut0`);
+			makeInfoWindow(g_msgInfoObj.I_0002, `fadeOut0`);
 			return;
 		} else if ((setKey === 46 && g_currentk === 0) ||
 			(keyIsDown(`MetaLeft`) && keyIsDown(`ShiftLeft`))) {
@@ -7463,9 +7467,11 @@ function MainInit() {
 			g_headerObj.readyDelayFrame + g_stateObj.adjustment > 0) {
 			readyDelayFrame = g_headerObj.readyDelayFrame + g_stateObj.adjustment;
 		}
+		const readyHtml = (g_headerObj.readyHtml !== `` ? g_headerObj.readyHtml :
+			`<span style='color:${readyColor};font-size:60px;'>R</span>EADY<span style='font-size:50px;'>?</span>`);
 
 		divRoot.appendChild(
-			createDivCss2Label(`lblReady`, `<span style='color:${readyColor};font-size:60px;'>R</span>EADY<span style='font-size:50px;'>?</span>`, {
+			createDivCss2Label(`lblReady`, readyHtml, {
 				x: g_headerObj.playingX + g_headerObj.playingWidth / 2 - 100,
 				y: (g_sHeight + g_posObj.stepYR) / 2 - 75,
 				w: 200, h: 50, siz: 40,
@@ -8907,7 +8913,7 @@ function resultInit() {
 	createMultipleSprite(`backResultSprite`, g_headerObj.backResultMaxDepth);
 
 	// タイトル文字描画
-	divRoot.appendChild(getTitleDivLabel(`lblTitle`, `RESULT`, 0, 15, `settings_Title`));
+	divRoot.appendChild(getTitleDivLabel(`lblTitle`, g_lblNameObj.result, 0, 15, `settings_Title`));
 
 	const playDataWindow = createSprite(`divRoot`, `playDataWindow`, g_sWidth / 2 - 225, 70 + (g_sHeight - 500) / 2, 450, 110);
 	playDataWindow.classList.add(g_cssObj.result_PlayDataWindow);
@@ -9038,9 +9044,9 @@ function resultInit() {
 		uwan: { pos: 4, id: `Uwan`, color: `uwan`, label: C_JCR_UWAN, },
 		kita: { pos: 5, id: `Kita`, color: `kita`, label: C_JCR_KITA, },
 		iknai: { pos: 6, id: `Iknai`, color: `iknai`, label: C_JCR_IKNAI, },
-		maxCombo: { pos: 7, id: `MCombo`, color: `combo`, label: `MaxCombo`, },
-		fmaxCombo: { pos: 8, id: `FCombo`, color: `combo`, label: `FreezeCombo`, },
-		score: { pos: 10, id: `Score`, color: `score`, label: `Score`, },
+		maxCombo: { pos: 7, id: `MCombo`, color: `combo`, label: g_lblNameObj.j_maxCombo, },
+		fmaxCombo: { pos: 8, id: `FCombo`, color: `combo`, label: g_lblNameObj.j_fmaxCombo, },
+		score: { pos: 10, id: `Score`, color: `score`, label: g_lblNameObj.j_score, },
 	};
 
 	// キャラクタ、スコア描画
@@ -9052,8 +9058,8 @@ function resultInit() {
 	});
 	if (g_stateObj.autoAll === C_FLG_OFF) {
 		multiAppend(resultWindow,
-			makeCssResultSymbol(`lblFast`, 350, g_cssObj.common_matari, 0, `Fast`),
-			makeCssResultSymbol(`lblSlow`, 350, g_cssObj.common_shobon, 2, `Slow`),
+			makeCssResultSymbol(`lblFast`, 350, g_cssObj.common_matari, 0, g_lblNameObj.j_fast),
+			makeCssResultSymbol(`lblSlow`, 350, g_cssObj.common_shobon, 2, g_lblNameObj.j_slow),
 			makeCssResultSymbol(`lblFastS`, 260, g_cssObj.score, 1, g_resultObj.fast, C_ALIGN_RIGHT),
 			makeCssResultSymbol(`lblSlowS`, 260, g_cssObj.score, 3, g_resultObj.slow, C_ALIGN_RIGHT),
 		);
@@ -9235,7 +9241,7 @@ function resultInit() {
 	multiAppend(divRoot,
 
 		// タイトル画面へ戻る
-		createCss2Button(`btnBack`, `Back`, _ => {
+		createCss2Button(`btnBack`, g_lblNameObj.b_back, _ => {
 			if (g_finishFlg) {
 				g_audio.pause();
 			}
@@ -9248,9 +9254,9 @@ function resultInit() {
 		}, g_cssObj.button_Back),
 
 		// リザルトデータをクリップボードへコピー
-		createCss2Button(`btnCopy`, `CopyResult`, _ => {
+		createCss2Button(`btnCopy`, g_lblNameObj.b_copy, _ => {
 			copyTextToClipboard(resultText);
-			makeInfoWindow(C_MSG_I_0001, `leftToRightFade`);
+			makeInfoWindow(g_msgInfoObj.I_0001, `leftToRightFade`);
 		}, {
 			x: g_sWidth / 4,
 			w: g_sWidth / 2,
@@ -9259,21 +9265,21 @@ function resultInit() {
 		}, g_cssObj.button_Setting),
 
 		// リザルトデータをTwitterへ転送
-		createCss2Button(`btnTweet`, `Tweet`, _ => openLink(tweetResult), {
+		createCss2Button(`btnTweet`, g_lblNameObj.b_tweet, _ => openLink(tweetResult), {
 			x: g_sWidth / 4, y: g_sHeight - 100 + C_BTN_HEIGHT * 5 / 8,
 			w: g_sWidth / 4, h: C_BTN_HEIGHT * 5 / 8, siz: 24,
 			animationName: `smallToNormalY`,
 		}, g_cssObj.button_Tweet),
 
 		// Gitterへのリンク
-		createCss2Button(`btnGitter`, `Gitter`, _ => openLink(`https://gitter.im/danonicw/freeboard`), {
+		createCss2Button(`btnGitter`, g_lblNameObj.b_gitter, _ => openLink(`https://gitter.im/danonicw/freeboard`), {
 			x: g_sWidth / 2, y: g_sHeight - 100 + C_BTN_HEIGHT * 5 / 8,
 			w: g_sWidth / 4, h: C_BTN_HEIGHT * 5 / 8, siz: 24,
 			animationName: `smallToNormalY`,
 		}, g_cssObj.button_Default),
 
 		// リトライ
-		createCss2Button(`btnRetry`, `Retry`, _ => {
+		createCss2Button(`btnRetry`, g_lblNameObj.b_retry, _ => {
 			if (g_finishFlg) {
 				g_audio.pause();
 			}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2528,6 +2528,14 @@ function headerConvert(_dosObj) {
 		}
 	}
 
+	// ラベルテキスト、オンマウステキスト、確認メッセージ定義の上書き設定
+	if (typeof g_local_lblNameObj === C_TYP_OBJECT) {
+		Object.keys(g_local_lblNameObj).forEach(property => g_lblNameObj[property] = g_local_lblNameObj[property]);
+	}
+	if (typeof g_local_msgObj === C_TYP_OBJECT) {
+		Object.keys(g_local_msgObj).forEach(property => g_msgObj[property] = g_local_msgObj[property]);
+	}
+
 	// 曲名
 	obj.musicTitles = [];
 	obj.musicTitlesForView = [];

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4061,20 +4061,20 @@ function createOptionWindow(_sprite) {
 			${push3CntStr}`.split(`,`).join(`/`);
 
 		if (document.querySelector(`#lblDouji`) === null) {
-			makeDifInfoLabel(`lblDouji`, `同時補正`);
-			makeDifInfoLabel(`lblTate`, `縦連補正`, { x: 270 });
+			makeDifInfoLabel(`lblDouji`, g_msgObj.difInfoDouji);
+			makeDifInfoLabel(`lblTate`, g_msgObj.difInfoTate, { x: 270 });
 			makeDifInfoLabel(`dataDouji`, g_detailObj.toolDif[_scoreId].douji, { x: 200, w: 160 });
 			makeDifInfoLabel(`dataTate`, g_detailObj.toolDif[_scoreId].tate, { x: 345, w: 160 });
 			makeDifInfoLabel(`lblArrowInfo`, `All Arrows`, { x: 130, y: 45, w: 290, siz: C_SIZ_JDGCNTS });
 			makeDifInfoLabel(`dataArrowInfo`, ArrowInfo, { x: 270, y: 45, w: 160, siz: C_SIZ_JDGCNTS });
-			makeDifInfoLabel(`lblArrowInfo2`, `- 矢印 Arrow:<br><br>- 氷矢 Frz:<br><br>- 3つ押し位置 (${g_detailObj.toolDif[_scoreId].push3cnt}):`,
+			makeDifInfoLabel(`lblArrowInfo2`, g_msgObj.difInfoCnt.split(`{0}`).join(g_detailObj.toolDif[_scoreId].push3cnt),
 				{ x: 130, y: 70, w: 200, h: 90 });
 			makeDifInfoLabel(`dataArrowInfo2`, ArrowInfo2, { x: 140, y: 70, w: 275, h: 150, overflow: `auto` });
 
 		} else {
 			dataDouji.textContent = g_detailObj.toolDif[_scoreId].douji;
 			dataTate.textContent = g_detailObj.toolDif[_scoreId].tate;
-			lblArrowInfo2.innerHTML = `- 矢印 Arrow:<br><br>- 氷矢 Frz:<br><br>- 3つ押し位置 (${g_detailObj.toolDif[_scoreId].push3cnt}):`;
+			lblArrowInfo2.innerHTML = g_msgObj.difInfoCnt.split(`{0}`).join(g_detailObj.toolDif[_scoreId].push3cnt);
 			dataArrowInfo.innerHTML = ArrowInfo;
 			dataArrowInfo2.innerHTML = ArrowInfo2;
 		}
@@ -4111,10 +4111,10 @@ function createOptionWindow(_sprite) {
 					`${playingTime}\r\n`;
 			}
 			detailToolDif.appendChild(
-				makeSettingLblCssButton(`lnkDifInfo`, `データ出力`, 0, _ => {
+				makeSettingLblCssButton(`lnkDifInfo`, g_msgObj.difInfoPrint, 0, _ => {
 					copyTextToClipboard(
-						`****** Dancing☆Onigiri レベル計算ツール+++ [${g_version}] ******\r\n\r\n`
-						+ `\t難易度\t同時\t縦連\t総数\t矢印\t氷矢印\tAPM\t時間\r\n\r\n${printData}`
+						`****** ${g_msgObj.difInfoPrintTitle} [${g_version}] ******\r\n\r\n`
+						+ `\t${g_msgObj.difInfoPrintHeader}\r\n\r\n${printData}`
 					);
 				}, {
 					x: 10, y: 30, w: 100, borderStyle: `solid`

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -162,3 +162,21 @@ const g_presetFrzStartjdgUse = `false`;
 const g_presetResultVals = {
 	// exScore: `exScore`,
 };
+
+/**
+ * ラベルテキスト (g_lblNameObj) に対応するプロパティを上書きする設定
+ * ※danoni_setting.js の他、customjsにも利用可
+ * ※設定可能項目についてはdanoni_constants.jsをご覧ください。
+ */
+const g_local_lblNameObj = {
+
+};
+
+/**
+ * オンマウステキスト、確認メッセージ定義 (g_msgObj) に対応するプロパティを上書きする設定
+ * ※danoni_setting.js の他、customjsにも利用可
+ * ※設定可能項目についてはdanoni_constants.jsをご覧ください。
+ */
+const g_local_msgObj = {
+
+};

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1778,6 +1778,11 @@ const g_lblNameObj = {
     Fadein: `Fadein`,
     Volume: `Volume`,
 
+    g_start: `Start`,
+    g_border: `Border`,
+    g_recovery: `Recovery`,
+    g_damage: `Damage`,
+
     d_StepZone: `StepZone`,
     d_Judgment: `Judgment`,
     d_FastSlow: `FastSlow`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1783,6 +1783,22 @@ const g_lblNameObj = {
     g_recovery: `Recovery`,
     g_damage: `Damage`,
 
+    s_speed: `Speed`,
+    s_boost: `Boost`,
+    s_apm: `APM`,
+    s_time: `Time`,
+    s_arrow: `Arrow`,
+    s_frz: `Frz`,
+
+    s_level: `Level`,
+    s_douji: `同時補正`,
+    s_tate: `縦連補正`,
+    s_cnts: `All Arrows`,
+    s_linecnts: `- 矢印 Arrow:<br><br>- 氷矢 Frz:<br><br>- 3つ押し位置 ({0}):`,
+    s_print: `データ出力`,
+    s_printTitle: `Dancing☆Onigiri レベル計算ツール+++`,
+    s_printHeader: `難易度\t同時\t縦連\t総数\t矢印\t氷矢印\tAPM\t時間`,
+
     d_StepZone: `StepZone`,
     d_Judgment: `Judgment`,
     d_FastSlow: `FastSlow`,
@@ -1900,12 +1916,5 @@ const g_msgObj = {
     kcShortcutDesc: `プレイ中ショートカット：「{0}」タイトルバック / 「{1}」リトライ`,
     transKeyDesc: `別キーモードではハイスコア、キーコンフィグ等は保存されません`,
     sdShortcutDesc: `Hid+/Sud+時ショートカット：「pageUp」カバーを上へ / 「pageDown」下へ`,
-
-    difInfoDouji: `同時補正`,
-    difInfoTate: `縦連補正`,
-    difInfoCnt: `- 矢印 Arrow:<br><br>- 氷矢 Frz:<br><br>- 3つ押し位置 ({0}):`,
-    difInfoPrint: `データ出力`,
-    difInfoPrintTitle: `Dancing☆Onigiri レベル計算ツール+++`,
-    difInfoPrintHeader: `難易度\t同時\t縦連\t総数\t矢印\t氷矢印\tAPM\t時間`,
 
 };

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1750,6 +1750,12 @@ let g_lblNameObj = {
     config: `CONFIG`,
     result: `RESULT`,
 
+    kcDesc: `[BackSpaceキー:スキップ / Deleteキー:(代替キーのみ)キー無効化]`,
+    sdDesc: `[クリックでON/OFFを切替、灰色でOFF]`,
+    kcShortcutDesc: `プレイ中ショートカット：「{0}」タイトルバック / 「{1}」リトライ`,
+    transKeyDesc: `別キーモードではハイスコア、キーコンフィグ等は保存されません`,
+    sdShortcutDesc: `Hid+/Sud+時ショートカット：「pageUp」カバーを上へ / 「pageDown」下へ`,
+
     maker: `Maker`,
     artist: `Artist`,
 
@@ -1757,6 +1763,9 @@ let g_lblNameObj = {
     dataSave: `Data Save`,
     clickHere: `Click Here!!`,
     comment: `Comment`,
+
+    nowLoading: `Now Loading...`,
+    pleaseWait: `Please Wait...`,
 
     b_back: `Back`,
     b_keyConfig: `KeyConfig`,
@@ -1912,11 +1921,5 @@ let g_msgObj = {
 
     appearance: `流れる矢印の見え方を制御します。`,
     opacity: `判定キャラクタ、コンボ数、Fast/Slow、Hidden+/Sudden+の\n境界線表示の透明度を設定します。`,
-
-    kcDesc: `[BackSpaceキー:スキップ / Deleteキー:(代替キーのみ)キー無効化]`,
-    sdDesc: `[クリックでON/OFFを切替、灰色でOFF]`,
-    kcShortcutDesc: `プレイ中ショートカット：「{0}」タイトルバック / 「{1}」リトライ`,
-    transKeyDesc: `別キーモードではハイスコア、キーコンフィグ等は保存されません`,
-    sdShortcutDesc: `Hid+/Sud+時ショートカット：「pageUp」カバーを上へ / 「pageDown」下へ`,
 
 };

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -132,6 +132,7 @@ let g_imgExtensions = [`png`, `gif`, `bmp`, `jpg`, `jpeg`, `svg`];
 const g_typeLists = {
     arrow: [`arrow`, `dummyArrow`, `frz`, `dummyFrz`],
     color: [`color`, `acolor`, `shadowColor`, `ashadowColor`],
+    frzColor: [`Normal`, `NormalBar`, `Hit`, `HitBar`],
     dataList: [
         `Arrow`, `FrzArrow`, `FrzLength`,
         `Color`, `ColorCd`, `FColor`, `FColorCd`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -214,16 +214,6 @@ const C_JDG_KITA = 0;
 const C_JDG_SFSF = 1;
 const C_JDG_IKNAI = 2;
 
-let C_JCR_II = "(・∀・)ｲｲ!!";
-let C_JCR_SHAKIN = "(`・ω・)ｼｬｷﾝ";
-let C_JCR_MATARI = "( ´∀`)ﾏﾀｰﾘ";
-let C_JCR_SHOBON = "(´・ω・`)ｼｮﾎﾞｰﾝ";
-let C_JCR_UWAN = "( `Д´)ｳﾜｧﾝ!!";
-
-let C_JCR_KITA = "(ﾟ∀ﾟ)ｷﾀ-!!";
-let C_JCR_SFSF = "";
-let C_JCR_IKNAI = "(・A・)ｲｸﾅｲ";
-
 const C_CLR_DUMMY = `#777777`;
 
 const C_LEN_JDGCHARA_WIDTH = 200;
@@ -280,14 +270,6 @@ const g_rankObj = {
     rankColorF: `#999999`,
     rankMarkX: `X`,
     rankColorX: `#996600`
-};
-
-const g_resultMsgObj = {
-    allPerfect: `<span class="result_AllPerfect">All Perfect!!</span>`,
-    perfect: `<span class="result_Perfect">Perfect!!</span>`,
-    fullCombo: `<span class="result_FullCombo">FullCombo!</span>`,
-    cleared: `<span class="result_Cleared">CLEARED!</span>`,
-    failed: `<span class="result_Failed">FAILED...</span>`,
 };
 
 const g_pointAllocation = {
@@ -1710,45 +1692,159 @@ const g_cssCheckStr = {
 
 /** 
  * メッセージ定義 
- * - 変数名は `C_MSG_X_YYYY` の形で、末尾に (X-YYYY) をつける。
+ * - 変数名は `X_YYYY` の形で、末尾に (X-YYYY) をつける。
  * - 記述不正の場合、書き方を2行目に指定すると親切。
 */
-const C_MSG_W_0001 = `お使いのブラウザは動作保証外です。<br>
-	Chrome/Opera/Vivaldiなど、WebKit系ブラウザの利用を推奨します。(W-0001)`;
-const C_MSG_W_0011 = `fileスキームでの動作のため、内蔵の画像データを使用します。(W-0011)<br>
-	imgフォルダ以下の画像の変更は適用されません。`;
-const C_MSG_E_0011 = `アーティスト名が未入力です。(E-0011)`;
-const C_MSG_E_0012 = `曲名情報が未設定です。(E-0012)<br>
-	|musicTitle=曲名,アーティスト名,アーティストURL|`;
-const C_MSG_E_0021 = `譜面情報が未指定か、フォーマットが間違っています。(E-0021)<br>
-	|difData=キー数,譜面名,初期速度|`;
-const C_MSG_E_0022 = `外部譜面ファイルのフォーマットが間違っています。(E-0022)<br>
-	function externalDosInit() { g_externalDos = \`(譜面データ)\`; }`;
-const C_MSG_E_0023 = `譜面情報が未指定です。(E-0023)<br>
+const g_msgInfoObj = {
+    W_0001: `お使いのブラウザは動作保証外です。<br>
+    Chrome/Opera/Vivaldiなど、WebKit系ブラウザの利用を推奨します。(W-0001)`,
+    W_0011: `fileスキームでの動作のため、内蔵の画像データを使用します。(W-0011)<br>
+    imgフォルダ以下の画像の変更は適用されません。`,
+
+    E_0011: `アーティスト名が未入力です。(E-0011)`,
+    E_0012: `曲名情報が未設定です。(E-0012)<br>
+    |musicTitle=曲名,アーティスト名,アーティストURL|`,
+    E_0021: `譜面情報が未指定か、フォーマットが間違っています。(E-0021)<br>
+    |difData=キー数,譜面名,初期速度|`,
+    E_0022: `外部譜面ファイルのフォーマットが間違っています。(E-0022)<br>
+    function externalDosInit() { g_externalDos = \`(譜面データ)\`; }`,
+    E_0023: `譜面情報が未指定です。(E-0023)<br>
 	以下のいずれか、または両方を指定してください。<br>
 	&lt;input type="hidden" name="externalDos" id="externalDos" value="dos.txt"&gt;<br>
-	&lt;input type="hidden" name="dos" id="dos" value="(譜面データ)"&gt;<br>`;
-const C_MSG_E_0031 = `楽曲ファイルが未指定か、フォーマットが間違っています。(E-0031)<br>
-	|musicUrl=****.mp3|`;
-const C_MSG_E_0032 = `楽曲ファイルの読み込みに失敗しました。(E-0032)`;
-const C_MSG_E_0033 = `楽曲ファイルの読み込み中に接続がタイムアウトしました。(E-0033)`;
-const C_MSG_E_0034 = `楽曲ファイルの読み込み中にエラーが発生しました。(E-0034)`;
-const C_MSG_E_0035 = `お使いのOSでは指定された楽曲フォーマットに対応していません。(E-0035)`;
-const C_MSG_E_0041 = `ファイル:{0}の読み込みに失敗しました。(E-0041)<br>`;
-const C_MSG_E_0042 = `{0}は0より大きい値を指定する必要があります。(E-0042)`;
-const C_MSG_E_0051 = `Displayオプションのデフォルト設定(XXXXChainOFF)で、<br>指定できない組み合わせが設定されています。(E-0051)`;
+    &lt;input type="hidden" name="dos" id="dos" value="(譜面データ)"&gt;<br>`,
+    E_0031: `楽曲ファイルが未指定か、フォーマットが間違っています。(E-0031)<br>
+    |musicUrl=****.mp3|`,
+    E_0032: `楽曲ファイルの読み込みに失敗しました。(E-0032)`,
+    E_0033: `楽曲ファイルの読み込み中に接続がタイムアウトしました。(E-0033)`,
+    E_0034: `楽曲ファイルの読み込み中にエラーが発生しました。(E-0034)`,
+    E_0035: `お使いのOSでは指定された楽曲フォーマットに対応していません。(E-0035)`,
+    E_0041: `ファイル:{0}の読み込みに失敗しました。(E-0041)<br>`,
+    E_0042: `{0}は0より大きい値を指定する必要があります。(E-0042)`,
+    E_0051: `Displayオプションのデフォルト設定(XXXXChainOFF)で、<br>指定できない組み合わせが設定されています。(E-0051)`,
 
-const C_MSG_E_0101 = `新しいキー:{0}の[color]が未定義です。(E-0101)<br>
-	|color{0}=0,1,0,1,0,2|`;
-const C_MSG_E_0102 = `新しいキー:{0}の[chara]が未定義です。(E-0102)<br>
-	|chara{0}=arrowA,arrowB,arrowC,arrowD,arrowE,arrowF|`;
-const C_MSG_E_0103 = `新しいキー:{0}の[stepRtn]が未定義です。(E-0103)<br>
-	|stepRtn{0}=0,45,-90,135,180,onigiri|`;
-const C_MSG_E_0104 = `新しいキー:{0}の[keyCtrl]が未定義です。(E-0104)<br>
-    |keyCtrl{0}=75,79,76,80,187,32/0|`;
-const C_MSG_I_0001 = `リザルトデータをクリップボードにコピーしました！`;
-const C_MSG_I_0002 = `入力したキーは割り当てできません。他のキーを指定してください。`;
+    E_0101: `新しいキー:{0}の[color]が未定義です。(E-0101)<br>
+    |color{0}=0,1,0,1,0,2|`,
+    E_0102: `新しいキー:{0}の[chara]が未定義です。(E-0102)<br>
+    |chara{0}=arrowA,arrowB,arrowC,arrowD,arrowE,arrowF|`,
+    E_0103: `新しいキー:{0}の[stepRtn]が未定義です。(E-0103)<br>
+    |stepRtn{0}=0,45,-90,135,180,onigiri|`,
+    E_0104: `新しいキー:{0}の[keyCtrl]が未定義です。(E-0104)<br>
+    |keyCtrl{0}=75,79,76,80,187,32/0|`,
 
+    I_0001: `リザルトデータをクリップボードにコピーしました！`,
+    I_0002: `入力したキーは割り当てできません。他のキーを指定してください。`,
+    I_0003: `各譜面の明細情報をクリップボードにコピーしました！`,
+};
+
+/**
+ * ラベル表示定義
+ */
+const g_lblNameObj = {
+    dancing: `DANCING`,
+    star: `☆`,
+    onigiri: `ONIGIRI`,
+    settings: `SETTINGS`,
+    display: `DISPLAY`,
+    key: `KEY`,
+    config: `CONFIG`,
+    result: `RESULT`,
+
+    maker: `Maker`,
+    artist: `Artist`,
+
+    dataReset: `Data Reset`,
+    dataSave: `Data Save`,
+    clickHere: `Click Here!!`,
+
+    b_back: `Back`,
+    b_keyConfig: `KeyConfig`,
+    b_play: `PLAY!`,
+    b_reset: `Reset`,
+    b_settings: `To Settings`,
+    b_copy: `CopyResult`,
+    b_tweet: `Tweet`,
+    b_gitter: `Gitter`,
+    b_retry: `Retry`,
+
+    Difficulty: `Difficulty`,
+    Speed: `Speed`,
+    Motion: `Motion`,
+    Scroll: `Scroll`,
+    Reverse: `Reverse`,
+    Shuffle: `Shuffle`,
+    AutoPlay: `AutoPlay`,
+    Gauge: `Gauge`,
+    Adjustment: `Adjustment`,
+    Fadein: `Fadein`,
+    Volume: `Volume`,
+
+    d_StepZone: `StepZone`,
+    d_Judgment: `Judgment`,
+    d_FastSlow: `FastSlow`,
+    d_LifeGauge: `LifeGauge`,
+    d_Score: `Score`,
+    d_MusicInfo: `MusicInfo`,
+    d_FilterLine: `FilterLine`,
+    d_Speed: `Speed`,
+    d_Color: `Color`,
+    d_Lyrics: `Lyrics`,
+    d_Background: `Background`,
+    d_ArrowEffect: `ArrowEffect`,
+    d_Special: `Special`,
+
+    Appearance: `Appearance`,
+    Opacity: `Opacity`,
+
+    ConfigType: `ConfigType`,
+    ColorType: `ColorType`,
+    KeyPattern: `KeyPattern`,
+
+    j_ii: "(・∀・)ｲｲ!!",
+    j_shakin: "(`・ω・)ｼｬｷﾝ",
+    j_matari: "( ´∀`)ﾏﾀｰﾘ",
+    j_shobon: "(´・ω・`)ｼｮﾎﾞｰﾝ",
+    j_uwan: "( `Д´)ｳﾜｧﾝ!!",
+
+    j_kita: "(ﾟ∀ﾟ)ｷﾀ-!!",
+    j_iknai: "(・A・)ｲｸﾅｲ",
+
+    j_maxCombo: `MaxCombo`,
+    j_fmaxCombo: `FreezeCombo`,
+    j_score: `Score`,
+
+    j_fast: `Fast`,
+    j_slow: `Slow`,
+
+    allPerfect: `All Perfect!!`,
+    perfect: `Perfect!!`,
+    fullCombo: `FullCombo!`,
+    cleared: `CLEARED!`,
+    failed: `FAILED...`,
+};
+
+// クリア表示
+const g_resultMsgObj = {
+    allPerfect: `<span class="result_AllPerfect">${g_lblNameObj.allPerfect}</span>`,
+    perfect: `<span class="result_Perfect">${g_lblNameObj.perfect}</span>`,
+    fullCombo: `<span class="result_FullCombo">${g_lblNameObj.fullCombo}</span>`,
+    cleared: `<span class="result_Cleared">${g_lblNameObj.cleared}</span>`,
+    failed: `<span class="result_Failed">${g_lblNameObj.failed}</span>`,
+};
+
+// 判定名
+let C_JCR_II = g_lblNameObj.j_ii;
+let C_JCR_SHAKIN = g_lblNameObj.j_shakin;
+let C_JCR_MATARI = g_lblNameObj.j_matari;
+let C_JCR_SHOBON = g_lblNameObj.j_shobon;
+let C_JCR_UWAN = g_lblNameObj.j_uwan;
+
+let C_JCR_KITA = g_lblNameObj.j_kita;
+let C_JCR_SFSF = "";
+let C_JCR_IKNAI = g_lblNameObj.j_iknai;
+
+/**
+ * メッセージ、補足表示定義
+ */
 const g_msgObj = {
 
     reload: `ページを再読込します。`,
@@ -1756,6 +1852,9 @@ const g_msgObj = {
     dataReset: `この作品で保存されているハイスコアや\nAdjustment情報等をリセットします。`,
     github: `Dancing☆Onigiri (CW Edition)のGitHubページへ移動します。`,
     security: `Dancing☆Onigiri (CW Edition)のサポート情報ページへ移動します。`,
+
+    dataResetConfirm: `この作品のローカル設定をクリアします。よろしいですか？\n(ハイスコアやAdjustment等のデータがクリアされます)`,
+    keyResetConfirm: `キーを初期配置に戻します。よろしいですか？`,
 
     difficulty: `譜面を選択します。`,
     speed: `矢印の流れる速度を設定します。`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1797,4 +1797,11 @@ const g_msgObj = {
     transKeyDesc: `別キーモードではハイスコア、キーコンフィグ等は保存されません`,
     sdShortcutDesc: `Hid+/Sud+時ショートカット：「pageUp」カバーを上へ / 「pageDown」下へ`,
 
+    difInfoDouji: `同時補正`,
+    difInfoTate: `縦連補正`,
+    difInfoCnt: `- 矢印 Arrow:<br><br>- 氷矢 Frz:<br><br>- 3つ押し位置 ({0}):`,
+    difInfoPrint: `データ出力`,
+    difInfoPrintTitle: `Dancing☆Onigiri レベル計算ツール+++`,
+    difInfoPrintHeader: `難易度\t同時\t縦連\t総数\t矢印\t氷矢印\tAPM\t時間`,
+
 };

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1696,7 +1696,7 @@ const g_cssCheckStr = {
  * - 変数名は `X_YYYY` の形で、末尾に (X-YYYY) をつける。
  * - 記述不正の場合、書き方を2行目に指定すると親切。
 */
-const g_msgInfoObj = {
+let g_msgInfoObj = {
     W_0001: `お使いのブラウザは動作保証外です。<br>
     Chrome/Opera/Vivaldiなど、WebKit系ブラウザの利用を推奨します。(W-0001)`,
     W_0011: `fileスキームでの動作のため、内蔵の画像データを使用します。(W-0011)<br>
@@ -1740,7 +1740,7 @@ const g_msgInfoObj = {
 /**
  * ラベル表示定義
  */
-const g_lblNameObj = {
+let g_lblNameObj = {
     dancing: `DANCING`,
     star: `☆`,
     onigiri: `ONIGIRI`,
@@ -1756,6 +1756,7 @@ const g_lblNameObj = {
     dataReset: `Data Reset`,
     dataSave: `Data Save`,
     clickHere: `Click Here!!`,
+    comment: `Comment`,
 
     b_back: `Back`,
     b_keyConfig: `KeyConfig`,
@@ -1867,7 +1868,7 @@ let C_JCR_IKNAI = g_lblNameObj.j_iknai;
 /**
  * メッセージ、補足表示定義
  */
-const g_msgObj = {
+let g_msgObj = {
 
     reload: `ページを再読込します。`,
     howto: `ゲーム画面の見方や設定の詳細についてのページへ移動します（GitHub Wiki）。`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -119,8 +119,29 @@ const g_imgObj = {
     lifeBorder: C_IMG_LIFEBORDER,
 };
 
+// g_imgObjのうち、初期読込するリスト
+const g_imgInitList = [
+    `arrow`, `arrowShadow`, `onigiri`, `onigiriShadow`,
+    `giko`, `iyo`, `c`, `morara`, `monar`, `cursor`, `frzBar`, `lifeBorder`,
+];
+
 // 読込対象の画像拡張子
 let g_imgExtensions = [`png`, `gif`, `bmp`, `jpg`, `jpeg`, `svg`];
+
+// オブジェクト種別
+const g_typeLists = {
+    arrow: [`arrow`, `dummyArrow`, `frz`, `dummyFrz`],
+    color: [`color`, `acolor`, `shadowColor`, `ashadowColor`],
+    dataList: [
+        `Arrow`, `FrzArrow`, `FrzLength`,
+        `Color`, `ColorCd`, `FColor`, `FColorCd`,
+        `AColor`, `AColorCd`, `FAColor`, `FAColorCd`,
+        `shadowColor`, `shadowColorCd`, `FshadowColor`, `FshadowColorCd`,
+        `AshadowColor`, `AshadowColorCd`, `FAshadowColor`, `FAshadowColorCd`,
+        `ArrowCssMotion`, `ArrowCssMotionName`,
+        `FrzCssMotion`, `FrzCssMotionName`,
+    ],
+};
 
 // Motionオプション配列の基準位置
 const C_MOTION_STD_POS = 15;
@@ -390,6 +411,8 @@ let g_displays = [`stepZone`, `judgment`, `fastSlow`, `lifeGauge`, `score`, `mus
 
 let g_storeSettings = [`appearance`, `opacity`, `d_stepzone`, `d_judgment`, `d_fastslow`, `d_lifegauge`,
     `d_score`, `d_musicinfo`, `d_filterline`];
+
+let g_canDisabledSettings = [`motion`, `scroll`, `shuffle`, `autoPlay`, `gauge`, `appearance`];
 
 // サイズ(後で指定)
 let g_sWidth;
@@ -1591,6 +1614,49 @@ const g_keyObj = {
     dummy: 0	// ダミー(カンマ抜け落ち防止)
 };
 
+// 特殊キーのコピー種 (simple: 代入、multiple: 配列ごと代入)
+const g_keyCopyLists = {
+    simple: [`div`, `blank`, `scale`, `keyRetry`, `keyTitleBack`, `transKey`, `scrollDir`, `assistPos`],
+    multiple: [`chara`, `color`, `stepRtn`, `pos`, `shuffle`],
+};
+
+// タイトル画面関連のリスト群
+const g_titleLists = {
+    /** タイトル画面で利用する初期オブジェクトのリスト */
+    init: [`title`, `titleArrow`, `titleAnimation`, `back`, `backMain`, `ready`],
+
+    /** タイトルのデフォルトフォント */
+    defaultFonts: [`'メイリオ'`],
+
+    /** グラデーション関連初期リスト */
+    grdList: [`titlegrd`, `titlearrowgrd`],
+
+    /** タイトル用アニメーションの設定種 */
+    animation: [`Name`, `Duration`, `Delay`, `TimingFunction`],
+
+};
+
+const g_animationData = [`back`, `mask`];
+
+/**
+ * データ種, 最小データ長のセット
+ */
+const g_dataMinObj = {
+    speed: 2,
+    boost: 2,
+    color: 3,
+    acolor: 3,
+    shadowcolor: 3,
+    ashadowcolor: 3,
+    arrowCssMotion: 3,
+    frzCssMotion: 3,
+    dummyArrowCssMotion: 3,
+    dummyFrzCssMotion: 3,
+    word: 3,
+    mask: 1,
+    back: 1,
+};
+
 const g_dfColorObj = {
 
     // 矢印初期色情報
@@ -1633,6 +1699,13 @@ const g_escapeStr = {
     escapeCode: [
         [`<script>`, ``], [`</script>`, ``],
     ],
+};
+
+// グラデーションで、カラーコードではないパーセント表記、位置表記系を除外するためのリスト
+// 'at', 'to'のみ、'to left'や'to right'のように方向が入るため、半角スペースまで込みで判断
+const g_cssCheckStr = {
+    header: [`at `, `to `, `from`, `circle`, `ellipse`, `closest-`, `farthest-`, `transparent`],
+    footer: [`deg`, `rad`, `grad`, `turn`, `repeat`],
 };
 
 /** 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1696,7 +1696,7 @@ const g_cssCheckStr = {
  * - 変数名は `X_YYYY` の形で、末尾に (X-YYYY) をつける。
  * - 記述不正の場合、書き方を2行目に指定すると親切。
 */
-let g_msgInfoObj = {
+const g_msgInfoObj = {
     W_0001: `お使いのブラウザは動作保証外です。<br>
     Chrome/Opera/Vivaldiなど、WebKit系ブラウザの利用を推奨します。(W-0001)`,
     W_0011: `fileスキームでの動作のため、内蔵の画像データを使用します。(W-0011)<br>
@@ -1740,7 +1740,7 @@ let g_msgInfoObj = {
 /**
  * ラベル表示定義
  */
-let g_lblNameObj = {
+const g_lblNameObj = {
     dancing: `DANCING`,
     star: `☆`,
     onigiri: `ONIGIRI`,
@@ -1875,9 +1875,9 @@ let C_JCR_SFSF = "";
 let C_JCR_IKNAI = g_lblNameObj.j_iknai;
 
 /**
- * メッセージ、補足表示定義
+ * オンマウステキスト、確認メッセージ定義
  */
-let g_msgObj = {
+const g_msgObj = {
 
     reload: `ページを再読込します。`,
     howto: `ゲーム画面の見方や設定の詳細についてのページへ移動します（GitHub Wiki）。`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1791,4 +1791,10 @@ const g_msgObj = {
     appearance: `流れる矢印の見え方を制御します。`,
     opacity: `判定キャラクタ、コンボ数、Fast/Slow、Hidden+/Sudden+の\n境界線表示の透明度を設定します。`,
 
+    kcDesc: `[BackSpaceキー:スキップ / Deleteキー:(代替キーのみ)キー無効化]`,
+    sdDesc: `[クリックでON/OFFを切替、灰色でOFF]`,
+    kcShortcutDesc: `プレイ中ショートカット：「{0}」タイトルバック / 「{1}」リトライ`,
+    transKeyDesc: `別キーモードではハイスコア、キーコンフィグ等は保存されません`,
+    sdShortcutDesc: `Hid+/Sud+時ショートカット：「pageUp」カバーを上へ / 「pageDown」下へ`,
+
 };


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 定数系配列をdanoni_constants.jsへ移動しました。
2. ラベルテキストをdanoni_constants.jsへ移動しました。
`g_msgObj` 及び `g_msgInfoObj`、`g_lblNameObj` 内にて設定しています。
今後はこれらのプロパティ値を変えることで表示内容の変更が可能になります。
また、警告メッセージの変数が下記のように変わっています。
```
C_MSG_W_0001 -> g_msgInfoObj.W_0001
C_MSG_E_0011 -> g_msgInfoObj.E_0011
```
3. 譜面ヘッダー：readyHtml にてReady? の文字の代わりを設定できるようにしました。
※文字のスタイルは無視されます。HTMLタグが使用できます。
```
|readyHtml=<span style="color:#ff9999">Start!</span>|
```
4. 各譜面の譜面情報を出力する「データ出力」を押したとき、メッセージが出るようにしました。
5. ラベルテキスト、オンマウスメッセージをカスタムで定義できるようにしました。
```javascript
/**
 * ラベルテキスト (g_lblNameObj) に対応するプロパティを上書きする設定
 * ※danoni_setting.js の他、customjsにも利用可
 * ※設定可能項目についてはdanoni_constants.jsをご覧ください。
 */
const g_local_lblNameObj = {
    settings: `オプション`,
};

/**
 * オンマウステキスト、確認メッセージ定義 (g_msgObj) に対応するプロパティを上書きする設定
 * ※danoni_setting.js の他、customjsにも利用可
 * ※設定可能項目についてはdanoni_constants.jsをご覧ください。
 */
const g_local_msgObj = {

};
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 後でまとめて変更する際に有用となるため。
2. 表示を後で変えやすくするときに、変数の中身を変えるだけで変更できるようにするため。
3. Ready?の文字を変更する方法が無かったため。
4. クリップボードへコピーしたかどうかがわからないため。
5. ラベルテキスト、オンマウスメッセージを独自定義しやすくするため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/106287788-92a18580-628a-11eb-85f9-49a9fdb47532.png" width="60%">
<img src="https://user-images.githubusercontent.com/44026291/106287866-a947dc80-628a-11eb-85b1-49dfdbaf5377.png" width="50%">
<img src="https://user-images.githubusercontent.com/44026291/106287943-c2e92400-628a-11eb-9141-f05376a3b6d0.png" width="60%">

## :pencil: その他コメント / Other Comments
