### PR TITLE
[0384/cr-keyconfig] キーコンフィグ周りのコード整理

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5196,7 +5196,7 @@ function keyConfigInit(_kcType = g_kcType) {
 
 		// キーコンフィグ表示用の矢印・おにぎりを表示
 		const keyconX = g_keyObj.blank * stdPos + (kWidth - C_ARW_WIDTH) / 2;
-		const keyconY = C_KYC_HEIGHT * (posj <= divideCnt ? 0 : 1);
+		const keyconY = C_KYC_HEIGHT * (Number(posj > divideCnt));
 		const colorPos = g_keyObj[`color${keyCtrlPtn}`][j];
 		const arrowColor = getKeyConfigColor(j, colorPos);
 
@@ -5307,12 +5307,10 @@ function keyConfigInit(_kcType = g_kcType) {
 	 */
 	const setKeyConfigCursor = _ => {
 		const posj = g_keyObj[`pos${keyCtrlPtn}`][g_currentj];
-		const posMax = (g_keyObj[`divMax${keyCtrlPtn}`] !== undefined ?
-			g_keyObj[`divMax${keyCtrlPtn}`] : g_keyObj[`pos${keyCtrlPtn}`][keyNum - 1] + 1);
 		const stdPos = posj - ((posj <= divideCnt ? 0 : posMax) + divideCnt) / 2;
 
 		cursor.style.left = `${(kWidth - C_ARW_WIDTH) / 2 + g_keyObj.blank * stdPos - 10}px`;
-		const baseY = C_KYC_HEIGHT * (posj <= divideCnt ? 0 : 1) + 45;
+		const baseY = C_KYC_HEIGHT * Number(posj > divideCnt) + 45;
 		if (g_currentk >= 1) {
 			cursor.style.top = `${baseY + C_KYC_REPHEIGHT}px`;
 		} else {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5192,7 +5192,7 @@ function keyConfigInit(_kcType = g_kcType) {
 	for (let j = 0; j < keyNum; j++) {
 
 		const posj = g_keyObj[`pos${keyCtrlPtn}`][j];
-		const stdPos = posj - ((posj <= divideCnt ? 0 : posMax) + divideCnt) / 2;
+		const stdPos = posj - ((posj > divideCnt ? posMax : 0) + divideCnt) / 2;
 
 		// キーコンフィグ表示用の矢印・おにぎりを表示
 		const keyconX = g_keyObj.blank * stdPos + (kWidth - C_ARW_WIDTH) / 2;
@@ -5307,7 +5307,7 @@ function keyConfigInit(_kcType = g_kcType) {
 	 */
 	const setKeyConfigCursor = _ => {
 		const posj = g_keyObj[`pos${keyCtrlPtn}`][g_currentj];
-		const stdPos = posj - ((posj <= divideCnt ? 0 : posMax) + divideCnt) / 2;
+		const stdPos = posj - ((posj > divideCnt ? posMax : 0) + divideCnt) / 2;
 
 		cursor.style.left = `${(kWidth - C_ARW_WIDTH) / 2 + g_keyObj.blank * stdPos - 10}px`;
 		const baseY = C_KYC_HEIGHT * Number(posj > divideCnt) + 45;
@@ -5489,12 +5489,17 @@ function keyConfigInit(_kcType = g_kcType) {
 			(keyIsDown(`MetaLeft`) && keyIsDown(`ShiftLeft`))) {
 			return;
 		}
+
 		if (setKey === C_KEY_RETRY && (!g_isMac || (g_isMac && g_currentk === 0))) {
+			// スキップ
 		} else {
+			// キー割り当て処理
 			if (setKey === C_KEY_TITLEBACK || setKey === C_KEY_RETRY) {
+				// キー無効化（代替キーのみ）
 				setKey = 0;
 			}
 			if (g_keyObj[`keyCtrl${keyCtrlPtn}d`][g_currentj][g_currentk] !== setKey) {
+				// 既定キーと異なる場合は色付け
 				removeClassList(g_currentj, g_currentk);
 				keyCdObj.classList.add(g_cssObj.keyconfig_Changekey);
 			}
@@ -5503,9 +5508,9 @@ function keyConfigInit(_kcType = g_kcType) {
 			g_prevKey = setKey;
 		}
 
-		// 後続に代替キーが存在する場合
-		if (g_currentk < g_keyObj[`keyCtrl${keyCtrlPtn}`][g_currentj].length - 1 &&
-			g_kcType !== `Main`) {
+		// カーソル移動
+		if (g_currentk < g_keyObj[`keyCtrl${keyCtrlPtn}`][g_currentj].length - 1 && g_kcType !== `Main`) {
+			// 後続に代替キーが存在する場合
 			g_currentk++;
 			cursor.style.top = `${parseInt(cursor.style.top) + C_KYC_REPHEIGHT}px`;
 
@@ -7000,7 +7005,7 @@ function getArrowSettings() {
 
 		const posj = g_keyObj[`pos${keyCtrlPtn}`][j];
 		const colorj = g_keyObj[`color${keyCtrlPtn}`][j];
-		const stdPos = posj - ((posj <= divideCnt ? 0 : posMax) + divideCnt) / 2;
+		const stdPos = posj - ((posj > divideCnt ? posMax : 0) + divideCnt) / 2;
 
 		g_workObj.stepX[j] = g_keyObj.blank * stdPos + (g_headerObj.playingWidth - C_ARW_WIDTH) / 2;
 		g_workObj.dividePos[j] = ((posj <= divideCnt ? 0 : 1) + (scrollDirOptions[j] === 1 ? 0 : 1) + (g_stateObj.reverse === C_FLG_OFF ? 0 : 1)) % 2;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -394,7 +394,6 @@ g_settings.opacityNum = g_settings.opacitys.length - 1;
 
 const g_keycons = {
     configTypes: [`Main`, `Replaced`, `ALL`],
-    configFunc: [resetCursorMain, resetCursorReplaced, resetCursorALL],
     configTypeNum: 0,
 
     colorTypes: [`Default`, `Type0`, `Type1`, `Type2`],


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. キーコンフィグ周りのコードを整理しました。
    - resetCursor, setKeyConfigCursor関数の引数を整理し、冗長な引数をカット。keyConfigInit配下に配置。
    - resetCursorMain, resetCursorReplaced, resetCursorALL関数を廃止。
    直接resetCursorを呼び出すように変更。
    - カーソル移動用の関数としてsearchNextCursor関数を切り出し。
    - 二重定義箇所を見直し、基本的にkeyConfigInitで定義した変数を利用するように変更。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. #1006 にてeval関数を削除したが、構造的にあまり変わっておらずコードの見通しが悪いため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
