### PR TITLE
[0389/multi-custom-gauge2] customGaugeの複数譜面対応、デフォルト値対応(事前設定版)　他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3241,7 +3241,7 @@ function headerConvert(_dosObj) {
  * @param {string} _obj
  */
 function addGaugeFulls(_obj) {
-	_obj.map(key => g_gaugeOptionObj.customFulls[key] = false);
+	_obj.map(key => g_gaugeOptionObj.customFulls[key] = hasVal(g_gaugeOptionObj.customFulls[key]));
 }
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3453,16 +3453,18 @@ function getGaugeSetting(_dosObj, _name, _difLength, { scoreId = 0 } = {}) {
 	};
 
 	/**
-	 * gaugeNormal2, gaugeEasy2などの個別設定があった場合にその値を適用
+	 * gaugeNormal2, gaugeEasy2などの個別設定があった場合にその値から配列を作成
 	 * @param {number} _scoreId 
+	 * @param {array} _defaultGaugeList
 	 */
-	const setGaugeAnother = _scoreId => {
+	const getGaugeDetailList = (_scoreId, _defaultGaugeList) => {
 		if (_scoreId > 0) {
 			const headerName = `gauge${_name}${setScoreIdHeader(_scoreId)}`;
 			if (hasVal(_dosObj[headerName])) {
-				setGaugeDetails(_scoreId, _dosObj[headerName].split(`,`));
+				return _dosObj[headerName].split(`,`);
 			}
 		}
+		return _defaultGaugeList;
 	};
 
 	if (hasVal(_dosObj[`gauge${_name}`])) {
@@ -3477,13 +3479,12 @@ function getGaugeSetting(_dosObj, _name, _difLength, { scoreId = 0 } = {}) {
 		} else {
 			const gauges = _dosObj[`gauge${_name}`].split(`$`);
 			for (let j = 0; j < gauges.length; j++) {
-				setGaugeDetails(j, gauges[j].split(`,`));
-				setGaugeAnother(j);
+				setGaugeDetails(j, getGaugeDetailList(j, gauges[j].split(`,`)));
 			}
 			if (gauges.length < _difLength) {
+				const defaultGaugeList = gauges[0].split(`,`);
 				for (let j = gauges.length; j < _difLength; j++) {
-					setGaugeDetails(j, gauges[0].split(`,`));
-					setGaugeAnother(j);
+					setGaugeDetails(j, getGaugeDetailList(j, defaultGaugeList));
 				}
 			}
 			g_gaugeOptionObj[`gauge${_name}s`] = Object.assign({}, obj);
@@ -3496,8 +3497,7 @@ function getGaugeSetting(_dosObj, _name, _difLength, { scoreId = 0 } = {}) {
 			g_presetGaugeCustom[_name].Damage, g_presetGaugeCustom[_name].Init,
 		]
 		for (let j = 0; j < _difLength; j++) {
-			setGaugeDetails(j, gaugeDetails);
-			setGaugeAnother(j);
+			setGaugeDetails(j, getGaugeDetailList(j, gaugeDetails));
 		}
 		g_gaugeOptionObj[`gauge${_name}s`] = Object.assign({}, obj);
 	}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2911,7 +2911,6 @@ function headerConvert(_dosObj) {
 
 	// ライフ設定のカスタム部分取得（譜面ヘッダー加味）
 	Object.keys(g_gaugeOptionObj.customFulls).forEach(gaugePtn => getGaugeSetting(_dosObj, gaugePtn, obj.difLabels.length));
-	console.log(g_gaugeOptionObj.customFulls);
 
 	// ダミー譜面の設定
 	if (hasVal(_dosObj.dummyId)) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3437,26 +3437,26 @@ function getGaugeSetting(_dosObj, _name, _difLength) {
 		lifeInits: []
 	};
 
-	const setGaugeDetails = gaugeDetails => {
-		if (gaugeDetails[0] === `x`) {
-			obj.lifeBorders.push(`x`);
+	const setGaugeDetails = (_scoreId, _gaugeDetails) => {
+		if (_gaugeDetails[0] === `x`) {
+			obj.lifeBorders[_scoreId] = `x`;
 		} else {
-			obj.lifeBorders.push(setVal(gaugeDetails[0], ``, C_TYP_FLOAT));
+			obj.lifeBorders[_scoreId] = setVal(_gaugeDetails[0], ``, C_TYP_FLOAT);
 		}
-		obj.lifeRecoverys.push(setVal(gaugeDetails[1], ``, C_TYP_FLOAT));
-		obj.lifeDamages.push(setVal(gaugeDetails[2], ``, C_TYP_FLOAT));
-		obj.lifeInits.push(setVal(gaugeDetails[3], ``, C_TYP_FLOAT));
+		obj.lifeRecoverys[_scoreId] = setVal(_gaugeDetails[1], ``, C_TYP_FLOAT);
+		obj.lifeDamages[_scoreId] = setVal(_gaugeDetails[2], ``, C_TYP_FLOAT);
+		obj.lifeInits[_scoreId] = setVal(_gaugeDetails[3], ``, C_TYP_FLOAT);
 	};
 
 	if (hasVal(_dosObj[`gauge${_name}`])) {
 		const gauges = _dosObj[`gauge${_name}`].split(`$`);
 
 		for (let j = 0; j < gauges.length; j++) {
-			setGaugeDetails(gauges[j].split(`,`));
+			setGaugeDetails(j, gauges[j].split(`,`));
 		}
 		if (gauges.length < _difLength) {
 			for (let j = gauges.length; j < _difLength; j++) {
-				setGaugeDetails(gauges[0].split(`,`));
+				setGaugeDetails(j, gauges[0].split(`,`));
 			}
 		}
 		g_gaugeOptionObj[`gauge${_name}s`] = Object.assign({}, obj);
@@ -3468,7 +3468,7 @@ function getGaugeSetting(_dosObj, _name, _difLength) {
 			g_presetGaugeCustom[_name].Damage, g_presetGaugeCustom[_name].Init,
 		]
 		for (let j = 0; j < _difLength; j++) {
-			setGaugeDetails(gaugeDetails);
+			setGaugeDetails(j, gaugeDetails);
 		}
 		g_gaugeOptionObj[`gauge${_name}s`] = Object.assign({}, obj);
 	}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2893,7 +2893,6 @@ function headerConvert(_dosObj) {
 		g_gaugeOptionObj.custom = g_gaugeOptionObj.customDefault.concat();
 		g_gaugeOptionObj.varCustom = g_gaugeOptionObj.varCustomDefault.concat();
 	}
-	console.log(g_gaugeOptionObj.customDefault);
 
 	// カスタムゲージ設定、初期色設定（譜面ヘッダー）の譜面別設定
 	for (let j = 0; j < obj.difLabels.length; j++) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3473,8 +3473,7 @@ function getGaugeSetting(_dosObj, _name, _difLength, { scoreId = 0 } = {}) {
 			setGaugeDetails(scoreId, _dosObj[`gauge${_name}`].split(`,`));
 			if (hasVal(g_gaugeOptionObj[`gauge${_name}s`])) {
 				Object.keys(obj).forEach(key => Object.assign(g_gaugeOptionObj[`gauge${_name}s`][key] || [], obj[key]));
-			} else {
-				g_gaugeOptionObj[`gauge${_name}s`] = Object.assign({}, obj);
+				return;
 			}
 		} else {
 			const gauges = _dosObj[`gauge${_name}`].split(`$`);
@@ -3487,8 +3486,8 @@ function getGaugeSetting(_dosObj, _name, _difLength, { scoreId = 0 } = {}) {
 					setGaugeDetails(j, getGaugeDetailList(j, defaultGaugeList));
 				}
 			}
-			g_gaugeOptionObj[`gauge${_name}s`] = Object.assign({}, obj);
 		}
+		g_gaugeOptionObj[`gauge${_name}s`] = obj;
 
 	} else if (typeof g_presetGaugeCustom === C_TYP_OBJECT && g_presetGaugeCustom[_name]) {
 
@@ -3496,10 +3495,18 @@ function getGaugeSetting(_dosObj, _name, _difLength, { scoreId = 0 } = {}) {
 			g_presetGaugeCustom[_name].Border, g_presetGaugeCustom[_name].Recovery,
 			g_presetGaugeCustom[_name].Damage, g_presetGaugeCustom[_name].Init,
 		]
-		for (let j = 0; j < _difLength; j++) {
-			setGaugeDetails(j, getGaugeDetailList(j, gaugeDetails));
+		if (g_stateObj.scoreLockFlg) {
+			setGaugeDetails(scoreId, gaugeDetails);
+			if (hasVal(g_gaugeOptionObj[`gauge${_name}s`])) {
+				Object.keys(obj).forEach(key => Object.assign(g_gaugeOptionObj[`gauge${_name}s`][key] || [], obj[key]));
+				return;
+			}
+		} else {
+			for (let j = 0; j < _difLength; j++) {
+				setGaugeDetails(j, getGaugeDetailList(j, gaugeDetails));
+			}
 		}
-		g_gaugeOptionObj[`gauge${_name}s`] = Object.assign({}, obj);
+		g_gaugeOptionObj[`gauge${_name}s`] = obj;
 	}
 }
 
@@ -4534,7 +4541,7 @@ function createOptionWindow(_sprite) {
 
 		// ゲージ設定別に個別設定した場合はここで設定を上書き
 		// 譜面ヘッダー：gaugeXXX で設定した値がここで適用される
-		if (g_gaugeOptionObj[`gauge${g_stateObj.gauge}s`] !== undefined) {
+		if (hasVal(g_gaugeOptionObj[`gauge${g_stateObj.gauge}s`])) {
 			const tmpGaugeObj = g_gaugeOptionObj[`gauge${g_stateObj.gauge}s`];
 			if (hasVal(tmpGaugeObj.lifeBorders[tmpScoreId])) {
 				changeLifeMode(tmpGaugeObj);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1275,7 +1275,7 @@ function loadDos(_afterFunc, _scoreId = g_stateObj.scoreId, _cyclicFlg = false) 
 	g_stateObj.scoreLockFlg = setVal(dosLockInput !== null ? dosLockInput.value : getQueryParamVal(`dosLock`), false, C_TYP_BOOLEAN);
 	if (queryDos !== `` && dosDivideFlg && g_stateObj.scoreLockFlg) {
 		const scoreList = Object.keys(g_rootObj).filter(data => {
-			return data.endsWith(`_data`) || data.endsWith(`_change`) || data.endsWith(`Color`) || data === `customGauge`;
+			return listMatching(data, g_checkStr.resetDosFooter, { suffix: `$` });
 		});
 		scoreList.forEach(scoredata => g_rootObj[scoredata] = ``);
 	}
@@ -2050,8 +2050,8 @@ const isColorCd = _str => _str.substring(0, 1) === `#`;
  * @param {string} _str 
  * @returns 
  */
-const hasAnglePointInfo = _str => listMatching(_str, g_cssCheckStr.header, { prefix: `^` }) ||
-	listMatching(_str, g_cssCheckStr.footer, { suffix: `$` });
+const hasAnglePointInfo = _str => listMatching(_str, g_checkStr.cssHeader, { prefix: `^` }) ||
+	listMatching(_str, g_checkStr.cssFooter, { suffix: `$` });
 
 /**
  * 色名をカラーコードへ変換 (元々カラーコードの場合は除外)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3241,7 +3241,7 @@ function headerConvert(_dosObj) {
  * @param {string} _obj
  */
 function addGaugeFulls(_obj) {
-	_obj.map(key => g_gaugeOptionObj.customFulls[key] = ``);
+	_obj.map(key => g_gaugeOptionObj.customFulls[key] = false);
 }
 
 /**
@@ -3427,6 +3427,9 @@ function resetCustomGauge(_dosObj, { scoreId = 0, scoreLockFlg = false } = {}) {
  */
 function getGaugeSetting(_dosObj, _name, _difLength) {
 
+	if (g_gaugeOptionObj.customFulls[_name]) {
+		return;
+	}
 	const obj = {
 		lifeBorders: [],
 		lifeRecoverys: [],
@@ -3469,6 +3472,8 @@ function getGaugeSetting(_dosObj, _name, _difLength) {
 		}
 		g_gaugeOptionObj[`gauge${_name}s`] = Object.assign({}, obj);
 	}
+
+	g_gaugeOptionObj.customFulls[_name] = true;
 }
 
 /**

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1921,11 +1921,17 @@ const g_escapeStr = {
     ],
 };
 
-// グラデーションで、カラーコードではないパーセント表記、位置表記系を除外するためのリスト
-// 'at', 'to'のみ、'to left'や'to right'のように方向が入るため、半角スペースまで込みで判断
-const g_cssCheckStr = {
-    header: [`at `, `to `, `from`, `circle`, `ellipse`, `closest-`, `farthest-`, `transparent`],
-    footer: [`deg`, `rad`, `grad`, `turn`, `repeat`],
+/**
+ * 文字列部分一致用リスト
+ */
+const g_checkStr = {
+    // グラデーションで、カラーコードではないパーセント表記、位置表記系を除外するためのリスト
+    // 'at', 'to'のみ、'to left'や'to right'のように方向が入るため、半角スペースまで込みで判断
+    cssHeader: [`at `, `to `, `from`, `circle`, `ellipse`, `closest-`, `farthest-`, `transparent`],
+    cssFooter: [`deg`, `rad`, `grad`, `turn`, `repeat`],
+
+    // 譜面分割あり、譜面番号固定時のみ譜面データを一時クリアする際の条件
+    resetDosFooter: [`_data`, `_change`, `Color`, `customGauge`],
 };
 
 /** 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -298,6 +298,7 @@ let C_WOD_FRAME = 30;
 
 // 譜面データ持ち回り用
 const g_stateObj = {
+    dosDivideFlg: false,
     scoreLockFlg: false,
     scoreId: 0,
     dummyId: ``,
@@ -1931,6 +1932,7 @@ const g_checkStr = {
     cssFooter: [`deg`, `rad`, `grad`, `turn`, `repeat`],
 
     // 譜面分割あり、譜面番号固定時のみ譜面データを一時クリアする際の条件
+    resetDosHeader: [`gauge`],
     resetDosFooter: [`_data`, `_change`, `Color`, `customGauge`],
 };
 


### PR DESCRIPTION
## 補足
- #1023 と基本的に同じですが、getGaugeSetting をheaderConvert関数及びloadDos関数で
事前に設定することで、後からcustomTitleInitを呼び出しても影響が無いように変更しています。

## :hammer: 変更内容 / Details of Changes
1. customGaugeの複数譜面化に対応しました。
```
|customGauge=Normal::V,Hard::V|
|customGauge2=Easy::V,Normal::V,SuddenDeath::F|
|customGauge3=Original::F,Normal::V,Hard::V|
```

2. danoni_setting.jsにカスタムゲージ(`g_presetGaugeList`)が設定されていれば、
値に`Default`を指定することで`g_presetGaugeList`を参照するよう変更しました。
```
|customGauge=Normal::V,Hard::V|
|customGauge2=Default|                       // 1譜面目では無く、g_presetGaugeListを継承
|customGauge3=Original::F,Normal::V,Hard::V| // 3譜面目は独自
// 以降を未指定にした場合（この場合は4譜面目以降）は1譜面目の設定を継承
```
3. listMatching関数に適用するオブジェクトを`g_checkStr`に集約しました。
（従来のg_cssCheckStrは廃止）
4. getGaugeSetting関数の第三引数を`_headerObj`から`_difLength`に変更しました。
5. gaugeXXXについて、gaugeXXX2, gaugeXXX3 のような分割記法に対応しました。
$区切りと混在した場合は、分割記法側が優先されます。
分割記法を使用する場合、gaugeXXXの指定は省略不可です。
```
|gaugeHard=x,2,20,100$x,1,20,100$x,1,50,100| // 従来の記法
|gaugeHard=x,2,20,100| // 一律設定

|gaugeHard=x,2,20,100| // 分割記法
|gaugeHard2=x,1,20,100| // 分割記法　※ $区切りは使えません
|gaugeHard3=x,1,50,100| // 分割記法　※ $区切りは使えません
|gaugeHard5=x,1,50,100| // 分割記法　※ $区切りは使えません（gaugeHard4を指定しないことは可能です）
```
6. 譜面分割＆譜面番号可変時、初期矢印・フリーズアロー色（setColor2, frzColor2, ...）を
譜面番号固定時と同様、個別の譜面ファイルへ記載できるようになりました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. customGauge設定は一度設定すると固定されてしまうため。
2. 譜面ヘッダーと共通設定ファイルとの棲み分けの利便性向上のため。
3. CSS以外の用途でチェックにかけるケースがあるため。
今回の変更に関連してCodeClimateより指摘があった件の対応です。
4. 結果的に譜面数情報しか必要ないのにもかかわらず、大きなオブジェクトを渡す仕組みになっていたため。
5. 譜面数が多い場合、どの譜面の設定かがわかりにくくなるため。
6. 仕様を他と揃えるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- カスタムを設定している場合、従来のノルマ・ライフ制のゲージ設定は使えません。