### PR TITLE
[0367/code-refactoring] ゼロパディングのコード集約 (String.padStartの利用)　他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1803,7 +1803,7 @@ function loadMusic() {
 	}
 
 	g_headerObj.musicUrl = musicUrl;
-	g_musicEncodedFlg = (musicUrl.slice(-3) === `.js` || musicUrl.slice(-4) === `.txt`) ? true : false;
+	g_musicEncodedFlg = listMatching(musicUrl, [`.js`, `.txt`], { suffix: `$` });
 	drawDefaultBackImage(``);
 
 	// Now Loadingを表示
@@ -2074,7 +2074,7 @@ const colorNameToCode = _color => {
  * 10進 -> 16進数変換 (カラーコード形式になるよう0埋め)
  * @param {number} _num 
  */
-const byteToHex = _num => (`${('0' + _num.toString(16)).slice(-2)}`);
+const byteToHex = _num => (`${_num.toString(16).padStart(2, '0')}`);
 
 /**
  * 色名をカラーコードへ変換 (元々カラーコードの場合は除外)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5126,7 +5126,7 @@ function keyConfigInit(_kcType = g_kcType) {
 			`<div class="settings_Title">${g_lblNameObj.key}</div><div class="settings_Title2">${g_lblNameObj.config}</div>`
 				.replace(/[\t\n]/g, ``), 0, 15, g_cssObj.flex_centering),
 
-		createDivCss2Label(`kcDesc`, g_lblNameObj.kcDesc.split(`{0}`).join(g_isMac ? `Delete` : `BackSpace`)
+		createDivCss2Label(`kcDesc`, g_lblNameObj.kcDesc.split(`{0}`).join(g_kCd[C_KEY_RETRY])
 			.split(`{1}:`).join(g_isMac ? `` : `Delete:`), {
 			x: 0, y: 65, w: g_sWidth, h: 20, siz: C_SIZ_MAIN,
 		}),
@@ -5251,14 +5251,13 @@ function keyConfigInit(_kcType = g_kcType) {
 		lnkColorType.textContent = `${g_colorType}${g_localStorage.colorType === g_colorType ? ' *' : ''}`;
 	}
 
-	const macRetryCode = g_kCd[g_headerObj.keyRetry === C_KEY_RETRY ? C_KEY_TITLEBACK : g_headerObj.keyRetry];
 	multiAppend(divRoot,
 
 		// ショートカットキーメッセージ
 		createDivCss2Label(
 			`scMsg`,
-			g_lblNameObj.kcShortcutDesc.split(`{0}`).join(g_isMac ? `Shift+${macRetryCode}` : g_kCd[g_headerObj.keyTitleBack])
-				.split(`{1}`).join(g_isMac ? macRetryCode : g_kCd[g_headerObj.keyRetry]),
+			g_lblNameObj.kcShortcutDesc.split(`{0}`).join(g_isMac ? `Shift+${g_kCd[g_headerObj.keyRetry]}` : g_kCd[g_headerObj.keyTitleBack])
+				.split(`{1}`).join(g_kCd[g_headerObj.keyRetry]),
 			{
 				x: 0, y: g_sHeight - 45, w: g_sWidth, h: 20, siz: C_SIZ_MAIN,
 			}),

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1470,7 +1470,7 @@ function initAfterDosLoaded() {
 				paddingLen = String(setVal(termRoopCnts[1], 1, C_TYP_STRING)).length;
 			}
 			for (let k = startCnt; k <= lastCnt; k++) {
-				preloadFile(`image`, tmpPreloadImages[0].replace(/\*/g, paddingLeft(String(k), paddingLen, `0`)));
+				preloadFile(`image`, tmpPreloadImages[0].replace(/\*/g, String(k).padStart(paddingLen, `0`)));
 			}
 		}
 	});
