### PR TITLE
[ver21.1.0] カスタムゲージの譜面別設定の実装　他

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -5,10 +5,10 @@ Created: 2021/02/01
 Revised: 2021/02/28
 
 // 置換用文字列リスト
-@version@ v20.4.0
-@pre_version@ v20.3.1
-@major_version@ v20
-@pre_major_version@ v19
+@version@ v21.1.0
+@pre_version@ v21.0.0
+@major_version@ v21
+@pre_major_version@ v20
 
 -->
 
@@ -22,18 +22,18 @@ Revised: 2021/02/28
 <!-- 変更ファイル一覧 -->
 ## 🔃 Files changed (@major_version@)
 
-|フォルダ|ファイル名||最終更新|
+|フォルダ<br>Directory|ファイル名<br>FileName||最終更新<br>Last Updated|
 |----|----|----|----|
 |/js|danoni_main.js|[:inbox_tray:](../../releases/download/@version@/danoni_main.js)|**@version@**|
-|/js|[danoni_setting(-template).js](../../compare/v20.2.1...v20.3.1#files_bucket)|[:inbox_tray:](../../releases/download/v20.3.1/danoni_setting-template.js)|[v20.3.1](../../releases/tag/v20.3.1)|
-|/js/lib|danoni_constants.js|[:inbox_tray:](../../releases/download/v20.4.0/danoni_constants.js)|[v20.4.0](../../releases/tag/v20.4.0)|
-|/js/lib|danoni_legacy_function.js|[:inbox_tray:](../../releases/download/v19.0.0/danoni_legacy_function.js)|[v20.0.0](../../releases/tag/v20.0.0)|
+|/js/lib|danoni_constants.js|[:inbox_tray:](../../releases/download/v21.0.0/danoni_constants.js)|[v21.0.0](../../releases/tag/v21.0.0)|
+|/js/lib|danoni_legacy_function.js|[:inbox_tray:](../../releases/download/v21.0.0/danoni_legacy_function.js)|[v21.0.0](../../releases/tag/v21.0.0)|
 
 <details>
 <summary>（参考）@pre_major_version@以前の差分ファイル一覧</summary>
 
 |フォルダ|ファイル名||最終更新|
 |----|----|----|----|
+|/js|[danoni_setting(-template).js](../../compare/v20.2.1...v20.3.1#files_bucket)|[:inbox_tray:](../../releases/download/v20.3.1/danoni_setting-template.js)|[v20.3.1](../../releases/tag/v20.3.1)|
 |/js/lib|danoni_localbinary.js|[:inbox_tray:](../../releases/download/v15.1.0/danoni_localbinary.js)|[v15.1.0](../../releases/tag/v15.1.0)|
 |/css|danoni_main.css|[:inbox_tray:](../../releases/download/v18.5.0/danoni_main.css)|[v18.5.0](../../releases/tag/v18.5.0)|
 |/img|aaShadow.svg<br>arrow.svg<br>arrowShadow.svg<br>borderline.svg<br>c.svg<br>cursor.svg<br>giko.svg<br>iyo.svg<br>monar.svg<br>morara.svg<br>onigiri.svg|[:inbox_tray:](../../releases/download/v15.1.0/img.zip)|[v15.1.0](../../releases/tag/v15.1.0)|
@@ -79,5 +79,5 @@ Revised: 2021/02/28
 
 <!-- 直近の更新 -->
 ## 💡 Recent Changes
-- [@pre_version@](../../releases/tag/@pre_version@) / [v20.2.1](../../releases/tag/v20.2.1) / [v20.2.0](../../releases/tag/v20.2.0) / [v20.1.2](../../releases/tag/v20.1.2) / [v20.0.0](../../releases/tag/v20.0.0)
+- [@pre_version@](../../releases/tag/@pre_version@) / [v20.5.1](../../releases/tag/v20.5.1) / [v20.4.0](../../releases/tag/v20.4.0) / [v20.3.1](../../releases/tag/v20.3.1) / [v20.2.1](../../releases/tag/v20.2.1)
 </details>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ v14, 20の対応終了時期はv23リリース開始時を予定しています�
 
 | Version | Supported          | Latest Version | First Release | End of Support |
 | ------- | ------------------ |----------------|---------------|----------------|
-| v21     | :heavy_check_mark: |[v21.0.0](../../releases/tag/v21.0.0)          |2021-03-12|-|
+| v21     | :heavy_check_mark: |[v21.1.0](../../releases/tag/v21.1.0)          |2021-03-12|-|
 | v20     | :heavy_check_mark: |[v20.5.2](../../releases/tag/v20.5.2)          |2021-02-12|(At Release v23)|
 | v19     | :heavy_check_mark: |[v19.5.6](../../releases/tag/v19.5.6)          |2021-01-17|-|
 | v18     | :x:                |[v18.9.6 (final)](../../releases/tag/v18.9.6)  |2020-10-25|2021-03-12|

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2021/03/12
+ * Revised : 2021/03/19
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 21.0.0`;
-const g_revisedDate = `2021/03/12`;
+const g_version = `Ver 21.1.0`;
+const g_revisedDate = `2021/03/19`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -5,7 +5,7 @@
  *
  * Source by tickle
  * Created : 2019/11/19
- * Revised : 2021/03/12 (v21.0.0)
+ * Revised : 2021/03/19 (v21.1.0)
  *
  * https://github.com/cwtickle/danoniplus
  */


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- #1024 customGaugeの複数譜面化対応
- #1024 gaugeXXXについて、gaugeXXX2, gaugeXXX3 のような分割記法に対応
- #1024 譜面分割＆譜面番号可変時、初期矢印・フリーズアロー色（setColor2, frzColor2, ...）を
譜面番号固定時と同様、個別の譜面ファイルへ記載できるように変更
- #1024 #1025 文字列関連のコード整理
- #1026 カスタムゲージについて、ライフ制ゲージ/ノルマ制ゲージ/共通設定ファイルで指定のリストを指定できるよう変更

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments