### PR TITLE
[ver21.2.0] 背景状況により明暗用のカラーセットを使用するよう変更　他

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ v14, 20の対応終了時期はv23リリース開始時を予定しています�
 
 | Version | Supported          | Latest Version | First Release | End of Support |
 | ------- | ------------------ |----------------|---------------|----------------|
-| v21     | :heavy_check_mark: |[v21.1.0](../../releases/tag/v21.1.0)          |2021-03-12|-|
+| v21     | :heavy_check_mark: |[v21.2.0](../../releases/tag/v21.2.0)          |2021-03-12|-|
 | v20     | :heavy_check_mark: |[v20.5.2](../../releases/tag/v20.5.2)          |2021-02-12|(At Release v23)|
 | v19     | :heavy_check_mark: |[v19.5.6](../../releases/tag/v19.5.6)          |2021-01-17|-|
 | v18     | :x:                |[v18.9.6 (final)](../../releases/tag/v18.9.6)  |2020-10-25|2021-03-12|

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3737,6 +3737,18 @@ const commonSettingBtn = _labelName => {
 			w: C_LEN_SETMINI_WIDTH, h: 40, title: g_msgObj[`to${_labelName}`],
 			resetFunc: _ => (_labelName === `Display` ? settingsDisplayInit() : optionInit()),
 		}, g_cssObj.button_Mini),
+
+		// データセーブフラグの切替
+		createCss2Button(`btnSave`, g_lblNameObj.dataSave, evt => {
+			g_stateObj.dataSaveFlg = !g_stateObj.dataSaveFlg;
+			const [from, to] = (g_stateObj.dataSaveFlg ? [C_FLG_OFF, C_FLG_ON] : [C_FLG_ON, C_FLG_OFF]);
+			evt.target.classList.replace(g_cssObj[`button_${from}`], g_cssObj[`button_${to}`]);
+		}, {
+			x: 0, y: 5,
+			w: g_sWidth / 5, h: 16, siz: 12,
+			title: g_msgObj.dataSave,
+			borderStyle: `solid`,
+		}, g_cssObj.button_Default, (g_stateObj.dataSaveFlg ? g_cssObj.button_ON : g_cssObj.button_OFF)),
 	);
 };
 
