### PR TITLE
[0397/warning-window] 警告ウィンドウの仕様変更 (g_errMsgObjのプロパティを配列化)

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2589,8 +2589,16 @@ function titleInit() {
  */
 function makeWarningWindow(_text = ``, _resetFlg = false) {
 	const displayName = (g_currentPage === `initial` ? `title` : g_currentPage);
-	g_errMsgObj[displayName] = (_resetFlg ? `` : g_errMsgObj[displayName]) + (_text === `` ? `` : `<p>${_text}</p>`);
-	divRoot.appendChild(setWindowStyle(g_errMsgObj[displayName], `#ffcccc`, `#660000`));
+	if (_text !== ``) {
+		if (_resetFlg) {
+			g_errMsgObj[displayName] = [_text];
+		} else if (g_errMsgObj[displayName].findIndex(val => val === _text) === -1) {
+			g_errMsgObj[displayName].push(_text);
+		}
+	}
+	if (g_errMsgObj[displayName].length > 0) {
+		divRoot.appendChild(setWindowStyle(`<p>${g_errMsgObj[displayName].join('</p><p>')}</p>`, `#ffcccc`, `#660000`));
+	}
 }
 
 /**

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2297,10 +2297,10 @@ const g_msgObj = {
  * エラーメッセージ管理
  */
 const g_errMsgObj = {
-    title: ``,
-    option: ``,
-    settingsDisplay: ``,
-    loading: ``,
-    main: ``,
-    result: ``,
+    title: [],
+    option: [],
+    settingsDisplay: [],
+    loading: [],
+    main: [],
+    result: [],
 };


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 警告ウィンドウで使用するメッセージ(g_errMsgObjのプロパティ)について、配列化管理に変更しました。
`makeWarningWindow`及び`setWindowStyle`の使い方は変わりません。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 画面切り替え時、同じメッセージが二重に表示されないようにするための対策です。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
