### PR TITLE
[0376/code-refactoring] キーコンフィグ画面内のeval関数を排除

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5167,26 +5167,14 @@ function keyConfigInit(_kcType = g_kcType) {
 	keyconSprite.style.transform = `scale(${g_keyObj.scale})`;
 	const kWidth = parseInt(keyconSprite.style.width);
 
-	/** 同行の中心から見た場合の位置(x座標) */
-	let stdPos = 0;
-	/** 行位置 */
-	let dividePos = 0;
-	let posj = 0;
-
 	for (let j = 0; j < keyNum; j++) {
 
-		posj = g_keyObj[`pos${keyCtrlPtn}`][j];
-		if (posj > divideCnt) {
-			stdPos = posj - (posMax + divideCnt) / 2;
-			dividePos = 1;
-		} else {
-			stdPos = posj - divideCnt / 2;
-			dividePos = 0;
-		}
+		const posj = g_keyObj[`pos${keyCtrlPtn}`][j];
+		const stdPos = posj - ((posj <= divideCnt ? 0 : posMax) + divideCnt) / 2;
 
 		// キーコンフィグ表示用の矢印・おにぎりを表示
 		const keyconX = g_keyObj.blank * stdPos + (kWidth - C_ARW_WIDTH) / 2;
-		const keyconY = C_KYC_HEIGHT * dividePos;
+		const keyconY = C_KYC_HEIGHT * (posj <= divideCnt ? 0 : 1);
 		const colorPos = g_keyObj[`color${keyCtrlPtn}`][j];
 		const arrowColor = getKeyConfigColor(j, colorPos);
 
@@ -5228,7 +5216,7 @@ function keyConfigInit(_kcType = g_kcType) {
 			}
 		}
 	}
