### PR TITLE
[0361/shortcut-wait-time] ボタン・ショートカットキーの有効化時間を設定できるようにする

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -51,6 +51,7 @@ const g_remoteFlg = g_rootPath.match(`^https://cwtickle.github.io/danoniplus/`) 
 
 window.onload = _ => {
 	g_loadObj.main = true;
+	g_currentPage = `initial`;
 
 	// ロード直後に定数・初期化ファイル、旧バージョン定義関数を読込
 	const randTime = new Date().getTime();
@@ -775,7 +776,7 @@ function deleteChildspriteAll(_parentObjName) {
  * @param {...any} _classes 
  */
 function createCss2Button(_id, _text, _func = _ => true, { x = 0, y = g_sHeight - 100, w = g_sWidth / 3, h = C_BTN_HEIGHT,
-	siz = C_LBL_BTNSIZE, align = C_ALIGN_CENTER, title = ``,
+	siz = C_LBL_BTNSIZE, align = C_ALIGN_CENTER, title = ``, displayName = g_currentPage, pointerEvents = C_DIS_NONE,
 	resetFunc = _ => true, cxtFunc = _ => true, ...rest } = {}, ..._classes) {
 
 	const div = createDiv(_id, x, y, w, h);
@@ -792,6 +793,13 @@ function createCss2Button(_id, _text, _func = _ => true, { x = 0, y = g_sHeight 
 		style.animationDuration = `1s`;
 	}
 	Object.keys(rest).forEach(property => style[property] = rest[property]);
+
+	// ボタン有効化操作
+	if (pointerEvents === C_DIS_NONE) {
+		style.pointerEvents = C_DIS_NONE;
+		setTimeout(_ => style.pointerEvents = `auto`,
+			g_initialFlg && g_btnWaitTime[displayName].initial ? 0 : g_btnWaitTime[displayName].b_time);
+	}
 
 	// ボタンを押したときの動作
 	const lsnrkey = g_handler.addListener(div, `click`, evt => {
@@ -2196,7 +2204,7 @@ const setShortcutEvent = (_displayName, _func = _ => true) => {
 			document.onkeydown = evt => commonKeyDown(evt, g_currentPage, _func);
 			document.onkeyup = evt => commonKeyUp(evt);
 		}
-	}, g_shortcutWaitTime[_displayName]);
+	}, (g_initialFlg && g_btnWaitTime[_displayName].initial ? 0 : g_btnWaitTime[_displayName].s_time));
 }
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2187,6 +2187,19 @@ const createScTextCommon = _displayName => {
 }
 
 /**
+ * ショートカットキー有効化
+ * @param {string} _displayName 
+ */
+const setShortcutEvent = (_displayName, _func = _ => true) => {
+	setTimeout(_ => {
+		if (g_currentPage === _displayName) {
+			document.onkeydown = evt => commonKeyDown(evt, g_currentPage, _func);
+			document.onkeyup = evt => commonKeyUp(evt);
+		}
+	}, g_shortcutWaitTime[_displayName]);
+}
+
+/**
  *  タイトル画面初期化
  */
 function titleInit() {
@@ -2505,8 +2518,7 @@ function titleInit() {
 	g_timeoutEvtTitleId = setTimeout(_ => flowTitleTimeline(), 1000 / g_fps);
 
 	// キー操作イベント（デフォルト）
-	document.onkeydown = evt => commonKeyDown(evt, g_currentPage);
-	document.onkeyup = evt => commonKeyUp(evt);
+	setShortcutEvent(g_currentPage);
 
 	document.oncontextmenu = _ => true;
 	divRoot.oncontextmenu = _ => false;
@@ -3700,8 +3712,7 @@ function optionInit() {
 	createScTextCommon(g_currentPage);
 
 	// キー操作イベント（デフォルト）
-	document.onkeydown = evt => commonKeyDown(evt, g_currentPage);
-	document.onkeyup = evt => commonKeyUp(evt);
+	setShortcutEvent(g_currentPage);
 	document.oncontextmenu = _ => true;
 	g_initialFlg = true;
 
@@ -4909,12 +4920,10 @@ function settingsDisplayInit() {
 
 	// ボタン描画
 	commonSettingBtn(`Settings`);
-
 	createScTextCommon(g_currentPage);
 
 	// キー操作イベント（デフォルト）
-	document.onkeydown = evt => commonKeyDown(evt, g_currentPage);
-	document.onkeyup = evt => commonKeyUp(evt);
+	setShortcutEvent(g_currentPage);
 	document.oncontextmenu = _ => true;
 
 	if (typeof skinSettingsDisplayInit === C_TYP_FUNCTION) {
@@ -5377,7 +5386,7 @@ function keyConfigInit(_kcType = g_kcType) {
 	createScTextCommon(g_currentPage);
 
 	// キーボード押下時処理
-	document.onkeydown = evt => commonKeyDown(evt, g_currentPage, setCode => {
+	setShortcutEvent(g_currentPage, setCode => {
 		const keyCdObj = document.querySelector(`#keycon${g_currentj}_${g_currentk}`);
 		const cursor = document.querySelector(`#cursor`);
 		const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
@@ -9398,13 +9407,7 @@ function resultInit() {
 	g_timeoutEvtResultId = setTimeout(_ => flowResultTimeline(), 1000 / g_fps);
 
 	// キー操作イベント（デフォルト）
-	setTimeout(_ => {
-		if (g_currentPage === `result`) {
-			document.onkeydown = evt => commonKeyDown(evt, g_currentPage);
-			document.onkeyup = evt => commonKeyUp(evt);
-		}
-	}, g_shortcutWaitTime.result);
-
+	setShortcutEvent(g_currentPage);
 	document.oncontextmenu = _ => true;
 
 	if (typeof skinResultInit === C_TYP_FUNCTION) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -798,7 +798,7 @@ function createCss2Button(_id, _text, _func = _ => true, { x = 0, y = g_sHeight 
 	if (initDisabledFlg) {
 		style.pointerEvents = C_DIS_NONE;
 		setTimeout(_ => style.pointerEvents = setVal(rest.pointerEvents, `auto`, C_TYP_STRING),
-			g_initialFlg && g_btnWaitTime[groupName].initial ? 0 : g_btnWaitTime[groupName].b_time);
+			g_initialFlg && g_btnWaitFrame[groupName].initial ? 0 : g_btnWaitFrame[groupName].b_frame) * 1000 / g_fps;
 	}
 
 	// ボタンを押したときの動作
@@ -2204,7 +2204,7 @@ const setShortcutEvent = (_displayName, _func = _ => true) => {
 			document.onkeydown = evt => commonKeyDown(evt, g_currentPage, _func);
 			document.onkeyup = evt => commonKeyUp(evt);
 		}
-	}, (g_initialFlg && g_btnWaitTime[_displayName].initial ? 0 : g_btnWaitTime[_displayName].s_time));
+	}, (g_initialFlg && g_btnWaitFrame[_displayName].initial ? 0 : g_btnWaitFrame[_displayName].s_frame) * 1000 / g_fps);
 }
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -796,9 +796,12 @@ function createCss2Button(_id, _text, _func = _ => true, { x = 0, y = g_sHeight 
 
 	// ボタン有効化操作
 	if (initDisabledFlg) {
-		style.pointerEvents = C_DIS_NONE;
-		setTimeout(_ => style.pointerEvents = setVal(rest.pointerEvents, `auto`, C_TYP_STRING),
-			g_initialFlg && g_btnWaitFrame[groupName].initial ? 0 : g_btnWaitFrame[groupName].b_frame) * 1000 / g_fps;
+		if (g_initialFlg && g_btnWaitFrame[groupName].initial) {
+		} else {
+			style.pointerEvents = C_DIS_NONE;
+			setTimeout(_ => style.pointerEvents = setVal(rest.pointerEvents, `auto`, C_TYP_STRING),
+				g_btnWaitFrame[groupName].b_frame * 1000 / g_fps);
+		}
 	}
 
 	// ボタンを押したときの動作
@@ -2196,15 +2199,23 @@ const createScTextCommon = _displayName => {
 
 /**
  * ショートカットキー有効化
- * @param {string} _displayName 
+ * @param {string} _displayName
+ * @param {function} _func 
  */
 const setShortcutEvent = (_displayName, _func = _ => true) => {
-	setTimeout(_ => {
-		if (g_currentPage === _displayName) {
-			document.onkeydown = evt => commonKeyDown(evt, g_currentPage, _func);
-			document.onkeyup = evt => commonKeyUp(evt);
-		}
-	}, (g_initialFlg && g_btnWaitFrame[_displayName].initial ? 0 : g_btnWaitFrame[_displayName].s_frame) * 1000 / g_fps);
+	const evList = _ => {
+		document.onkeydown = evt => commonKeyDown(evt, _displayName, _func);
+		document.onkeyup = evt => commonKeyUp(evt);
+	}
+	if (g_initialFlg && g_btnWaitFrame[_displayName].initial) {
+		evList();
+	} else {
+		setTimeout(_ => {
+			if (g_currentPage === _displayName) {
+				evList();
+			}
+		}, g_btnWaitFrame[_displayName].s_frame * 1000 / g_fps);
+	}
 }
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -772,11 +772,11 @@ function deleteChildspriteAll(_parentObjName) {
  * @param {string} _id 
  * @param {string} _text
  * @param {function} _func
- * @param {object} _obj (x, y, w, h, siz, align, ...rest)
+ * @param {object} _obj (x, y, w, h, siz, align, title, groupName, initDisabledFlg, ...rest)
  * @param {...any} _classes 
  */
 function createCss2Button(_id, _text, _func = _ => true, { x = 0, y = g_sHeight - 100, w = g_sWidth / 3, h = C_BTN_HEIGHT,
-	siz = C_LBL_BTNSIZE, align = C_ALIGN_CENTER, title = ``, displayName = g_currentPage, pointerEvents = C_DIS_NONE,
+	siz = C_LBL_BTNSIZE, align = C_ALIGN_CENTER, title = ``, groupName = g_currentPage, initDisabledFlg = true,
 	resetFunc = _ => true, cxtFunc = _ => true, ...rest } = {}, ..._classes) {
 
 	const div = createDiv(_id, x, y, w, h);
@@ -795,10 +795,10 @@ function createCss2Button(_id, _text, _func = _ => true, { x = 0, y = g_sHeight 
 	Object.keys(rest).forEach(property => style[property] = rest[property]);
 
 	// ボタン有効化操作
-	if (pointerEvents === C_DIS_NONE) {
+	if (initDisabledFlg) {
 		style.pointerEvents = C_DIS_NONE;
-		setTimeout(_ => style.pointerEvents = `auto`,
-			g_initialFlg && g_btnWaitTime[displayName].initial ? 0 : g_btnWaitTime[displayName].b_time);
+		setTimeout(_ => style.pointerEvents = setVal(rest.pointerEvents, `auto`, C_TYP_STRING),
+			g_initialFlg && g_btnWaitTime[groupName].initial ? 0 : g_btnWaitTime[groupName].b_time);
 	}
 
 	// ボタンを押したときの動作

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -826,7 +826,7 @@ const g_shortcutObj = {
 // initial: 初回のみ有効化時間を設定する場合、trueを設定
 const g_btnWaitFrame = {
     initial: { b_frame: 0, s_frame: 0 },
-    title: { b_frame: 0, s_frame: 0, initial: true },
+    title: { b_frame: 0, s_frame: 0 },
     option: { b_frame: 0, s_frame: 0, initial: true },
     settingsDisplay: { b_frame: 0, s_frame: 0 },
     loading: { b_frame: 0, s_frame: 0 },

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -829,6 +829,7 @@ const g_btnWaitTime = {
     title: { b_time: 0, s_time: 0, initial: true },
     option: { b_time: 0, s_time: 0, initial: true },
     loading: { b_time: 0, s_time: 0 },
+    main: { b_time: 0, s_time: 0 },
     settingsDisplay: { b_time: 0, s_time: 0 },
     keyConfig: { b_time: 0, s_time: 0 },
     result: { b_time: 0, s_time: 2000 },

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -821,18 +821,18 @@ const g_shortcutObj = {
     },
 };
 
-// ボタン・ショートカットキーの有効化時間（ミリ秒）
-// b_time: ボタンの有効化時間、s_time: ショートカットキーの有効化時間
+// ボタン・ショートカットキーの有効化時間（フレーム数）
+// b_frame: ボタンの有効化フレーム数、s_frame: ショートカットキーの有効化フレーム数
 // initial: 初回のみ有効化時間を設定する場合、trueを設定
-const g_btnWaitTime = {
-    initial: { b_time: 0, s_time: 0 },
-    title: { b_time: 0, s_time: 0, initial: true },
-    option: { b_time: 0, s_time: 0, initial: true },
-    settingsDisplay: { b_time: 0, s_time: 0 },
-    loading: { b_time: 0, s_time: 0 },
-    main: { b_time: 0, s_time: 0 },
-    keyConfig: { b_time: 0, s_time: 0 },
-    result: { b_time: 0, s_time: 2000 },
+const g_btnWaitFrame = {
+    initial: { b_frame: 0, s_frame: 0 },
+    title: { b_frame: 0, s_frame: 0, initial: true },
+    option: { b_frame: 0, s_frame: 0, initial: true },
+    settingsDisplay: { b_frame: 0, s_frame: 0 },
+    loading: { b_frame: 0, s_frame: 0 },
+    main: { b_frame: 0, s_frame: 0 },
+    keyConfig: { b_frame: 0, s_frame: 0 },
+    result: { b_frame: 0, s_frame: 120 },
 };
 
 // 主要ボタンのリスト

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -828,9 +828,9 @@ const g_btnWaitTime = {
     initial: { b_time: 0, s_time: 0 },
     title: { b_time: 0, s_time: 0, initial: true },
     option: { b_time: 0, s_time: 0, initial: true },
+    settingsDisplay: { b_time: 0, s_time: 0 },
     loading: { b_time: 0, s_time: 0 },
     main: { b_time: 0, s_time: 0 },
-    settingsDisplay: { b_time: 0, s_time: 0 },
     keyConfig: { b_time: 0, s_time: 0 },
     result: { b_time: 0, s_time: 2000 },
 };

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -821,13 +821,17 @@ const g_shortcutObj = {
     },
 };
 
-// ショートカットキーの有効化時間（ミリ秒）
-const g_shortcutWaitTime = {
-    title: 0,
-    option: 0,
-    settingsDisplay: 0,
-    keyConfig: 0,
-    result: 2000,
+// ボタン・ショートカットキーの有効化時間（ミリ秒）
+// b_time: ボタンの有効化時間、s_time: ショートカットキーの有効化時間
+// initial: 初回のみ有効化時間を設定する場合、trueを設定
+const g_btnWaitTime = {
+    initial: { b_time: 0, s_time: 0 },
+    title: { b_time: 0, s_time: 0, initial: true },
+    option: { b_time: 0, s_time: 0, initial: true },
+    loading: { b_time: 0, s_time: 0 },
+    settingsDisplay: { b_time: 0, s_time: 0 },
+    keyConfig: { b_time: 0, s_time: 0 },
+    result: { b_time: 0, s_time: 2000 },
 };
 
 // 主要ボタンのリスト

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -821,8 +821,12 @@ const g_shortcutObj = {
     },
 };
 
-// ショートカットキーの有効化時間（ミリ秒）※結果画面のみ利用
+// ショートカットキーの有効化時間（ミリ秒）
 const g_shortcutWaitTime = {
+    title: 0,
+    option: 0,
+    settingsDisplay: 0,
+    keyConfig: 0,
     result: 2000,
 };
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. タイトル画面・設定画面・キーコンフィグ画面でボタン・ショートカットキーの有効化時間を設定できるようにしました。PR #964 関連。
`g_btnWaitFrame`で指定できます。
`danoni_constants.js`で定義しているため、`danoni_setting.js`や`danoni_custom.js`で置き換え可能です。

```javascript
// ボタン・ショートカットキーの有効化時間（フレーム数）
// b_frame: ボタンの有効化フレーム数、s_frame: ショートカットキーの有効化フレーム数
// initial: 初回のみ有効化時間を設定する場合、trueを設定
const g_btnWaitFrame = {
    initial: { b_frame: 0, s_frame: 0 },
    title: { b_frame: 0, s_frame: 0 },
    option: { b_frame: 0, s_frame: 0, initial: true },
    settingsDisplay: { b_frame: 0, s_frame: 0 },
    loading: { b_frame: 0, s_frame: 0 },
    main: { b_frame: 0, s_frame: 0 },
    keyConfig: { b_frame: 0, s_frame: 0 },
    result: { b_frame: 0, s_frame: 120 },
};
```

2. ボタン作成関数で、原則として初期はボタンが使用できない状態に変更しました。
`g_btnWaitTime[グループ名].b_time`ミリ秒後に使用できるようになります。

|引数|型|デフォルト|用途|
|----|----|----|----|
|groupName|string|g_currentPage|ボタンが所属するグループ。<br>既定はそのボタンが置かれている画面名が入ります。<br>ボタンの有効化までにかかる時間で利用します。|
|initDisabledFlg|boolean|true|初期利用不可フラグ。<br>既定は利用不可で、指定時間後に利用可の設定。<br>ただし、`g_btnWaitFrame[グループ名].initial = true`となっている場合のみ、2回目以降は指定時間ゼロで使用できる。<br><br>※g_initialFlgを利用するため、事前に`g_initialFlg = false;`と`g_initialFlg = true;`を設定しておく必要があります。|

```javascript
function createCss2Button(_id, _text, _func = _ => true, { x = 0, y = g_sHeight - 100, w = g_sWidth / 3, h = C_BTN_HEIGHT,
	siz = C_LBL_BTNSIZE, align = C_ALIGN_CENTER, title = ``, groupName = g_currentPage, initDisabledFlg = true,
	resetFunc = _ => true, cxtFunc = _ => true, ...rest } = {}, ..._classes) {

        // 省略

	// ボタン有効化操作
	if (initDisabledFlg) {
		if (g_initialFlg && g_btnWaitFrame[groupName].initial) {
		} else {
			style.pointerEvents = C_DIS_NONE;
			setTimeout(_ => style.pointerEvents = setVal(rest.pointerEvents, `auto`, C_TYP_STRING),
				g_btnWaitFrame[groupName].b_frame * 1000 / g_fps);
		}
	}

        // 省略
}
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 結果画面のみで利用できていた、ショートカットキーの有効化時間について
状況によっては他画面でも使用する場合がありえるため。
2. ショートカットキーが使用できない場合、ボタンも同様に使用できなくする必要があることが多いため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 局所的のため、譜面ヘッダー化するかどうかは今のところ未定です。
