### PR TITLE
[ver18.9.5] imgタグ、preloadの設定に関する修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -611,7 +611,7 @@ function createDivCss2Label(_id, _text, { x = 0, y = 0, w = C_LEN_SETLBL_WIDTH, 
  */
 function createImg(_id, _imgPath, _x, _y, _width, _height) {
 	const div = createDiv(_id, _x, _y, _width, _height);
-	div.innerHTML = `<img id=${_id}img src=${_imgPath} style=width:${_width}px;height:${_height}px>`;
+	div.innerHTML = `<img id="${_id}img" src="${_imgPath}" style="width:${_width}px;height:${_height}px"${location.href.match(`^file`) ? `` : ` crossOrigin="anonimous"`}>`;
 
 	return div;
 }

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2021/02/12
+ * Revised : 2021/02/20
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 18.9.4`;
-const g_revisedDate = `2021/02/12`;
+const g_version = `Ver 18.9.5`;
+const g_revisedDate = `2021/02/20`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -67,7 +67,11 @@ let g_enableAmpersandSplit = true;
 let g_enableDecodeURI = false;
 
 // プリロード済ファイル
-const g_preloadImgs = [];
+const g_preloadFiles = {
+	all: [],
+	image: [],
+	font: [],
+};
 
 // 矢印サイズ
 const C_ARW_WIDTH = 50;
@@ -385,12 +389,17 @@ function roundZero(_num, _init = 0) {
  */
 function preloadFile(_as, _href, _type = ``, _crossOrigin = `anonymous`) {
 
-	const preloadFlg = g_preloadImgs.find(v => v === _href);
+	const preloadFlg = g_preloadFiles.all.find(v => v === _href);
 
 	if (preloadFlg === undefined) {
-		g_preloadImgs.push(_href);
+		g_preloadFiles.all.push(_href);
 
-		if (g_userAgent.indexOf(`firefox`) !== -1) {
+		if (g_preloadFiles[_as] === undefined) {
+			g_preloadFiles[_as] = [];
+		}
+		g_preloadFiles[_as].push(_href);
+
+		if (g_userAgent.indexOf(`firefox`) !== -1 && _as === `image`) {
 			// Firefoxの場合のみpreloadが効かないため、画像読込形式にする
 			g_loadObj[_href] = false;
 			const img = new Image();
@@ -5823,7 +5832,7 @@ function loadingScoreInit() {
 			}
 			if (g_audio.duration !== undefined) {
 				if (g_userAgent.indexOf(`firefox`) !== -1) {
-					if (g_preloadImgs.every(v => g_loadObj[v] === true)) {
+					if (g_preloadFiles.image.every(v => g_loadObj[v] === true)) {
 						executeMain();
 					}
 				} else {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- #988 imgタグ生成時においてcrossOrigin属性を付与するよう変更
- #989 preloadFile関数においてas:image以外が来た時の問題を修正

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
