### PR TITLE
[ver20.4.0] タイトル画面、ロード画面(IOSのみ)にショートカットを追加　他

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ v18の対応終了時期はv21リリース開始時を予定しています。�
 
 | Version | Supported          | Latest Version | First Release | End of Support |
 | ------- | ------------------ |----------------|---------------|----------------|
-| v20     | :heavy_check_mark: |[v20.3.1](../../releases/tag/v20.3.1)          |2021-02-12|-|
+| v20     | :heavy_check_mark: |[v20.4.0](../../releases/tag/v20.4.0)          |2021-02-12|-|
 | v19     | :heavy_check_mark: |[v19.5.5](../../releases/tag/v19.5.5)          |2021-01-17|-|
 | v18     | :warning:          |[v18.9.5](../../releases/tag/v18.9.5)          |2020-10-25|(At Release v21)|
 | v17     | :x:                |[v17.5.9 (final)](../../releases/tag/v17.5.9)  |2020-09-27|2021-02-12|

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2021/02/24
+ * Revised : 2021/02/27
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 20.3.1`;
-const g_revisedDate = `2021/02/24`;
+const g_version = `Ver 20.4.0`;
+const g_revisedDate = `2021/02/27`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -5,7 +5,7 @@
  *
  * Source by tickle
  * Created : 2019/11/19
- * Revised : 2021/02/24 (v20.3.1)
+ * Revised : 2021/02/27 (v20.4.0)
  *
  * https://github.com/cwtickle/danoniplus
  */


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- #1002 タイトル画面にショートカットキーを追加
- #1002 ロード画面(iOSのみ)にショートカットキーを追加
- #1002 ショートカットキーでキーコンフィグ画面へ移動した場合、0.5秒の待ち時間を設けるよう変更
- #1003 clearWindow関数にキーを押した状態の初期化処理、背景再描画処理を包含

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
