### PR TITLE
[0369/code-refactoring] 重複記述の見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9481,10 +9481,9 @@ function resultInit() {
  * @param {string, number} _text
  * @param {string} _align
  */
-function makeCssResultPlayData(_id, _x, _class, _heightPos, _text, _align = C_ALIGN_CENTER) {
+function makeCssResultPlayData(_id, _x, _class, _heightPos, _text, _align = C_ALIGN_CENTER, { w = 400, siz = C_SIZ_MAIN } = {}) {
 	return createDivCss2Label(_id, _text, {
-		x: _x, y: 18 * _heightPos,
-		w: 400, h: 18, siz: C_SIZ_MAIN, align: _align,
+		x: _x, y: C_SIZ_SETMINI * _heightPos, w, h: C_SIZ_SETMINI, siz, align: _align,
 	}, _class);
 }
 
@@ -9498,10 +9497,7 @@ function makeCssResultPlayData(_id, _x, _class, _heightPos, _text, _align = C_AL
  * @param {string} _align
  */
 function makeCssResultSymbol(_id, _x, _class, _heightPos, _text, _align = C_ALIGN_LEFT) {
-	return createDivCss2Label(_id, _text, {
-		x: _x, y: 18 * _heightPos,
-		w: 150, h: 18, siz: C_SIZ_JDGCNTS, align: _align,
-	}, _class);
+	return makeCssResultPlayData(_id, _x, _class, _heightPos, _text, _align, { w: 150, siz: C_SIZ_JDGCNTS });
 }
 
 // ライセンス原文、以下は削除しないでください

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4013,6 +4013,21 @@ function createOptionWindow(_sprite) {
 	}
 
 	/**
+	 * 譜面基礎データの取得
+	 * @param {number} _scoreId 
+	 */
+	function getScoreBaseData(_scoreId) {
+		const arrowCnts = g_detailObj.arrowCnt[_scoreId].reduce((p, x) => p + x);
+		const frzCnts = g_detailObj.frzCnt[_scoreId].reduce((p, x) => p + x);
+		return {
+			arrowCnts: arrowCnts,
+			frzCnts: frzCnts,
+			apm: Math.round((arrowCnts + frzCnts) / (g_detailObj.playingFrame[_scoreId] / g_fps / 60)),
+			playingTime: transFrameToTimer(g_detailObj.playingFrame[_scoreId]),
+		};
+	}
+
+	/**
 	 * 速度変化グラフの描画
 	 * @param {number} _scoreId
 	 */
@@ -4081,9 +4096,6 @@ function createOptionWindow(_sprite) {
 	 */
 	function drawDensityGraph(_scoreId) {
 
-		const arrowCnts = g_detailObj.arrowCnt[_scoreId].reduce((p, x) => p + x);
-		const frzCnts = g_detailObj.frzCnt[_scoreId].reduce((p, x) => p + x);
-
 		const canvas = document.querySelector(`#graphDensity`);
 		const context = canvas.getContext(`2d`);
 		drawBaseLine(context);
@@ -4096,12 +4108,11 @@ function createOptionWindow(_sprite) {
 			context.stroke();
 		}
 
-		const apm = Math.round((arrowCnts + frzCnts) / (g_detailObj.playingFrame[_scoreId] / g_fps / 60));
-		makeScoreDetailLabel(`Density`, g_lblNameObj.s_apm, apm, 0);
-		const playingTime = transFrameToTimer(g_detailObj.playingFrameWithBlank[_scoreId]);
-		makeScoreDetailLabel(`Density`, g_lblNameObj.s_time, playingTime, 1);
-		makeScoreDetailLabel(`Density`, g_lblNameObj.s_arrow, arrowCnts, 3);
-		makeScoreDetailLabel(`Density`, g_lblNameObj.s_frz, frzCnts, 4);
+		const obj = getScoreBaseData(_scoreId);
+		makeScoreDetailLabel(`Density`, g_lblNameObj.s_apm, obj.apm, 0);
+		makeScoreDetailLabel(`Density`, g_lblNameObj.s_time, obj.playingTime, 1);
+		makeScoreDetailLabel(`Density`, g_lblNameObj.s_arrow, obj.arrowCnts, 3);
+		makeScoreDetailLabel(`Density`, g_lblNameObj.s_frz, obj.frzCnts, 4);
 	}
 
 	/**
@@ -4231,11 +4242,7 @@ function createOptionWindow(_sprite) {
 		if (document.querySelector(`#lnkDifInfo`) === null) {
 			let printData = ``;
 			for (let j = 0; j < g_detailObj.arrowCnt.length; j++) {
-				const arrowCnts = g_detailObj.arrowCnt[j].reduce((p, x) => p + x);
-				const frzCnts = g_detailObj.frzCnt[j].reduce((p, x) => p + x);
-				const apm = Math.round((arrowCnts + frzCnts) / (g_detailObj.playingFrame[j] / g_fps / 60));
-				const playingTime = transFrameToTimer(g_detailObj.playingFrame[j]);
-
+				const obj = getScoreBaseData(j);
 				printData +=
 					// 譜面番号
 					`[${j + 1}]\t` +
@@ -4246,15 +4253,15 @@ function createOptionWindow(_sprite) {
 					// 縦連
 					`${g_detailObj.toolDif[j].tate}\t` +
 					// 総矢印数
-					`${(arrowCnts + frzCnts)}\t` +
+					`${(obj.arrowCnts + obj.frzCnts)}\t` +
 					// 矢印
-					`${arrowCnts}\t` +
+					`${obj.arrowCnts}\t` +
 					// フリーズアロー
-					`${frzCnts}\t` +
+					`${obj.frzCnts}\t` +
 					// APM
-					`${apm}\t` +
+					`${obj.apm}\t` +
 					// 時間(分秒)
-					`${playingTime}\r\n`;
+					`${obj.playingTime}\r\n`;
 			}
 			detailToolDif.appendChild(
 				makeSettingLblCssButton(`lnkDifInfo`, g_lblNameObj.s_print, 0, _ => {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -313,7 +313,7 @@ const commonKeyUp = _evt => {
 };
 
 /**
- * 外部リンクを新規タグで開く
+ * 外部リンクを新規タブで開く
  * @param {string} _url 
  */
 const openLink = _url => {
@@ -376,6 +376,8 @@ function setVal(_checkStr, _default, _type) {
  * 配列の型及び最小配列長のチェック
  * - チェックのみで変換は行わないため、変換が必要な場合は別途処理を組むこと。
  * - 型は最初の要素のみチェックを行う。
+ * 
+ * @deprecated v20以降非推奨
  * @param {array} _checkArray 
  * @param {string} _type 
  * @param {number} _minLength 最小配列長
@@ -507,6 +509,7 @@ function getBasicFont(_priorityFont = ``) {
 
 /**
  * 半角換算の文字数を計算
+ * @deprecated v20以降非推奨
  * @param {string} _str 
  */
 function getStrLength(_str) {
@@ -559,6 +562,7 @@ function getFontSize(_str, _maxWidth, _font = getBasicFont(), _maxFontsize = 64)
 
 /**
  * 左パディング
+ * @deprecated v20以降非推奨
  * @param {string} _str 元の文字列 
  * @param {number} _length パディング後の長さ 
  * @param {string} _chr パディング文字列
@@ -630,6 +634,8 @@ function createDiv(_id, _x, _y, _width, _height) {
 /**
  * 子div要素のラベル文字作成
  * - createDivLabelに加えて、独自フォントが指定できる形式。
+ * 
+ * @deprecated v20以降非推奨
  * @param {string} _id 
  * @param {number} _x 
  * @param {number} _y 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -477,8 +477,7 @@ function preloadFile(_as, _href, _type = ``, _crossOrigin = `anonymous`) {
 			if (_type !== ``) {
 				link.type = _type;
 			}
-			if (location.href.match(`^file`)) {
-			} else {
+			if (!isFile) {
 				link.crossOrigin = _crossOrigin;
 			}
 			document.head.appendChild(link);
@@ -688,7 +687,7 @@ function createDivCss2Label(_id, _text, { x = 0, y = 0, w = C_LEN_SETLBL_WIDTH, 
  */
 function createImg(_id, _imgPath, _x, _y, _width, _height) {
 	const div = createDiv(_id, _x, _y, _width, _height);
-	div.innerHTML = `<img id="${_id}img" src="${_imgPath}" style="width:${_width}px;height:${_height}px"${location.href.match(`^file`) ? `` : ` crossOrigin="anonimous"`}>`;
+	div.innerHTML = `<img id="${_id}img" src="${_imgPath}" style="width:${_width}px;height:${_height}px"${isFile ? `` : ` crossOrigin="anonimous"`}>`;
 
 	return div;
 }
@@ -1194,6 +1193,16 @@ function getLoadingLabel() {
 		x: 0, y: g_sHeight - 40, w: g_sWidth, h: C_LEN_SETLBL_HEIGHT,
 		siz: C_SIZ_SETLBL, align: C_ALIGN_RIGHT,
 	});
+}
+
+/**
+ * フレーム数に対応する時間表示を作成
+ * @param {number} _frame 
+ */
+const getPlayingTime = _frame => {
+	const minutes = Math.floor(_frame / g_fps / 60);
+	const seconds = `${Math.floor((_frame / g_fps) % 60)}`.padStart(2, `0`);
+	return `${minutes}:${seconds}`;
 }
 
 /*-----------------------------------------------------------*/
@@ -1811,7 +1820,7 @@ function loadMusic() {
 	divRoot.appendChild(lblLoading);
 
 	// ローカル動作時
-	if (location.href.match(`^file`)) {
+	if (isFile) {
 		setAudio(url);
 		return;
 	}
@@ -1897,7 +1906,7 @@ function makePlayButton(_func) {
 function setAudio(_url) {
 
 	const loadMp3 = _ => {
-		if (location.href.match(`^file`)) {
+		if (isFile) {
 			g_audio.src = _url;
 			musicAfterLoaded();
 		} else {
@@ -2368,12 +2377,12 @@ function titleInit() {
 	if (g_userAgent.indexOf(`msie`) !== -1 ||
 		g_userAgent.indexOf(`trident`) !== -1 ||
 		g_userAgent.indexOf(`edge`) !== -1 ||
-		(g_userAgent.indexOf(`firefox`) !== -1 && location.href.match(`^file`))) {
+		(g_userAgent.indexOf(`firefox`) !== -1 && isFile)) {
 
 		makeWarningWindow(g_msgInfoObj.W_0001);
 	}
 
-	if (location.href.match(/^file/)) {
+	if (isFile) {
 		makeWarningWindow(g_msgInfoObj.W_0011);
 	}
 
@@ -2683,7 +2692,7 @@ function headerConvert(_dosObj) {
 	g_headerObj.customFont = obj.customFont;
 
 	// 画像ルートパス、拡張子の設定 (サーバ上のみ)
-	if (!location.href.match(`^file`)) {
+	if (!isFile) {
 		Object.keys(g_imgObj).forEach(key => g_imgObj[key] = `${g_rootPath}${g_imgObj[key]}`);
 		if (typeof g_presetOverrideExtension === C_TYP_STRING) {
 			Object.keys(g_imgObj).forEach(key => g_imgObj[key] = `${g_imgObj[key].slice(0, -3)}${g_presetOverrideExtension}`);
@@ -3372,7 +3381,7 @@ function headerConvert(_dosObj) {
 	obj.playingX = setVal(_dosObj.playingX, 0, C_TYP_NUMBER);
 
 	// ジャストフレームの設定 (ローカル: 0フレーム, リモートサーバ上: 1フレーム以内)
-	obj.justFrames = (location.href.match(`^file`) || location.href.indexOf(`localhost`) !== -1) ? 0 : 1;
+	obj.justFrames = (isLocal) ? 0 : 1;
 
 	// リザルトデータのカスタマイズ
 	const resultFormatDefault = `【#danoni[hashTag]】[musicTitle]([keyLabel]) /[maker] /Rank:[rank]/Score:[score]/Playstyle:[playStyle]/[arrowJdg]/[frzJdg]/[maxCombo] [url]`;
@@ -4094,9 +4103,7 @@ function createOptionWindow(_sprite) {
 
 		const apm = Math.round((arrowCnts + frzCnts) / (g_detailObj.playingFrame[_scoreId] / g_fps / 60));
 		makeScoreDetailLabel(`Density`, g_lblNameObj.s_apm, apm, 0);
-		const minutes = Math.floor(g_detailObj.playingFrameWithBlank[_scoreId] / g_fps / 60);
-		const seconds = `${Math.floor((g_detailObj.playingFrameWithBlank[_scoreId] / g_fps) % 60)}`.padStart(2, `0`);
-		const playingTime = `${minutes}:${seconds}`;
+		const playingTime = getPlayingTime(g_detailObj.playingFrameWithBlank[_scoreId]);
 		makeScoreDetailLabel(`Density`, g_lblNameObj.s_time, playingTime, 1);
 		makeScoreDetailLabel(`Density`, g_lblNameObj.s_arrow, arrowCnts, 3);
 		makeScoreDetailLabel(`Density`, g_lblNameObj.s_frz, frzCnts, 4);
@@ -4232,9 +4239,7 @@ function createOptionWindow(_sprite) {
 				const arrowCnts = g_detailObj.arrowCnt[j].reduce((p, x) => p + x);
 				const frzCnts = g_detailObj.frzCnt[j].reduce((p, x) => p + x);
 				const apm = Math.round((arrowCnts + frzCnts) / (g_detailObj.playingFrame[j] / g_fps / 60));
-				const minutes = Math.floor(g_detailObj.playingFrame[j] / g_fps / 60);
-				const seconds = `${Math.floor((g_detailObj.playingFrame[j] / g_fps) % 60)}`.padStart(2, `0`);
-				const playingTime = `${minutes}:${seconds}`;
+				const playingTime = getPlayingTime(g_detailObj.playingFrame[j]);
 
 				printData +=
 					// 譜面番号
@@ -7400,11 +7405,7 @@ function MainInit() {
 
 	const nominalDiff = g_headerObj.blankFrame - g_headerObj.blankFrameDef + g_stateObj.adjustment;
 	g_scoreObj.nominalFrameNum = g_scoreObj.frameNum - nominalDiff;
-	const nominalFullFrame = fullFrame - nominalDiff;
-
-	const fullMin = Math.floor(nominalFullFrame / 60 / g_fps);
-	const fullSec = `${Math.floor(Math.floor(nominalFullFrame / g_fps) % 60)}`.padStart(2, `0`);
-	const fullTime = `${fullMin}:${fullSec}`;
+	const fullTime = getPlayingTime(fullFrame - nominalDiff);
 
 	// フレーム数
 	divRoot.appendChild(
@@ -7552,8 +7553,7 @@ function MainInit() {
 	}
 
 	// ローカル時のみフレーム数を残す
-	if (location.href.match(`^file`) || location.href.indexOf(`localhost`) !== -1) {
-	} else {
+	if (!isLocal) {
 		lblframe.style.display = C_DIS_NONE;
 	}
 
@@ -8399,9 +8399,7 @@ function MainInit() {
 			// タイマー
 			if (Math.floor(g_scoreObj.nominalFrameNum % g_fps) === 0) {
 				if (g_scoreObj.nominalFrameNum >= 0) {
-					const currentMin = Math.floor(g_scoreObj.nominalFrameNum / 60 / g_fps);
-					const currentSec = `${Math.floor(g_scoreObj.nominalFrameNum / g_fps) % 60}`.padStart(2, `0`);
-					lblTime1.textContent = `${currentMin}:${currentSec}`;
+					lblTime1.textContent = getPlayingTime(g_scoreObj.nominalFrameNum);
 				}
 			}
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1737,8 +1737,7 @@ function calcLevel(_scoreObj) {
 	//--------------------------------------------------------------
 	return {
 		// 難易度レベル
-		tool: (allCnt === 3 ? `0.01` :
-			`${Math.floor(difLevel)}.${`${Math.round((difLevel * 100) % 100)}`.padStart(2, `0`)}${(push3Cnt > 0 ? "*" : "")}`),
+		tool: (allCnt === 3 ? `0.01` : `${difLevel.toFixed(2)}${(push3Cnt > 0 ? "*" : "")}`),
 		// 縦連打補正
 		tate: toDecimal2(baseDifLevel - calcDifLevel(leveltmp)),
 		// 同時押し補正

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -36,6 +36,16 @@ const g_userAgent = window.navigator.userAgent.toLowerCase(); // msie, edge, chr
 const g_isIos = listMatching(g_userAgent, [`iphone`, `ipad`, `ipod`]);
 const g_isMac = listMatching(g_userAgent, [`iphone`, `ipad`, `ipod`, `mac os`]);
 
+/**
+ * ローカル実行かどうかのチェック (localhostを含まない)
+ */
+const isFile = _ => location.href.match(/^file/);
+
+/**
+ * ローカル実行かどうかのチェック (localhostを含む)
+ */
+const isLocal = _ => location.href.match(/^file/) || location.href.indexOf(`localhost`) !== -1;
+
 // 変数型
 const C_TYP_BOOLEAN = `boolean`;
 const C_TYP_NUMBER = `number`;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. フレーム数から分秒に変換する処理、ローカルかどうかの判断処理、
譜面基礎データの取得処理を関数化しました。
2. `(条件式) ? true : false` の記述を `(条件式)` に変更しました。
3. 結果ラベル生成処理を一部集約しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. コード重複回避のため。
2. 条件式そのものが true/false を返しており、三項演算子が不要のため。
3. コードのほとんどが共通化していたため、片側の関数に寄せました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
