### PR TITLE
[0350/ready-width] Ready? の文字幅を画面幅に合わせる変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7514,9 +7514,9 @@ function MainInit() {
 
 		divRoot.appendChild(
 			createDivCss2Label(`lblReady`, readyHtml, {
-				x: g_headerObj.playingX + g_headerObj.playingWidth / 2 - 100,
+				x: g_headerObj.playingX + (g_headerObj.playingWidth - g_sWidth) / 2,
 				y: (g_sHeight + g_posObj.stepYR) / 2 - 75,
-				w: 200, h: 50, siz: 40,
+				w: g_sWidth, h: 50, siz: 40,
 				animationDuration: `${g_headerObj.readyAnimationFrame / g_fps}s`,
 				animationName: g_headerObj.readyAnimationName,
 				animationDelay: `${readyDelayFrame / g_fps}s`, opacity: 0,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. Ready? の文字幅を画面幅に合わせるようにしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 譜面ヘッダー：readyHtmlを追加しましたが、横幅が従来の幅（200px）になっていたため
長い場合、折り返しが発生する状況になっていました。
元々中央寄せされているため、横幅いっぱいに広げても支障はないと考えます。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- Ready?の文字を置き換えることが目的なので、縦幅の変更や細かい位置変更などについては考えていません。
このような場合は、|customReadyUse=true|としてReady?を非表示化したうえで、
mask_dataなどを使って表現する方が自由度が高く、良いと考えます。