### PR TITLE
[0393/display-save] データセーブフラグ切替ボタンをDisplay画面にも表示

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3737,6 +3737,18 @@ const commonSettingBtn = _labelName => {
 			w: C_LEN_SETMINI_WIDTH, h: 40, title: g_msgObj[`to${_labelName}`],
 			resetFunc: _ => (_labelName === `Display` ? settingsDisplayInit() : optionInit()),
 		}, g_cssObj.button_Mini),
+
+		// データセーブフラグの切替
+		createCss2Button(`btnSave`, g_lblNameObj.dataSave, evt => {
+			g_stateObj.dataSaveFlg = !g_stateObj.dataSaveFlg;
+			const [from, to] = (g_stateObj.dataSaveFlg ? [C_FLG_OFF, C_FLG_ON] : [C_FLG_ON, C_FLG_OFF]);
+			evt.target.classList.replace(g_cssObj[`button_${from}`], g_cssObj[`button_${to}`]);
+		}, {
+			x: 0, y: 5,
+			w: g_sWidth / 5, h: 16, siz: 12,
+			title: g_msgObj.dataSave,
+			borderStyle: `solid`,
+		}, g_cssObj.button_Default, (g_stateObj.dataSaveFlg ? g_cssObj.button_ON : g_cssObj.button_OFF)),
 	);
 };
 
@@ -3767,21 +3779,6 @@ function optionInit() {
 
 	// ボタン描画
 	commonSettingBtn(`Display`);
-
-	multiAppend(divRoot,
-
-		// データセーブフラグの切替
-		createCss2Button(`btnSave`, g_lblNameObj.dataSave, evt => {
-			g_stateObj.dataSaveFlg = !g_stateObj.dataSaveFlg;
-			const [from, to] = (g_stateObj.dataSaveFlg ? [C_FLG_OFF, C_FLG_ON] : [C_FLG_ON, C_FLG_OFF]);
-			evt.target.classList.replace(g_cssObj[`button_${from}`], g_cssObj[`button_${to}`]);
-		}, {
-			x: 0, y: 5,
-			w: g_sWidth / 5, h: 16, siz: 12,
-			title: g_msgObj.dataSave,
-			borderStyle: `solid`,
-		}, g_cssObj.button_Default, (g_stateObj.dataSaveFlg ? g_cssObj.button_ON : g_cssObj.button_OFF))
-	);
 
 	// キー操作イベント（デフォルト）
 	setShortcutEvent(g_currentPage);

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -845,6 +845,7 @@ const g_shortcutObj = {
         NumpadSubtract: { id: `lnkarrowEffect` },
         NumpadDivide: { id: `lnkspecial` },
 
+        KeyZ: { id: `btnSave` },
         Escape: { id: `btnBack` },
         Space: { id: `btnKeyConfig` },
         Enter: { id: `btnPlay` },
@@ -888,7 +889,7 @@ const g_btnPatterns = {
     title: { Start: 0, Comment: -10 },
     option: { Back: 0, KeyConfig: 0, Play: 0, Display: -5, Save: -10, Graph: -25 },
     difSelector: {},
-    settingsDisplay: { Back: 0, KeyConfig: 0, Play: 0, Settings: -5 },
+    settingsDisplay: { Back: 0, KeyConfig: 0, Play: 0, Save: -10, Settings: -5 },
     loadingIos: { Play: 0 },
     keyConfig: { Back: -3 },
     result: { Back: -5, Copy: -5, Tweet: -5, Gitter: -5, Retry: 0 },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. データセーブフラグ切替ボタンをDisplay画面にも表示しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 各種Display設定がローカルストレージの保存対象になっているため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
