### PR TITLE
[0378/cr-colorgrd] グラデーション周りのコード見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3071,12 +3071,15 @@ function headerConvert(_dosObj) {
 
 			for (let j = 0; j < colorList.length; j++) {
 				const tmpSetColorOrg = colorStr[j].replace(/0x/g, `#`).split(`:`);
-				tmpSetColorOrg.some(tmpColorOrg => {
-					if (isColorCd(tmpColorOrg) || !cssCheck(tmpColorOrg) || tmpColorOrg === `Default`) {
-						colorOrg[j] = colorCdPadding(_colorCdPaddingUse, tmpColorOrg);
+				const hasColor = tmpSetColorOrg.some(tmpColorOrg => {
+					if (hasVal(tmpColorOrg) && (isColorCd(tmpColorOrg) || !cssCheck(tmpColorOrg) || tmpColorOrg === `Default`)) {
+						colorOrg[j] = colorCdPadding(_colorCdPaddingUse, colorToHex(tmpColorOrg));
 						return true;
 					}
 				});
+				if (!hasColor) {
+					colorOrg[j] = _colorInit[j];
+				}
 				colorList[j] = makeColorGradation(colorStr[j] === `` ? _colorInit[j] : colorStr[j], {
 					_defaultColorgrd, _colorCdPaddingUse, _objType, _shadowFlg,
 				});

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3090,11 +3090,9 @@ function headerConvert(_dosObj) {
 			// 未定義の場合は指定されたデフォルト配列(_colorInit)で再定義
 			colorStr = _colorInit.concat();
 			colorOrg = _colorInit.concat();
-			for (let j = 0; j < _colorInit.length; j++) {
-				colorList[j] = makeColorGradation(_colorInit[j], {
-					_defaultColorgrd, _colorCdPaddingUse, _shadowFlg,
-				});
-			}
+			colorList = _colorInit.map(colorStr => makeColorGradation(colorStr, {
+				_defaultColorgrd, _colorCdPaddingUse, _shadowFlg,
+			}));
 		}
 
 		return [colorList, colorStr, colorOrg];

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2145,11 +2145,9 @@ const colorToHex = (_color) => {
 	// 透明度はカラーコード形式に変換してRGBの後ろに設定
 	const tmpColor = _color.split(`;`);
 	const colorSet = tmpColor[0].split(` `);
-	let alphaVal = ``;
-	if (tmpColor.length > 1) {
-		alphaVal = byteToHex(setVal(tmpColor[1], 255, C_TYP_NUMBER));
-	}
-	return `${colorNameToCode(colorSet[0])}${alphaVal}${colorSet[1] !== undefined ? ` ${colorSet.slice(1).join(' ')}` : ''}`;
+	return colorNameToCode(colorSet[0]) +
+		(tmpColor.length > 1 ? byteToHex(setVal(tmpColor[1], 255, C_TYP_NUMBER)) : '') +
+		(colorSet[1] !== undefined ? ` ${colorSet.slice(1).join(' ')}` : '');
 }
 
 /**
@@ -2188,27 +2186,27 @@ function makeColorGradation(_colorStr, { _defaultColorgrd = g_headerObj.defaultC
 	const colorArray = tmpColorStr[0].split(`:`);
 	for (let j = 0; j < colorArray.length; j++) {
 		colorArray[j] = colorCdPadding(_colorCdPaddingUse, colorToHex(colorArray[j].replace(/0x/g, `#`)));
-		if (j === 0 && !isColorCd(colorArray[0])) {
-		} else if (colorArray[j].length === 7) {
+		if (isColorCd(colorArray[j]) && colorArray[j].length === 7) {
 			colorArray[j] += alphaVal;
 		}
 	}
 
 	const gradationType = (tmpColorStr.length > 1 ? tmpColorStr[1] : `linear-gradient`);
-	const defaultDir = (_objType === `titleArrow` ? `to left` : `to right`);
+	const defaultDir = `to ${(_objType === 'titleArrow' ? 'left' : 'right')}, `;
 	if (colorArray.length === 1) {
 		if (_objType === `titleMusic`) {
-			convertColorStr = `${defaultDir}, ${colorArray[0]} 100%, #eeeeee${alphaVal} 0%`;
+			convertColorStr = `${defaultDir}${colorArray[0]} 100%, #eeeeee${alphaVal} 0%`;
 		} else if (_defaultColorgrd[0]) {
-			convertColorStr = `${defaultDir}, ${colorArray[0]}, ${_defaultColorgrd[1]}${alphaVal}, ${colorArray[0]}`;
+			convertColorStr = `${defaultDir}${colorArray[0]}, ${_defaultColorgrd[1]}${alphaVal}, ${colorArray[0]}`;
 		} else {
-			convertColorStr = `${defaultDir}, ${colorArray[0]}, ${colorArray[0]}`;
+			return colorArray[0];
 		}
-	} else if (gradationType === `linear-gradient` && (isColorCd(colorArray[0]) || !cssCheck(colorArray[0]))) {
-		// "to XXXX" もしくは "XXXdeg(rad, grad, turn)"のパターン以外は方向を補完する
-		convertColorStr = `${defaultDir}, ${colorArray.join(', ')}`;
 	} else {
-		convertColorStr = `${colorArray.join(', ')}`;
+		if (gradationType === `linear-gradient` && (isColorCd(colorArray[0]) || !cssCheck(colorArray[0]))) {
+			// "to XXXX" もしくは "XXXdeg(rad, grad, turn)"のパターン以外は方向を補完する
+			convertColorStr = `${defaultDir}`;
+		}
+		convertColorStr += `${colorArray.join(', ')}`;
 	}
 
 	return `${gradationType}(${convertColorStr})`;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2173,8 +2173,8 @@ function makeColorGradation(_colorStr, { _defaultColorgrd = g_headerObj.defaultC
 	// |color_data=300,20,#ffff99:#ffffff:#9999ff@radial-gradient|
 	// |color_data=300,20,#ffff99:#ffffff:#9999ff@conic-gradient|
 
-	if (_colorStr === `Default`) {
-		return `Default`;
+	if (_colorStr === `Default` || _colorStr === ``) {
+		return _colorStr;
 	}
 
 	// 矢印の塗りつぶしの場合：透明度を50%にする
@@ -3088,7 +3088,7 @@ function headerConvert(_dosObj) {
 			colorStr = _colorInit.concat();
 			colorOrg = _colorInit.concat();
 			for (let j = 0; j < _colorInit.length; j++) {
-				colorList[j] = _colorInit[j] === `` ? `` : makeColorGradation(_colorInit[j], {
+				colorList[j] = makeColorGradation(_colorInit[j], {
 					_defaultColorgrd, _colorCdPaddingUse, _shadowFlg,
 				});
 			}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2127,7 +2127,7 @@ const isColorCd = _str => _str.substring(0, 1) === `#`;
  * @param {string} _str 
  * @returns 
  */
-const cssCheck = _str => listMatching(_str, g_cssCheckStr.header, { prefix: `^` }) ||
+const hasAnglePointInfo = _str => listMatching(_str, g_cssCheckStr.header, { prefix: `^` }) ||
 	listMatching(_str, g_cssCheckStr.header, { prefix: `^` });
 
 /**
@@ -2137,7 +2137,7 @@ const cssCheck = _str => listMatching(_str, g_cssCheckStr.header, { prefix: `^` 
 const colorToHex = (_color) => {
 
 	// すでにカラーコードのものやパーセント表記、位置表記系を除外
-	if (!isNaN(parseFloat(_color)) || isColorCd(_color) || cssCheck(_color)) {
+	if (!isNaN(parseFloat(_color)) || isColorCd(_color) || hasAnglePointInfo(_color)) {
 		return _color;
 	}
 
@@ -2202,7 +2202,7 @@ function makeColorGradation(_colorStr, { _defaultColorgrd = g_headerObj.defaultC
 			return colorArray[0];
 		}
 	} else {
-		if (gradationType === `linear-gradient` && (isColorCd(colorArray[0]) || !cssCheck(colorArray[0]))) {
+		if (gradationType === `linear-gradient` && (isColorCd(colorArray[0]) || !hasAnglePointInfo(colorArray[0]))) {
 			// "to XXXX" もしくは "XXXdeg(rad, grad, turn)"のパターン以外は方向を補完する
 			convertColorStr = `${defaultDir}`;
 		}
@@ -3072,7 +3072,7 @@ function headerConvert(_dosObj) {
 			for (let j = 0; j < colorList.length; j++) {
 				const tmpSetColorOrg = colorStr[j].replace(/0x/g, `#`).split(`:`);
 				const hasColor = tmpSetColorOrg.some(tmpColorOrg => {
-					if (hasVal(tmpColorOrg) && (isColorCd(tmpColorOrg) || !cssCheck(tmpColorOrg) || tmpColorOrg === `Default`)) {
+					if (hasVal(tmpColorOrg) && (isColorCd(tmpColorOrg) || !hasAnglePointInfo(tmpColorOrg) || tmpColorOrg === `Default`)) {
 						colorOrg[j] = colorCdPadding(_colorCdPaddingUse, colorToHex(tmpColorOrg));
 						return true;
 					}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. グラデーション周りのコード見直しました。
2. setColorを部分的に未指定にした場合（`例：|setColor=,#ff6666|`）、
タイトルの背景矢印や文字が未指定になってしまう問題を修正しました。
デフォルトの色配列から取得するように変更しています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. コード集約によるコードの見やすさのため。
2. 上記問題の解消のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 条件式を統一した結果、条件が変わっているものがあるので影響が無いか確認すること。
- 2.のケースはヘッダ一部未指定時の補完処理のため、過去バージョンの適用までは基本行わない。