### PR TITLE
[0398/empty-sprite] 空スプライト作成処理を新関数に置き換え

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -804,7 +804,7 @@ function createCss2Button(_id, _text, _func = _ => true, { x = 0, y = g_sHeight 
  * @param {string} _id 
  * @param {object} _obj (x, y, w, h, siz, align, title, ...rest) 
  */
-function changeStyle(_id, { x, y, w, h, siz = C_SIZ_SETLBL, align, title, ...rest } = {}) {
+function changeStyle(_id, { x, y, w, h, siz, align, title, ...rest } = {}) {
 	const div = document.querySelector(`#${_id}`);
 	const style = div.style;
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 空スプライト作成処理を`createSprite`関数から`createEmptySprite`関数に変更しました。
※`createDivCss2Label`と同じように、オブジェクト引数を持っています。
2. `createOptionWindow`, `createSettingsDisplayWindow`関数の引数をオブジェクトに変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 空スプライト作成処理のみ、拡張性に乏しい関数になっていたため。
2. 引数が文字列となっていたことで煩雑になっていたため。
## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
