### PR TITLE
[0362/shortcut-none] 対象が無いときにショートカットキーを使うとエラーになることがある問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -290,7 +290,10 @@ const commonKeyDown = (_evt, _displayName, _func = _code => { }) => {
 			g_inputKeyBuffer[setCode] = false;
 		}
 		// 対象ボタン処理を実行
-		document.getElementById(g_shortcutObj[_displayName][scLists[0]].id).click();
+		const targetId = document.getElementById(g_shortcutObj[_displayName][scLists[0]].id);
+		if (targetId !== null && targetId.style.display !== C_DIS_NONE) {
+			targetId.click();
+		}
 		return blockCode(setCode);
 	}
 	_func(setCode);
@@ -2181,9 +2184,10 @@ const createScText = (_obj, _settingLabel, { displayName = `option`, dfLabel = `
  * @param {string} _displayName 
  */
 const createScTextCommon = _displayName => {
-	Object.keys(g_btnPatterns[_displayName]).forEach(target =>
-		createScText(document.getElementById(`btn${target}`), target,
-			{ displayName: _displayName, targetLabel: `btn${target}`, x: g_btnPatterns[_displayName][target] }));
+	Object.keys(g_btnPatterns[_displayName]).filter(target => document.getElementById(`btn${target}`) !== null)
+		.forEach(target =>
+			createScText(document.getElementById(`btn${target}`), target,
+				{ displayName: _displayName, targetLabel: `btn${target}`, x: g_btnPatterns[_displayName][target] }));
 }
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -291,7 +291,7 @@ const commonKeyDown = (_evt, _displayName, _func = _code => { }) => {
 		}
 		// 対象ボタン処理を実行
 		const targetId = document.getElementById(g_shortcutObj[_displayName][scLists[0]].id);
-		if (targetId !== null && targetId.style.display !== C_DIS_NONE) {
+		if (targetId !== null && targetId.style.display !== C_DIS_NONE && targetId.style.pointerEvents !== C_DIS_NONE) {
 			targetId.click();
 		}
 		return blockCode(setCode);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 対象が無いときにショートカットキーを使うとエラーになることがある問題を修正しました。
具体的には、`|scoreDetailUse=false|`時にエラーになります。
また、意図的にボタンを非表示（`display: none` もしくは `pointer-events: none`）にしているとき、
ショートカットキーが動く問題も合わせて修正しています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. いずれも意図しない操作であるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- ver19.5.0以降で発生します。