### PR TITLE
[0394/default-grd-color] 背景状況により明暗用のカラーセットを使用するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2890,7 +2890,7 @@ function headerConvert(_dosObj) {
 
 	// グラデーションのデフォルト中間色を設定
 	divRoot.appendChild(createDivCss2Label(`dummyLabel`, ``, { pointerEvents: C_DIS_NONE }));
-	obj.baseBrightFlg = checkLightOrDark(colorNameToCode(window.getComputedStyle(dummyLabel, ``).color));
+	obj.baseBrightFlg = setVal(_dosObj.baseBright, checkLightOrDark(colorNameToCode(window.getComputedStyle(dummyLabel, ``).color)), C_TYP_BOOLEAN);
 	const intermediateColor = obj.baseBrightFlg ? `#111111` : `#eeeeee`;
 
 	// 矢印の色変化を常時グラデーションさせる設定

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2580,17 +2580,9 @@ function titleInit() {
  * @param {boolean} _resetFlg
  */
 function makeWarningWindow(_text = ``, _resetFlg = false) {
-	let lblWarning;
 	const displayName = (g_currentPage === `initial` ? `title` : g_currentPage);
 	g_errMsgObj[displayName] = (_resetFlg ? `` : g_errMsgObj[displayName]) + (_text === `` ? `` : `<p>${_text}</p>`);
-	if (document.querySelector(`#lblWarning`) === null) {
-	} else {
-		lblWarning = document.querySelector(`#lblWarning`);
-		divRoot.removeChild(document.querySelector(`#lblWarning`));
-	}
-	lblWarning = getTitleDivLabel(`lblWarning`, g_errMsgObj[displayName], 0, 70);
-	setWindowStyle(lblWarning, `#ffcccc`, `#660000`);
-	divRoot.appendChild(lblWarning);
+	divRoot.appendChild(setWindowStyle(g_errMsgObj[displayName], `#ffcccc`, `#660000`));
 }
 
 /**
@@ -2598,14 +2590,7 @@ function makeWarningWindow(_text = ``, _resetFlg = false) {
  * @param {string} _text 
  */
 function makeInfoWindow(_text, _animationName = ``) {
-	let lblWarning;
-	if (document.querySelector(`#lblWarning`) === null) {
-	} else {
-		lblWarning = document.querySelector(`#lblWarning`);
-		divRoot.removeChild(document.querySelector(`#lblWarning`));
-	}
-	lblWarning = getTitleDivLabel(`lblWarning`, `<p>${_text}</p>`, 0, 70);
-	setWindowStyle(lblWarning, `#ccccff`, `#000066`, C_ALIGN_CENTER);
+	const lblWarning = setWindowStyle(`<p>${_text}</p>`, `#ccccff`, `#000066`, C_ALIGN_CENTER);
 	lblWarning.style.pointerEvents = C_DIS_NONE;
 
 	if (_animationName !== ``) {
@@ -2623,24 +2608,31 @@ function makeInfoWindow(_text, _animationName = ``) {
  * @param {string} _bkColor 
  * @param {string} _textColor 
  */
-function setWindowStyle(_lbl, _bkColor, _textColor, _align = C_ALIGN_LEFT) {
+function setWindowStyle(_text, _bkColor, _textColor, _align = C_ALIGN_LEFT) {
 
-	const len = _lbl.innerHTML.split(`<br>`).length + _lbl.innerHTML.split(`<p>`).length - 1;
+	if (document.querySelector(`#lblWarning`) === null) {
+	} else {
+		divRoot.removeChild(document.querySelector(`#lblWarning`));
+	}
+	const lbl = getTitleDivLabel(`lblWarning`, _text, 0, 70);
+	const len = lbl.innerHTML.split(`<br>`).length + lbl.innerHTML.split(`<p>`).length - 1;
 	let warnHeight;
 	if (len * 21 <= 150) {
 		warnHeight = len * 21;
 	} else {
 		warnHeight = 150;
-		_lbl.style.overflow = `auto`;
+		lbl.style.overflow = `auto`;
 	}
-	_lbl.style.backgroundColor = _bkColor;
-	_lbl.style.opacity = 0.9;
-	_lbl.style.height = `${warnHeight}px`;
-	_lbl.style.lineHeight = `15px`;
-	_lbl.style.fontSize = `${C_SIZ_MAIN}px`;
-	_lbl.style.color = _textColor;
-	_lbl.style.textAlign = _align;
-	_lbl.style.fontFamily = getBasicFont();
+	lbl.style.backgroundColor = _bkColor;
+	lbl.style.opacity = 0.9;
+	lbl.style.height = `${warnHeight}px`;
+	lbl.style.lineHeight = `15px`;
+	lbl.style.fontSize = `${C_SIZ_MAIN}px`;
+	lbl.style.color = _textColor;
+	lbl.style.textAlign = _align;
+	lbl.style.fontFamily = getBasicFont();
+
+	return lbl;
 }
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -233,15 +233,8 @@ const checkLightOrDark = _colorStr => {
 	const r = parseInt(_colorStr.substring(1, 3), 16);
 	const g = parseInt(_colorStr.substring(3, 5), 16);
 	const b = parseInt(_colorStr.substring(5, 7), 16);
-	return ((((r * 299) + (g * 587) + (b * 114)) / 1000) >= 128);
+	return ((((r * 299) + (g * 587) + (b * 114)) / 1000) < 128);
 };
-
-/**
- * 対象のカラーコードが明暗どちらかを判定し、白もしくは黒色を返却
- * @param {string} _colorStr 
- * @returns 
- */
-const getLightOrDark = _colorStr => checkLightOrDark(_colorStr) ? `#eeeeee` : `#111111`;
 
 /**
  * イベントハンドラ用オブジェクト
@@ -2897,7 +2890,8 @@ function headerConvert(_dosObj) {
 
 	// グラデーションのデフォルト中間色を設定
 	divRoot.appendChild(createDivCss2Label(`dummyLabel`, ``, { pointerEvents: C_DIS_NONE }));
-	const intermediateColor = getLightOrDark(colorNameToCode(window.getComputedStyle(dummyLabel, ``).color));
+	obj.baseBrightFlg = checkLightOrDark(colorNameToCode(window.getComputedStyle(dummyLabel, ``).color));
+	const intermediateColor = obj.baseBrightFlg ? `#111111` : `#eeeeee`;
 
 	// 矢印の色変化を常時グラデーションさせる設定
 	obj.defaultColorgrd = [false, intermediateColor];
@@ -2934,6 +2928,9 @@ function headerConvert(_dosObj) {
 
 	// 初期色情報
 	Object.keys(g_dfColorObj).forEach(key => obj[key] = g_dfColorObj[key].concat());
+	if (obj.baseBrightFlg) {
+		Object.keys(g_dfColorLightObj).forEach(key => obj[key] = g_dfColorLightObj[key].concat());
+	}
 	obj.frzColorDefault = [];
 
 	// ダミー用初期矢印色

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -225,6 +225,25 @@ const fuzzyListMatching = (_str, _headerList, _footerList) =>
 	listMatching(_str, _headerList, { prefix: `^` }) || listMatching(_str, _footerList, { suffix: `$` });
 
 /**
+ * 対象のカラーコードが明暗どちらかを判定 (true: 明色, false: 暗色)
+ * @param {string} _colorStr 
+ * @returns 
+ */
+const checkLightOrDark = _colorStr => {
+	const r = parseInt(_colorStr.substring(1, 3), 16);
+	const g = parseInt(_colorStr.substring(3, 5), 16);
+	const b = parseInt(_colorStr.substring(5, 7), 16);
+	return ((((r * 299) + (g * 587) + (b * 114)) / 1000) >= 128);
+};
+
+/**
+ * 対象のカラーコードが明暗どちらかを判定し、白もしくは黒色を返却
+ * @param {string} _colorStr 
+ * @returns 
+ */
+const getLightOrDark = _colorStr => checkLightOrDark(_colorStr) ? `#eeeeee` : `#111111`;
+
+/**
  * イベントハンドラ用オブジェクト
  * 参考: http://webkatu.com/remove-eventlistener/
  * 
@@ -455,11 +474,13 @@ function preloadFile(_as, _href, _type = ``, _crossOrigin = `anonymous`) {
  * CSSファイルの読み込み（danoni_main.css以外）
  * デフォルトは danoni_skin_default.css を読み込む
  * @param {url} _href 
+ * @param {function} _func
  */
-function importCssFile(_href) {
+function importCssFile(_href, _func) {
 	const link = document.createElement(`link`);
 	link.rel = `stylesheet`;
 	link.href = _href;
+	link.onload = _ => _func();
 	document.head.appendChild(link);
 }
 
@@ -1385,13 +1406,8 @@ function initAfterDosLoaded() {
 	// クエリで譜面番号が指定されていればセット
 	g_stateObj.scoreId = setVal(getQueryParamVal(`scoreId`), 0, C_TYP_NUMBER);
 
-	// 譜面ヘッダー、特殊キー情報の読込
-	g_headerObj = headerConvert(g_rootObj);
-	keysConvert(g_rootObj);
-
-	// キー数情報を初期化
-	g_keyObj.currentKey = g_headerObj.keyLabels[g_stateObj.scoreId];
-	g_keyObj.currentPtn = 0;
+	// 譜面ヘッダーの読込
+	Object.assign(g_headerObj, preheaderConvert(g_rootObj));
 
 	// CSSファイル内のbackgroundを取得するために再描画
 	if (document.querySelector(`#layer0`) === null) {
@@ -1403,58 +1419,75 @@ function initAfterDosLoaded() {
 
 	// CSSファイルの読み込み
 	const randTime = new Date().getTime();
-	importCssFile(`${g_headerObj.skinRoot}danoni_skin_${g_headerObj.skinType}.css?${randTime}`);
-	if (g_headerObj.skinType2 !== ``) {
-		importCssFile(`${g_headerObj.skinRoot2}danoni_skin_${g_headerObj.skinType2}.css?${randTime}`);
-	}
-
-	// 画像ファイルの読み込み
-	g_imgInitList.forEach(img => preloadFile(`image`, g_imgObj[img]));
-
-	// その他の画像ファイルの読み込み
-	g_headerObj.preloadImages.filter(image => hasVal(image)).forEach(preloadImage => {
-
-		// Pattern A: |preloadImages=file.png|
-		// Pattern B: |preloadImages=file*.png@10|  -> file01.png ~ file10.png
-		// Pattern C: |preloadImages=file*.png@2-9| -> file2.png  ~ file9.png
-		// Pattern D: |preloadImages=file*.png@003-018| -> file003.png  ~ file018.png
-
-		const tmpPreloadImages = preloadImage.split(`@`);
-		if (tmpPreloadImages.length === 1) {
-			// Pattern Aの場合
-			preloadFile(`image`, preloadImage);
+	importCssFile(`${g_headerObj.skinRoot}danoni_skin_${g_headerObj.skinType}.css?${randTime}`, _ => {
+		if (g_headerObj.skinType2 !== ``) {
+			importCssFile(`${g_headerObj.skinRoot2}danoni_skin_${g_headerObj.skinType2}.css?${randTime}`, _ => initAfterCssLoaded());
 		} else {
-			const termRoopCnts = tmpPreloadImages[1].split(`-`);
-			let startCnt = 1;
-			let lastCnt;
-			let paddingLen;
-
-			if (termRoopCnts.length === 1) {
-				// Pattern Bの場合
-				lastCnt = setVal(tmpPreloadImages[1], 1, C_TYP_NUMBER);
-				paddingLen = String(setVal(tmpPreloadImages[1], 1, C_TYP_STRING)).length;
-			} else {
-				// Pattern C, Dの場合
-				startCnt = setVal(termRoopCnts[0], 1, C_TYP_NUMBER);
-				lastCnt = setVal(termRoopCnts[1], 1, C_TYP_NUMBER);
-				paddingLen = String(setVal(termRoopCnts[1], 1, C_TYP_STRING)).length;
-			}
-			for (let k = startCnt; k <= lastCnt; k++) {
-				preloadFile(`image`, tmpPreloadImages[0].replace(/\*/g, String(k).padStart(paddingLen, `0`)));
-			}
+			initAfterCssLoaded();
 		}
 	});
 
-	if (g_loadObj.main) {
-		// customjsの読み込み後、譜面詳細情報取得のために譜面をロード
-		loadCustomjs(_ => {
-			loadDos(_ => {
-				getScoreDetailData(0);
-			}, 0, true);
+	/**
+	 * スキンCSSファイルを読み込んだ後の処理
+	 */
+	function initAfterCssLoaded() {
+
+		// 譜面ヘッダー、特殊キー情報の読込
+		Object.assign(g_headerObj, headerConvert(g_rootObj));
+		keysConvert(g_rootObj);
+
+		// キー数情報を初期化
+		g_keyObj.currentKey = g_headerObj.keyLabels[g_stateObj.scoreId];
+		g_keyObj.currentPtn = 0;
+
+		// 画像ファイルの読み込み
+		g_imgInitList.forEach(img => preloadFile(`image`, g_imgObj[img]));
+
+		// その他の画像ファイルの読み込み
+		g_headerObj.preloadImages.filter(image => hasVal(image)).forEach(preloadImage => {
+
+			// Pattern A: |preloadImages=file.png|
+			// Pattern B: |preloadImages=file*.png@10|  -> file01.png ~ file10.png
+			// Pattern C: |preloadImages=file*.png@2-9| -> file2.png  ~ file9.png
+			// Pattern D: |preloadImages=file*.png@003-018| -> file003.png  ~ file018.png
+
+			const tmpPreloadImages = preloadImage.split(`@`);
+			if (tmpPreloadImages.length === 1) {
+				// Pattern Aの場合
+				preloadFile(`image`, preloadImage);
+			} else {
+				const termRoopCnts = tmpPreloadImages[1].split(`-`);
+				let startCnt = 1;
+				let lastCnt;
+				let paddingLen;
+
+				if (termRoopCnts.length === 1) {
+					// Pattern Bの場合
+					lastCnt = setVal(tmpPreloadImages[1], 1, C_TYP_NUMBER);
+					paddingLen = String(setVal(tmpPreloadImages[1], 1, C_TYP_STRING)).length;
+				} else {
+					// Pattern C, Dの場合
+					startCnt = setVal(termRoopCnts[0], 1, C_TYP_NUMBER);
+					lastCnt = setVal(termRoopCnts[1], 1, C_TYP_NUMBER);
+					paddingLen = String(setVal(termRoopCnts[1], 1, C_TYP_STRING)).length;
+				}
+				for (let k = startCnt; k <= lastCnt; k++) {
+					preloadFile(`image`, tmpPreloadImages[0].replace(/\*/g, String(k).padStart(paddingLen, `0`)));
+				}
+			}
 		});
-	} else {
-		getScoreDetailData(0);
-		reloadDos(0);
+
+		if (g_loadObj.main) {
+			// customjsの読み込み後、譜面詳細情報取得のために譜面をロード
+			loadCustomjs(_ => {
+				loadDos(_ => {
+					getScoreDetailData(0);
+				}, 0, true);
+			});
+		} else {
+			getScoreDetailData(0);
+			reloadDos(0);
+		}
 	}
 }
 
@@ -2651,7 +2684,40 @@ function getMusicNameMultiLine(_musicName) {
 }
 
 /**
- * 譜面ヘッダーの分解
+ * 譜面ヘッダーの分解（スキン、jsファイルなどの設定）
+ * @param {object} _dosObj 
+ * @returns 
+ */
+function preheaderConvert(_dosObj) {
+
+	// ヘッダー群の格納先
+	const obj = {};
+
+	// 外部スキンファイルの指定
+	const tmpSkinType = _dosObj.skinType || (typeof g_presetSkinType === C_TYP_STRING ? g_presetSkinType : `default`);
+	const skinTypes = tmpSkinType.split(`,`);
+	[obj.skinType2, obj.skinRoot2] = getFilePath(skinTypes.length > 1 ? skinTypes[1] : `blank`, C_DIR_SKIN);
+	[obj.skinType, obj.skinRoot] = getFilePath(skinTypes[0], C_DIR_SKIN);
+
+	// 外部jsファイルの指定
+	const tmpCustomjs = _dosObj.customjs || (typeof g_presetCustomJs === C_TYP_STRING ? g_presetCustomJs : C_JSF_CUSTOM);
+	const customjss = tmpCustomjs.split(`,`);
+	[obj.customjs2, obj.customjs2Root] = getFilePath(customjss.length > 1 ? customjss[1] : C_JSF_BLANK, C_DIR_JS);
+	[obj.customjs, obj.customjsRoot] = getFilePath(customjss[0], C_DIR_JS);
+
+	// デフォルト曲名表示、背景、Ready表示の利用有無
+	g_titleLists.init.forEach(objName => {
+		const objUpper = toCapitalize(objName);
+		obj[`custom${objUpper}Use`] = setVal(_dosObj[`custom${objUpper}Use`],
+			(typeof g_presetCustomDesignUse === C_TYP_OBJECT && (objName in g_presetCustomDesignUse) ?
+				setVal(g_presetCustomDesignUse[objName], false, C_TYP_BOOLEAN) : false), C_TYP_BOOLEAN);
+	});
+
+	return obj;
+}
+
+/**
+ * 譜面ヘッダーの分解（その他の設定）
  * @param {object} _dosObj 譜面データオブジェクト
  */
 function headerConvert(_dosObj) {
@@ -2829,12 +2895,16 @@ function headerConvert(_dosObj) {
 	g_stateObj.speed = obj.initSpeeds[g_stateObj.scoreId];
 	g_settings.speedNum = roundZero(g_settings.speeds.findIndex(speed => speed === g_stateObj.speed));
 
+	// グラデーションのデフォルト中間色を設定
+	divRoot.appendChild(createDivCss2Label(`dummyLabel`, ``, { pointerEvents: C_DIS_NONE }));
+	const intermediateColor = getLightOrDark(colorNameToCode(window.getComputedStyle(dummyLabel, ``).color));
+
 	// 矢印の色変化を常時グラデーションさせる設定
-	obj.defaultColorgrd = [false, `#eeeeee`];
+	obj.defaultColorgrd = [false, intermediateColor];
 	if (hasVal(_dosObj.defaultColorgrd)) {
 		obj.defaultColorgrd = _dosObj.defaultColorgrd.split(`,`);
 		obj.defaultColorgrd[0] = setVal(obj.defaultColorgrd[0], false, C_TYP_BOOLEAN);
-		obj.defaultColorgrd[1] = setVal(obj.defaultColorgrd[1], `#eeeeee`, C_TYP_STRING);
+		obj.defaultColorgrd[1] = setVal(obj.defaultColorgrd[1], intermediateColor, C_TYP_STRING);
 	}
 
 	// カラーコードのゼロパディング有無設定
@@ -2939,18 +3009,6 @@ function headerConvert(_dosObj) {
 		makeWarningWindow(g_msgInfoObj.E_0042.split(`{0}`).join(`playbackRate`));
 	}
 
-	// 外部スキンファイルの指定
-	const tmpSkinType = _dosObj.skinType || (typeof g_presetSkinType === C_TYP_STRING ? g_presetSkinType : `default`);
-	const skinTypes = tmpSkinType.split(`,`);
-	[obj.skinType2, obj.skinRoot2] = getFilePath(skinTypes.length > 1 ? skinTypes[1] : `blank`, C_DIR_SKIN);
-	[obj.skinType, obj.skinRoot] = getFilePath(skinTypes[0], C_DIR_SKIN);
-
-	// 外部jsファイルの指定
-	const tmpCustomjs = _dosObj.customjs || (typeof g_presetCustomJs === C_TYP_STRING ? g_presetCustomJs : C_JSF_CUSTOM);
-	const customjss = tmpCustomjs.split(`,`);
-	[obj.customjs2, obj.customjs2Root] = getFilePath(customjss.length > 1 ? customjss[1] : C_JSF_BLANK, C_DIR_JS);
-	[obj.customjs, obj.customjsRoot] = getFilePath(customjss[0], C_DIR_JS);
-
 	// ステップゾーン位置
 	g_posObj.stepY = (isNaN(parseFloat(_dosObj.stepY)) ? C_STEP_Y : parseFloat(_dosObj.stepY));
 	g_posObj.stepYR = (isNaN(parseFloat(_dosObj.stepYR)) ? C_STEP_YR : parseFloat(_dosObj.stepYR));
@@ -2994,14 +3052,6 @@ function headerConvert(_dosObj) {
 
 	// 更新日
 	obj.releaseDate = setVal(_dosObj.releaseDate, ``, C_TYP_STRING);
-
-	// デフォルト曲名表示、背景、Ready表示の利用有無
-	g_titleLists.init.forEach(objName => {
-		const objUpper = toCapitalize(objName);
-		obj[`custom${objUpper}Use`] = setVal(_dosObj[`custom${objUpper}Use`],
-			(typeof g_presetCustomDesignUse === C_TYP_OBJECT && (objName in g_presetCustomDesignUse) ?
-				setVal(g_presetCustomDesignUse[objName], false, C_TYP_BOOLEAN) : false), C_TYP_BOOLEAN);
-	});
 
 	// デフォルトReady/リザルト表示の遅延時間設定
 	[`ready`, `result`].forEach(objName => {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2292,3 +2292,15 @@ const g_msgObj = {
     opacity: `判定キャラクタ、コンボ数、Fast/Slow、Hidden+/Sudden+の\n境界線表示の透明度を設定します。`,
 
 };
+
+/**
+ * エラーメッセージ管理
+ */
+const g_errMsgObj = {
+    title: ``,
+    option: ``,
+    settingsDisplay: ``,
+    loading: ``,
+    main: ``,
+    result: ``,
+};

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1936,6 +1936,25 @@ const g_dfColorObj = {
     ],
 };
 
+const g_dfColorLightObj = {
+    setColorType1: [`#6666ff`, `#66cccc`, `#000000`, `#999966`, `#cc6600`],
+    setColorType2: [`#000000`, `#6666ff`, `#cc0000`, `#cc99cc`, `#cc3366`],
+    frzColorType1: [
+        [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
+        [`#00ffcc`, `#339999`, `#cccc33`, `#999933`],
+        [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
+        [`#cc99ff`, `#9966ff`, `#cccc33`, `#999933`],
+        [`#ff99cc`, `#ff6699`, `#cccc33`, `#999933`]
+    ],
+    frzColorType2: [
+        [`#cccccc`, `#999999`, `#cccc33`, `#999933`],
+        [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
+        [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
+        [`#cc99cc`, `#ff99ff`, `#cccc33`, `#999933`],
+        [`#ff6666`, `#ff9999`, `#cccc33`, `#999933`]
+    ],
+};
+
 const g_escapeStr = {
     escape: [[`&`, `&amp;`], [`<`, `&lt;`], [`>`, `&gt;`], [`"`, `&quot;`]],
     escapeTag: [

--- a/skin/danoni_skin_light.js
+++ b/skin/danoni_skin_light.js
@@ -11,19 +11,6 @@ function skinTitleInit() {
     // 背景矢印
     // $id(`lblArrow`).left = `0px`;
 
-    g_headerObj.setColorType1 = [`#6666ff`, `#66cccc`, `#000000`, `#999966`, `#cc6600`];
-    g_headerObj.setColorType2 = [`#000000`, `#6666ff`, `#cc0000`, `#cc99cc`, `#cc3366`];
-    g_headerObj.frzColorType1 = [[`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-    [`#00ffcc`, `#339999`, `#cccc33`, `#999933`],
-    [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-    [`#cc99ff`, `#9966ff`, `#cccc33`, `#999933`],
-    [`#ff99cc`, `#ff6699`, `#cccc33`, `#999933`]];
-    g_headerObj.frzColorType2 = [[`#cccccc`, `#999999`, `#cccc33`, `#999933`],
-    [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-    [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-    [`#cc99cc`, `#ff99ff`, `#cccc33`, `#999933`],
-    [`#ff6666`, `#ff9999`, `#cccc33`, `#999933`]];
-
 }
 
 /**

--- a/skin/danoni_skin_skyblue.js
+++ b/skin/danoni_skin_skyblue.js
@@ -11,19 +11,6 @@ function skinTitleInit() {
     // 背景矢印
     // $id(`lblArrow`).left = `0px`;
 
-    g_headerObj.setColorType1 = [`#6666ff`, `#66cccc`, `#000000`, `#999966`, `#cc6600`];
-    g_headerObj.setColorType2 = [`#000000`, `#6666ff`, `#cc0000`, `#cc99cc`, `#cc3366`];
-    g_headerObj.frzColorType1 = [[`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-    [`#00ffcc`, `#339999`, `#cccc33`, `#999933`],
-    [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-    [`#cc99ff`, `#9966ff`, `#cccc33`, `#999933`],
-    [`#ff99cc`, `#ff6699`, `#cccc33`, `#999933`]];
-    g_headerObj.frzColorType2 = [[`#cccccc`, `#999999`, `#cccc33`, `#999933`],
-    [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-    [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-    [`#cc99cc`, `#ff99ff`, `#cccc33`, `#999933`],
-    [`#ff6666`, `#ff9999`, `#cccc33`, `#999933`]];
-
 }
 
 /**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 背景状況 (厳密には、スキンCSSの `.title_base`で判断) により、
明暗用のColorTypeを自動適用するよう変更しました。
明背景の場合、明背景用のデフォルトColorTypeが適用されます。
```css
/* タイトル */
.title_base {
	color:#222222;
}
```
2. ColorType：Type0について、未指定かつ明背景の場合、自動で中間色を黒にするよう変更しました。
3. 強制的に明暗指定する譜面ヘッダー：backBright を追加しました。`true`: 明色、`false`: 暗色 です。
```
|backBright=true|
```
4. メッセージ周りが正しく表示されない問題を修正しました。
タイトル画面でのエラーメッセージがページ移動時に隠れる問題を改善しています。


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 明背景のとき、必ずjsファイルの加工が必要となり煩雑なため。
2. 明背景のとき、Type0が見づらくなる傾向があるため。
3. 間違って明背景と判断される可能性があるため。
※背景色は見ていません。標準の文字色を元に背景を推定して判断しています。
4. タイトル画面表示前にclearWindowを挟んだことで、メッセージ表示が隠れてしまったため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/112716966-f4017000-8f2c-11eb-8797-d19245f1b258.png" width="40%"><img src="https://user-images.githubusercontent.com/44026291/112716978-0b405d80-8f2d-11eb-9773-119a2c304e83.png" width="40%">

## :pencil: その他コメント / Other Comments
- スキンCSSファイルの先読み処理を行った関係で、処理の一部入れ替えを行っています。