### PR TITLE
[0374/clear-window] drawDefaultBackImage関数をclearWindow関数へ集約

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1847,7 +1847,6 @@ function loadMusic() {
 
 	g_headerObj.musicUrl = musicUrl;
 	g_musicEncodedFlg = listMatching(musicUrl, [`.js`, `.txt`], { suffix: `$` });
-	drawDefaultBackImage(``);
 
 	// Now Loadingを表示
 	const lblLoading = getLoadingLabel();

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -903,12 +903,12 @@ function resetKeyControl() {
 }
 
 /**
- * 画面上の描画、オブジェクトを全てクリア
+ * 画面上の描画・オブジェクトを全てクリアし、背景を再描画
  * - divオブジェクト(ボタンなど)はdivRoot配下で管理しているため、子要素のみを全削除している。
  * - dicRoot自体を削除しないよう注意すること。
  * - 再描画時に共通で表示する箇所はここで指定している。
  */
-function clearWindow() {
+function clearWindow(_redrawFlg = false, _customDisplayName = ``) {
 	resetKeyControl();
 
 	if (document.querySelector(`#layer0`) !== null) {
@@ -950,6 +950,10 @@ function clearWindow() {
 	// ボタン、オブジェクトをクリア (divRoot配下のもの)
 	deleteChildspriteAll(`divRoot`);
 
+	// 背景を再描画
+	if (_redrawFlg) {
+		drawDefaultBackImage(_customDisplayName);
+	}
 }
 
 /**
@@ -1830,7 +1834,7 @@ function loadSettingJs() {
 
 function loadMusic() {
 
-	clearWindow();
+	clearWindow(true);
 	g_currentPage = `loading`;
 
 	const musicUrl = g_headerObj.musicUrls[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.musicUrls[0];
@@ -2273,8 +2277,7 @@ const setShortcutEvent = (_displayName, _func = _ => true) => {
  */
 function titleInit() {
 
-	clearWindow();
-	drawDefaultBackImage(``);
+	clearWindow(true);
 	g_currentPage = `title`;
 
 	// タイトル用フレーム初期化
@@ -3712,8 +3715,7 @@ const commonSettingBtn = _labelName => {
  */
 function optionInit() {
 
-	clearWindow();
-	drawDefaultBackImage(``);
+	clearWindow(true);
 	const divRoot = document.querySelector(`#divRoot`);
 	g_baseDisp = `Settings`;
 	g_currentPage = `option`;
@@ -4938,8 +4940,7 @@ function makeMiniCssButton(_id, _directionFlg, _heightPos, _func, { dx = 0, dy =
 
 function settingsDisplayInit() {
 
-	clearWindow();
-	drawDefaultBackImage(``);
+	clearWindow(true);
 	const divRoot = document.querySelector(`#divRoot`);
 	g_baseDisp = `Display`;
 	g_currentPage = `settingsDisplay`;
@@ -5130,8 +5131,7 @@ function interlockingButton(_headerObj, _name, _current, _next, _buttonFlg = fal
  */
 function keyConfigInit(_kcType = g_kcType) {
 
-	clearWindow();
-	drawDefaultBackImage(``);
+	clearWindow(true);
 	const divRoot = document.querySelector(`#divRoot`);
 	g_kcType = _kcType;
 	g_currentPage = `keyConfig`;
@@ -7168,8 +7168,7 @@ function setKeyCtrl(_localStorage, _keyNum, _keyCtrlPtn) {
  * メイン画面初期化
  */
 function MainInit() {
-	clearWindow();
-	drawDefaultBackImage(`Main`);
+	clearWindow(true, `Main`);
 	const divRoot = document.querySelector(`#divRoot`);
 	document.oncontextmenu = _ => false;
 	g_currentPage = `main`;
@@ -8968,8 +8967,7 @@ function finishViewing() {
  */
 function resultInit() {
 
-	clearWindow();
-	drawDefaultBackImage(``);
+	clearWindow(true);
 	g_currentPage = `result`;
 
 	// 結果画面用フレーム初期化


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. drawDefaultBackImage関数をclearWindow関数へ集約しました。
（画面のクリアに加えて、背景を再描画する関数を付加）
clearWindow関数に引数を追加し、引数の指定があった場合のみ
drawDefaultBackImage関数を呼び出すようにします。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 従来のclearWindow関数はそのまま使えます。（引数が無い場合は画面クリアのみ実行）