-	posj = g_keyObj[`pos${keyCtrlPtn}`][0];
+	const posj = g_keyObj[`pos${keyCtrlPtn}`][0];
 
 	// カーソルの作成
 	const cursor = keyconSprite.appendChild(createImg(`cursor`, g_imgObj.cursor,
@@ -5544,18 +5532,10 @@ function setKeyConfigCursor(_width, _divideCnt, _keyCtrlPtn, _keyNum) {
 	const posj = g_keyObj[`pos${_keyCtrlPtn}`][g_currentj];
 	const posMax = (g_keyObj[`divMax${_keyCtrlPtn}`] !== undefined ?
 		g_keyObj[`divMax${_keyCtrlPtn}`] : g_keyObj[`pos${_keyCtrlPtn}`][_keyNum - 1] + 1);
-	let stdPos;
-	let dividePos;
-	if (posj > _divideCnt) {
-		stdPos = posj - (posMax + _divideCnt) / 2;
-		dividePos = 1;
-	} else {
-		stdPos = posj - _divideCnt / 2;
-		dividePos = 0;
-	}
+	const stdPos = posj - ((posj <= _divideCnt ? 0 : posMax) + _divideCnt) / 2;
 
 	cursor.style.left = `${(_width - C_ARW_WIDTH) / 2 + g_keyObj.blank * stdPos - 10}px`;
-	const baseY = C_KYC_HEIGHT * dividePos + 45;
+	const baseY = C_KYC_HEIGHT * (posj <= _divideCnt ? 0 : 1) + 45;
 	if (g_currentk >= 1) {
 		cursor.style.top = `${baseY + C_KYC_REPHEIGHT}px`;
 	} else {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5313,6 +5313,7 @@ function keyConfigInit(_kcType = g_kcType) {
 
 	);
 	setColorType(0);
+	g_keycons.configFunc[g_keycons.configTypeNum](kWidth, divideCnt, keyCtrlPtn);
 
 	/**
 	 * キーコンフィグ用の矢印色を取得
@@ -5384,9 +5385,6 @@ function keyConfigInit(_kcType = g_kcType) {
 					tempPtn : (g_keyObj[`keyCtrl${g_keyObj.currentKey}_-1`] !== undefined ? -1 : 0));
 
 				keyConfigInit();
-				const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
-				const divideCnt = g_keyObj[`div${keyCtrlPtn}`] - 1;
-				g_keycons.configFunc[g_keycons.configTypeNum](kWidth, divideCnt, keyCtrlPtn);
 			},
 		}, g_cssObj.button_Setting),
 
@@ -5400,9 +5398,6 @@ function keyConfigInit(_kcType = g_kcType) {
 					tempPtn : searchPattern(searchPattern(0, 1) - 1, -1, g_headerObj.transKeyUse, `transKey`));
 
 				keyConfigInit();
-				const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
-				const divideCnt = g_keyObj[`div${keyCtrlPtn}`] - 1;
-				g_keycons.configFunc[g_keycons.configTypeNum](kWidth, divideCnt, keyCtrlPtn);
 			},
 		}, g_cssObj.button_Setting),
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5240,13 +5240,13 @@ function keyConfigInit(_kcType = g_kcType) {
 	 * @param {event} _evt 
 	 * @param {number} _scrollNum 
 	 */
-	function setConfigType(_evt, _scrollNum = 1) {
+	function setConfigType(_scrollNum = 1) {
 		const typeNum = g_keycons.configTypes.findIndex(value => value === g_kcType);
 		const nextNum = (typeNum + g_keycons.configTypes.length + _scrollNum) % g_keycons.configTypes.length;
 		g_kcType = g_keycons.configTypes[nextNum];
-		g_keycons.configFunc[nextNum](kWidth, divideCnt, keyCtrlPtn, false);
+		g_keycons.configFunc[nextNum](kWidth, divideCnt, keyCtrlPtn, _scrollNum === 0);
 		g_keycons.configTypeNum = nextNum;
-		_evt.target.textContent = getStgDetailName(g_kcType);
+		lnkKcType.textContent = getStgDetailName(g_kcType);
 	}
 
 	/**
@@ -5296,9 +5296,9 @@ function keyConfigInit(_kcType = g_kcType) {
 			x: 30, y: 10, w: 70,
 		}, g_cssObj.keyconfig_ConfigType),
 
-		makeSettingLblCssButton(`lnkKcType`, getStgDetailName(g_kcType), 0, evt => setConfigType(evt), {
+		makeSettingLblCssButton(`lnkKcType`, getStgDetailName(g_kcType), 0, _ => setConfigType(), {
 			x: 30, y: 35, w: 100,
-			cxtFunc: evt => setConfigType(evt, -1),
+			cxtFunc: _ => setConfigType(-1),
 		}),
 
 		// キーカラータイプ切替ボタン
@@ -5312,6 +5312,7 @@ function keyConfigInit(_kcType = g_kcType) {
 		}),
 
 	);
+	setConfigType(0);
 	setColorType(0);
 
 	/**
@@ -5384,9 +5385,6 @@ function keyConfigInit(_kcType = g_kcType) {
 					tempPtn : (g_keyObj[`keyCtrl${g_keyObj.currentKey}_-1`] !== undefined ? -1 : 0));
 
 				keyConfigInit();
-				const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
-				const divideCnt = g_keyObj[`div${keyCtrlPtn}`] - 1;
-				g_keycons.configFunc[g_keycons.configTypeNum](kWidth, divideCnt, keyCtrlPtn);
 			},
 		}, g_cssObj.button_Setting),
 
@@ -5400,9 +5398,6 @@ function keyConfigInit(_kcType = g_kcType) {
 					tempPtn : searchPattern(searchPattern(0, 1) - 1, -1, g_headerObj.transKeyUse, `transKey`));
 
 				keyConfigInit();
-				const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
-				const divideCnt = g_keyObj[`div${keyCtrlPtn}`] - 1;
-				g_keycons.configFunc[g_keycons.configTypeNum](kWidth, divideCnt, keyCtrlPtn);
 			},
 		}, g_cssObj.button_Setting),
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5245,6 +5245,7 @@ function keyConfigInit(_kcType = g_kcType) {
 		const nextNum = (typeNum + g_keycons.configTypes.length + _scrollNum) % g_keycons.configTypes.length;
 		g_kcType = g_keycons.configTypes[nextNum];
 		g_keycons.configFunc[nextNum](kWidth, divideCnt, keyCtrlPtn, false);
+		g_keycons.configTypeNum = nextNum;
 		_evt.target.textContent = getStgDetailName(g_kcType);
 	}
 
@@ -5385,7 +5386,7 @@ function keyConfigInit(_kcType = g_kcType) {
 				keyConfigInit();
 				const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
 				const divideCnt = g_keyObj[`div${keyCtrlPtn}`] - 1;
-				eval(`resetCursor${g_kcType}`)(kWidth, divideCnt, keyCtrlPtn);
+				g_keycons.configFunc[g_keycons.configTypeNum](kWidth, divideCnt, keyCtrlPtn);
 			},
 		}, g_cssObj.button_Setting),
 
@@ -5401,7 +5402,7 @@ function keyConfigInit(_kcType = g_kcType) {
 				keyConfigInit();
 				const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
 				const divideCnt = g_keyObj[`div${keyCtrlPtn}`] - 1;
-				eval(`resetCursor${g_kcType}`)(kWidth, divideCnt, keyCtrlPtn);
+				g_keycons.configFunc[g_keycons.configTypeNum](kWidth, divideCnt, keyCtrlPtn);
 			},
 		}, g_cssObj.button_Setting),
 
@@ -5423,7 +5424,7 @@ function keyConfigInit(_kcType = g_kcType) {
 						);
 					}
 				}
-				eval(`resetCursor${g_kcType}`)(kWidth, divideCnt, keyCtrlPtn);
+				g_keycons.configFunc[g_keycons.configTypeNum](kWidth, divideCnt, keyCtrlPtn);
 			}
 		}, {
 			x: 0, y: g_sHeight - 75,
@@ -5488,7 +5489,7 @@ function keyConfigInit(_kcType = g_kcType) {
 
 		} else {
 			// 全ての矢印・代替キーの巡回が終わった場合は元の位置に戻す
-			eval(`resetCursor${g_kcType}`)(kWidth, divideCnt, keyCtrlPtn);
+			g_keycons.configFunc[g_keycons.configTypeNum](kWidth, divideCnt, keyCtrlPtn);
 		}
 	});
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5313,7 +5313,6 @@ function keyConfigInit(_kcType = g_kcType) {
 
 	);
 	setColorType(0);
-	g_keycons.configFunc[g_keycons.configTypeNum](kWidth, divideCnt, keyCtrlPtn);
 
 	/**
 	 * キーコンフィグ用の矢印色を取得
@@ -5385,6 +5384,9 @@ function keyConfigInit(_kcType = g_kcType) {
 					tempPtn : (g_keyObj[`keyCtrl${g_keyObj.currentKey}_-1`] !== undefined ? -1 : 0));
 
 				keyConfigInit();
+				const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
+				const divideCnt = g_keyObj[`div${keyCtrlPtn}`] - 1;
+				g_keycons.configFunc[g_keycons.configTypeNum](kWidth, divideCnt, keyCtrlPtn);
 			},
 		}, g_cssObj.button_Setting),
 
@@ -5398,6 +5400,9 @@ function keyConfigInit(_kcType = g_kcType) {
 					tempPtn : searchPattern(searchPattern(0, 1) - 1, -1, g_headerObj.transKeyUse, `transKey`));
 
 				keyConfigInit();
+				const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
+				const divideCnt = g_keyObj[`div${keyCtrlPtn}`] - 1;
+				g_keycons.configFunc[g_keycons.configTypeNum](kWidth, divideCnt, keyCtrlPtn);
 			},
 		}, g_cssObj.button_Setting),
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5404,11 +5404,6 @@ function keyConfigInit(_kcType = g_kcType) {
 		// キーコンフィグリセットボタン描画
 		createCss2Button(`btnReset`, g_lblNameObj.b_reset, _ => {
 			if (window.confirm(g_msgObj.keyResetConfirm)) {
-				g_keyObj.currentKey = g_headerObj.keyLabels[g_stateObj.scoreId];
-				const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
-				const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
-				const divideCnt = g_keyObj[`div${keyCtrlPtn}`] - 1;
-
 				for (let j = 0; j < keyNum; j++) {
 					for (let k = 0; k < g_keyObj[`keyCtrl${keyCtrlPtn}`][j].length; k++) {
 						g_keyObj[`keyCtrl${keyCtrlPtn}`][j][k] = setVal(g_keyObj[`keyCtrl${keyCtrlPtn}d`][j][k], 0, C_TYP_NUMBER);
@@ -5431,8 +5426,6 @@ function keyConfigInit(_kcType = g_kcType) {
 	// キーボード押下時処理
 	setShortcutEvent(g_currentPage, setCode => {
 		const keyCdObj = document.querySelector(`#keycon${g_currentj}_${g_currentk}`);
-		const cursor = document.querySelector(`#cursor`);
-		const keyNum = g_keyObj[`chara${keyCtrlPtn}`].length;
 		let setKey = g_kCdN.findIndex(kCd => kCd === setCode);
 
 		// 全角切替、BackSpace、Deleteキー、Escキーは割り当て禁止
@@ -5561,16 +5554,16 @@ function setKeyConfigCursor(_width, _divideCnt, _keyCtrlPtn, _keyNum) {
 		dividePos = 0;
 	}
 
-	const cursor = document.querySelector(`#cursor`);
 	cursor.style.left = `${(_width - C_ARW_WIDTH) / 2 + g_keyObj.blank * stdPos - 10}px`;
+	const baseY = C_KYC_HEIGHT * dividePos + 45;
 	if (g_currentk >= 1) {
-		cursor.style.top = `${45 + C_KYC_REPHEIGHT + C_KYC_HEIGHT * dividePos}px`;
+		cursor.style.top = `${baseY + C_KYC_REPHEIGHT}px`;
 	} else {
 		if (g_kcType === `Replaced`) {
 			g_kcType = C_FLG_ALL;
 		}
 		lnkKcType.textContent = g_kcType;
-		cursor.style.top = `${45 + C_KYC_HEIGHT * dividePos}px`;
+		cursor.style.top = `${baseY}px`;
 	}
 }
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5327,10 +5327,8 @@ function keyConfigInit(_kcType = g_kcType) {
 	}
 
 	// キーパターン表示
-	let lblTransKey = ``;
-	if (hasVal(g_keyObj[`transKey${g_keyObj.currentKey}_${g_keyObj.currentPtn}`])) {
-		lblTransKey = '(' + setVal(g_keyObj[`transKey${g_keyObj.currentKey}_${g_keyObj.currentPtn}`], ``, C_TYP_STRING) + ')';
-	}
+	const lblTransKey = hasVal(g_keyObj[`transKey${keyCtrlPtn}`]) ?
+		'(' + setVal(g_keyObj[`transKey${keyCtrlPtn}`], ``, C_TYP_STRING) + ')' : ``;
 
 	// パターン検索
 	const searchPattern = (_tempPtn, _sign, _transKeyUse = false, _keyCheck = `keyCtrl`) => {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. キーコンフィグ画面内のeval関数を排除しました。
2. キーコンフィグ周りのコードを一部整理しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. すでにeval関数を使わないためのオブジェクトが用意されているため。
2. 同じ処理の繰り返しコードが混在していたため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
