### PR TITLE
[0391/customg-default] カスタムゲージのデフォルト値設定の見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2849,7 +2849,7 @@ function headerConvert(_dosObj) {
 
 	// ゲージ初期設定（最大ライフ反映）
 	g_gaugeOptionObj.defaultList.forEach(type => {
-		const pos = g_gaugeOptionObj[`dmg${toCapitalize(type)}`].findIndex(val => val === `maxLife`);
+		const pos = g_gaugeOptionObj[`dmg${toCapitalize(type)}`].findIndex(val => val === C_LFE_MAXLIFE);
 		g_gaugeOptionObj[`dmg${toCapitalize(type)}`][pos] = obj.maxLifeVal;
 	});
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3384,6 +3384,7 @@ function resetCustomGauge(_dosObj, { scoreId = 0 } = {}) {
 			obj[`custom${scoreId}`] = g_gaugeOptionObj[dosCustomGauge].concat();
 			obj[`varCustom${scoreId}`] = g_gaugeOptionObj[`var${toCapitalize(dosCustomGauge)}`].concat();
 			if (g_gaugeOptionObj.defaultList.includes(dosCustomGauge)) {
+				obj[`defaultGauge${scoreId}`] = dosCustomGauge;
 				obj[`typeCustom${scoreId}`] = g_gaugeOptionObj[`type${toCapitalize(dosCustomGauge)}`].concat();
 			}
 		} else {
@@ -4518,12 +4519,14 @@ function createOptionWindow(_sprite) {
 			// 設定されたゲージ設定、カーソルに合わせて設定値を更新
 			g_stateObj.lifeVariable = g_gaugeOptionObj[`var${g_gaugeType}`][_gaugeNum];
 			if (g_gaugeOptionObj.custom.length === 0 ||
-				g_gaugeOptionObj.defaultList.includes(g_gaugeOptionObj[`typeCustom${tmpScoreId}`])) {
-				g_stateObj.lifeMode = g_gaugeOptionObj[`type${g_gaugeType}`][_gaugeNum];
-				g_stateObj.lifeBorder = g_gaugeOptionObj[`clear${g_gaugeType}`][_gaugeNum];
-				g_stateObj.lifeInit = g_gaugeOptionObj[`init${g_gaugeType}`][_gaugeNum];
-				g_stateObj.lifeRcv = g_gaugeOptionObj[`rcv${g_gaugeType}`][_gaugeNum];
-				g_stateObj.lifeDmg = g_gaugeOptionObj[`dmg${g_gaugeType}`][_gaugeNum];
+				g_gaugeOptionObj.defaultList.includes(g_gaugeOptionObj[`defaultGauge${tmpScoreId}`])) {
+				const gType = (g_gaugeType === C_LFE_CUSTOM ?
+					toCapitalize(g_gaugeOptionObj[`defaultGauge${tmpScoreId}`]) : g_gaugeType);
+				g_stateObj.lifeMode = g_gaugeOptionObj[`type${gType}`][_gaugeNum];
+				g_stateObj.lifeBorder = g_gaugeOptionObj[`clear${gType}`][_gaugeNum];
+				g_stateObj.lifeInit = g_gaugeOptionObj[`init${gType}`][_gaugeNum];
+				g_stateObj.lifeRcv = g_gaugeOptionObj[`rcv${gType}`][_gaugeNum];
+				g_stateObj.lifeDmg = g_gaugeOptionObj[`dmg${gType}`][_gaugeNum];
 			}
 		}
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2847,31 +2847,11 @@ function headerConvert(_dosObj) {
 		makeWarningWindow(g_msgInfoObj.E_0042.split(`{0}`).join(`maxLifeVal`));
 	}
 
-	// ゲージ設定詳細（初期値）
-	g_gaugeOptionObj = {
-		survival: [`Original`, `Heavy`, `NoRecovery`, `SuddenDeath`, `Practice`, `Light`],
-		border: [`Normal`, `Hard`, `SuddenDeath`, `Easy`],
-		custom: [],
-		customDefault: [],
-		customFulls: {},
-
-		initSurvival: [25, 50, 100, 100, 50, 25],
-		rcvSurvival: [6, 2, 0, 0, 0, 12],
-		dmgSurvival: [40, 50, 50, obj.maxLifeVal, 0, 40],
-		typeSurvival: [C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL],
-		varSurvival: [C_FLG_OFF, C_FLG_OFF, C_FLG_OFF, C_FLG_OFF, C_FLG_OFF, C_FLG_OFF],
-		clearSurvival: [0, 0, 0, 0, 0, 0],
-
-		initBorder: [25, 100, 100, 25],
-		rcvBorder: [2, 1, 0, 4],
-		dmgBorder: [7, 50, obj.maxLifeVal, 7],
-		typeBorder: [C_LFE_BORDER, C_LFE_BORDER, C_LFE_SURVIVAL, C_LFE_BORDER],
-		varBorder: [C_FLG_ON, C_FLG_ON, C_FLG_OFF, C_FLG_ON],
-		clearBorder: [70, 0, 0, 70],
-
-		varCustom: [],
-		varCustomDefault: [],
-	};
+	// ゲージ初期設定（最大ライフ反映）
+	g_gaugeOptionObj.defaultList.forEach(type => {
+		const pos = g_gaugeOptionObj[`dmg${toCapitalize(type)}`].findIndex(val => val === `maxLife`);
+		g_gaugeOptionObj[`dmg${toCapitalize(type)}`][pos] = obj.maxLifeVal;
+	});
 
 	// フリーズアローのデフォルト色セットの利用有無 (true: 使用, false: 矢印色を優先してセット)
 	if (hasVal(_dosObj.defaultFrzColorUse)) {
@@ -3398,12 +3378,16 @@ function resetCustomGauge(_dosObj, { scoreId = 0 } = {}) {
 
 	const obj = {};
 	const scoreIdHeader = setScoreIdHeader(scoreId, g_stateObj.scoreLockFlg);
-	if (hasVal(_dosObj[`customGauge${scoreIdHeader}`])) {
-		if (_dosObj[`customGauge${scoreIdHeader}`] === `Default`) {
-			obj[`custom${scoreId}`] = g_gaugeOptionObj.customDefault.concat();
-			obj[`varCustom${scoreId}`] = g_gaugeOptionObj.varCustomDefault.concat();
+	const dosCustomGauge = _dosObj[`customGauge${scoreIdHeader}`];
+	if (hasVal(dosCustomGauge)) {
+		if (g_gaugeOptionObj.defaultPlusList.includes(dosCustomGauge)) {
+			obj[`custom${scoreId}`] = g_gaugeOptionObj[dosCustomGauge].concat();
+			obj[`varCustom${scoreId}`] = g_gaugeOptionObj[`var${toCapitalize(dosCustomGauge)}`].concat();
+			if (g_gaugeOptionObj.defaultList.includes(dosCustomGauge)) {
+				obj[`typeCustom${scoreId}`] = g_gaugeOptionObj[`type${toCapitalize(dosCustomGauge)}`].concat();
+			}
 		} else {
-			const customGauges = _dosObj[`customGauge${scoreIdHeader}`].split(`,`);
+			const customGauges = dosCustomGauge.split(`,`);
 
 			obj[`custom${scoreId}`] = [];
 			obj[`varCustom${scoreId}`] = [];
@@ -4533,7 +4517,8 @@ function createOptionWindow(_sprite) {
 		} else {
 			// 設定されたゲージ設定、カーソルに合わせて設定値を更新
 			g_stateObj.lifeVariable = g_gaugeOptionObj[`var${g_gaugeType}`][_gaugeNum];
-			if (g_gaugeOptionObj.custom.length === 0) {
+			if (g_gaugeOptionObj.custom.length === 0 ||
+				g_gaugeOptionObj.defaultList.includes(g_gaugeOptionObj[`typeCustom${tmpScoreId}`])) {
 				g_stateObj.lifeMode = g_gaugeOptionObj[`type${g_gaugeType}`][_gaugeNum];
 				g_stateObj.lifeBorder = g_gaugeOptionObj[`clear${g_gaugeType}`][_gaugeNum];
 				g_stateObj.lifeInit = g_gaugeOptionObj[`init${g_gaugeType}`][_gaugeNum];

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -349,6 +349,7 @@ let C_CLR_BORDER = `#555555`;
 const C_LFE_SURVIVAL = `Survival`;
 const C_LFE_BORDER = `Border`;
 const C_LFE_CUSTOM = `Custom`;
+const C_LFE_MAXLIFE = `maxLife`;
 
 /**
  * ゲージ初期設定
@@ -362,14 +363,14 @@ const g_gaugeOptionObj = {
 
     initSurvival: [25, 50, 100, 100, 50, 25],
     rcvSurvival: [6, 2, 0, 0, 0, 12],
-    dmgSurvival: [40, 50, 50, `maxLife`, 0, 40],
+    dmgSurvival: [40, 50, 50, C_LFE_MAXLIFE, 0, 40],
     typeSurvival: [C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL],
     varSurvival: [C_FLG_OFF, C_FLG_OFF, C_FLG_OFF, C_FLG_OFF, C_FLG_OFF, C_FLG_OFF],
     clearSurvival: [0, 0, 0, 0, 0, 0],
 
     initBorder: [25, 100, 100, 25],
     rcvBorder: [2, 1, 0, 4],
-    dmgBorder: [7, 50, `maxLife`, 7],
+    dmgBorder: [7, 50, C_LFE_MAXLIFE, 7],
     typeBorder: [C_LFE_BORDER, C_LFE_BORDER, C_LFE_SURVIVAL, C_LFE_BORDER],
     varBorder: [C_FLG_ON, C_FLG_ON, C_FLG_OFF, C_FLG_ON],
     clearBorder: [70, 0, 0, 70],

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -350,7 +350,35 @@ const C_LFE_SURVIVAL = `Survival`;
 const C_LFE_BORDER = `Border`;
 const C_LFE_CUSTOM = `Custom`;
 
-let g_gaugeOptionObj = {};
+/**
+ * ゲージ初期設定
+ */
+const g_gaugeOptionObj = {
+    survival: [`Original`, `Heavy`, `NoRecovery`, `SuddenDeath`, `Practice`, `Light`],
+    border: [`Normal`, `Hard`, `SuddenDeath`, `Easy`],
+    custom: [],
+    customDefault: [],
+    customFulls: {},
+
+    initSurvival: [25, 50, 100, 100, 50, 25],
+    rcvSurvival: [6, 2, 0, 0, 0, 12],
+    dmgSurvival: [40, 50, 50, `maxLife`, 0, 40],
+    typeSurvival: [C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL, C_LFE_SURVIVAL],
+    varSurvival: [C_FLG_OFF, C_FLG_OFF, C_FLG_OFF, C_FLG_OFF, C_FLG_OFF, C_FLG_OFF],
+    clearSurvival: [0, 0, 0, 0, 0, 0],
+
+    initBorder: [25, 100, 100, 25],
+    rcvBorder: [2, 1, 0, 4],
+    dmgBorder: [7, 50, `maxLife`, 7],
+    typeBorder: [C_LFE_BORDER, C_LFE_BORDER, C_LFE_SURVIVAL, C_LFE_BORDER],
+    varBorder: [C_FLG_ON, C_FLG_ON, C_FLG_OFF, C_FLG_ON],
+    clearBorder: [70, 0, 0, 70],
+
+    varCustom: [],
+    varCustomDefault: [],
+    defaultList: [`survival`, `border`],
+    defaultPlusList: [`survival`, `border`, `customDefault`],
+};
 let g_gaugeType;
 
 const g_autoPlaysBase = [C_FLG_OFF, C_FLG_ALL];


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. カスタムゲージのデフォルト値設定を見直しました。
    - Default から customDefaullt に変更しています。
2. カスタムゲージについて、一部ライフ制ゲージ、ノルマ制ゲージのデフォルト設定を
使えるようになりました。
```
|customGauge2=survival|  
// ライフ制ゲージ設定を継承：[`Original`, `Heavy`, `NoRecovery`, `SuddenDeath`, `Practice`, `Light`]
|customGauge3=border|
// ノルマ制ゲージ設定を継承：[`Normal`, `Hard`, `SuddenDeath`, `Easy`]
|customGauge4=customDefault|
// 共通設定ファイルで定義しているゲージ設定を継承
```
3. g_gaugeOptionObj の初期値を danoni_constants.js へ移動しました。
4. g_gaugeOptionObj を let -> const へ変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Resolves #1026 
2. 部分的にカスタムゲージを採用したいケースに対応するため。
3. 最大ライフ以外は固定値のため。
4. 3.の変更に伴い、直接代入する必要がなくなったため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
### g_gaugeOptionObj の初期値における最大ライフ値仕様について
- dmgSurvival / dmgBorder プロパティ中にある`maxLife`という文字を検知して、
最大ライフ値が判明した時点で反映するようにしています。
```javascript
const g_gaugeOptionObj = {
    // 
    dmgSurvival: [40, 50, 50, `maxLife`, 0, 40],
    // 
    dmgBorder: [7, 50, `maxLife`, 7],
    // 
}
```