### PR TITLE
[0385/ex-setcolor] 初期矢印・フリーズアロー色の定義拡張

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3264,10 +3264,8 @@ function resetBaseColorList(_baseObj, _dosObj, { scoreId = `` } = {}) {
 			});
 		}
 
-		if (pattern === ``) {
-			obj[`${_name}Default`] = obj[_name].concat();
-			obj[`${_frzName}Default`] = obj[_frzName].concat();
-		}
+		obj[`${_name}Default`] = obj[_name].concat();
+		obj[`${_frzName}Default`] = obj[_frzName].concat();
 	});
 
 	return obj;
@@ -5143,6 +5141,7 @@ function keyConfigInit(_kcType = g_kcType) {
 	});
 	keyconSprite.style.transform = `scale(${g_keyObj.scale})`;
 	const kWidth = parseInt(keyconSprite.style.width);
+	changeSetColor();
 
 	/**
 	 * キーコンフィグ用の矢印色を取得
@@ -5339,8 +5338,17 @@ function keyConfigInit(_kcType = g_kcType) {
 			g_stateObj.d_color = g_keycons.colorDefs[nextNum];
 		}
 		changeSetColor();
+
 		for (let j = 0; j < keyNum; j++) {
-			$id(`arrow${j}`).background = getKeyConfigColor(j, g_keyObj[`color${keyCtrlPtn}`][j]);
+			const colorPos = g_keyObj[`color${keyCtrlPtn}`][j];
+			const arrowColor = getKeyConfigColor(j, colorPos);
+			$id(`arrow${j}`).background = arrowColor;
+
+			if (g_headerObj.setShadowColor[colorPos] !== ``) {
+				const shadowColor = (g_headerObj.setShadowColor[colorPos] === `Default` ? arrowColor :
+					g_headerObj.setShadowColor[colorPos]);
+				$id(`arrowShadow${j}`).background = shadowColor;
+			}
 		}
 		lnkColorType.textContent = `${getStgDetailName(g_colorType)}${g_localStorage.colorType === g_colorType ? ' *' : ''}`;
 	};
@@ -5513,11 +5521,18 @@ function keyConfigInit(_kcType = g_kcType) {
  * 初期矢印色・フリーズアロー色の変更
  */
 function changeSetColor() {
-	const currentType = ([`Default`, `Type0`].includes(g_colorType) ? setScoreIdHeader(g_stateObj.scoreId) + g_colorType : g_colorType);
-	g_headerObj.setColor = JSON.parse(JSON.stringify(g_headerObj[`setColor${currentType}`]));
-	for (let j = 0; j < g_headerObj.setColorInit.length; j++) {
-		g_headerObj.frzColor[j] = JSON.parse(JSON.stringify(g_headerObj[`frzColor${currentType}`][j]));
-	}
+	const isDefault = [`Default`, `Type0`].includes(g_colorType);
+	const defaultType = setScoreIdHeader(g_stateObj.scoreId) + g_colorType;
+	const currentTypes = {
+		'': (isDefault ? defaultType : g_colorType),
+		'Shadow': (isDefault ? defaultType : `Default`),
+	};
+	Object.keys(currentTypes).forEach(pattern => {
+		g_headerObj[`set${pattern}Color`] = JSON.parse(JSON.stringify(g_headerObj[`set${pattern}Color${currentTypes[pattern]}`]));
+		for (let j = 0; j < g_headerObj.setColorInit.length; j++) {
+			g_headerObj[`frz${pattern}Color`][j] = JSON.parse(JSON.stringify(g_headerObj[`frz${pattern}Color${currentTypes[pattern]}`][j]));
+		}
+	});
 }
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5545,10 +5545,11 @@ function keyConfigInit(_kcType = g_kcType) {
  */
 function changeSetColor() {
 	const isDefault = [`Default`, `Type0`].includes(g_colorType);
-	const defaultType = setScoreIdHeader(g_stateObj.scoreId) + g_colorType;
+	const scoreIdHeader = setScoreIdHeader(g_stateObj.scoreId);
+	const defaultType = scoreIdHeader + g_colorType;
 	const currentTypes = {
 		'': (isDefault ? defaultType : g_colorType),
-		'Shadow': (isDefault ? defaultType : `Default`),
+		'Shadow': (isDefault ? defaultType : `${scoreIdHeader}Default`),
 	};
 	Object.keys(currentTypes).forEach(pattern => {
 		g_headerObj[`set${pattern}Color`] = JSON.parse(JSON.stringify(g_headerObj[`set${pattern}Color${currentTypes[pattern]}`]));

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1270,7 +1270,7 @@ function loadDos(_afterFunc, _scoreId = g_stateObj.scoreId, _cyclicFlg = false) 
 	g_stateObj.scoreLockFlg = setVal(dosLockInput !== null ? dosLockInput.value : getQueryParamVal(`dosLock`), false, C_TYP_BOOLEAN);
 	if (queryDos !== `` && dosDivideFlg && g_stateObj.scoreLockFlg) {
 		const scoreList = Object.keys(g_rootObj).filter(data => {
-			return data.endsWith(`_data`) || data.endsWith(`_change`);
+			return data.endsWith(`_data`) || data.endsWith(`_change`) || data.endsWith(`Color`);
 		});
 		scoreList.forEach(scoredata => g_rootObj[scoredata] = ``);
 	}
@@ -1318,6 +1318,10 @@ function loadDos(_afterFunc, _scoreId = g_stateObj.scoreId, _cyclicFlg = false) 
 			}
 			_afterFunc();
 			if (_cyclicFlg) {
+				if (dosDivideFlg && g_stateObj.scoreLockFlg && _scoreId > 0) {
+					Object.assign(g_rootObj, copySetColor(g_rootObj, _scoreId));
+					Object.assign(g_headerObj, resetBaseColorList(g_headerObj, g_rootObj, { scoreId: _scoreId }));
+				}
 				reloadDos(_scoreId);
 			}
 		}, false, charset);
@@ -1337,6 +1341,25 @@ function reloadDos(_scoreId) {
 	} else {
 		titleInit();
 	}
+}
+
+/**
+ * 譜面番号固定かつ譜面ファイル分割時に初期色情報を他譜面へコピー
+ * @param {object} _baseObj 
+ * @param {number} _scoreId 
+ * @returns 
+ */
+function copySetColor(_baseObj, _scoreId) {
+	const obj = {};
+	const scoreIdHeader = setScoreIdHeader(_scoreId);
+	[``, `Shadow`].forEach(pattern => {
+		[`set`, `frz`].forEach(arrow => {
+			if (hasVal(_baseObj[`${arrow}${pattern}Color`])) {
+				obj[`${arrow}${pattern}Color${scoreIdHeader}`] = _baseObj[`${arrow}${pattern}Color`].concat();
+			}
+		});
+	});
+	return obj;
 }
 
 /**
@@ -3205,7 +3228,7 @@ function headerConvert(_dosObj) {
 /**
  * 矢印・フリーズアロー色のデータ変換
  * @param {object} _baseObj 
- * @param {string} _dosObj
+ * @param {object} _dosObj
  * @param {object} objectList 
  * @returns オブジェクト ※Object.assign(obj, resetBaseColorList(...))の形で呼び出しが必要
  */


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 初期矢印・フリーズアロー色の展開処理をheaderConvert関数の外へ移動しました。
2. 初期矢印・フリーズアロー色の設定拡張を行いました。
2譜面目、3譜面目、…の初期色をsetColor2/frzColor2, setColor3/frzColor3, ...で指定することができます。
※影矢印についてはsetShadowColor2/frzShadowColor2, ... に対応
3. 譜面分割＆譜面番号固定時、個別の譜面ファイル内にsetColor/frzColor/setShadowColor/frzShadowColorの記述があれば、その値を採用するよう変更しました。
（キーコンフィグ画面にも反映されます）
4. キーコンフィグ画面の影矢印部分がColorTypeを変えても変更しない問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 後から再定義しやすくするため。
2. Issue #390 への対応です。
3. 2.の対応の派生対応です。譜面分割＆譜面番号可変時にも対応しています。
4. 元々仕様でしたが、1～3の対応に合わせて変わるように変更しました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 今回追加した`resetBaseColorList`関数はオブジェクトを返却します。
オブジェクトが上書きされるため、`obj = Object.assign(obj, resetBaseColorList(...));`
のように指定が必要です。
- このPull Requestの変更は過去バージョンへの反映対象外です。