### PR TITLE
[0396/file-loading] ファイルロード時のg_loadObjの管理方法を一部変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -470,12 +470,17 @@ function preloadFile(_as, _href, _type = ``, _crossOrigin = `anonymous`) {
  * @param {function} _func
  */
 function importCssFile(_href, _func) {
+	const baseUrl = _href.split(`?`)[0];
+	g_loadObj[baseUrl] = false;
 	const link = document.createElement(`link`);
 	link.rel = `stylesheet`;
 	link.href = _href;
-	link.onload = _ => _func();
+	link.onload = _ => {
+		g_loadObj[baseUrl] = true;
+		_func();
+	};
 	link.onerror = _ => {
-		makeWarningWindow(g_msgInfoObj.E_0041.split(`{0}`).join(_href.split(`?`)[0]), `title`);
+		makeWarningWindow(g_msgInfoObj.E_0041.split(`{0}`).join(baseUrl), `title`);
 		_func();
 	};
 	document.head.appendChild(link);
@@ -879,17 +884,20 @@ function clearWindow(_redrawFlg = false, _customDisplayName = ``) {
  * @param {string} _charset (default : UTF-8)
  */
 function loadScript(_url, _callback, _requiredFlg = true, _charset = `UTF-8`) {
-	g_loadObj[_url.split(`?`)[0]] = true;
+	const baseUrl = _url.split(`?`)[0];
+	g_loadObj[baseUrl] = false;
 	const script = document.createElement(`script`);
 	script.type = `text/javascript`;
 	script.src = _url;
 	script.charset = _charset;
-	script.onload = _ => _callback();
+	script.onload = _ => {
+		g_loadObj[baseUrl] = true;
+		_callback();
+	};
 	script.onerror = _ => {
 		if (_requiredFlg) {
 			makeWarningWindow(g_msgInfoObj.E_0041.split(`{0}`).join(_url.split(`?`)[0]));
 		} else {
-			g_loadObj[_url.split(`?`)[0]] = false;
 			_callback();
 		}
 	};


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. g_loadObjについて、読込完了時に設定値を`true`に変えるよう統一しました。
※これまでは失敗時のみ`false`にしていたり（loadScript）、未設定（importCssFile）でした。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. ファイルの読み込み状態を正確に把握し、意図しない動作をブロックするため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments