### PR TITLE
[0381/titlegrd] グラデーションにdeg/radなどが入っているときに文字が表示されない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2136,7 +2136,7 @@ const isColorCd = _str => _str.substring(0, 1) === `#`;
  * @returns 
  */
 const hasAnglePointInfo = _str => listMatching(_str, g_cssCheckStr.header, { prefix: `^` }) ||
-	listMatching(_str, g_cssCheckStr.header, { prefix: `^` });
+	listMatching(_str, g_cssCheckStr.footer, { suffix: `$` });
 
 /**
  * 色名をカラーコードへ変換 (元々カラーコードの場合は除外)


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. グラデーション文字列にdeg/radなどが入っているときに文字が表示されない問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 位置表記を抽出する条件式に誤りがあり、
180degや0.5turnが入っている場合でも to left/to right が保管されるようになっていました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- ver20.5.1に実装した`hasAnglePointInfo`関数の実装間違いによるものです。 