### PR TITLE
[0355/adjustment-shortcut] Adjustment設定のショートカットにテンキーを割り当て

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -751,6 +751,12 @@ const g_shortcutObj = {
         Semicolon: { id: `lnkAdjustmentRR` },
         ShiftLeft_Minus: { id: `lnkAdjustmentL` },
         Minus: { id: `lnkAdjustmentLL` },
+
+        ShiftLeft_NumpadAdd: { id: `lnkAdjustmentR` },
+        NumpadAdd: { id: `lnkAdjustmentRR` },
+        ShiftLeft_NumpadSubtract: { id: `lnkAdjustmentL` },
+        NumpadSubtract: { id: `lnkAdjustmentLL` },
+
         ShiftLeft_KeyV: { id: `lnkVolumeL` },
         KeyV: { id: `lnkVolumeR` },
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. Adjustment設定のショートカットにテンキーの「+」「-」を割り当てました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 利便性向上のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- danoni_constants.js のみの修正です。
- 設定のみの修正のため、v19にも反映予定です。