### PR TITLE
[0366/preload-image] preloadFile関数においてas:image以外が来た時の問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -78,7 +78,11 @@ let g_enableAmpersandSplit = true;
 let g_enableDecodeURI = false;
 
 // プリロード済ファイル
-const g_preloadImgs = [];
+const g_preloadFiles = {
+	all: [],
+	image: [],
+	font: [],
+};
 
 // 矢印サイズ
 const C_ARW_WIDTH = 50;
@@ -447,10 +451,15 @@ function roundZero(_num, _init = 0) {
  */
 function preloadFile(_as, _href, _type = ``, _crossOrigin = `anonymous`) {
 
-	const preloadFlg = g_preloadImgs.find(v => v === _href);
+	const preloadFlg = g_preloadFiles.all.find(v => v === _href);
 
 	if (preloadFlg === undefined) {
-		g_preloadImgs.push(_href);
+		g_preloadFiles.all.push(_href);
+
+		if (g_preloadFiles[_as] === undefined) {
+			g_preloadFiles[_as] = [];
+		}
+		g_preloadFiles[_as].push(_href);
 
 		if (g_userAgent.indexOf(`firefox`) !== -1 && _as === `image`) {
 			// Firefoxの場合のみpreloadが効かないため、画像読込形式にする
@@ -5794,7 +5803,7 @@ function loadingScoreInit() {
 			}
 			if (g_audio.duration !== undefined) {
 				if (g_userAgent.indexOf(`firefox`) !== -1) {
-					if (g_preloadImgs.every(v => g_loadObj[v] === true)) {
+					if (g_preloadFiles.image.every(v => g_loadObj[v] === true)) {
 						executeMain();
 					}
 				} else {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -452,7 +452,7 @@ function preloadFile(_as, _href, _type = ``, _crossOrigin = `anonymous`) {
 	if (preloadFlg === undefined) {
 		g_preloadImgs.push(_href);
 
-		if (g_userAgent.indexOf(`firefox`) !== -1) {
+		if (g_userAgent.indexOf(`firefox`) !== -1 && _as === `image`) {
 			// Firefoxの場合のみpreloadが効かないため、画像読込形式にする
 			g_loadObj[_href] = false;
 			const img = new Image();


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. preloadFile関数においてas:image以外が来た時の問題を修正しました。
2. preloadを管理するオブジェクトを `g_preloadImgs`から`g_preloadFiles`に変更しました。
全体を`g_preloadFiles.all`, 画像を`g_preloadFiles.image`で管理するようにします。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 現在は利用例がないが、_as引数がimage以外の場合に問題となるため。
2. 上記と同じ理由です。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- Firefox 85以降はrel=preloadに対応したため、将来的にこの分岐は不要となる見通し。
https://hacks.mozilla.org/2021/01/january-brings-us-firefox-85/
- オブジェクト名の変更となるが、このオブジェクトはpreloadFile関数とFirefox時のチェックでしか利用しておらず、影響は局所的と判断。