### PR TITLE
[0370/difname-size] タイトル文字、譜面名のフォントサイズに関する修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4666,8 +4666,7 @@ function createOptionWindow(_sprite) {
 		// 譜面名設定 (Difficulty)
 		const difWidth = parseFloat(lnkDifficulty.style.width);
 		const difNames = [`${g_keyObj.currentKey} key / ${g_headerObj.difLabels[g_stateObj.scoreId]}`];
-		lnkDifficulty.style.fontSize = `${getFontSize(lnkDifficulty.textContent,
-			difWidth, getBasicFont(), C_SIZ_SETLBL)}px`;
+		lnkDifficulty.style.fontSize = `${getFontSize(difNames[0], difWidth, getBasicFont(), C_SIZ_SETLBL)}px`;
 
 		if (g_headerObj.makerView) {
 			difNames.push(`(${g_headerObj.creatorNames[g_stateObj.scoreId]})`);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -538,7 +538,7 @@ function getStrLength(_str) {
 function getStrWidth(_str, _fontsize, _font) {
 	const ctx = document.createElement(`canvas`).getContext(`2d`);
 	ctx.font = `${_fontsize}px ${_font}`;
-	return ctx.measureText(_str).width;
+	return ctx.measureText(unEscapeHtml(_str)).width;
 }
 
 /**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. タイトル文字、譜面名にエスケープ対象の文字がある場合、
その文字分を長さとして取得してしまう問題を修正しました。
今後は一度エスケープを取ってから(unEscapeHtml関数を適用後)長さを計測するように変更します。
2. 譜面名について、前回の譜面名を元にフォントサイズを決定してしまう問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. タイトル文字、譜面名にエスケープ文字が含まれる場合、文字列が長くなります。
例：`&` => `&amp;`, `"` => `&quot;` 
これを考慮すると、エスケープ文字を含んだ内容で描画幅が計算され、
結果として全体文字が小さくなってしまうため、これを改善します。
2. コード整理時のミスです。前の譜面名の長さを取得するようになっていました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- ver20.1.2 で発生する不具合。過去バージョンの適用対象外です。
