### PR TITLE
[0373/shortcut-title] タイトル画面、ロード画面(IOSのみ)にショートカットを追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -894,15 +894,22 @@ function getTitleDivLabel(_id, _titlename, _x, _y, ..._classes) {
 }
 
 /**
+ * キーコントロールの初期化
+ */
+function resetKeyControl() {
+	document.onkeyup = _ => { };
+	document.onkeydown = evt => blockCode(transCode(evt.code));
+	g_inputKeyBuffer = {};
+}
+
+/**
  * 画面上の描画、オブジェクトを全てクリア
  * - divオブジェクト(ボタンなど)はdivRoot配下で管理しているため、子要素のみを全削除している。
  * - dicRoot自体を削除しないよう注意すること。
  * - 再描画時に共通で表示する箇所はここで指定している。
  */
 function clearWindow() {
-	document.onkeyup = _ => { };
-	document.onkeydown = evt => blockCode(transCode(evt.code));
-	g_inputKeyBuffer = {};
+	resetKeyControl();
 
 	if (document.querySelector(`#layer0`) !== null) {
 
@@ -1825,7 +1832,6 @@ function loadMusic() {
 
 	clearWindow();
 	g_currentPage = `loading`;
-	setShortcutEvent(g_currentPage);
 
 	const musicUrl = g_headerObj.musicUrls[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.musicUrls[0];
 	let url = `${g_rootPath}../${g_headerObj.musicFolder}/${musicUrl}`;
@@ -1944,7 +1950,7 @@ function setAudio(_url) {
 			lblLoading.textContent = `Click to Start!`;
 			divRoot.appendChild(makePlayButton(evt => {
 				g_currentPage = `loading`;
-				setShortcutEvent(g_currentPage);
+				resetKeyControl();
 				divRoot.removeChild(evt.target);
 				_func();
 			}));
@@ -8380,10 +8386,7 @@ function MainInit() {
 			if (g_stateObj.lifeMode === C_LFE_BORDER && g_workObj.lifeVal < g_workObj.lifeBorder) {
 				g_gameOverFlg = true;
 			}
-
-			document.onkeydown = evt => blockCode(transCode(evt.code));
-			document.onkeyup = evt => { }
-
+			resetKeyControl();
 			clearTimeout(g_timeoutEvtId);
 			setTimeout(_ => resultInit(), 100);
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1937,38 +1937,34 @@ function setAudio(_url) {
 		}
 	};
 
+	const readyToStart = _func => {
+		if (g_isIos) {
+			g_currentPage = `loadingIos`;
+			lblLoading.textContent = `Click to Start!`;
+			divRoot.appendChild(makePlayButton(evt => {
+				divRoot.removeChild(evt.target);
+				_func();
+			}));
+			createScTextCommon(g_currentPage);
+			setShortcutEvent(g_currentPage);
+		} else {
+			_func();
+		}
+	};
+
 	if (g_musicEncodedFlg) {
 		loadScript(_url, _ => {
 			if (typeof musicInit === C_TYP_FUNCTION) {
 				musicInit();
-				if (g_isIos) {
-					lblLoading.textContent = `Click to Start!`;
-					divRoot.appendChild(
-						makePlayButton(evt => {
-							divRoot.removeChild(evt.target);
-							initWebAudioAPI(`data:audio/mp3;base64,${g_musicdata}`);
-						})
-					);
-				} else {
-					initWebAudioAPI(`data:audio/mp3;base64,${g_musicdata}`);
-				}
+				readyToStart(_ => initWebAudioAPI(`data:audio/mp3;base64,${g_musicdata}`));
 			} else {
 				makeWarningWindow(g_msgInfoObj.E_0031);
 				musicAfterLoaded();
 			}
 		});
 
-	} else if (g_isIos) {
-		lblLoading.textContent = `Click to Start!`;
-		divRoot.appendChild(
-			makePlayButton(evt => {
-				divRoot.removeChild(evt.target);
-				loadMp3();
-			})
-		);
-
 	} else {
-		loadMp3();
+		readyToStart(_ => loadMp3());
 	}
 }
 
@@ -2518,7 +2514,6 @@ function titleInit() {
 			resetFunc: _ => openLink(`https://github.com/cwtickle/danoniplus/security/policy`),
 		}, g_cssObj.button_Tweet),
 	);
-	createScTextCommon(g_currentPage);
 
 	// コメントエリア作成
 	if (g_headerObj.commentVal !== ``) {
@@ -2547,6 +2542,7 @@ function titleInit() {
 			);
 		}
 	}
+	createScTextCommon(g_currentPage);
 
 	// マスクスプライトを作成
 	const maskTitleSprite = createMultipleSprite(`maskTitleSprite`, g_headerObj.maskTitleMaxDepth);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1954,7 +1954,6 @@ function setAudio(_url) {
 				divRoot.removeChild(evt.target);
 				_func();
 			}));
