### PR TITLE
[0379/colorgrd-init] グラデーション変数の初期化漏れを修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2189,7 +2189,7 @@ function makeColorGradation(_colorStr, { _defaultColorgrd = g_headerObj.defaultC
 	// 背景矢印の場合　　　　：透明度を25%にする
 	const alphaVal = (_shadowFlg && _objType !== `frz`) ? `80` : (_objType === `titleArrow` ? `40` : ``);
 
-	let convertColorStr;
+	let convertColorStr = ``;
 	const tmpColorStr = _colorStr.split(`@`);
 	const colorArray = tmpColorStr[0].split(`:`);
 	for (let j = 0; j < colorArray.length; j++) {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. グラデーション変数の初期化漏れを修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. makeColorGradation関数のconvertColorStr変数について、これまでは初期化しなくても良い記述になっていましたが、ver20.5.0の変更により文字列結合する箇所が追加されたため、初期化が必要になりました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
