### PR TITLE
[0368/setting-name] 設定名を置き換える機能を実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9086,13 +9086,13 @@ function resultInit() {
 	].filter(value => value !== ``).join(`, `);
 
 	let displayData = [
-		withOptions(g_stateObj.d_stepzone, C_FLG_ON, `Step`),
-		withOptions(g_stateObj.d_judgment, C_FLG_ON, `Judge`),
-		withOptions(g_stateObj.d_fastslow, C_FLG_ON, `FS`),
-		withOptions(g_stateObj.d_lifegauge, C_FLG_ON, `Life`),
-		withOptions(g_stateObj.d_score, C_FLG_ON, `Score`),
-		withOptions(g_stateObj.d_musicinfo, C_FLG_ON, `MusicInfo`),
-		withOptions(g_stateObj.d_filterline, C_FLG_ON, `Filter`)
+		withOptions(g_stateObj.d_stepzone, C_FLG_ON, g_lblNameObj.rd_StepZone),
+		withOptions(g_stateObj.d_judgment, C_FLG_ON, g_lblNameObj.rd_Judgment),
+		withOptions(g_stateObj.d_fastslow, C_FLG_ON, g_lblNameObj.rd_FastSlow),
+		withOptions(g_stateObj.d_lifegauge, C_FLG_ON, g_lblNameObj.rd_LifeGauge),
+		withOptions(g_stateObj.d_score, C_FLG_ON, g_lblNameObj.rd_Score),
+		withOptions(g_stateObj.d_musicinfo, C_FLG_ON, g_lblNameObj.rd_MusicInfo),
+		withOptions(g_stateObj.d_filterline, C_FLG_ON, g_lblNameObj.rd_FilterLine),
 	].filter(value => value !== ``).join(`, `);
 	if (displayData === ``) {
 		displayData = `All Visible`;
@@ -9101,26 +9101,26 @@ function resultInit() {
 	}
 
 	let display2Data = [
-		withOptions(g_stateObj.d_speed, C_FLG_ON, `Speed`),
-		withOptions(g_stateObj.d_color, C_FLG_ON, `Color`),
-		withOptions(g_stateObj.d_lyrics, C_FLG_ON, `Lyrics`),
-		withOptions(g_stateObj.d_background, C_FLG_ON, `Back`),
-		withOptions(g_stateObj.d_arroweffect, C_FLG_ON, `Effect`),
-		withOptions(g_stateObj.d_special, C_FLG_ON, `SP`)
+		withOptions(g_stateObj.d_speed, C_FLG_ON, g_lblNameObj.rd_Speed),
+		withOptions(g_stateObj.d_color, C_FLG_ON, g_lblNameObj.rd_Color),
+		withOptions(g_stateObj.d_lyrics, C_FLG_ON, g_lblNameObj.rd_Lyrics),
+		withOptions(g_stateObj.d_background, C_FLG_ON, g_lblNameObj.rd_Background),
+		withOptions(g_stateObj.d_arroweffect, C_FLG_ON, g_lblNameObj.rd_ArrowEffect),
+		withOptions(g_stateObj.d_special, C_FLG_ON, g_lblNameObj.rd_Special),
 	].filter(value => value !== ``).join(`, `);
 	if (display2Data !== ``) {
 		display2Data += ` : OFF`;
 	}
 
 	multiAppend(playDataWindow,
-		makeCssResultPlayData(`lblMusic`, 20, g_cssObj.result_lbl, 0, `Music`, C_ALIGN_LEFT),
+		makeCssResultPlayData(`lblMusic`, 20, g_cssObj.result_lbl, 0, g_lblNameObj.rt_Music, C_ALIGN_LEFT),
 		makeCssResultPlayData(`lblMusicData`, 60, g_cssObj.result_style, 0, mTitleForView[0]),
 		makeCssResultPlayData(`lblMusicData2`, 60, g_cssObj.result_style, 1, mTitleForView[1]),
-		makeCssResultPlayData(`lblDifficulty`, 20, g_cssObj.result_lbl, 2, `Difficulty`, C_ALIGN_LEFT),
+		makeCssResultPlayData(`lblDifficulty`, 20, g_cssObj.result_lbl, 2, g_lblNameObj.rt_Difficulty, C_ALIGN_LEFT),
 		makeCssResultPlayData(`lblDifData`, 60, g_cssObj.result_style, 2, difData),
-		makeCssResultPlayData(`lblStyle`, 20, g_cssObj.result_lbl, 3, `Playstyle`, C_ALIGN_LEFT),
+		makeCssResultPlayData(`lblStyle`, 20, g_cssObj.result_lbl, 3, g_lblNameObj.rt_Style, C_ALIGN_LEFT),
 		makeCssResultPlayData(`lblStyleData`, 60, g_cssObj.result_style, 3, playStyleData),
-		makeCssResultPlayData(`lblDisplay`, 20, g_cssObj.result_lbl, 4, `Display`, C_ALIGN_LEFT),
+		makeCssResultPlayData(`lblDisplay`, 20, g_cssObj.result_lbl, 4, g_lblNameObj.rt_Display, C_ALIGN_LEFT),
 		makeCssResultPlayData(`lblDisplayData`, 60, g_cssObj.result_style, 4, displayData),
 		makeCssResultPlayData(`lblDisplay2Data`, 60, g_cssObj.result_style, 5, display2Data),
 	);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4784,6 +4784,14 @@ function createLblSetting(_settingName, _adjY = 0, _settingLabel = _settingName)
 }
 
 /**
+ * 設定名の置き換え処理
+ * @param {string} _name 
+ */
+function getStgDetailName(_name) {
+	return g_lblNameObj[`u_${_name}`] === undefined ? _name : g_lblNameObj[`u_${_name}`];
+}
+
+/**
  * 設定メイン・汎用
  * @param {number} _scrollNum 
  * @param {string} _settingName
@@ -4804,7 +4812,7 @@ function setSetting(_scrollNum, _settingName, _unitName = ``) {
 	g_stateObj[_settingName] = settingList[settingNum];
 	g_settings[`${_settingName}Num`] = settingNum;
 	document.querySelector(`#lnk${toCapitalize(_settingName)}`).textContent =
-		`${g_stateObj[_settingName]}${_unitName}${g_localStorage[_settingName] === g_stateObj[_settingName] ? ' *' : ''}`;
+		`${getStgDetailName(g_stateObj[_settingName])}${_unitName}${g_localStorage[_settingName] === g_stateObj[_settingName] ? ' *' : ''}`;
 }
 
 /**
@@ -9065,14 +9073,14 @@ function resultInit() {
 		`${g_headerObj.keyLabels[g_stateObj.scoreId]}${transKeyData} key / ${g_headerObj.difLabels[g_stateObj.scoreId]}`,
 		`${withOptions(g_autoPlaysBase.includes(g_stateObj.autoPlay), true, `-${g_stateObj.autoPlay}less`)}`,
 		`${withOptions(g_headerObj.makerView, false, `(${g_headerObj.creatorNames[g_stateObj.scoreId]})`)}`,
-		`${withOptions(g_stateObj.shuffle, C_FLG_OFF, `[${g_stateObj.shuffle}]`)}`
+		`${withOptions(g_stateObj.shuffle, C_FLG_OFF, `[${getStgDetailName(g_stateObj.shuffle)}]`)}`
 	].filter(value => value !== ``).join(` `);
 
 	let playStyleData = [
 		`${g_stateObj.speed}x`,
 		`${withOptions(g_stateObj.motion, C_FLG_OFF)}`,
 		`${withOptions(g_stateObj.reverse, C_FLG_OFF,
-			(g_stateObj.scroll !== '---' ? 'R-' : 'Reverse'))}${withOptions(g_stateObj.scroll, '---')}`,
+			getStgDetailName(g_stateObj.scroll !== '---' ? 'R-' : 'Reverse'))}${withOptions(g_stateObj.scroll, '---')}`,
 		`${withOptions(g_stateObj.appearance, `Visible`)}`,
 		`${withOptions(g_stateObj.gauge, g_settings.gauges[0])}`
 	].filter(value => value !== ``).join(`, `);
@@ -9124,7 +9132,7 @@ function resultInit() {
 	 * @param {string} _displayText 
 	 */
 	function withOptions(_flg, _defaultSet, _displayText = _flg) {
-		return (_flg !== _defaultSet ? _displayText : ``);
+		return (_flg !== _defaultSet ? getStgDetailName(_displayText) : ``);
 	}
 
 	// キャラクタ、スコア描画のID共通部、色CSS名、スコア変数名

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3951,7 +3951,7 @@ function createOptionWindow(_sprite) {
 			createScoreDetail(`Speed`),
 			createScoreDetail(`Density`),
 			createScoreDetail(`ToolDif`, false),
-			makeSettingLblCssButton(`lnkScoreDetail`, `${g_stateObj.scoreDetail}`, 0, _ => {
+			makeSettingLblCssButton(`lnkScoreDetail`, `${getStgDetailName(g_stateObj.scoreDetail)}`, 0, _ => {
 				g_stateObj.scoreDetailViewFlg = true;
 				scoreDetail.style.visibility = `visible`;
 				$id(`detail${g_stateObj.scoreDetail}`).visibility = `hidden`;
@@ -4286,7 +4286,7 @@ function createOptionWindow(_sprite) {
 		];
 
 		spriteList.scroll.appendChild(
-			createCss2Button(`btnReverse`, `${g_lblNameObj.Reverse}:${g_stateObj.reverse}`, evt => setReverse(evt.target), {
+			createCss2Button(`btnReverse`, `${g_lblNameObj.Reverse}:${getStgDetailName(g_stateObj.reverse)}`, evt => setReverse(evt.target), {
 				x: 160, y: 0,
 				w: 90, h: 21, siz: C_SIZ_DIFSELECTOR,
 				borderStyle: `solid`,
@@ -4305,7 +4305,7 @@ function createOptionWindow(_sprite) {
 	function setReverseView(_btn) {
 		_btn.classList.replace(g_cssObj[`button_Rev${g_settings.reverses[(g_settings.reverseNum + 1) % 2]}`],
 			g_cssObj[`button_Rev${g_settings.reverses[g_settings.reverseNum]}`]);
-		_btn.textContent = `${g_lblNameObj.Reverse}:${g_stateObj.reverse}`;
+		_btn.textContent = `${g_lblNameObj.Reverse}:${getStgDetailName(g_stateObj.reverse)}`;
 	}
 
 	// ---------------------------------------------------
@@ -4340,7 +4340,7 @@ function createOptionWindow(_sprite) {
 		createScText(spriteList.gauge, `Gauge`);
 	} else {
 		lblGauge.classList.add(g_cssObj.settings_Disabled);
-		spriteList.gauge.appendChild(makeDisabledLabel(`lnkGauge`, 0, g_stateObj.gauge));
+		spriteList.gauge.appendChild(makeDisabledLabel(`lnkGauge`, 0, getStgDetailName(g_stateObj.gauge)));
 	}
 
 	/**
@@ -4706,7 +4706,7 @@ function createOptionWindow(_sprite) {
 
 		// オート・アシスト設定 (AutoPlay)
 		g_stateObj.autoPlay = g_settings.autoPlays[g_settings.autoPlayNum];
-		lnkAutoPlay.textContent = g_stateObj.autoPlay;
+		lnkAutoPlay.textContent = getStgDetailName(g_stateObj.autoPlay);
 
 		// ゲージ設定 (Gauge)
 		setGauge(0);
@@ -4740,12 +4740,13 @@ function createGeneralSetting(_obj, _settingName, { unitName = ``, skipTerm = 0,
 
 	const settingUpper = toCapitalize(_settingName);
 	const linkId = `lnk${settingUpper}`;
+	const initName = `${getStgDetailName(g_stateObj[_settingName])}${unitName}`;
 	_obj.appendChild(createLblSetting(settingUpper, 0, toCapitalize(settingLabel)));
 
 	if (g_headerObj[`${_settingName}Use`] === undefined || g_headerObj[`${_settingName}Use`]) {
 
 		multiAppend(_obj,
-			makeSettingLblCssButton(linkId, `${g_stateObj[_settingName]}${unitName}${g_localStorage[_settingName] === g_stateObj[_settingName] ? ' *' : ''}`, 0,
+			makeSettingLblCssButton(linkId, `${initName}${g_localStorage[_settingName] === g_stateObj[_settingName] ? ' *' : ''}`, 0,
 				_ => setSetting(1, _settingName, unitName),
 				{ cxtFunc: _ => setSetting(-1, _settingName, unitName) }),
 
@@ -4767,7 +4768,7 @@ function createGeneralSetting(_obj, _settingName, { unitName = ``, skipTerm = 0,
 
 	} else {
 		document.querySelector(`#lbl${settingUpper}`).classList.add(g_cssObj.settings_Disabled);
-		_obj.appendChild(makeDisabledLabel(linkId, 0, `${g_stateObj[_settingName]}${unitName}`));
+		_obj.appendChild(makeDisabledLabel(linkId, 0, initName));
 	}
 }
 
@@ -4788,7 +4789,8 @@ function createLblSetting(_settingName, _adjY = 0, _settingLabel = _settingName)
  * @param {string} _name 
  */
 function getStgDetailName(_name) {
-	return g_lblNameObj[`u_${_name}`] === undefined ? _name : g_lblNameObj[`u_${_name}`];
+	return g_lblNameObj[`u_${_name}`] === undefined || typeof g_lblRenames !== C_TYP_OBJECT || !g_lblRenames[g_currentPage] ?
+		_name : g_lblNameObj[`u_${_name}`];
 }
 
 /**
@@ -5233,7 +5235,7 @@ function keyConfigInit(_kcType = g_kcType) {
 		const nextNum = (typeNum + g_keycons.configTypes.length + _scrollNum) % g_keycons.configTypes.length;
 		g_kcType = g_keycons.configTypes[nextNum];
 		g_keycons.configFunc[nextNum](kWidth, divideCnt, keyCtrlPtn, false);
-		_evt.target.textContent = g_kcType;
+		_evt.target.textContent = getStgDetailName(g_kcType);
 	}
 
 	/**
@@ -5255,7 +5257,7 @@ function keyConfigInit(_kcType = g_kcType) {
 		for (let j = 0; j < keyNum; j++) {
 			$id(`arrow${j}`).background = getKeyConfigColor(j, g_keyObj[`color${keyCtrlPtn}`][j]);
 		}
-		lnkColorType.textContent = `${g_colorType}${g_localStorage.colorType === g_colorType ? ' *' : ''}`;
+		lnkColorType.textContent = `${getStgDetailName(g_colorType)}${g_localStorage.colorType === g_colorType ? ' *' : ''}`;
 	}
 
 	const macRetryCode = g_kCd[g_headerObj.keyRetry === C_KEY_RETRY ? C_KEY_TITLEBACK : g_headerObj.keyRetry];
@@ -5284,7 +5286,7 @@ function keyConfigInit(_kcType = g_kcType) {
 			x: 30, y: 10, w: 70,
 		}, g_cssObj.keyconfig_ConfigType),
 
-		makeSettingLblCssButton(`lnkKcType`, g_kcType, 0, evt => setConfigType(evt), {
+		makeSettingLblCssButton(`lnkKcType`, getStgDetailName(g_kcType), 0, evt => setConfigType(evt), {
 			x: 30, y: 35, w: 100,
 			cxtFunc: evt => setConfigType(evt, -1),
 		}),
@@ -5294,7 +5296,7 @@ function keyConfigInit(_kcType = g_kcType) {
 			x: g_sWidth - 120, y: 10, w: 70,
 		}, g_cssObj.keyconfig_ColorType),
 
-		makeSettingLblCssButton(`lnkColorType`, g_colorType, 0, _ => setColorType(), {
+		makeSettingLblCssButton(`lnkColorType`, getStgDetailName(g_colorType), 0, _ => setColorType(), {
 			x: g_sWidth - 130, y: 35, w: 100,
 			cxtFunc: _ => setColorType(-1),
 		}),
@@ -9305,7 +9307,7 @@ function resultInit() {
 	const hashTag = (g_headerObj.hashTag !== undefined ? ` ${g_headerObj.hashTag}` : ``);
 	let tweetDifData = `${g_headerObj.keyLabels[g_stateObj.scoreId]}${transKeyData}k-${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}`;
 	if (g_stateObj.shuffle !== `OFF`) {
-		tweetDifData += `:${g_stateObj.shuffle}`;
+		tweetDifData += `:${getStgDetailName(g_stateObj.shuffle)}`;
 	}
 	const twiturl = new URL(g_localStorageUrl);
 	twiturl.searchParams.append(`scoreId`, g_stateObj.scoreId);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3930,7 +3930,7 @@ function createOptionWindow(_sprite) {
 	// ---------------------------------------------------
 	// 速度(Speed)
 	// 縦位置: 2  短縮ショートカットあり
-	createGeneralSetting(spriteList.speed, `speed`, { unitName: ` x`, skipTerm: 4, scLabel: g_lblNameObj.sc_speed });
+	createGeneralSetting(spriteList.speed, `speed`, { unitName: ` ${getStgDetailName(g_lblNameObj.multi)}`, skipTerm: 4, scLabel: g_lblNameObj.sc_speed });
 
 	if (g_headerObj.scoreDetailUse) {
 		spriteList.speed.appendChild(
@@ -4509,7 +4509,7 @@ function createOptionWindow(_sprite) {
 	// 縦位置: 11 スライダーあり
 	spriteList.fadein.appendChild(createLblSetting(`Fadein`));
 
-	const lnkFadein = createDivCss2Label(`lnkFadein`, `${g_stateObj.fadein}%`, {
+	const lnkFadein = createDivCss2Label(`lnkFadein`, `${g_stateObj.fadein}${getStgDetailName(g_lblNameObj.percent)}`, {
 		x: C_LEN_SETLBL_LEFT, y: 0,
 	}, g_cssObj.settings_FadeinBar);
 	spriteList.fadein.appendChild(lnkFadein);
@@ -4517,7 +4517,7 @@ function createOptionWindow(_sprite) {
 	const setFadein = _sign => {
 		g_stateObj.fadein = (g_stateObj.fadein + 100 + _sign) % 100;
 		fadeinSlider.value = g_stateObj.fadein;
-		lnkFadein.textContent = `${g_stateObj.fadein}%`;
+		lnkFadein.textContent = `${g_stateObj.fadein}${getStgDetailName(g_lblNameObj.percent)}`;
 	};
 
 	multiAppend(spriteList.fadein,
@@ -4536,13 +4536,13 @@ function createOptionWindow(_sprite) {
 	const fadeinSlider = document.querySelector(`#fadeinSlider`);
 	fadeinSlider.addEventListener(`input`, _ => {
 		g_stateObj.fadein = parseInt(fadeinSlider.value);
-		lnkFadein.textContent = `${g_stateObj.fadein}%`;
+		lnkFadein.textContent = `${g_stateObj.fadein}${getStgDetailName(g_lblNameObj.percent)}`;
 	}, false);
 
 	// ---------------------------------------------------
 	// ボリューム (Volume) 
 	// 縦位置: 12
-	createGeneralSetting(spriteList.volume, `volume`, { unitName: `%` });
+	createGeneralSetting(spriteList.volume, `volume`, { unitName: getStgDetailName(g_lblNameObj.percent) });
 
 	/**
 	 * 譜面初期化処理
@@ -4678,7 +4678,7 @@ function createOptionWindow(_sprite) {
 		lnkDifficulty.innerHTML = difNames.join(``);
 
 		// 速度設定 (Speed)
-		setSetting(0, `speed`, ` x`);
+		setSetting(0, `speed`, ` ${getStgDetailName(g_lblNameObj.multi)}`);
 		if (g_headerObj.scoreDetailUse) {
 			drawSpeedGraph(g_stateObj.scoreId);
 			drawDensityGraph(g_stateObj.scoreId);
@@ -5012,7 +5012,7 @@ function createSettingsDisplayWindow(_sprite) {
 	// ---------------------------------------------------
 	// 判定表示系の不透明度 (Opacity)
 	// 縦位置: 9
-	createGeneralSetting(spriteList.opacity, `opacity`, { unitName: `%`, displayName: g_currentPage });
+	createGeneralSetting(spriteList.opacity, `opacity`, { unitName: getStgDetailName(g_lblNameObj.percent), displayName: g_currentPage });
 
 	/**
 	 * Display表示/非表示ボタン
@@ -9079,7 +9079,7 @@ function resultInit() {
 	].filter(value => value !== ``).join(` `);
 
 	let playStyleData = [
-		`${g_stateObj.speed}x`,
+		`${g_stateObj.speed}${getStgDetailName(g_lblNameObj.multi)}`,
 		`${withOptions(g_stateObj.motion, C_FLG_OFF)}`,
 		`${withOptions(g_stateObj.reverse, C_FLG_OFF,
 			getStgDetailName(g_stateObj.scroll !== '---' ? 'R-' : 'Reverse'))}${withOptions(g_stateObj.scroll, '---')}`,

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -186,3 +186,13 @@ const g_local_lblNameObj = {
 const g_local_msgObj = {
 
 };
+
+/**
+ * 設定名の上書き可否設定
+ */
+const g_lblRenames = {
+	option: true,
+	settingsDisplay: true,
+	keyConfig: true,
+	result: true,
+};

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2091,6 +2091,25 @@ const g_lblNameObj = {
     fullCombo: `FullCombo!`,
     cleared: `CLEARED!`,
     failed: `FAILED...`,
+
+    rt_Music: `Music`,
+    rt_Difficulty: `Difficulty`,
+    rt_Style: `Playstyle`,
+    rt_Display: `Display`,
+
+    rd_StepZone: `Step`,
+    rd_Judgment: `Judge`,
+    rd_FastSlow: `FS`,
+    rd_LifeGauge: `Life`,
+    rd_Score: `Score`,
+    rd_MusicInfo: `MusicInfo`,
+    rd_FilterLine: `Filter`,
+    rd_Speed: `Speed`,
+    rd_Color: `Color`,
+    rd_Lyrics: `Lyrics`,
+    rd_Background: `Back`,
+    rd_ArrowEffect: `Effect`,
+    rd_Special: `SP`,
 };
 
 /**

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2066,6 +2066,61 @@ const g_lblNameObj = {
     Appearance: `Appearance`,
     Opacity: `Opacity`,
 
+    'u_OFF': `OFF`,
+    'u_ON': `ON`,
+    'u_Boost': `Boost`,
+    'u_Brake': `Brake`,
+
+    'u_Cross': `Cross`,
+    'u_Split': `Split`,
+    'u_Alternate': `Alternate`,
+    'u_Twist': `Twist`,
+    'u_Asymmetry': `Asymmetry`,
+    'u_Flat': `Flat`,
+    'u_R-': `R-`,
+    'u_Reverse': `Reverse`,
+
+    'u_Mirror': `Mirror`,
+    'u_Random': `Random`,
+    'u_Random+': `Random+`,
+    'u_S-Random': `S-Random`,
+    'u_S-Random+': `S-Random+`,
+
+    'u_ALL': `ALL`,
+    'u_Onigiri': `Onigiri`,
+    'u_Left': `Left`,
+    'u_Right': `Right`,
+
+    'u_Original': `Original`,
+    'u_Heavy': `Heavy`,
+    'u_NoRecovery': `NoRecovery`,
+    'u_SuddenDeath': `SuddenDeath`,
+    'u_Practice': `Practice`,
+    'u_Light': `Light`,
+
+    'u_Normal': `Normal`,
+    'u_Hard': `Hard`,
+    'u_Easy': `Easy`,
+
+    'u_Visible': `Visible`,
+    'u_Hidden': `Hidden`,
+    'u_Hidden+': `Hidden+`,
+    'u_Sudden': `Sudden`,
+    'u_Sudden+': `Sudden+`,
+    'u_Hid&Sud+': `Hid&Sud+`,
+
+    'u_Speed': `Speed`,
+    'u_Density': `Density`,
+    'u_ToolDif': `ToolDif`,
+
+    'u_Main': `Main`,
+    'u_Replaced': `Replaced`,
+
+    'u_Default': `Default`,
+    'u_Type0': `Type0`,
+    'u_Type1': `Type1`,
+    'u_Type2': `Type2`,
+
     ConfigType: `ConfigType`,
     ColorType: `ColorType`,
     KeyPattern: `KeyPattern`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2024,6 +2024,9 @@ const g_lblNameObj = {
     Fadein: `Fadein`,
     Volume: `Volume`,
 
+    multi: `x`,
+    percent: `%`,
+
     sc_speed: `←→`,
     sc_scroll: `↑/↓`,
     sc_adjustment: `- +`,
@@ -2065,6 +2068,9 @@ const g_lblNameObj = {
 
     Appearance: `Appearance`,
     Opacity: `Opacity`,
+
+    'u_x': `x`,
+    'u_%': `%`,
 
     'u_OFF': `OFF`,
     'u_ON': `ON`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 設定名（Boost, Brake, ...など）をg_lblNameObjに設定することで設定名を置き換える機能を実装しました。
項目名の前に`u_`をつけて指定します。
```javascript
g_lblNameObj.u_Boost = `ブースト`;
```
なお、ハイフンなどが含まれる場合は下記のようにします。
```javascript
g_lblNameObj[`u_R-`] = `(逆)`;
```

2. 結果画面の固定ラベル(Music, Playstyleなど)、Displayオプションの略名(Step, FSなど)を
g_lblNameObjに設定することでラベル名を置き換える機能を実装しました。
項目名の前に`rt_`, `rd_`をつけて指定します。
※この機能は3. の設定の影響を受けません。
```javascript
g_lblNameObj.rt_Music = `曲名`;
g_lblNameObj.rd_StepZone = `ステップ`;
```

3. danoni_setting.jsに設定名（`g_lblNameObj.u_`始まりのもの）を置き換えるかどうかを
画面別に設定できるようにしました。
例えば、設定画面はデフォルトのままにして、結果画面のみ簡略表示にするといった使い分けができます。
```javascript
/**
 * 設定名の上書き可否設定
 */
const g_lblRenames = {
	option: true,
	settingsDisplay: true,
	keyConfig: true,
	result: true,
};
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 設定名を変更する手段がこれまで無かったため。
2. 結果画面のラベルを変更する手段が直接変更する以外に無かったため。
3. Tweetで簡略表記した方が良い場面が考えられるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/108797048-97c5cc00-75cd-11eb-8df2-be5f3718cb98.png" width="30%"><img src="https://user-images.githubusercontent.com/44026291/108797077-b035e680-75cd-11eb-8eef-0a05f0408868.png" width="30%"><img src="https://user-images.githubusercontent.com/44026291/108797098-c17ef300-75cd-11eb-84e9-345de2ccb1c9.png" width="30%">

## :pencil: その他コメント / Other Comments
- 内部変数はそのままです。設定画面、結果画面の見た目のみ変わります。
- 3.の変更について、現状結果画面の表示とTweet表示を区分けすることはできません。
