### PR TITLE
[0380/dif-shortcut] 譜面セレクター表示時に関する仕様変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2269,8 +2269,10 @@ const createScTextCommon = _displayName => {
  * @param {string} _displayName
  * @param {function} _func 
  */
-const setShortcutEvent = (_displayName, _func = _ => true) => {
-	createScTextCommon(_displayName);
+const setShortcutEvent = (_displayName, _func = _ => true, _displayFlg = true) => {
+	if (_displayFlg) {
+		createScTextCommon(_displayName);
+	}
 	const evList = _ => {
 		document.onkeydown = evt => commonKeyDown(evt, _displayName, _func);
 		document.onkeyup = evt => commonKeyUp(evt);
@@ -3733,6 +3735,7 @@ function optionInit() {
 	const divRoot = document.querySelector(`#divRoot`);
 	g_baseDisp = `Settings`;
 	g_currentPage = `option`;
+	g_stateObj.filterKeys = ``;
 
 	// タイトル文字描画
 	divRoot.appendChild(getTitleDivLabel(`lblTitle`, g_lblNameObj.settings, 0, 15, `settings_Title`));
@@ -3856,10 +3859,9 @@ function createOptionWindow(_sprite) {
 	const resetDifWindow = _ => {
 		if (document.querySelector(`#difList`) !== null) {
 			deleteChildspriteAll(`difList`);
-			optionsprite.removeChild(document.querySelector(`#difList`));
-			optionsprite.removeChild(document.querySelector(`#difCover`));
+			[`difList`, `difCover`, `btnDifU`, `btnDifD`].forEach(obj => optionsprite.removeChild(document.getElementById(obj)));
 			g_currentPage = `option`;
-			setShortcutEvent(g_currentPage);
+			setShortcutEvent(g_currentPage, _ => true, false);
 		}
 	};
 
@@ -3891,7 +3893,7 @@ function createOptionWindow(_sprite) {
 					nextDifficulty(j - g_stateObj.scoreId);
 				}, { btnStyle: (j === g_stateObj.scoreId ? `Setting` : `Default`) }));
 				if (j === g_stateObj.scoreId) {
-					pos = k + 2;
+					pos = k + 6;
 				}
 				k++;
 			}
@@ -3900,39 +3902,77 @@ function createOptionWindow(_sprite) {
 		difList.scrollTop = (overlength > 0 ? overlength : 0);
 	};
 
+	/**
+	 * 譜面セレクター位置の変更ボタン
+	 * @param {number} _scrollNum 
+	 * @returns 
+	 */
+	const makeDifBtn = (_scrollNum = 1) => {
+		const dir = _scrollNum === 1 ? `D` : `U`;
+		return createCss2Button(`btnDif${dir}`, g_settingBtnObj.chara[dir], _ => {
+			do {
+				nextDifficulty(_scrollNum);
+			} while (g_stateObj.filterKeys !== `` && g_stateObj.filterKeys !== g_headerObj.keyLabels[g_stateObj.scoreId]);
+			createDifWindow(g_stateObj.filterKeys);
+		}, {
+			x: 430 + _scrollNum * 10, y: 40, w: 20, h: 20, siz: C_SIZ_JDGCNTS,
+		}, g_cssObj.button_Mini);
+	};
+
+	/**
+	 * 譜面変更セレクターの作成・再作成
+	 * @param {string} _key
+	 */
+	const createDifWindow = (_key = ``) => {
+		g_currentPage = `difSelector`;
+		setShortcutEvent(g_currentPage);
+		const difList = createSprite(`optionsprite`, `difList`, 165, 65, 280, 255);
+		difList.style.overflow = `auto`;
+		difList.classList.toggle(g_cssObj.settings_DifSelector, true);
+		const difCover = createSprite(`optionsprite`, `difCover`, 25, 65, 140, 255);
+		difCover.style.overflow = `auto`;
+		difCover.classList.toggle(g_cssObj.settings_DifSelector, true);
+		difCover.style.opacity = 0.95;
+
+		// リスト再作成
+		makeDifList(difList, _key);
+
+		// ランダム選択
+		difCover.appendChild(
+			makeDifLblCssButton(`difRandom`, `RANDOM`, 0, _ => {
+				nextDifficulty(Math.floor(Math.random() * g_headerObj.keyLabels.length));
+			}, { w: C_LEN_DIFCOVER_WIDTH })
+		);
+
+		// 全リスト
+		difCover.appendChild(
+			makeDifLblCssButton(`keyFilter`, `ALL`, 1.5, _ => {
+				deleteChildspriteAll(`difList`);
+				g_stateObj.filterKeys = ``;
+				makeDifList(difList);
+			}, { w: C_LEN_DIFCOVER_WIDTH })
+		);
+
+		// キー別フィルタボタン作成
+		g_headerObj.keyLists.forEach((targetKey, m) => {
+			difCover.appendChild(
+				makeDifLblCssButton(`keyFilter${m}`, `${targetKey} key`, m + 2.5, _ => {
+					deleteChildspriteAll(`difList`);
+					g_stateObj.filterKeys = targetKey;
+					makeDifList(difList, targetKey);
+				}, { w: C_LEN_DIFCOVER_WIDTH })
+			);
+		});
+
+		multiAppend(optionsprite, makeDifBtn(-1), makeDifBtn());
+	};
+
 	const lnkDifficulty = makeSettingLblCssButton(`lnkDifficulty`,
 		``, 0, _ => {
 			if (g_headerObj.difSelectorUse) {
+				g_stateObj.filterKeys = ``;
 				if (document.querySelector(`#difList`) === null) {
-					g_currentPage = `difSelector`;
-					setShortcutEvent(g_currentPage);
-					const difList = createSprite(`optionsprite`, `difList`, 165, 65, 280, 255);
-					difList.style.overflow = `auto`;
-					difList.classList.toggle(g_cssObj.settings_DifSelector, true);
-					const difCover = createSprite(`optionsprite`, `difCover`, 25, 65, 140, 255);
-					difCover.style.overflow = `auto`;
-					difCover.classList.toggle(g_cssObj.settings_DifSelector, true);
-					difCover.style.opacity = 0.95;
-
-					// 全リスト作成
-					makeDifList(difList);
-
-					// ランダム選択
-					difCover.appendChild(
-						makeDifLblCssButton(`difRandom`, `RANDOM`, 0, _ => {
-							nextDifficulty(Math.floor(Math.random() * g_headerObj.keyLabels.length));
-						}, { w: 110 })
-					);
-
-					// キー別フィルタボタン作成
-					g_headerObj.keyLists.forEach((targetKey, m) => {
-						difCover.appendChild(
-							makeDifLblCssButton(`keyFilter${m}`, `${targetKey} key`, m + 1.5, _ => {
-								deleteChildspriteAll(`difList`);
-								makeDifList(difList, targetKey);
-							}, { w: 110 })
-						);
-					});
+					createDifWindow();
 				} else {
 					resetDifWindow();
 				}
@@ -3943,6 +3983,7 @@ function createOptionWindow(_sprite) {
 		y: -10, h: C_LEN_SETLBL_HEIGHT + 10,
 		cxtFunc: _ => {
 			if (g_headerObj.difSelectorUse) {
+				g_stateObj.filterKeys = ``;
 				resetDifWindow();
 			} else {
 				nextDifficulty(-1);
@@ -3957,6 +3998,9 @@ function createOptionWindow(_sprite) {
 		makeMiniCssButton(`lnkDifficulty`, `L`, 0, _ => nextDifficulty(-1), { dy: -10, dh: 10 }),
 	)
 	createScText(spriteList.difficulty, `Difficulty`);
+	if (g_headerObj.difSelectorUse) {
+		createScText(spriteList.difficulty, `DifficultyList`, { x: 147, y: -10, targetLabel: `lnkDifficulty` });
+	}
 
 	// ---------------------------------------------------
 	// ハイスコア機能実装時に使用予定のスペース

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3911,9 +3911,11 @@ function createOptionWindow(_sprite) {
 		const dir = _scrollNum === 1 ? `D` : `U`;
 		return createCss2Button(`btnDif${dir}`, g_settingBtnObj.chara[dir], _ => {
 			do {
-				nextDifficulty(_scrollNum);
+				g_stateObj.scoreId = (g_stateObj.scoreId + g_headerObj.keyLabels.length + _scrollNum) % g_headerObj.keyLabels.length;
 			} while (g_stateObj.filterKeys !== `` && g_stateObj.filterKeys !== g_headerObj.keyLabels[g_stateObj.scoreId]);
-			createDifWindow(g_stateObj.filterKeys);
+			setDifficulty(true);
+			deleteChildspriteAll(`difList`);
+			makeDifList(difList, g_stateObj.filterKeys);
 		}, {
 			x: 430 + _scrollNum * 10, y: 40, w: 20, h: 20, siz: C_SIZ_JDGCNTS,
 		}, g_cssObj.button_Mini);
@@ -3947,22 +3949,28 @@ function createOptionWindow(_sprite) {
 		// 全リスト
 		difCover.appendChild(
 			makeDifLblCssButton(`keyFilter`, `ALL`, 1.5, _ => {
-				deleteChildspriteAll(`difList`);
+				resetDifWindow();
 				g_stateObj.filterKeys = ``;
-				makeDifList(difList);
-			}, { w: C_LEN_DIFCOVER_WIDTH })
+				createDifWindow();
+			}, { w: C_LEN_DIFCOVER_WIDTH, btnStyle: (g_stateObj.filterKeys === `` ? `Setting` : `Default`) })
 		);
 
 		// キー別フィルタボタン作成
+		let pos = 0;
 		g_headerObj.keyLists.forEach((targetKey, m) => {
 			difCover.appendChild(
 				makeDifLblCssButton(`keyFilter${m}`, `${targetKey} key`, m + 2.5, _ => {
-					deleteChildspriteAll(`difList`);
+					resetDifWindow();
 					g_stateObj.filterKeys = targetKey;
-					makeDifList(difList, targetKey);
-				}, { w: C_LEN_DIFCOVER_WIDTH })
+					createDifWindow(targetKey);
+				}, { w: C_LEN_DIFCOVER_WIDTH, btnStyle: (g_stateObj.filterKeys === targetKey ? `Setting` : `Default`) })
 			);
+			if (g_stateObj.filterKeys === targetKey) {
+				pos = m + 9;
+			}
 		});
+		const overlength = pos * C_LEN_SETLBL_HEIGHT - parseInt(difCover.style.height);
+		difCover.scrollTop = (overlength > 0 ? overlength : 0);
 
 		multiAppend(optionsprite, makeDifBtn(-1), makeDifBtn());
 	};

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3858,7 +3858,19 @@ function createOptionWindow(_sprite) {
 			deleteChildspriteAll(`difList`);
 			optionsprite.removeChild(document.querySelector(`#difList`));
 			optionsprite.removeChild(document.querySelector(`#difCover`));
+			g_currentPage = `option`;
+			setShortcutEvent(g_currentPage);
 		}
+	};
+
+	/**
+	 * 譜面選択処理
+	 * @param {number} _scrollNum 
+	 */
+	const nextDifficulty = (_scrollNum = 1) => {
+		g_stateObj.scoreId = (g_stateObj.scoreId + g_headerObj.keyLabels.length + _scrollNum) % g_headerObj.keyLabels.length;
+		setDifficulty(true);
+		resetDifWindow();
 	};
 
 	/**
@@ -3875,28 +3887,19 @@ function createOptionWindow(_sprite) {
 					text += ` (${g_headerObj.creatorNames[j]})`;
 				}
 				_difList.appendChild(makeDifLblCssButton(`dif${k}`, text, k, _ => {
-					g_stateObj.scoreId = j;
-					setDifficulty(true);
-					resetDifWindow();
+					nextDifficulty(j - g_stateObj.scoreId);
 				}));
 				k++;
 			}
 		});
 	};
 
-	// 譜面選択処理
-	const nextDifficulty = (_scrollNum = 1, _resetFlg = false) => {
-		g_stateObj.scoreId = (g_stateObj.scoreId + g_headerObj.keyLabels.length + _scrollNum) % g_headerObj.keyLabels.length;
-		setDifficulty(true);
-		if (_resetFlg) {
-			resetDifWindow();
-		}
-	};
-
 	const lnkDifficulty = makeSettingLblCssButton(`lnkDifficulty`,
 		``, 0, _ => {
 			if (g_headerObj.difSelectorUse) {
 				if (document.querySelector(`#difList`) === null) {
+					g_currentPage = `difSelector`;
+					setShortcutEvent(g_currentPage);
 					const difList = createSprite(`optionsprite`, `difList`, 165, 65, 280, 255);
 					difList.style.overflow = `auto`;
 					difList.classList.toggle(g_cssObj.settings_DifSelector, true);
@@ -3911,9 +3914,7 @@ function createOptionWindow(_sprite) {
 					// ランダム選択
 					difCover.appendChild(
 						makeDifLblCssButton(`difRandom`, `RANDOM`, 0, _ => {
-							g_stateObj.scoreId = Math.floor(Math.random() * g_headerObj.keyLabels.length);
-							setDifficulty(true);
-							resetDifWindow();
+							nextDifficulty(Math.floor(Math.random() * g_headerObj.keyLabels.length));
 						}, { w: 110 })
 					);
 
@@ -3946,8 +3947,8 @@ function createOptionWindow(_sprite) {
 	// 譜面選択ボタン（メイン、右回し、左回し）
 	multiAppend(spriteList.difficulty,
 		lnkDifficulty,
-		makeMiniCssButton(`lnkDifficulty`, `R`, 0, _ => nextDifficulty(1, true), { dy: -10, dh: 10 }),
-		makeMiniCssButton(`lnkDifficulty`, `L`, 0, _ => nextDifficulty(-1, true), { dy: -10, dh: 10 }),
+		makeMiniCssButton(`lnkDifficulty`, `R`, 0, _ => nextDifficulty(), { dy: -10, dh: 10 }),
+		makeMiniCssButton(`lnkDifficulty`, `L`, 0, _ => nextDifficulty(-1), { dy: -10, dh: 10 }),
 	)
 	createScText(spriteList.difficulty, `Difficulty`);
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3880,6 +3880,7 @@ function createOptionWindow(_sprite) {
 	 */
 	const makeDifList = (_difList, _targetKey = ``) => {
 		let k = 0;
+		let pos = 0;
 		g_headerObj.keyLabels.forEach((keyLabel, j) => {
 			if (_targetKey === `` || keyLabel === _targetKey) {
 				let text = `${keyLabel} / ${g_headerObj.difLabels[j]}`;
@@ -3889,9 +3890,14 @@ function createOptionWindow(_sprite) {
 				_difList.appendChild(makeDifLblCssButton(`dif${k}`, text, k, _ => {
 					nextDifficulty(j - g_stateObj.scoreId);
 				}, { btnStyle: (j === g_stateObj.scoreId ? `Setting` : `Default`) }));
+				if (j === g_stateObj.scoreId) {
+					pos = k + 2;
+				}
 				k++;
 			}
 		});
+		const overlength = pos * C_LEN_SETLBL_HEIGHT - parseInt(difList.style.height);
+		difList.scrollTop = (overlength > 0 ? overlength : 0);
 	};
 
 	const lnkDifficulty = makeSettingLblCssButton(`lnkDifficulty`,

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3888,7 +3888,7 @@ function createOptionWindow(_sprite) {
 				}
 				_difList.appendChild(makeDifLblCssButton(`dif${k}`, text, k, _ => {
 					nextDifficulty(j - g_stateObj.scoreId);
-				}));
+				}, { btnStyle: (j === g_stateObj.scoreId ? `Setting` : `Default`) }));
 				k++;
 			}
 		});
@@ -4925,13 +4925,13 @@ function makeSettingLblCssButton(_id, _name, _heightPos, _func, { x, y, w, h, si
  * @param {number} _heightPos 上からの配置順
  * @param {function} _func
  */
-function makeDifLblCssButton(_id, _name, _heightPos, _func, { x = 0, w = C_LEN_DIFSELECTOR_WIDTH, } = {}) {
+function makeDifLblCssButton(_id, _name, _heightPos, _func, { x = 0, w = C_LEN_DIFSELECTOR_WIDTH, btnStyle = `Default` } = {}) {
 	return createCss2Button(_id, _name, _func, {
 		x: x, y: C_LEN_SETLBL_HEIGHT * _heightPos,
 		w: w, h: C_LEN_SETLBL_HEIGHT,
 		siz: C_SIZ_DIFSELECTOR,
 		borderStyle: `solid`,
-	}, g_cssObj.button_Default, g_cssObj.button_ON);
+	}, g_cssObj[`button_${btnStyle}`], g_cssObj.button_ON);
 }
 
 /**

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -763,6 +763,17 @@ const g_shortcutObj = {
         ShiftLeft_Tab: { id: `btnBack` },
         Tab: { id: `btnDisplay` },
     },
+    difSelector: {
+        ShiftLeft_KeyD: { id: `lnkDifficultyL` },
+        KeyD: { id: `lnkDifficultyR` },
+        KeyR: { id: `difRandom` },
+
+        Escape: { id: `btnBack` },
+        Space: { id: `btnKeyConfig` },
+        Enter: { id: `btnPlay` },
+        ShiftLeft_Tab: { id: `btnBack` },
+        Tab: { id: `btnDisplay` },
+    },
     settingsDisplay: {
         ShiftLeft_KeyA: { id: `lnkAppearanceL` },
         KeyA: { id: `lnkAppearanceR` },
@@ -826,6 +837,7 @@ const g_btnWaitFrame = {
     initial: { b_frame: 0, s_frame: 0 },
     title: { b_frame: 0, s_frame: 0 },
     option: { b_frame: 0, s_frame: 0, initial: true },
+    difSelector: { b_frame: 0, s_frame: 0 },
     settingsDisplay: { b_frame: 0, s_frame: 0 },
     keyConfig: { b_frame: 0, s_frame: 30 },
     loading: { b_frame: 0, s_frame: 0 },
@@ -838,6 +850,7 @@ const g_btnWaitFrame = {
 const g_btnPatterns = {
     title: { Start: 0, Comment: -10 },
     option: { Back: 0, KeyConfig: 0, Play: 0, Display: -5, Save: -10, Graph: -25 },
+    difSelector: {},
     settingsDisplay: { Back: 0, KeyConfig: 0, Play: 0, Settings: -5 },
     loadingIos: { Play: 0 },
     keyConfig: { Back: -3 },

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -167,6 +167,7 @@ const C_BLOCK_KEYS = [
 const C_LEN_SETLBL_LEFT = 160;
 const C_LEN_SETLBL_WIDTH = 210;
 const C_LEN_DIFSELECTOR_WIDTH = 250;
+const C_LEN_DIFCOVER_WIDTH = 110;
 const C_LEN_SETLBL_HEIGHT = 23;
 const C_SIZ_SETLBL = 17;
 const C_LEN_SETDIFLBL_HEIGHT = 25;
@@ -190,6 +191,8 @@ const g_settingBtnObj = {
         LL: `<`,
         R: `>`,
         RR: `>`,
+        D: `↓`,
+        U: `↑`,
     },
     pos: {
         L: C_LEN_SETLBL_LEFT - C_LEN_SETMINI_WIDTH,
@@ -315,6 +318,7 @@ const g_stateObj = {
     lifeBorder: 70,
     lifeInit: 25,
     lifeVariable: C_FLG_OFF,
+    filterKeys: ``,
 
     extraKeyFlg: false,
     dataSaveFlg: true,
@@ -724,6 +728,7 @@ const g_shortcutObj = {
         ArrowRight: { id: `lnkSpeedRR` },
         ShiftLeft_ArrowLeft: { id: `lnkSpeedL` },
         ArrowLeft: { id: `lnkSpeedLL` },
+        KeyL: { id: `lnkDifficulty` },
 
         ShiftLeft_KeyM: { id: `lnkMotionL` },
         KeyM: { id: `lnkMotionR` },
@@ -767,10 +772,13 @@ const g_shortcutObj = {
         ShiftLeft_KeyD: { id: `lnkDifficultyL` },
         KeyD: { id: `lnkDifficultyR` },
         KeyR: { id: `difRandom` },
+        KeyL: { id: `lnkDifficulty` },
+        ArrowDown: { id: `btnDifD` },
+        ArrowUp: { id: `btnDifU` },
 
         Escape: { id: `btnBack` },
         Space: { id: `btnKeyConfig` },
-        Enter: { id: `btnPlay` },
+        Enter: { id: `lnkDifficulty` },
         ShiftLeft_Tab: { id: `btnBack` },
         Tab: { id: `btnDisplay` },
     },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 譜面セレクター表示時、非表示部のショートカットが動かないよう変更しました。
譜面セレクターを表示している間は、`g_currentPage = 'difSelector';`として動作します。
2. 譜面セレクター上選択済の譜面に色が付くよう変更しました。
3. 譜面数が多くスクロールがある場合、譜面セレクターを開き直したときに
選択中の譜面が見えるよう初期スクロール位置を調整しました。
4. 譜面セレクター表示時、上下キーで譜面移動できるようにしました。
また、`Enter`キーもしくは`L`キーでセレクターを閉じます。（逆に開く場合は`L`キー）
5. 譜面セレクターのキー別フィルターとは別に「ALL」を追加しました。（キー別フィルターの解除）

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 誤操作防止のため。
2. 選択中の譜面が何かわかるようにするため。
3. 2.に関連した修正です。
4. 2.に関連した修正です。
5. 2.に関連した修正です。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/110326834-887a6000-805c-11eb-807e-96d5e8f4eba7.png" width="70%">

## :pencil: その他コメント / Other Comments
- 譜面明細（速度グラフ、密度グラフ、ツール値表示）については画面扱いでは無くそのままです。
- setShortcutEvent関数の第三引数に`_displayFlg`を追加しています。
これを`false`に設定すると、ショートカットキーの表示部を描画しません。
画面を再描画せずそのまま利用する場合に利用します。
- makeDifLblCssButton関数のオブジェクト引数`btnStyle`を追加しました。
ボタンクラスをオプションで変更できるようになります。
- nextDifficulty関数の第二引数を削除しました（引数を分ける意味が無かったため）。