### PR TITLE
[0335/music-current] musicFolderのカレントディレクトリ対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1690,6 +1690,8 @@ function loadMusic() {
 	let url = `../${g_headerObj.musicFolder}/${musicUrl}`;
 	if (musicUrl.indexOf(C_MRK_CURRENT_DIRECTORY) !== -1) {
 		url = musicUrl.split(C_MRK_CURRENT_DIRECTORY)[1];
+	} else if (g_headerObj.musicFolder.indexOf(C_MRK_CURRENT_DIRECTORY) !== -1) {
+		url = `${g_headerObj.musicFolder.split(C_MRK_CURRENT_DIRECTORY)[1]}/${musicUrl}`;
 	}
 
 	g_headerObj.musicUrl = musicUrl;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- 譜面ヘッダー：musicFolderについて、他と同様にカレントディレクトリ指定`(..)`に対応しました。
```
|musicFolder=(..)music|
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- Resolves #935 

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments

