### PR TITLE
[0363/display-back] g_lblNameObjの適用忘れを修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5329,7 +5329,7 @@ function keyConfigInit(_kcType = g_kcType) {
 	multiAppend(divRoot,
 
 		// 設定画面へ戻る
-		createCss2Button(`btnBack`, `To Settings`, _ => {
+		createCss2Button(`btnBack`, g_lblNameObj.b_settings, _ => {
 			g_currentj = 0;
 			g_currentk = 0;
 			g_prevKey = 0;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. KeyConfig画面のTo Settingsボタンにg_lblNameObjが適用されていない問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 上記の通り。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
