### PR TITLE
[0358/dif-dfsize] 設定画面内の譜面名のMakerViewのフォントサイズ変更に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4625,12 +4625,17 @@ function createOptionWindow(_sprite) {
 		// 3. 名称の設定
 
 		// 譜面名設定 (Difficulty)
+		const difWidth = parseFloat(lnkDifficulty.style.width);
 		lnkDifficulty.innerHTML = `${g_keyObj.currentKey} key / ${g_headerObj.difLabels[g_stateObj.scoreId]}`;
 		lnkDifficulty.style.fontSize = `${getFontSize(lnkDifficulty.textContent,
-			parseFloat(lnkDifficulty.style.width), getBasicFont(), C_SIZ_SETLBL)}px`;
+			difWidth, getBasicFont(), C_SIZ_SETLBL)}px`;
 		if (g_headerObj.makerView) {
-			lnkDifficulty.innerHTML += `<br>(${g_headerObj.creatorNames[g_stateObj.scoreId]})`;
-			lnkDifficulty.style.fontSize = `14px`;
+			const difNames = [lnkDifficulty.textContent, `(${g_headerObj.creatorNames[g_stateObj.scoreId]})`];
+			difNames.forEach((difName, j) => {
+				const tmpSize = getFontSize(difName, difWidth, getBasicFont(), 14);
+				difNames[j] = `<span style="font-size:${tmpSize}px">${difName}</span>`;
+			});
+			lnkDifficulty.innerHTML = difNames.join(``);
 		}
 
 		// 速度設定 (Speed)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4627,7 +4627,7 @@ function createOptionWindow(_sprite) {
 		// 譜面名設定 (Difficulty)
 		lnkDifficulty.innerHTML = `${g_keyObj.currentKey} key / ${g_headerObj.difLabels[g_stateObj.scoreId]}`;
 		lnkDifficulty.style.fontSize = `${getFontSize(lnkDifficulty.textContent,
-			parseFloat(lnkDifficulty.style.width), getBasicFont(), C_SIZ_SETMINI)}px`;
+			parseFloat(lnkDifficulty.style.width), getBasicFont(), C_SIZ_SETLBL)}px`;
 		if (g_headerObj.makerView) {
 			lnkDifficulty.innerHTML += `<br>(${g_headerObj.creatorNames[g_stateObj.scoreId]})`;
 			lnkDifficulty.style.fontSize = `14px`;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 設定画面内の譜面名のMakerViewのフォントサイズ変更に対応しました。
2. 設定画面内の譜面名のデフォルトサイズを従来に戻しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1, 2. ver20.1.0の修正漏れの対応です。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