-			createScTextCommon(g_currentPage);
 			setShortcutEvent(g_currentPage);
 		} else {
 			_func();
@@ -2253,6 +2252,7 @@ const createScTextCommon = _displayName => {
  * @param {function} _func 
  */
 const setShortcutEvent = (_displayName, _func = _ => true) => {
+	createScTextCommon(_displayName);
 	const evList = _ => {
 		document.onkeydown = evt => commonKeyDown(evt, _displayName, _func);
 		document.onkeyup = evt => commonKeyUp(evt);
@@ -2550,7 +2550,6 @@ function titleInit() {
 			);
 		}
 	}
-	createScTextCommon(g_currentPage);
 
 	// マスクスプライトを作成
 	const maskTitleSprite = createMultipleSprite(`maskTitleSprite`, g_headerObj.maskTitleMaxDepth);
@@ -3750,7 +3749,6 @@ function optionInit() {
 			borderStyle: `solid`,
 		}, g_cssObj.button_Default, (g_stateObj.dataSaveFlg ? g_cssObj.button_ON : g_cssObj.button_OFF))
 	);
-	createScTextCommon(g_currentPage);
 
 	// キー操作イベント（デフォルト）
 	setShortcutEvent(g_currentPage);
@@ -4972,7 +4970,6 @@ function settingsDisplayInit() {
 
 	// ボタン描画
 	commonSettingBtn(`Settings`);
-	createScTextCommon(g_currentPage);
 
 	// キー操作イベント（デフォルト）
 	setShortcutEvent(g_currentPage);
@@ -5435,7 +5432,6 @@ function keyConfigInit(_kcType = g_kcType) {
 		}, g_cssObj.button_Reset)
 
 	);
-	createScTextCommon(g_currentPage);
 
 	// キーボード押下時処理
 	setShortcutEvent(g_currentPage, setCode => {
@@ -9396,7 +9392,6 @@ function resultInit() {
 			animationName: `smallToNormalY`, resetFunc: _ => loadMusic(),
 		}, g_cssObj.button_Reset),
 	);
