### PR TITLE
[0341/remote-js] 作品フォルダ位置の変更に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1679,7 +1679,8 @@ function loadCustomjs(_afterFunc) {
  * @param {string} _directory 
  */
 const getFolderAndType = (_path, _pos, _directory = ``) => {
-	return (_pos > 0 ? [_path.substring(_pos + 1), `${_path.substring(0, _pos)}/`] : [_path, `${g_localRootPath}${_directory}`]);
+	const rootPath = (_directory === `` ? `` : g_localRootPath);
+	return (_pos > 0 ? [_path.substring(_pos + 1), `${rootPath}${_path.substring(0, _pos)}/`] : [_path, `${rootPath}${_directory}`]);
 };
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -38,8 +38,12 @@ let g_localVersion2 = ``;
  *  clearWindow()で[divRoot]以外の全てのスプライトを削除。
  *  特定のスプライトに限り削除する場合は deleteChildspriteAll() 。
  */
+let g_remoteFlg = false;
 
 const current = _ => {
+	if (document.querySelector('script[data-jsmode="remote"]') !== null) {
+		g_remoteFlg = true;
+	}
 	if (document.currentScript) {
 		return document.currentScript.src;
 	}
@@ -48,13 +52,14 @@ const current = _ => {
 	return targetScript.src;
 };
 const g_rootPath = current().match(/(^.*\/)/)[0];
+const g_localRootPath = g_remoteFlg ? `` : g_rootPath;
 
 window.onload = _ => {
 	g_loadObj.main = true;
 
 	// ロード直後に定数・初期化ファイル、旧バージョン定義関数を読込
 	const randTime = new Date().getTime();
-	loadScript(`../js/lib/danoni_localbinary.js?${randTime}`, _ => {
+	loadScript(`${g_localRootPath}../js/lib/danoni_localbinary.js?${randTime}`, _ => {
 		loadScript(`${g_rootPath}../js/lib/danoni_constants.js?${randTime}`, _ => {
 			loadScript(`${g_rootPath}../js/lib/danoni_legacy_function.js?${randTime}`, _ => {
 				initialControl();
@@ -1674,7 +1679,7 @@ function loadCustomjs(_afterFunc) {
  * @param {string} _directory 
  */
 const getFolderAndType = (_path, _pos, _directory = ``) => {
-	return (_pos > 0 ? [_path.substring(_pos + 1), `${_path.substring(0, _pos)}/`] : [_path, _directory]);
+	return (_pos > 0 ? [_path.substring(_pos + 1), `${_path.substring(0, _pos)}/`] : [_path, `${g_localRootPath}${_directory}`]);
 };
 
 /**
@@ -1699,13 +1704,9 @@ const getFilePath = (_fileName, _directory = ``) => {
 function loadSettingJs() {
 
 	// 共通設定ファイルの指定
-	let settingType = ``;
-	let settingRoot = C_DIR_JS;
-	if (hasVal(g_rootObj.settingType)) {
-		[settingType, settingRoot] = getFilePath(g_rootObj.settingType, C_DIR_JS);
-		if (settingType !== ``) {
-			settingType = `_${settingType}`;
-		}
+	let [settingType, settingRoot] = getFilePath(g_rootObj.settingType || ``, C_DIR_JS);
+	if (settingType !== ``) {
+		settingType = `_${settingType}`;
 	}
 
 	const randTime = new Date().getTime();
@@ -1723,7 +1724,7 @@ function loadMusic() {
 	document.onkeydown = evt => blockCode(transCode(evt.code));
 
 	const musicUrl = g_headerObj.musicUrls[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.musicUrls[0];
-	let url = `../${g_headerObj.musicFolder}/${musicUrl}`;
+	let url = `${g_localRootPath}../${g_headerObj.musicFolder}/${musicUrl}`;
 	if (musicUrl.indexOf(C_MRK_CURRENT_DIRECTORY) !== -1) {
 		url = musicUrl.split(C_MRK_CURRENT_DIRECTORY)[1];
 	} else if (g_headerObj.musicFolder.indexOf(C_MRK_CURRENT_DIRECTORY) !== -1) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -39,24 +39,24 @@ let g_localVersion2 = ``;
  *  特定のスプライトに限り削除する場合は deleteChildspriteAll() 。
  */
 
+const current = _ => {
+	if (document.currentScript) {
+		return document.currentScript.src;
+	}
+	const scripts = document.getElementsByTagName(`script`);
+	const targetScript = scripts[scripts.length - 1];
+	return targetScript.src;
+};
+const g_rootPath = current().match(/(^.*\/)/)[0];
+
 window.onload = _ => {
 	g_loadObj.main = true;
-	const current = _ => {
-		if (document.currentScript) {
-			return document.currentScript.src;
-		} else {
-			const scripts = document.getElementsByTagName(`script`);
-			const targetScript = scripts[scripts.length - 1];
-			return targetScript.src;
-		}
-	}
-	g_loadObj.rootPath = current().match(/(^.*\/)/)[0];
 
 	// ロード直後に定数・初期化ファイル、旧バージョン定義関数を読込
 	const randTime = new Date().getTime();
-	loadScript(`${g_loadObj.rootPath}../js/lib/danoni_localbinary.js?${randTime}`, _ => {
-		loadScript(`${g_loadObj.rootPath}../js/lib/danoni_constants.js?${randTime}`, _ => {
-			loadScript(`${g_loadObj.rootPath}../js/lib/danoni_legacy_function.js?${randTime}`, _ => {
+	loadScript(`../js/lib/danoni_localbinary.js?${randTime}`, _ => {
+		loadScript(`${g_rootPath}../js/lib/danoni_constants.js?${randTime}`, _ => {
+			loadScript(`${g_rootPath}../js/lib/danoni_legacy_function.js?${randTime}`, _ => {
 				initialControl();
 			}, false);
 		});

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -41,12 +41,22 @@ let g_localVersion2 = ``;
 
 window.onload = _ => {
 	g_loadObj.main = true;
+	const current = _ => {
+		if (document.currentScript) {
+			return document.currentScript.src;
+		} else {
+			const scripts = document.getElementsByTagName(`script`);
+			const targetScript = scripts[scripts.length - 1];
+			return targetScript.src;
+		}
+	}
+	g_loadObj.rootPath = current().match(/(^.*\/)/)[0];
 
 	// ロード直後に定数・初期化ファイル、旧バージョン定義関数を読込
 	const randTime = new Date().getTime();
-	loadScript(`../js/lib/danoni_localbinary.js?${randTime}`, _ => {
-		loadScript(`../js/lib/danoni_constants.js?${randTime}`, _ => {
-			loadScript(`../js/lib/danoni_legacy_function.js?${randTime}`, _ => {
+	loadScript(`${g_loadObj.rootPath}../js/lib/danoni_localbinary.js?${randTime}`, _ => {
+		loadScript(`${g_loadObj.rootPath}../js/lib/danoni_constants.js?${randTime}`, _ => {
+			loadScript(`${g_loadObj.rootPath}../js/lib/danoni_legacy_function.js?${randTime}`, _ => {
 				initialControl();
 			}, false);
 		});

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -43,19 +43,19 @@ const C_TYP_SWITCH = `switch`;
 const C_TYP_CALC = `calc`;
 
 // 画像ファイル
-let C_IMG_ARROW = `../img/arrow.svg`;
-let C_IMG_ARROWSD = `../img/arrowShadow.svg`;
-let C_IMG_ONIGIRI = `../img/onigiri.svg`;
-let C_IMG_AASD = `../img/aaShadow.svg`;
-let C_IMG_GIKO = `../img/giko.svg`;
-let C_IMG_IYO = `../img/iyo.svg`;
-let C_IMG_C = `../img/c.svg`;
-let C_IMG_MORARA = `../img/morara.svg`;
-let C_IMG_MONAR = `../img/monar.svg`;
-let C_IMG_CURSOR = `../img/cursor.svg`;
-let C_IMG_FRZBAR = `../img/frzbar.svg`;
-let C_IMG_LIFEBAR = `../img/frzbar.svg`;
-let C_IMG_LIFEBORDER = `../img/borderline.svg`;
+let C_IMG_ARROW = `${g_localRootPath}../img/arrow.svg`;
+let C_IMG_ARROWSD = `${g_localRootPath}../img/arrowShadow.svg`;
+let C_IMG_ONIGIRI = `${g_localRootPath}../img/onigiri.svg`;
+let C_IMG_AASD = `${g_localRootPath}../img/aaShadow.svg`;
+let C_IMG_GIKO = `${g_localRootPath}../img/giko.svg`;
+let C_IMG_IYO = `${g_localRootPath}../img/iyo.svg`;
+let C_IMG_C = `${g_localRootPath}../img/c.svg`;
+let C_IMG_MORARA = `${g_localRootPath}../img/morara.svg`;
+let C_IMG_MONAR = `${g_localRootPath}../img/monar.svg`;
+let C_IMG_CURSOR = `${g_localRootPath}../img/cursor.svg`;
+let C_IMG_FRZBAR = `${g_localRootPath}../img/frzbar.svg`;
+let C_IMG_LIFEBAR = `${g_localRootPath}../img/frzbar.svg`;
+let C_IMG_LIFEBORDER = `${g_localRootPath}../img/borderline.svg`;
 
 if (typeof loadBinary === C_TYP_FUNCTION) {
     loadBinary();


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 作品フォルダを従来のサブフォルダに置くことができるようになりました。
js, cssファイルは下記のように、元の場所を指すように変更してください。
```html
<script src="../../js/danoni_main.js" charset="UTF-8">
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- 作品フォルダ配置場所の融通を利くようにするため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 実装に当たり、下記サイトを参考にしました。
https://qiita.com/kijtra/items/472cb34a8f0eb6dde459
https://qiita.com/suzunone/items/ce8894b8e338ee66a9d5

### 補足
- 将来的に共通のリモートJSファイルを置いて、そこを参照できるようにすることを想定しています。
（バージョンアップをある程度意識する必要が無くなる）
試験的に、data-jsmode="remote"と指定することでjs/libフォルダのみ連動するようになっています。
```html
<script src="https://xxxxxx/js/danoni_main.js" charset="UTF-8" data-jsmode="remote">
```