### PR TITLE
[0364/shortcut-view] ショートカット表示部分のフォーマット方法を拡張

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2172,13 +2172,14 @@ function drawTitleResultMotion(_displayName) {
  * @param {string} displayName 
  * @param {string} dfLabel 
  */
-const createScText = (_obj, _settingLabel, { displayName = `option`, dfLabel = ``, targetLabel = `lnk${_settingLabel}R`, x = 95 } = {}) => {
+const createScText = (_obj, _settingLabel, { displayName = `option`, dfLabel = ``, targetLabel = `lnk${_settingLabel}R`,
+	x = 95, y = 0, w = 40 } = {}) => {
 	const scKey = Object.keys(g_shortcutObj[displayName]).filter(key => g_shortcutObj[displayName][key].id === targetLabel);
 	if (scKey.length > 0) {
 		multiAppend(_obj,
 			createDivCss2Label(`sc${_settingLabel}`,
-				dfLabel !== `` ? `${dfLabel})` : `${setVal(g_kCd[g_kCdN.findIndex(kCd => kCd === scKey[0])], ``, C_TYP_STRING)})`, {
-				x: x, y: 0, w: 40, siz: 12, fontWeight: `bold`, opacity: 0.75, pointerEvents: C_DIS_NONE,
+				g_lblNameObj.scFormat.split(`{0}`).join(dfLabel !== `` ? `${dfLabel}` : `${setVal(g_kCd[g_kCdN.findIndex(kCd => kCd === scKey[0])], ``, C_TYP_STRING)}`), {
+				x, y, w, siz: 12, fontWeight: `bold`, opacity: 0.75, pointerEvents: C_DIS_NONE,
 			})
 		);
 	}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2173,13 +2173,13 @@ function drawTitleResultMotion(_displayName) {
  * @param {string} dfLabel 
  */
 const createScText = (_obj, _settingLabel, { displayName = `option`, dfLabel = ``, targetLabel = `lnk${_settingLabel}R`,
-	x = 95, y = 0, w = 40 } = {}) => {
+	x = g_scViewObj.x, y = g_scViewObj.y, w = g_scViewObj.w, siz = g_scViewObj.siz } = {}) => {
 	const scKey = Object.keys(g_shortcutObj[displayName]).filter(key => g_shortcutObj[displayName][key].id === targetLabel);
 	if (scKey.length > 0) {
 		multiAppend(_obj,
 			createDivCss2Label(`sc${_settingLabel}`,
-				g_lblNameObj.scFormat.split(`{0}`).join(dfLabel !== `` ? `${dfLabel}` : `${setVal(g_kCd[g_kCdN.findIndex(kCd => kCd === scKey[0])], ``, C_TYP_STRING)}`), {
-				x, y, w, siz: 12, fontWeight: `bold`, opacity: 0.75, pointerEvents: C_DIS_NONE,
+				g_scViewObj.format.split(`{0}`).join(dfLabel !== `` ? `${dfLabel}` : `${setVal(g_kCd[g_kCdN.findIndex(kCd => kCd === scKey[0])], ``, C_TYP_STRING)}`), {
+				x, y, w, siz, fontWeight: `bold`, opacity: 0.75, pointerEvents: C_DIS_NONE,
 			})
 		);
 	}

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1979,6 +1979,7 @@ const g_lblNameObj = {
     kcShortcutDesc: `プレイ中ショートカット：「{0}」タイトルバック / 「{1}」リトライ`,
     transKeyDesc: `別キーモードではハイスコア、キーコンフィグ等は保存されません`,
     sdShortcutDesc: `Hid+/Sud+時ショートカット：「pageUp」カバーを上へ / 「pageDown」下へ`,
+    scFormat: `{0})`,
 
     maker: `Maker`,
     artist: `Artist`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1962,6 +1962,17 @@ const g_msgInfoObj = {
 };
 
 /**
+ * ショートカット表示のデフォルト値設定
+ */
+const g_scViewObj = {
+    x: 95,
+    y: 0,
+    w: 40,
+    siz: 12,
+    format: `{0})`,
+};
+
+/**
  * ラベル表示定義
  */
 const g_lblNameObj = {
@@ -1979,7 +1990,6 @@ const g_lblNameObj = {
     kcShortcutDesc: `プレイ中ショートカット：「{0}」タイトルバック / 「{1}」リトライ`,
     transKeyDesc: `別キーモードではハイスコア、キーコンフィグ等は保存されません`,
     sdShortcutDesc: `Hid+/Sud+時ショートカット：「pageUp」カバーを上へ / 「pageDown」下へ`,
-    scFormat: `{0})`,
 
     maker: `Maker`,
     artist: `Artist`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. ショートカット表示部分のフォーマットを拡張しました。
`g_scViewObj`にて各種設定が可能です。
format属性のデフォルト値は`{0})`となっており、`{0}`の部分はショートカット表示に置き換わります。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. ショートカット表示部分がほぼ固定表示となっていたため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- これらの設定は基本、設定画面の各種設定用ボタンに対応する設定です。
それ以外のボタンはX座標位置のみ、`g_btnPatterns`にて行うことができます。