### PR TITLE
[0388/multi-custom-gauge] customGaugeの複数譜面対応、デフォルト値対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2893,7 +2893,6 @@ function headerConvert(_dosObj) {
 		g_gaugeOptionObj.custom = g_gaugeOptionObj.customDefault.concat();
 		g_gaugeOptionObj.varCustom = g_gaugeOptionObj.varCustomDefault.concat();
 	}
-	console.log(g_gaugeOptionObj.customDefault);
 
 	// カスタムゲージ設定、初期色設定（譜面ヘッダー）の譜面別設定
 	for (let j = 0; j < obj.difLabels.length; j++) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1275,7 +1275,7 @@ function loadDos(_afterFunc, _scoreId = g_stateObj.scoreId, _cyclicFlg = false) 
 	g_stateObj.scoreLockFlg = setVal(dosLockInput !== null ? dosLockInput.value : getQueryParamVal(`dosLock`), false, C_TYP_BOOLEAN);
 	if (queryDos !== `` && dosDivideFlg && g_stateObj.scoreLockFlg) {
 		const scoreList = Object.keys(g_rootObj).filter(data => {
-			return data.endsWith(`_data`) || data.endsWith(`_change`) || data.endsWith(`Color`) || data === `customGauge`;
+			return listMatching(data, g_checkStr.resetDosFooter, { suffix: `$` });
 		});
 		scoreList.forEach(scoredata => g_rootObj[scoredata] = ``);
 	}
@@ -2050,8 +2050,8 @@ const isColorCd = _str => _str.substring(0, 1) === `#`;
  * @param {string} _str 
  * @returns 
  */
-const hasAnglePointInfo = _str => listMatching(_str, g_cssCheckStr.header, { prefix: `^` }) ||
-	listMatching(_str, g_cssCheckStr.footer, { suffix: `$` });
+const hasAnglePointInfo = _str => listMatching(_str, g_checkStr.cssHeader, { prefix: `^` }) ||
+	listMatching(_str, g_checkStr.cssFooter, { suffix: `$` });
 
 /**
  * 色名をカラーコードへ変換 (元々カラーコードの場合は除外)

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1921,11 +1921,17 @@ const g_escapeStr = {
     ],
 };
 
-// グラデーションで、カラーコードではないパーセント表記、位置表記系を除外するためのリスト
-// 'at', 'to'のみ、'to left'や'to right'のように方向が入るため、半角スペースまで込みで判断
-const g_cssCheckStr = {
-    header: [`at `, `to `, `from`, `circle`, `ellipse`, `closest-`, `farthest-`, `transparent`],
-    footer: [`deg`, `rad`, `grad`, `turn`, `repeat`],
+/**
+ * 文字列部分一致用リスト
+ */
+const g_checkStr = {
+    // グラデーションで、カラーコードではないパーセント表記、位置表記系を除外するためのリスト
+    // 'at', 'to'のみ、'to left'や'to right'のように方向が入るため、半角スペースまで込みで判断
+    cssHeader: [`at `, `to `, `from`, `circle`, `ellipse`, `closest-`, `farthest-`, `transparent`],
+    cssFooter: [`deg`, `rad`, `grad`, `turn`, `repeat`],
+
+    // 譜面分割あり、譜面番号固定時のみ譜面データを一時クリアする際の条件
+    resetDosFooter: [`_data`, `_change`, `Color`, `customGauge`],
 };
 
 /** 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. customGaugeの複数譜面化に対応しました。
```
|customGauge=Normal::V,Hard::V|
|customGauge2=Easy::V,Normal::V,SuddenDeath::F|
|customGauge3=Original::F,Normal::V,Hard::V|
```

2. danoni_setting.jsにカスタムゲージ(`g_presetGaugeList`)が設定されていれば、
値に`Default`を指定することで`g_presetGaugeList`を参照するよう変更しました。
```
|customGauge=Normal::V,Hard::V|
|customGauge2=Default|                       // 1譜面目では無く、g_presetGaugeListを継承
|customGauge3=Original::F,Normal::V,Hard::V| // 3譜面目は独自
// 4譜面目以降は1譜面目の設定を継承
```
3. listMatching関数に適用するオブジェクトを`g_checkStr`に集約しました。
（従来のg_cssCheckStrは廃止）

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. customGauge設定は一度設定すると固定されてしまうため。
2. 譜面ヘッダーと共通設定ファイルとの棲み分けの利便性向上のため。
3. CSS以外の用途でチェックにかけるケースがあるため。
今回の変更に関連してCodeClimateより指摘があった件の対応です。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- カスタムを設定している場合、従来のノルマ・ライフ制のゲージ設定は使えません。