### PR TITLE
[0400/keyconfig-button] キーコンフィグの対応キー箇所をボタン化

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5471,14 +5471,10 @@ function keyConfigInit(_kcType = g_kcType) {
 
 		cursor.style.left = `${(kWidth - C_ARW_WIDTH) / 2 + g_keyObj.blank * stdPos - 10}px`;
 		const baseY = C_KYC_HEIGHT * Number(posj > divideCnt) + 45;
-		if (g_currentk >= 1) {
-			cursor.style.top = `${baseY + C_KYC_REPHEIGHT * g_currentk}px`;
-		} else {
-			if (g_kcType === `Replaced`) {
-				g_kcType = C_FLG_ALL;
-			}
-			lnkKcType.textContent = g_kcType;
-			cursor.style.top = `${baseY}px`;
+		cursor.style.top = `${baseY + C_KYC_REPHEIGHT * g_currentk}px`;
+		if (g_currentk === 0 && g_kcType === `Replaced`) {
+			g_kcType = C_FLG_ALL;
+			lnkKcType.textContent = getStgDetailName(g_kcType);
 		}
 	};
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5378,10 +5378,14 @@ function keyConfigInit(_kcType = g_kcType) {
 			g_keyObj[`keyCtrl${keyCtrlPtn}d`][j][k] = setVal(g_keyObj[`keyCtrl${keyCtrlPtn}d`][j][k], 0, C_TYP_NUMBER);
 
 			keyconSprite.appendChild(
-				createDivCss2Label(`keycon${j}_${k}`, g_kCd[g_keyObj[`keyCtrl${keyCtrlPtn}`][j][k]], {
+				createCss2Button(`keycon${j}_${k}`, g_kCd[g_keyObj[`keyCtrl${keyCtrlPtn}`][j][k]], _ => {
+					g_currentj = j;
+					g_currentk = k;
+					setKeyConfigCursor();
+				}, {
 					x: keyconX, y: 50 + C_KYC_REPHEIGHT * k + keyconY,
-					w: C_ARW_WIDTH, h: C_ARW_WIDTH, siz: C_SIZ_JDGCNTS,
-				})
+					w: C_ARW_WIDTH, h: C_LNK_HEIGHT, siz: C_SIZ_JDGCNTS,
+				}, g_cssObj.button_Default_NoColor)
 			);
 
 			// キーに色付け
@@ -5468,7 +5472,7 @@ function keyConfigInit(_kcType = g_kcType) {
 		cursor.style.left = `${(kWidth - C_ARW_WIDTH) / 2 + g_keyObj.blank * stdPos - 10}px`;
 		const baseY = C_KYC_HEIGHT * Number(posj > divideCnt) + 45;
 		if (g_currentk >= 1) {
-			cursor.style.top = `${baseY + C_KYC_REPHEIGHT}px`;
+			cursor.style.top = `${baseY + C_KYC_REPHEIGHT * g_currentk}px`;
 		} else {
 			if (g_kcType === `Replaced`) {
 				g_kcType = C_FLG_ALL;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -957,6 +957,7 @@ const g_cssObj = {
 
     button_Start: `button_Start`,
     button_Default: `button_Default`,
+    button_Default_NoColor: `button_Default_NoColor`,
     button_Mini: `button_Mini`,
     button_Back: `button_Back`,
     button_Setting: `button_Setting`,

--- a/skin/danoni_skin_default.css
+++ b/skin/danoni_skin_default.css
@@ -259,6 +259,13 @@
 	color: #ffffff;
 	background-color: #666666;
 }
+/* デフォルト(色指定なし) */
+.button_Default_NoColor {
+	background-color: #00000000;
+}
+.button_Default_NoColor:hover {
+	background-color: #666666;
+}
 /* カーソル */
 .button_Mini {
 	color: #ffffff;

--- a/skin/danoni_skin_light.css
+++ b/skin/danoni_skin_light.css
@@ -259,6 +259,13 @@
 	color: #000000;
 	background-color: #bbbbbb;
 }
+/* デフォルト(色指定なし) */
+.button_Default_NoColor {
+	background-color: #00000000;
+}
+.button_Default_NoColor:hover {
+	background-color: #bbbbbb;
+}
 /* カーソル */
 .button_Mini {
 	color: #000000;

--- a/skin/danoni_skin_skyblue.css
+++ b/skin/danoni_skin_skyblue.css
@@ -259,6 +259,13 @@
 	color: #000000;
 	background-color: #99ccff;
 }
+/* デフォルト(色指定なし) */
+.button_Default_NoColor {
+	background-color: #00000000;
+}
+.button_Default_NoColor:hover {
+	background-color: #99ccff;
+}
 /* カーソル */
 .button_Mini {
 	color: #000000;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. キーコンフィグの対応キー箇所をボタン化しました。
ボタンをクリックすることで直接そのキーを変更できます。

- danoni_skin_default/light/skyblue.css の変更があります。
```css
/* デフォルト(色指定なし) */
.button_Default_NoColor {
	background-color: #00000000;
}
.button_Default_NoColor:hover {
	background-color: #666666;
}
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. キー数が多いとき、一部のみ変更したいことがあるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/113507641-bd5bd300-9586-11eb-9add-e3a60de385e2.png" width="50%">

## :pencil: その他コメント / Other Comments
