### PR TITLE
[0360/ios-shortcut] 戻るボタンのショートカットキーにShift+Tabを追加割り当て

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -104,8 +104,6 @@ let g_maxScore = 1000000;
 let g_gameOverFlg = false;
 let g_finishFlg = true;
 
-const g_userAgent = window.navigator.userAgent.toLowerCase(); // msie, edge, chrome, safari, firefox, opera
-
 /** 共通オブジェクト */
 const g_loadObj = {};
 const g_rootObj = {};
@@ -1873,10 +1871,6 @@ function makePlayButton(_func) {
  * @param {string} _url 
  */
 function setAudio(_url) {
-	const ua = navigator.userAgent;
-	const isIOS = ua.indexOf(`iPhone`) >= 0
-		|| ua.indexOf(`iPad`) >= 0
-		|| ua.indexOf(`iPod`) >= 0;
 
 	const loadMp3 = _ => {
 		if (location.href.match(`^file`)) {
@@ -1891,7 +1885,7 @@ function setAudio(_url) {
 		loadScript(_url, _ => {
 			if (typeof musicInit === C_TYP_FUNCTION) {
 				musicInit();
-				if (isIOS) {
+				if (g_isIos) {
 					lblLoading.textContent = `Click to Start!`;
 					divRoot.appendChild(
 						makePlayButton(evt => {
@@ -1908,7 +1902,7 @@ function setAudio(_url) {
 			}
 		});
 
-	} else if (isIOS) {
+	} else if (g_isIos) {
 		lblLoading.textContent = `Click to Start!`;
 		divRoot.appendChild(
 			makePlayButton(evt => {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5208,13 +5208,14 @@ function keyConfigInit(_kcType = g_kcType) {
 		lnkColorType.textContent = `${g_colorType}${g_localStorage.colorType === g_colorType ? ' *' : ''}`;
 	}
 
+	const macRetryCode = g_kCd[g_headerObj.keyRetry === C_KEY_RETRY ? C_KEY_TITLEBACK : g_headerObj.keyRetry];
 	multiAppend(divRoot,
 
 		// ショートカットキーメッセージ
 		createDivCss2Label(
 			`scMsg`,
-			g_lblNameObj.kcShortcutDesc.split(`{0}`).join(g_isMac ? `Shift+Delete` : g_kCd[g_headerObj.keyTitleBack])
-				.split(`{1}`).join(g_isMac ? `Delete` : g_kCd[g_headerObj.keyRetry]),
+			g_lblNameObj.kcShortcutDesc.split(`{0}`).join(g_isMac ? `Shift+${macRetryCode}` : g_kCd[g_headerObj.keyTitleBack])
+				.split(`{1}`).join(g_isMac ? macRetryCode : g_kCd[g_headerObj.keyRetry]),
 			{
 				x: 0, y: g_sHeight - 45, w: g_sWidth, h: 20, siz: C_SIZ_MAIN,
 			}),

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5083,7 +5083,8 @@ function keyConfigInit(_kcType = g_kcType) {
 			`<div class="settings_Title">${g_lblNameObj.key}</div><div class="settings_Title2">${g_lblNameObj.config}</div>`
 				.replace(/[\t\n]/g, ``), 0, 15, g_cssObj.flex_centering),
 
-		createDivCss2Label(`kcDesc`, g_lblNameObj.kcDesc, {
+		createDivCss2Label(`kcDesc`, g_lblNameObj.kcDesc.split(`{0}`).join(g_isMac ? `Delete` : `BackSpace`)
+			.split(`{1}:`).join(g_isMac ? `` : `Delete:`), {
 			x: 0, y: 65, w: g_sWidth, h: 20, siz: C_SIZ_MAIN,
 		}),
 
@@ -5212,8 +5213,8 @@ function keyConfigInit(_kcType = g_kcType) {
 		// ショートカットキーメッセージ
 		createDivCss2Label(
 			`scMsg`,
-			g_lblNameObj.kcShortcutDesc.split(`{0}`).join(g_kCd[g_headerObj.keyTitleBack])
-				.split(`{1}`).join(g_kCd[g_headerObj.keyRetry]),
+			g_lblNameObj.kcShortcutDesc.split(`{0}`).join(g_isMac ? `Shift+Delete` : g_kCd[g_headerObj.keyTitleBack])
+				.split(`{1}`).join(g_isMac ? `Delete` : g_kCd[g_headerObj.keyRetry]),
 			{
 				x: 0, y: g_sHeight - 45, w: g_sWidth, h: 20, siz: C_SIZ_MAIN,
 			}),
@@ -5383,13 +5384,13 @@ function keyConfigInit(_kcType = g_kcType) {
 		if (disabledKeys.includes(setKey) || g_kCdN[setKey] === undefined) {
 			makeInfoWindow(g_msgInfoObj.I_0002, `fadeOut0`);
 			return;
-		} else if ((setKey === 46 && g_currentk === 0) ||
+		} else if ((setKey === C_KEY_TITLEBACK && g_currentk === 0) ||
 			(keyIsDown(`MetaLeft`) && keyIsDown(`ShiftLeft`))) {
 			return;
 		}
-		if (setKey === 8) {
+		if (setKey === C_KEY_RETRY && (!g_isMac || (g_isMac && g_currentk === 0))) {
 		} else {
-			if (setKey === 46) {
+			if (setKey === C_KEY_TITLEBACK || setKey === C_KEY_RETRY) {
 				setKey = 0;
 			}
 			if (g_keyObj[`keyCtrl${keyCtrlPtn}d`][g_currentj][g_currentk] !== setKey) {
@@ -7571,7 +7572,15 @@ function MainInit() {
 
 		// 曲中リトライ、タイトルバック
 		if (setCode === g_kCdN[g_headerObj.keyRetry]) {
-			if (g_audio.volume >= g_stateObj.volume / 100 && g_scoreObj.frameNum >= g_headerObj.blankFrame) {
+
+			if (g_isMac && keyIsDown(`ShiftLeft`)) {
+				// Mac OS、IPad OSはDeleteキーが無いためShift+BSで代用
+				g_audio.pause();
+				clearTimeout(g_timeoutEvtId);
+				titleInit();
+
+			} else if (g_audio.volume >= g_stateObj.volume / 100 && g_scoreObj.frameNum >= g_headerObj.blankFrame) {
+				// 連打対策として指定ボリュームになるまでリトライを禁止
 				g_audio.pause();
 				clearTimeout(g_timeoutEvtId);
 				clearWindow();

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -34,6 +34,7 @@ const C_SPRITE_ROOT = `divRoot`;
 
 const g_userAgent = window.navigator.userAgent.toLowerCase(); // msie, edge, chrome, safari, firefox, opera
 const g_isIos = listMatching(g_userAgent, [`iphone`, `ipad`, `ipod`]);
+const g_isMac = listMatching(g_userAgent, [`iphone`, `ipad`, `ipod`, `mac os`]);
 
 // 変数型
 const C_TYP_BOOLEAN = `boolean`;
@@ -1922,7 +1923,7 @@ const g_lblNameObj = {
     config: `CONFIG`,
     result: `RESULT`,
 
-    kcDesc: `[BackSpaceキー:スキップ / Deleteキー:(代替キーのみ)キー無効化]`,
+    kcDesc: `[{0}:スキップ / {1}:(代替キーのみ)キー無効化]`,
     sdDesc: `[クリックでON/OFFを切替、灰色でOFF]`,
     kcShortcutDesc: `プレイ中ショートカット：「{0}」タイトルバック / 「{1}」リトライ`,
     transKeyDesc: `別キーモードではハイスコア、キーコンフィグ等は保存されません`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -32,6 +32,9 @@ const C_LNK_HEIGHT = 20;
 // スプライト（ムービークリップ相当）のルート
 const C_SPRITE_ROOT = `divRoot`;
 
+const g_userAgent = window.navigator.userAgent.toLowerCase(); // msie, edge, chrome, safari, firefox, opera
+const g_isIos = listMatching(g_userAgent, [`iphone`, `ipad`, `ipod`]);
+
 // 変数型
 const C_TYP_BOOLEAN = `boolean`;
 const C_TYP_NUMBER = `number`;
@@ -768,6 +771,7 @@ const g_shortcutObj = {
         Escape: { id: `btnBack` },
         Space: { id: `btnKeyConfig` },
         Enter: { id: `btnPlay` },
+        ShiftLeft_Tab: { id: `btnBack` },
         Tab: { id: `btnDisplay` },
     },
     settingsDisplay: {
@@ -807,6 +811,7 @@ const g_shortcutObj = {
         Escape: { id: `btnBack` },
         Space: { id: `btnKeyConfig` },
         Enter: { id: `btnPlay` },
+        ShiftLeft_Tab: { id: `btnBack` },
         Tab: { id: `btnSettings` },
     },
     keyConfig: {
@@ -814,7 +819,8 @@ const g_shortcutObj = {
     },
     result: {
         Escape: { id: `btnBack` },
-        KeyC: { id: `btnCopy` },
+        ShiftLeft_Tab: { id: `btnBack` },
+        KeyC: { id: `btnCopy`, reset: true },
         KeyT: { id: `btnTweet`, reset: true },
         KeyG: { id: `btnGitter`, reset: true },
         Backspace: { id: `btnRetry` },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 戻るボタンのショートカットキーにShift+Tabを追加割り当てするようにしました。
※キーコンフィグ画面を除きます。
2. 結果画面のCopyResultのショートカットキー（「C」キー）を押した際、
強制的にkeyUpするよう変更しました。
3. iPad/iPhone/iPod Touch判定用の処理をdanoni_constants.jsへ移動しました。
4. MacOS, iPadのとき、割り当てキーと役割を一部変更しました。
    - メイン画面　`Shift`+`Backspace(Delete)`: タイトルバック
    - キーコンフィグ画面　`Backspace(Delete)`：スキップ兼代替キーの無効化
    ※Windowsで言う⌫Backspaceは、Macでは⌫Deleteと呼称します。（codeはBackspaceと同一）

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. MacOSやiPadの場合、Escapeキーが無い場合があるため。
ただし、キーコンフィグ画面では現状代替先キーが無いためそのままにします。
2. iPad (Chrome)にてショートカットキーを使ってクリップボードコピーを行うと、
keyUpが動作しない問題があったため。
3. 今後、OSによる処理分岐が想定されるため。
4. MacOS、iPadOSにWindowsのDelete相当キー (MacではForward Deleteと呼称)が存在しないため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- その他、MacOS系ではDeleteキーが無い問題があります。
メイン処理のショートカット操作は他と異なるため、一旦保留しています。→　対応しました。