-	createScTextCommon(g_currentPage);
 
 	// マスクスプライトを作成
 	const maskResultSprite = createMultipleSprite(`maskResultSprite`, g_headerObj.maskResultMaxDepth);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -902,6 +902,7 @@ function getTitleDivLabel(_id, _titlename, _x, _y, ..._classes) {
 function clearWindow() {
 	document.onkeyup = _ => { };
 	document.onkeydown = evt => blockCode(transCode(evt.code));
+	g_inputKeyBuffer = {};
 
 	if (document.querySelector(`#layer0`) !== null) {
 
@@ -1824,7 +1825,7 @@ function loadMusic() {
 
 	clearWindow();
 	g_currentPage = `loading`;
-	document.onkeydown = evt => blockCode(transCode(evt.code));
+	setShortcutEvent(g_currentPage);
 
 	const musicUrl = g_headerObj.musicUrls[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.musicUrls[0];
 	let url = `${g_rootPath}../${g_headerObj.musicFolder}/${musicUrl}`;
@@ -1942,6 +1943,8 @@ function setAudio(_url) {
 			g_currentPage = `loadingIos`;
 			lblLoading.textContent = `Click to Start!`;
 			divRoot.appendChild(makePlayButton(evt => {
+				g_currentPage = `loading`;
+				setShortcutEvent(g_currentPage);
 				divRoot.removeChild(evt.target);
 				_func();
 			}));
@@ -2266,7 +2269,6 @@ function titleInit() {
 
 	clearWindow();
 	drawDefaultBackImage(``);
-	g_inputKeyBuffer = {};
 	g_currentPage = `title`;
 
 	// タイトル用フレーム初期化
@@ -3709,7 +3711,6 @@ function optionInit() {
 	drawDefaultBackImage(``);
 	const divRoot = document.querySelector(`#divRoot`);
 	g_baseDisp = `Settings`;
-	g_inputKeyBuffer = {};
 	g_currentPage = `option`;
 
 	// タイトル文字描画
@@ -4937,7 +4938,6 @@ function settingsDisplayInit() {
 	drawDefaultBackImage(``);
 	const divRoot = document.querySelector(`#divRoot`);
 	g_baseDisp = `Display`;
-	g_inputKeyBuffer = {};
 	g_currentPage = `settingsDisplay`;
 
 	// 譜面初期情報ロード許可フラグ
@@ -5131,7 +5131,6 @@ function keyConfigInit(_kcType = g_kcType) {
 	drawDefaultBackImage(``);
 	const divRoot = document.querySelector(`#divRoot`);
 	g_kcType = _kcType;
-	g_inputKeyBuffer = {};
 	g_currentPage = `keyConfig`;
 
 	// 譜面初期情報ロード許可フラグ
@@ -8984,7 +8983,6 @@ function resultInit() {
 	g_scoreObj.maskResultLoopCount = 0;
 
 	const divRoot = document.querySelector(`#divRoot`);
-	g_inputKeyBuffer = {};
 
 	// 曲時間制御変数
 	let thisTime;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -731,7 +731,6 @@ g_kCdN[240] = `CapsLock`;
 const g_shortcutObj = {
     title: {
         Enter: { id: `btnStart` },
-        KeyR: { id: `btnReload` },
         Slash: { id: `btnHelp`, reset: true },
         F1: { id: `btnHelp`, reset: true },
         KeyC: { id: `btnComment` },

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -731,6 +731,10 @@ g_kCdN[240] = `CapsLock`;
 const g_shortcutObj = {
     title: {
         Enter: { id: `btnStart` },
+        KeyR: { id: `btnReload` },
+        Slash: { id: `btnHelp`, reset: true },
+        F1: { id: `btnHelp`, reset: true },
+        KeyC: { id: `btnComment` },
     },
     option: {
         ShiftLeft_KeyD: { id: `lnkDifficultyL` },
@@ -818,6 +822,9 @@ const g_shortcutObj = {
         ShiftLeft_Tab: { id: `btnBack` },
         Tab: { id: `btnSettings` },
     },
+    loadingIos: {
+        Enter: { id: `btnPlay` },
+    },
     keyConfig: {
         Escape: { id: `btnBack` },
     },
@@ -840,6 +847,7 @@ const g_btnWaitFrame = {
     option: { b_frame: 0, s_frame: 0, initial: true },
     settingsDisplay: { b_frame: 0, s_frame: 0 },
     loading: { b_frame: 0, s_frame: 0 },
+    loadingIos: { b_frame: 0, s_frame: 0 },
     main: { b_frame: 0, s_frame: 0 },
     keyConfig: { b_frame: 0, s_frame: 0 },
     result: { b_frame: 0, s_frame: 120 },
@@ -847,9 +855,10 @@ const g_btnWaitFrame = {
 
 // 主要ボタンのリスト
 const g_btnPatterns = {
-    title: { Start: 0 },
+    title: { Start: 0, Comment: -10 },
     option: { Back: 0, KeyConfig: 0, Play: 0, Display: -5, Save: -10, Graph: -25 },
     settingsDisplay: { Back: 0, KeyConfig: 0, Play: 0, Settings: -5 },
+    loadingIos: { Play: 0 },
     keyConfig: { Back: -3 },
     result: { Back: -5, Copy: -5, Tweet: -5, Gitter: -5, Retry: 0 },
 };

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -822,11 +822,11 @@ const g_shortcutObj = {
         ShiftLeft_Tab: { id: `btnBack` },
         Tab: { id: `btnSettings` },
     },
-    loadingIos: {
-        Enter: { id: `btnPlay` },
-    },
     keyConfig: {
         Escape: { id: `btnBack` },
+    },
+    loadingIos: {
+        Enter: { id: `btnPlay` },
     },
     result: {
         Escape: { id: `btnBack` },
@@ -846,10 +846,10 @@ const g_btnWaitFrame = {
     title: { b_frame: 0, s_frame: 0 },
     option: { b_frame: 0, s_frame: 0, initial: true },
     settingsDisplay: { b_frame: 0, s_frame: 0 },
+    keyConfig: { b_frame: 0, s_frame: 30 },
     loading: { b_frame: 0, s_frame: 0 },
     loadingIos: { b_frame: 0, s_frame: 0 },
     main: { b_frame: 0, s_frame: 0 },
-    keyConfig: { b_frame: 0, s_frame: 0 },
     result: { b_frame: 0, s_frame: 120 },
 };
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. タイトル画面にショートカットキーを追加しました。
    - `C`キー：Commentボタンがあれば開閉
    - `/ ?`キー もしくは `F1`キー：プレイ画面説明（Wiki）のページを表示
2. ロード画面（iOS系のみ）のプレイ開始ボタンに対してEnterキーを割り当てました。
3. ロード画面のプレイ開始ボタン周りのコードを整理しました。
4. ショートカットキーでキーコンフィグ画面へ移動した場合、0.5秒の待ち時間を設けるよう変更しました。
5. clearWindow関数に`g_inputKeyBuffer`を初期化する処理を包含しました。
6. setShortcutEvent関数にcreateScTextCommon関数を包含しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. ショートカットキーを割り当てても支障が無いため。
「Reset」ボタンについてはローカルデータの消去になるため、ショートカットキーの割り当てはしていません。
「R(eload)」ボタンについても、リロードキーの一部で利用済みのため割り当てしないようにしました。
2. このボタンのみEnterが未対応だったため。
なお、iPad(Safari)ではこの画面が出ることは無く、iPhoneもしくはiPad(Chromeアプリ)で表示されます。
現在用途としては限定的ですが、今後このあたりの制限が強化される場合を考慮して実装します。
3. コードの見やすさのため。
4. スペースキー連打によるキー割り当てを防ぐため。
5. 画面クリア時にキーを押した状態を管理する変数(g_inputKeyBuffer)は初期化した方が良いため。
また、clearWindow関数に処理を統合することで呼び出し漏れを無くすことが目的です。
6. 連続的に実行されることが多いため、setShortcutEvent関数に集約しました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
- iOSで開いた場合の動作イメージ（楽曲データのロードが完了した後に表示されます）
<img src="https://user-images.githubusercontent.com/44026291/109269159-7247f500-784f-11eb-80ad-fad59c3a1200.png" width="70%">

## :pencil: その他コメント / Other Comments
- ロード画面（iOS系のみ）のプレイ開始ボタンのショートカットキーを割り当てるために、
`g_currentPage = "loadingIos";`というショートカットキー割り当て用ページを間に挟んでいます。
Playボタンが押されると`g_currentPage = "loading";`へ戻り、処理が続行される仕組みです。