@@ -1710,7 +1710,7 @@ function calcLevel(_scoreObj) {
 	return {
 		// 難易度レベル
 		tool: (allCnt === 3 ? `0.01` :
-			`${Math.floor(difLevel)}.${`00${Math.round((difLevel * 100) % 100)}`.slice(-2)}${(push3Cnt > 0 ? "*" : "")}`),
+			`${Math.floor(difLevel)}.${`${Math.round((difLevel * 100) % 100)}`.padStart(2, `0`)}${(push3Cnt > 0 ? "*" : "")}`),
 		// 縦連打補正
 		tate: toDecimal2(baseDifLevel - calcDifLevel(leveltmp)),
 		// 同時押し補正
@@ -2129,7 +2129,7 @@ function makeColorGradation(_colorStr, { _defaultColorgrd = g_headerObj.defaultC
 	for (let j = 0; j < colorArray.length; j++) {
 		colorArray[j] = colorToHex(colorArray[j].replace(/0x/g, `#`));
 		if (_colorCdPaddingUse) {
-			colorArray[j] = `#${paddingLeft(colorArray[j].slice(1), 6, `0`)}`;
+			colorArray[j] = `#${colorArray[j].slice(1).padStart(6, `0`)}`;
 		}
 		if (j === 0 && colorArray[0].substring(0, 1) !== `#`) {
 		} else if (colorArray[j].length === 7) {
@@ -3030,7 +3030,7 @@ function headerConvert(_dosObj) {
 					}
 				});
 				if (_colorCdPaddingUse) {
-					colorOrg[j] = `#${paddingLeft(colorOrg[j].slice(1), 6, `0`)}`;
+					colorOrg[j] = `#${colorOrg[j].slice(1).padStart(6, `0`)}`;
 				}
 				colorList[j] = makeColorGradation(colorStr[j] === `` ? _colorInit[j] : colorStr[j], {
 					_defaultColorgrd: _defaultColorgrd,
@@ -4094,7 +4094,7 @@ function createOptionWindow(_sprite) {
 		const apm = Math.round((arrowCnts + frzCnts) / (g_detailObj.playingFrame[_scoreId] / g_fps / 60));
 		makeScoreDetailLabel(`Density`, g_lblNameObj.s_apm, apm, 0);
 		const minutes = Math.floor(g_detailObj.playingFrameWithBlank[_scoreId] / g_fps / 60);
-		const seconds = `00${Math.floor((g_detailObj.playingFrameWithBlank[_scoreId] / g_fps) % 60)}`.slice(-2);
+		const seconds = `${Math.floor((g_detailObj.playingFrameWithBlank[_scoreId] / g_fps) % 60)}`.padStart(2, `0`);
 		const playingTime = `${minutes}:${seconds}`;
 		makeScoreDetailLabel(`Density`, g_lblNameObj.s_time, playingTime, 1);
 		makeScoreDetailLabel(`Density`, g_lblNameObj.s_arrow, arrowCnts, 3);
@@ -4232,7 +4232,7 @@ function createOptionWindow(_sprite) {
 				const frzCnts = g_detailObj.frzCnt[j].reduce((p, x) => p + x);
 				const apm = Math.round((arrowCnts + frzCnts) / (g_detailObj.playingFrame[j] / g_fps / 60));
 				const minutes = Math.floor(g_detailObj.playingFrame[j] / g_fps / 60);
-				const seconds = `00${Math.floor((g_detailObj.playingFrame[j] / g_fps) % 60)}`.slice(-2);
+				const seconds = `${Math.floor((g_detailObj.playingFrame[j] / g_fps) % 60)}`.padStart(2, `0`);
 				const playingTime = `${minutes}:${seconds}`;
 
 				printData +=
@@ -7393,7 +7393,7 @@ function MainInit() {
 	const nominalFullFrame = fullFrame - nominalDiff;
 
 	const fullMin = Math.floor(nominalFullFrame / 60 / g_fps);
-	const fullSec = `00${Math.floor(Math.floor(nominalFullFrame / g_fps) % 60)}`.slice(-2);
+	const fullSec = `${Math.floor(Math.floor(nominalFullFrame / g_fps) % 60)}`.padStart(2, `0`);
 	const fullTime = `${fullMin}:${fullSec}`;
 
 	// フレーム数
@@ -8390,7 +8390,7 @@ function MainInit() {
 			if (Math.floor(g_scoreObj.nominalFrameNum % g_fps) === 0) {
 				if (g_scoreObj.nominalFrameNum >= 0) {
 					const currentMin = Math.floor(g_scoreObj.nominalFrameNum / 60 / g_fps);
-					const currentSec = `00${Math.floor(g_scoreObj.nominalFrameNum / g_fps) % 60}`.slice(-2);
+					const currentSec = `${Math.floor(g_scoreObj.nominalFrameNum / g_fps) % 60}`.padStart(2, `0`);
 					lblTime1.textContent = `${currentMin}:${currentSec}`;
 				}
 			}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3892,7 +3892,7 @@ function createOptionWindow(_sprite) {
 					// キー別フィルタボタン作成
 					g_headerObj.keyLists.forEach((targetKey, m) => {
 						difCover.appendChild(
-							makeDifLblCssButton(`keyFilter`, `${targetKey} key`, m + 1.5, _ => {
+							makeDifLblCssButton(`keyFilter${m}`, `${targetKey} key`, m + 1.5, _ => {
 								deleteChildspriteAll(`difList`);
 								makeDifList(difList, targetKey);
 							}, { w: 110 })

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9161,7 +9161,8 @@ function resultInit() {
 	// ランク描画
 	resultWindow.appendChild(
 		createDivCss2Label(`lblRank`, rankMark, {
-			x: 340, y: 160, w: 70, h: 20, siz: 50, align: C_ALIGN_CENTER, fontFamily: getBasicFont(`"Bookman Old Style"`),
+			x: 340, y: 160, w: 70, h: 20, siz: 50, align: C_ALIGN_CENTER,
+			color: rankColor, fontFamily: getBasicFont(`"Bookman Old Style"`),
 		})
 	);
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -499,10 +499,11 @@ function importCssFile(_href) {
 }
 
 /**
- * 基本フォントを取得
+ * 画面共通のフォント設定
+ * @param {string} _priorityFont 
  */
-function getBasicFont() {
-	return (g_headerObj.customFont === `` ? C_LBL_BASICFONT : `${g_headerObj.customFont},${C_LBL_BASICFONT}`);
+function getBasicFont(_priorityFont = ``) {
+	return [_priorityFont, g_headerObj.customFont, C_LBL_BASICFONT].filter(value => value !== ``).join(`,`);
 }
 
 /**
@@ -9158,10 +9159,11 @@ function resultInit() {
 	}
 
 	// ランク描画
-	const lblRank = createDivCustomLabel(`lblRank`, 340, 160, 70, 20, 50, `#ffffff`,
-		`<span style=color:${rankColor}>${rankMark}</span>`, `"Bookman Old Style", "Meiryo UI", sans-serif`);
-	lblRank.style.textAlign = C_ALIGN_CENTER;
-	resultWindow.appendChild(lblRank);
+	resultWindow.appendChild(
+		createDivCss2Label(`lblRank`, rankMark, {
+			x: 340, y: 160, w: 70, h: 20, siz: 50, align: C_ALIGN_CENTER, fontFamily: getBasicFont(`"Bookman Old Style"`),
+		})
+	);
 
 	// Cleared & Failed表示
 	const lblResultPre = createDivCss2Label(

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -499,7 +499,7 @@ for (let j = 0; j < 255; j++) {
 // キー表示用
 g_kCd[0] = `- - -`;
 g_kCd[1] = `Unknown`;
-g_kCd[8] = `BackSpace`;
+g_kCd[8] = (g_isMac ? `Delete` : `BackSpace`);
 g_kCd[9] = `Tab`;
 g_kCd[12] = `Clear`;
 g_kCd[13] = `Enter`;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. ゼロパディングのコード集約を行いました。 (String.padStartの利用)
https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/String/padStart
2. 設定画面上の譜面選択リストにあるキー別フィルターボタンのID重複を解消しました。
これまで、ID: `keyFilter`となっていましたが ID: `keyFilter0`, `keyFilter1`, ... のように分けます。
3. 結果画面のランク部分のラベル表示をcreateDivCss2Labelに合わせました。
合わせて、画面共通フォントの設定関数`getBasicFont`を拡張し、優先フォントを指定できるようにしました。
4. MacOSのキー表示関係のオンコード部分を改善し、設定に関する部分をdanoni_constants.jsへ極力移しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 実装方法が統一されていなかったため。標準関数に合わせます。
2. 特定のボタンに対して処理をしたい場合の阻害になるため。
3. 結果画面のランク部分のみ、他と違う動きになっていたため。
4. 無用なif文を減らすため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 従来の関数`paddingLeft`, `createDivCustomLabel`は互換として残します。
後者は利用頻度が低いと思われるので、今後削除を検討しています。