@@ -3767,21 +3779,6 @@ function optionInit() {
 
 	// ボタン描画
 	commonSettingBtn(`Display`);
-
-	multiAppend(divRoot,
-
-		// データセーブフラグの切替
-		createCss2Button(`btnSave`, g_lblNameObj.dataSave, evt => {
-			g_stateObj.dataSaveFlg = !g_stateObj.dataSaveFlg;
-			const [from, to] = (g_stateObj.dataSaveFlg ? [C_FLG_OFF, C_FLG_ON] : [C_FLG_ON, C_FLG_OFF]);
-			evt.target.classList.replace(g_cssObj[`button_${from}`], g_cssObj[`button_${to}`]);
-		}, {
-			x: 0, y: 5,
-			w: g_sWidth / 5, h: 16, siz: 12,
-			title: g_msgObj.dataSave,
-			borderStyle: `solid`,
-		}, g_cssObj.button_Default, (g_stateObj.dataSaveFlg ? g_cssObj.button_ON : g_cssObj.button_OFF))
-	);
 
 	// キー操作イベント（デフォルト）
 	setShortcutEvent(g_currentPage);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2021/03/19
+ * Revised : 2021/03/27
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 21.1.0`;
-const g_revisedDate = `2021/03/19`;
+const g_version = `Ver 21.2.0`;
+const g_revisedDate = `2021/03/27`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -225,6 +225,18 @@ const fuzzyListMatching = (_str, _headerList, _footerList) =>
 	listMatching(_str, _headerList, { prefix: `^` }) || listMatching(_str, _footerList, { suffix: `$` });
 
 /**
+ * 対象のカラーコードが明暗どちらかを判定 (true: 明色, false: 暗色)
+ * @param {string} _colorStr 
+ * @returns 
+ */
+const checkLightOrDark = _colorStr => {
+	const r = parseInt(_colorStr.substring(1, 3), 16);
+	const g = parseInt(_colorStr.substring(3, 5), 16);
+	const b = parseInt(_colorStr.substring(5, 7), 16);
+	return ((((r * 299) + (g * 587) + (b * 114)) / 1000) < 128);
+};
+
+/**
  * イベントハンドラ用オブジェクト
  * 参考: http://webkatu.com/remove-eventlistener/
  * 
@@ -455,11 +467,17 @@ function preloadFile(_as, _href, _type = ``, _crossOrigin = `anonymous`) {
  * CSSファイルの読み込み（danoni_main.css以外）
  * デフォルトは danoni_skin_default.css を読み込む
  * @param {url} _href 
+ * @param {function} _func
  */
-function importCssFile(_href) {
+function importCssFile(_href, _func) {
 	const link = document.createElement(`link`);
 	link.rel = `stylesheet`;
 	link.href = _href;
+	link.onload = _ => _func();
+	link.onerror = _ => {
+		makeWarningWindow(g_msgInfoObj.E_0041.split(`{0}`).join(_href.split(`?`)[0]), `title`);
+		_func();
+	};
 	document.head.appendChild(link);
 }
 
@@ -1385,13 +1403,8 @@ function initAfterDosLoaded() {
 	// クエリで譜面番号が指定されていればセット
 	g_stateObj.scoreId = setVal(getQueryParamVal(`scoreId`), 0, C_TYP_NUMBER);
 
-	// 譜面ヘッダー、特殊キー情報の読込
-	g_headerObj = headerConvert(g_rootObj);
-	keysConvert(g_rootObj);
-
-	// キー数情報を初期化
-	g_keyObj.currentKey = g_headerObj.keyLabels[g_stateObj.scoreId];
-	g_keyObj.currentPtn = 0;
+	// 譜面ヘッダーの読込
+	Object.assign(g_headerObj, preheaderConvert(g_rootObj));
 
 	// CSSファイル内のbackgroundを取得するために再描画
 	if (document.querySelector(`#layer0`) === null) {
@@ -1403,58 +1416,89 @@ function initAfterDosLoaded() {
 
 	// CSSファイルの読み込み
 	const randTime = new Date().getTime();
-	importCssFile(`${g_headerObj.skinRoot}danoni_skin_${g_headerObj.skinType}.css?${randTime}`);
-	if (g_headerObj.skinType2 !== ``) {
-		importCssFile(`${g_headerObj.skinRoot2}danoni_skin_${g_headerObj.skinType2}.css?${randTime}`);
-	}
-
-	// 画像ファイルの読み込み
-	g_imgInitList.forEach(img => preloadFile(`image`, g_imgObj[img]));
-
-	// その他の画像ファイルの読み込み
-	g_headerObj.preloadImages.filter(image => hasVal(image)).forEach(preloadImage => {
-
-		// Pattern A: |preloadImages=file.png|
-		// Pattern B: |preloadImages=file*.png@10|  -> file01.png ~ file10.png
-		// Pattern C: |preloadImages=file*.png@2-9| -> file2.png  ~ file9.png
-		// Pattern D: |preloadImages=file*.png@003-018| -> file003.png  ~ file018.png
-
-		const tmpPreloadImages = preloadImage.split(`@`);
-		if (tmpPreloadImages.length === 1) {
-			// Pattern Aの場合
-			preloadFile(`image`, preloadImage);
+	importCssFile(`${g_headerObj.skinRoot}danoni_skin_${g_headerObj.skinType}.css?${randTime}`, _ => {
+		if (g_headerObj.skinType2 !== ``) {
+			importCssFile(`${g_headerObj.skinRoot2}danoni_skin_${g_headerObj.skinType2}.css?${randTime}`, _ => initAfterCssLoaded());
 		} else {
-			const termRoopCnts = tmpPreloadImages[1].split(`-`);
-			let startCnt = 1;
-			let lastCnt;
-			let paddingLen;
-
-			if (termRoopCnts.length === 1) {
-				// Pattern Bの場合
-				lastCnt = setVal(tmpPreloadImages[1], 1, C_TYP_NUMBER);
-				paddingLen = String(setVal(tmpPreloadImages[1], 1, C_TYP_STRING)).length;
-			} else {
-				// Pattern C, Dの場合
-				startCnt = setVal(termRoopCnts[0], 1, C_TYP_NUMBER);
-				lastCnt = setVal(termRoopCnts[1], 1, C_TYP_NUMBER);
-				paddingLen = String(setVal(termRoopCnts[1], 1, C_TYP_STRING)).length;
-			}
-			for (let k = startCnt; k <= lastCnt; k++) {
-				preloadFile(`image`, tmpPreloadImages[0].replace(/\*/g, String(k).padStart(paddingLen, `0`)));
-			}
+			initAfterCssLoaded();
 		}
 	});
 
-	if (g_loadObj.main) {
-		// customjsの読み込み後、譜面詳細情報取得のために譜面をロード
-		loadCustomjs(_ => {
-			loadDos(_ => {
-				getScoreDetailData(0);
-			}, 0, true);
+	/**
+	 * スキンCSSファイルを読み込んだ後の処理
+	 */
+	function initAfterCssLoaded() {
+
+		// 譜面ヘッダー、特殊キー情報の読込
+		Object.assign(g_headerObj, headerConvert(g_rootObj));
+		keysConvert(g_rootObj);
+
+		// キー数情報を初期化
+		g_keyObj.currentKey = g_headerObj.keyLabels[g_stateObj.scoreId];
+		g_keyObj.currentPtn = 0;
+
+		// 画像ファイルの読み込み
+		g_imgInitList.forEach(img => preloadFile(`image`, g_imgObj[img]));
+
+		// その他の画像ファイルの読み込み
+		g_headerObj.preloadImages.filter(image => hasVal(image)).forEach(preloadImage => {
+
+			// Pattern A: |preloadImages=file.png|
+			// Pattern B: |preloadImages=file*.png@10|  -> file01.png ~ file10.png
+			// Pattern C: |preloadImages=file*.png@2-9| -> file2.png  ~ file9.png
+			// Pattern D: |preloadImages=file*.png@003-018| -> file003.png  ~ file018.png
+
+			const tmpPreloadImages = preloadImage.split(`@`);
+			if (tmpPreloadImages.length === 1) {
+				// Pattern Aの場合
+				preloadFile(`image`, preloadImage);
+			} else {
+				const termRoopCnts = tmpPreloadImages[1].split(`-`);
+				let startCnt = 1;
+				let lastCnt;
+				let paddingLen;
+
+				if (termRoopCnts.length === 1) {
+					// Pattern Bの場合
+					lastCnt = setVal(tmpPreloadImages[1], 1, C_TYP_NUMBER);
+					paddingLen = String(setVal(tmpPreloadImages[1], 1, C_TYP_STRING)).length;
+				} else {
+					// Pattern C, Dの場合
+					startCnt = setVal(termRoopCnts[0], 1, C_TYP_NUMBER);
+					lastCnt = setVal(termRoopCnts[1], 1, C_TYP_NUMBER);
+					paddingLen = String(setVal(termRoopCnts[1], 1, C_TYP_STRING)).length;
+				}
+				for (let k = startCnt; k <= lastCnt; k++) {
+					preloadFile(`image`, tmpPreloadImages[0].replace(/\*/g, String(k).padStart(paddingLen, `0`)));
+				}
+			}
 		});
-	} else {
-		getScoreDetailData(0);
-		reloadDos(0);
+
+		// 非推奨ブラウザに対して警告文を表示
+		// Firefoxはローカル環境時、Ver65以降矢印が表示されなくなるため非推奨表示
+		if (g_userAgent.indexOf(`msie`) !== -1 ||
+			g_userAgent.indexOf(`trident`) !== -1 ||
+			g_userAgent.indexOf(`edge`) !== -1 ||
+			(g_userAgent.indexOf(`firefox`) !== -1 && g_isFile)) {
+
+			makeWarningWindow(g_msgInfoObj.W_0001);
+		}
+
+		if (g_isFile) {
+			makeWarningWindow(g_msgInfoObj.W_0011);
+		}
+
+		if (g_loadObj.main) {
+			// customjsの読み込み後、譜面詳細情報取得のために譜面をロード
+			loadCustomjs(_ => {
+				loadDos(_ => {
+					getScoreDetailData(0);
+				}, 0, true);
+			});
+		} else {
+			getScoreDetailData(0);
+			reloadDos(0);
+		}
 	}
 }
 
@@ -2345,18 +2389,8 @@ function titleInit() {
 		divRoot.appendChild(lblmusicTitle);
 	}
 
-	// 非推奨ブラウザに対して警告文を表示
-	// Firefoxはローカル環境時、Ver65以降矢印が表示されなくなるため非推奨表示
-	if (g_userAgent.indexOf(`msie`) !== -1 ||
-		g_userAgent.indexOf(`trident`) !== -1 ||
-		g_userAgent.indexOf(`edge`) !== -1 ||
-		(g_userAgent.indexOf(`firefox`) !== -1 && g_isFile)) {
-
-		makeWarningWindow(g_msgInfoObj.W_0001);
-	}
-
-	if (g_isFile) {
-		makeWarningWindow(g_msgInfoObj.W_0011);
+	if (g_errMsgObj.title !== ``) {
+		makeWarningWindow();
 	}
 
 	// ユーザカスタムイベント(初期)
@@ -2543,19 +2577,12 @@ function titleInit() {
 /**
  * 警告用ウィンドウ（汎用）を表示
  * @param {string} _text 
+ * @param {boolean} _resetFlg
  */
-function makeWarningWindow(_text) {
-	let lblWarning;
-	if (document.querySelector(`#lblWarning`) === null) {
-		lblWarning = getTitleDivLabel(`lblWarning`, `<p>${_text}</p>`, 0, 70);
-	} else {
-		lblWarning = document.querySelector(`#lblWarning`);
-		const text = lblWarning.innerHTML + `<p>${_text}</p>`;
-		divRoot.removeChild(document.querySelector(`#lblWarning`));
-		lblWarning = getTitleDivLabel(`lblWarning`, text, 0, 70);
-	}
-	setWindowStyle(lblWarning, `#ffcccc`, `#660000`);
-	divRoot.appendChild(lblWarning);
+function makeWarningWindow(_text = ``, _resetFlg = false) {
+	const displayName = (g_currentPage === `initial` ? `title` : g_currentPage);
+	g_errMsgObj[displayName] = (_resetFlg ? `` : g_errMsgObj[displayName]) + (_text === `` ? `` : `<p>${_text}</p>`);
+	divRoot.appendChild(setWindowStyle(g_errMsgObj[displayName], `#ffcccc`, `#660000`));
 }
 
 /**
@@ -2563,14 +2590,8 @@ function makeWarningWindow(_text) {
  * @param {string} _text 
  */
 function makeInfoWindow(_text, _animationName = ``) {
-	let lblWarning;
-	if (document.querySelector(`#lblWarning`) === null) {
-	} else {
-		lblWarning = document.querySelector(`#lblWarning`);
-		divRoot.removeChild(document.querySelector(`#lblWarning`));
-	}
-	lblWarning = getTitleDivLabel(`lblWarning`, `<p>${_text}</p>`, 0, 70);
-	setWindowStyle(lblWarning, `#ccccff`, `#000066`, C_ALIGN_CENTER);
+	const lblWarning = setWindowStyle(`<p>${_text}</p>`, `#ccccff`, `#000066`, C_ALIGN_CENTER);
+	lblWarning.style.pointerEvents = C_DIS_NONE;
 
 	if (_animationName !== ``) {
 		lblWarning.style.animationName = _animationName;
@@ -2587,25 +2608,31 @@ function makeInfoWindow(_text, _animationName = ``) {
  * @param {string} _bkColor 
  * @param {string} _textColor 
  */
-function setWindowStyle(_lbl, _bkColor, _textColor, _align = C_ALIGN_LEFT) {
+function setWindowStyle(_text, _bkColor, _textColor, _align = C_ALIGN_LEFT) {
 
-	const len = _lbl.innerHTML.split(`<br>`).length + _lbl.innerHTML.split(`<p>`).length - 1;
+	if (document.querySelector(`#lblWarning`) === null) {
+	} else {
+		divRoot.removeChild(document.querySelector(`#lblWarning`));
+	}
+	const lbl = getTitleDivLabel(`lblWarning`, _text, 0, 70);
+	const len = lbl.innerHTML.split(`<br>`).length + lbl.innerHTML.split(`<p>`).length - 1;
 	let warnHeight;
 	if (len * 21 <= 150) {
 		warnHeight = len * 21;
 	} else {
 		warnHeight = 150;
-		_lbl.style.overflow = `auto`;
+		lbl.style.overflow = `auto`;
 	}
-	_lbl.style.backgroundColor = _bkColor;
-	_lbl.style.opacity = 0.9;
-	_lbl.style.height = `${warnHeight}px`;
-	_lbl.style.lineHeight = `15px`;
-	_lbl.style.fontSize = `${C_SIZ_MAIN}px`;
-	_lbl.style.color = _textColor;
-	_lbl.style.textAlign = _align;
-	_lbl.style.fontFamily = getBasicFont();
-	_lbl.style.pointerEvents = C_DIS_NONE;
+	lbl.style.backgroundColor = _bkColor;
+	lbl.style.opacity = 0.9;
+	lbl.style.height = `${warnHeight}px`;
+	lbl.style.lineHeight = `15px`;
+	lbl.style.fontSize = `${C_SIZ_MAIN}px`;
+	lbl.style.color = _textColor;
+	lbl.style.textAlign = _align;
+	lbl.style.fontFamily = getBasicFont();
+
+	return lbl;
 }
 
 /**
@@ -2651,7 +2678,40 @@ function getMusicNameMultiLine(_musicName) {
 }
 
 /**
- * 譜面ヘッダーの分解
+ * 譜面ヘッダーの分解（スキン、jsファイルなどの設定）
+ * @param {object} _dosObj 
+ * @returns 
+ */
+function preheaderConvert(_dosObj) {
+
+	// ヘッダー群の格納先
+	const obj = {};
+
+	// 外部スキンファイルの指定
+	const tmpSkinType = _dosObj.skinType || (typeof g_presetSkinType === C_TYP_STRING ? g_presetSkinType : `default`);
+	const skinTypes = tmpSkinType.split(`,`);
+	[obj.skinType2, obj.skinRoot2] = getFilePath(skinTypes.length > 1 ? skinTypes[1] : `blank`, C_DIR_SKIN);
+	[obj.skinType, obj.skinRoot] = getFilePath(skinTypes[0], C_DIR_SKIN);
+
+	// 外部jsファイルの指定
+	const tmpCustomjs = _dosObj.customjs || (typeof g_presetCustomJs === C_TYP_STRING ? g_presetCustomJs : C_JSF_CUSTOM);
+	const customjss = tmpCustomjs.split(`,`);
+	[obj.customjs2, obj.customjs2Root] = getFilePath(customjss.length > 1 ? customjss[1] : C_JSF_BLANK, C_DIR_JS);
+	[obj.customjs, obj.customjsRoot] = getFilePath(customjss[0], C_DIR_JS);
+
+	// デフォルト曲名表示、背景、Ready表示の利用有無
+	g_titleLists.init.forEach(objName => {
+		const objUpper = toCapitalize(objName);
+		obj[`custom${objUpper}Use`] = setVal(_dosObj[`custom${objUpper}Use`],
+			(typeof g_presetCustomDesignUse === C_TYP_OBJECT && (objName in g_presetCustomDesignUse) ?
+				setVal(g_presetCustomDesignUse[objName], false, C_TYP_BOOLEAN) : false), C_TYP_BOOLEAN);
+	});
+
+	return obj;
+}
+
+/**
+ * 譜面ヘッダーの分解（その他の設定）
  * @param {object} _dosObj 譜面データオブジェクト
  */
 function headerConvert(_dosObj) {
@@ -2829,12 +2889,17 @@ function headerConvert(_dosObj) {
 	g_stateObj.speed = obj.initSpeeds[g_stateObj.scoreId];
 	g_settings.speedNum = roundZero(g_settings.speeds.findIndex(speed => speed === g_stateObj.speed));
 
+	// グラデーションのデフォルト中間色を設定
+	divRoot.appendChild(createDivCss2Label(`dummyLabel`, ``, { pointerEvents: C_DIS_NONE }));
+	obj.baseBrightFlg = setVal(_dosObj.baseBright, checkLightOrDark(colorNameToCode(window.getComputedStyle(dummyLabel, ``).color)), C_TYP_BOOLEAN);
+	const intermediateColor = obj.baseBrightFlg ? `#111111` : `#eeeeee`;
+
 	// 矢印の色変化を常時グラデーションさせる設定
-	obj.defaultColorgrd = [false, `#eeeeee`];
+	obj.defaultColorgrd = [false, intermediateColor];
 	if (hasVal(_dosObj.defaultColorgrd)) {
 		obj.defaultColorgrd = _dosObj.defaultColorgrd.split(`,`);
 		obj.defaultColorgrd[0] = setVal(obj.defaultColorgrd[0], false, C_TYP_BOOLEAN);
-		obj.defaultColorgrd[1] = setVal(obj.defaultColorgrd[1], `#eeeeee`, C_TYP_STRING);
+		obj.defaultColorgrd[1] = setVal(obj.defaultColorgrd[1], intermediateColor, C_TYP_STRING);
 	}
 
 	// カラーコードのゼロパディング有無設定
@@ -2864,6 +2929,9 @@ function headerConvert(_dosObj) {
 
 	// 初期色情報
 	Object.keys(g_dfColorObj).forEach(key => obj[key] = g_dfColorObj[key].concat());
+	if (obj.baseBrightFlg) {
+		Object.keys(g_dfColorLightObj).forEach(key => obj[key] = g_dfColorLightObj[key].concat());
+	}
 	obj.frzColorDefault = [];
 
 	// ダミー用初期矢印色
@@ -2939,18 +3007,6 @@ function headerConvert(_dosObj) {
 		makeWarningWindow(g_msgInfoObj.E_0042.split(`{0}`).join(`playbackRate`));
 	}
 
-	// 外部スキンファイルの指定
-	const tmpSkinType = _dosObj.skinType || (typeof g_presetSkinType === C_TYP_STRING ? g_presetSkinType : `default`);
-	const skinTypes = tmpSkinType.split(`,`);
-	[obj.skinType2, obj.skinRoot2] = getFilePath(skinTypes.length > 1 ? skinTypes[1] : `blank`, C_DIR_SKIN);
-	[obj.skinType, obj.skinRoot] = getFilePath(skinTypes[0], C_DIR_SKIN);
-
-	// 外部jsファイルの指定
-	const tmpCustomjs = _dosObj.customjs || (typeof g_presetCustomJs === C_TYP_STRING ? g_presetCustomJs : C_JSF_CUSTOM);
-	const customjss = tmpCustomjs.split(`,`);
-	[obj.customjs2, obj.customjs2Root] = getFilePath(customjss.length > 1 ? customjss[1] : C_JSF_BLANK, C_DIR_JS);
-	[obj.customjs, obj.customjsRoot] = getFilePath(customjss[0], C_DIR_JS);
-
 	// ステップゾーン位置
 	g_posObj.stepY = (isNaN(parseFloat(_dosObj.stepY)) ? C_STEP_Y : parseFloat(_dosObj.stepY));
 	g_posObj.stepYR = (isNaN(parseFloat(_dosObj.stepYR)) ? C_STEP_YR : parseFloat(_dosObj.stepYR));
@@ -2994,14 +3050,6 @@ function headerConvert(_dosObj) {
 
 	// 更新日
 	obj.releaseDate = setVal(_dosObj.releaseDate, ``, C_TYP_STRING);
-
-	// デフォルト曲名表示、背景、Ready表示の利用有無
-	g_titleLists.init.forEach(objName => {
-		const objUpper = toCapitalize(objName);
-		obj[`custom${objUpper}Use`] = setVal(_dosObj[`custom${objUpper}Use`],
-			(typeof g_presetCustomDesignUse === C_TYP_OBJECT && (objName in g_presetCustomDesignUse) ?
-				setVal(g_presetCustomDesignUse[objName], false, C_TYP_BOOLEAN) : false), C_TYP_BOOLEAN);
-	});
 
 	// デフォルトReady/リザルト表示の遅延時間設定
 	[`ready`, `result`].forEach(objName => {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1936,6 +1936,25 @@ const g_dfColorObj = {
     ],
 };
 
+const g_dfColorLightObj = {
+    setColorType1: [`#6666ff`, `#66cccc`, `#000000`, `#999966`, `#cc6600`],
+    setColorType2: [`#000000`, `#6666ff`, `#cc0000`, `#cc99cc`, `#cc3366`],
+    frzColorType1: [
+        [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
+        [`#00ffcc`, `#339999`, `#cccc33`, `#999933`],
+        [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
+        [`#cc99ff`, `#9966ff`, `#cccc33`, `#999933`],
+        [`#ff99cc`, `#ff6699`, `#cccc33`, `#999933`]
+    ],
+    frzColorType2: [
+        [`#cccccc`, `#999999`, `#cccc33`, `#999933`],
+        [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
+        [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
+        [`#cc99cc`, `#ff99ff`, `#cccc33`, `#999933`],
+        [`#ff6666`, `#ff9999`, `#cccc33`, `#999933`]
+    ],
+};
+
 const g_escapeStr = {
     escape: [[`&`, `&amp;`], [`<`, `&lt;`], [`>`, `&gt;`], [`"`, `&quot;`]],
     escapeTag: [
@@ -2272,4 +2291,16 @@ const g_msgObj = {
     appearance: `流れる矢印の見え方を制御します。`,
     opacity: `判定キャラクタ、コンボ数、Fast/Slow、Hidden+/Sudden+の\n境界線表示の透明度を設定します。`,
 
+};
+
+/**
+ * エラーメッセージ管理
+ */
+const g_errMsgObj = {
+    title: ``,
+    option: ``,
+    settingsDisplay: ``,
+    loading: ``,
+    main: ``,
+    result: ``,
 };

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -845,6 +845,7 @@ const g_shortcutObj = {
         NumpadSubtract: { id: `lnkarrowEffect` },
         NumpadDivide: { id: `lnkspecial` },
 
+        KeyZ: { id: `btnSave` },
         Escape: { id: `btnBack` },
         Space: { id: `btnKeyConfig` },
         Enter: { id: `btnPlay` },
@@ -888,7 +889,7 @@ const g_btnPatterns = {
     title: { Start: 0, Comment: -10 },
     option: { Back: 0, KeyConfig: 0, Play: 0, Display: -5, Save: -10, Graph: -25 },
     difSelector: {},
-    settingsDisplay: { Back: 0, KeyConfig: 0, Play: 0, Settings: -5 },
+    settingsDisplay: { Back: 0, KeyConfig: 0, Play: 0, Save: -10, Settings: -5 },
     loadingIos: { Play: 0 },
     keyConfig: { Back: -3 },
     result: { Back: -5, Copy: -5, Tweet: -5, Gitter: -5, Retry: 0 },

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -5,7 +5,7 @@
  *
  * Source by tickle
  * Created : 2019/11/19
- * Revised : 2021/03/19 (v21.1.0)
+ * Revised : 2021/03/27 (v21.2.0)
  *
  * https://github.com/cwtickle/danoniplus
  */

--- a/js/sample/danoni_custom-003.js
+++ b/js/sample/danoni_custom-003.js
@@ -22,29 +22,19 @@
  */
 function customTitleInit() {
 
-	// 背景の矢印オブジェクトを表示
-	var lblC = createArrowEffect("lblC", "#ffffff", g_sWidth / 2 - 300, 0, 100, "onigiri");
-	lblC.style.opacity = 0.25;
-	divRoot.appendChild(lblC);
+	multiAppend(divRoot,
+		// 背景の矢印オブジェクトを表示
+		createColorObject2(`lblC`, {
+			x: g_sWidth / 2 - 300, y: 0, w: 100, h: 100, rotate: `onigiri`, opacity: 0.25,
+			background: `#ffffff`,
+		}),
 
-
-	// Tweetボタン描画
-	var btnTweet = createButton({
-		id: "btnTweet",
-		name: "Info",
-		x: g_sWidth / 4 * 3,
-		y: 340,
-		width: g_sWidth / 4,
-		height: C_BTN_HEIGHT,
-		fontsize: C_LBL_BTNSIZE,
-		normalColor: C_CLR_DEFAULT,
-		hoverColor: C_CLR_TWEET,
-		align: C_ALIGN_CENTER
-	}, function () {
-		clearWindow();
-		customCommentInit();
-	});
-	divRoot.appendChild(btnTweet);
+		// Infoボタン描画
+		createCss2Button(`btnTweet`, `Info`, _ => clearTimeout(g_timeoutEvtTitleId), {
+			x: g_sWidth / 4 * 3, y: 340, w: g_sWidth / 4,
+			resetFunc: _ => customCommentInit(),
+		}, g_cssObj.button_Tweet)
+	);
 }
 
 /**
@@ -52,41 +42,35 @@ function customTitleInit() {
  */
 function customCommentInit() {
 
-	// タイトル文字描画
-	var lblTitle = getTitleDivLabel("lblTitle",
-		"<span style='color:#6666ff;font-size:40px;'>I</span>NFO", 0, 15);
-	divRoot.appendChild(lblTitle);
+	clearWindow(true);
 
-	var comment = "これはカスタムページのテストです。<br>" +
-		"このように、作品別に特殊なページを作ることもできます。<br><br>" +
-		"下記のような戻るボタンがあると良いですね。(・∀・)";
+	// テキスト
+	const comment = `これはカスタムページのテストです。<br>
+		このように、作品別に特殊なページを作ることもできます。<br><br>
+		下記のような戻るボタンがあると良いですね。(・∀・)`;
 
-	var lblComment = createDivLabel("lblComment", g_sWidth / 2 - 200, 100, 400, 20, 14, "#cccccc",
-		comment);
-	lblComment.style.textAlign = C_ALIGN_LEFT;
-	divRoot.appendChild(lblComment);
+	// 各種ラベル追加
+	multiAppend(divRoot,
 
-	var lblC = createArrowEffect("lblC", "#ffffff", g_sWidth / 2 + 200, 350, 100, "onigiri");
-	divRoot.appendChild(lblC);
+		// タイトル文字
+		getTitleDivLabel(`lblTitle`,
+			`<span style='color:#6666ff;font-size:40px;'>I</span>NFO`, 0, 15),
 
-	// 戻るボタン描画
-	var btnBack = createButton({
-		id: "btnBack",
-		name: "Back",
-		x: 0,
-		y: g_sHeight - 100,
-		width: g_sWidth / 3,
-		height: C_BTN_HEIGHT,
-		fontsize: C_LBL_BTNSIZE,
-		normalColor: C_CLR_DEFAULT,
-		hoverColor: C_CLR_BACK,
-		align: C_ALIGN_CENTER
-	}, function () {
-		// タイトル画面へ戻る
-		clearWindow();
-		titleInit();
-	});
-	divRoot.appendChild(btnBack);
+		// コメント文
+		createDivCss2Label(`lblComment`, comment, {
+			x: g_sWidth / 2 - 200, y: 100, w: 400, h: 20, siz: 14, color: `#cccccc`,
+			align: C_ALIGN_LEFT,
+		}),
+
+		// おにぎりオブジェクトの配置
+		createColorObject2(`lblC`, {
+			x: g_sWidth / 2 + 200, y: 350, w: 100, h: 100, rotate: `onigiri`,
+			background: `#ffffff`,
+		}),
+
+		// 戻るボタン描画
+		createCss2Button(`btnBack`, g_lblNameObj.b_back, _ => true, { resetFunc: _ => titleInit() }, g_cssObj.button_Back),
+	)
 }
 
 /**

--- a/skin/danoni_skin_light.js
+++ b/skin/danoni_skin_light.js
@@ -11,19 +11,6 @@ function skinTitleInit() {
     // 背景矢印
     // $id(`lblArrow`).left = `0px`;
 
-    g_headerObj.setColorType1 = [`#6666ff`, `#66cccc`, `#000000`, `#999966`, `#cc6600`];
-    g_headerObj.setColorType2 = [`#000000`, `#6666ff`, `#cc0000`, `#cc99cc`, `#cc3366`];
-    g_headerObj.frzColorType1 = [[`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-    [`#00ffcc`, `#339999`, `#cccc33`, `#999933`],
-    [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-    [`#cc99ff`, `#9966ff`, `#cccc33`, `#999933`],
-    [`#ff99cc`, `#ff6699`, `#cccc33`, `#999933`]];
-    g_headerObj.frzColorType2 = [[`#cccccc`, `#999999`, `#cccc33`, `#999933`],
-    [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-    [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-    [`#cc99cc`, `#ff99ff`, `#cccc33`, `#999933`],
-    [`#ff6666`, `#ff9999`, `#cccc33`, `#999933`]];
-
 }
 
 /**

--- a/skin/danoni_skin_skyblue.js
+++ b/skin/danoni_skin_skyblue.js
@@ -11,19 +11,6 @@ function skinTitleInit() {
     // 背景矢印
     // $id(`lblArrow`).left = `0px`;
 
-    g_headerObj.setColorType1 = [`#6666ff`, `#66cccc`, `#000000`, `#999966`, `#cc6600`];
-    g_headerObj.setColorType2 = [`#000000`, `#6666ff`, `#cc0000`, `#cc99cc`, `#cc3366`];
-    g_headerObj.frzColorType1 = [[`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-    [`#00ffcc`, `#339999`, `#cccc33`, `#999933`],
-    [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-    [`#cc99ff`, `#9966ff`, `#cccc33`, `#999933`],
-    [`#ff99cc`, `#ff6699`, `#cccc33`, `#999933`]];
-    g_headerObj.frzColorType2 = [[`#cccccc`, `#999999`, `#cccc33`, `#999933`],
-    [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-    [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-    [`#cc99cc`, `#ff99ff`, `#cccc33`, `#999933`],
-    [`#ff6666`, `#ff9999`, `#cccc33`, `#999933`]];
-
 }
 
 /**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- #1032 データセーブフラグ切替ボタンをDisplay画面にも表示
- #1033 背景状況により明暗用のカラーセットを使用するよう変更
- #1033 ColorType：Type0について、未指定かつ明背景の場合、自動で中間色を黒にするよう変更
- #1033 メッセージ周りが正しく表示されない問題を修正
- #1034 danoni3.html のカスタムjsサンプルを更新

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- danoni_skin_light.js, danoni_skin_skyblue.js にてcolorTypeの独自定義が不要になったため、
独自記述をカットしています。
（残したままでも問題はありません）