### PR TITLE
[0349/window-pointer] 譜面明細画面でデータ出力ボタンを押した後、譜面選択できない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2498,6 +2498,7 @@ function setWindowStyle(_lbl, _bkColor, _textColor, _align = C_ALIGN_LEFT) {
 	_lbl.style.color = _textColor;
 	_lbl.style.textAlign = _align;
 	_lbl.style.fontFamily = getBasicFont();
+	_lbl.style.pointerEvents = C_DIS_NONE;
 }
 
 /**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 譜面明細画面でデータ出力ボタンを押した後、譜面選択できない問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. メッセージウィンドウが手前に来ており、その裏側にあるボタンが押せなくなっていました。
メッセージウィンドウそのものは透過させても問題ないため、
メッセージウィンドウ用のオブジェクトに対して、`pointer-events: none`を適用しました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 参考リンク
https://developer.mozilla.org/ja/docs/Web/CSS/pointer-events
- ver19.3.0以降でのみ発生する事象です。
