### PR TITLE
[0401/cr-keys] キー数周りのコード整理

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3685,6 +3685,9 @@ function keysConvert(_dosObj) {
 		// 読込変数の接頭辞 (charaX_Y)
 		tmpMinPatterns = newKeyMultiParam(newKey, `chara`, toString, `E_0102`);
 
+		// 矢印の回転量指定、キャラクタパターン (stepRtnX_Y)
+		tmpMinPatterns = newKeyMultiParam(newKey, `stepRtn`, toStringOrNumber, `E_0103`);
+
 		// 各キーの区切り位置 (divX_Y)
 		if (_dosObj[`div${newKey}`] !== undefined) {
 			const tmpDivs = _dosObj[`div${newKey}`].split(`$`);
@@ -3705,9 +3708,6 @@ function keysConvert(_dosObj) {
 				}
 			}
 		}
-
-		// 矢印の回転量指定、キャラクタパターン (stepRtnX_Y)
-		tmpMinPatterns = newKeyMultiParam(newKey, `stepRtn`, toStringOrNumber, `E_0103`);
 
 		// ステップゾーン位置 (posX_Y)
 		if (_dosObj[`pos${newKey}`] !== undefined) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3602,11 +3602,11 @@ function keysConvert(_dosObj) {
 	 * @param {string} _key キー数
 	 * @param {string} _name 名前
 	 * @param {function} _convFunc マッピング関数
-	 * @param {string} _obj errCd エラーコード, baseCopyFlg コピー配列の準備可否
+	 * @param {object} _obj errCd エラーコード, baseCopyFlg コピー配列の準備可否, loopFunc パターン別に処理する個別関数
 	 * @returns 最小パターン数
 	 */
 	const newKeyMultiParam = (_key, _name, _convFunc, { errCd = ``, baseCopyFlg = false, loopFunc = _ => true } = {}) => {
-		let tmpMinPatterns = -1;
+		let tmpMinPatterns = 1;
 		const keyheader = _name + _key;
 		if (hasVal(_dosObj[keyheader])) {
 			const tmpArray = _dosObj[keyheader].split(`$`);
@@ -3655,8 +3655,8 @@ function keysConvert(_dosObj) {
 		const keyheader = _name + _key;
 		const keyheaderName = `${_name}Name${_key}`;
 
-		if (_dosObj[`${keyheader}`] !== undefined) {
-			const tmpParams = _dosObj[`${keyheader}`].split(`$`);
+		if (_dosObj[keyheader] !== undefined) {
+			const tmpParams = _dosObj[keyheader].split(`$`);
 			for (let k = 0; k < tmpParams.length; k++) {
 				const pairName = `${_pairName}${_key}_${k}`;
 				if (!hasVal(tmpParams[k])) {
@@ -3678,6 +3678,7 @@ function keysConvert(_dosObj) {
 		}
 	};
 
+	// 対象キー毎に処理
 	for (let j = 0; j < keyExtraList.length; j++) {
 		const newKey = keyExtraList[j];
 		let tmpDivPtn = [];

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5338,6 +5338,30 @@ function keyConfigInit(_kcType = g_kcType) {
 		return arrowColor;
 	}
 
+	/**
+	 * 対象割り当てキーの色変更
+	 * @param {number} _j 
+	 * @param {number} _k 
+	 * @param {string} _cssName 
+	 */
+	const changeKeyConfigColor = (_j, _k, _cssName) => {
+		const obj = document.querySelector(`#keycon${_j}_${_k}`);
+
+		// CSSクラスの除去
+		if (obj.classList.contains(g_cssObj.keyconfig_Changekey)) {
+			obj.classList.remove(g_cssObj.keyconfig_Changekey);
+		}
+		if (obj.classList.contains(g_cssObj.keyconfig_Defaultkey)) {
+			obj.classList.remove(g_cssObj.keyconfig_Defaultkey);
+		}
+		if (obj.classList.contains(g_cssObj.title_base)) {
+			obj.classList.remove(g_cssObj.title_base);
+		}
+
+		// 指定されたCSSクラスを適用
+		obj.classList.add(_cssName);
+	};
+
 	for (let j = 0; j < keyNum; j++) {
 
 		const posj = g_keyObj[`pos${keyCtrlPtn}`][j];
@@ -5383,11 +5407,9 @@ function keyConfigInit(_kcType = g_kcType) {
 
 			// キーに色付け
 			if (g_keyObj[`keyCtrl${keyCtrlPtn}d`][j][k] !== g_keyObj[`keyCtrl${keyCtrlPtn}`][j][k]) {
-				removeClassList(j, k);
-				document.querySelector(`#keycon${j}_${k}`).classList.add(g_cssObj.keyconfig_Changekey);
+				changeKeyConfigColor(j, k, g_cssObj.keyconfig_Changekey);
 			} else if (g_keyObj.currentPtn === -1) {
-				removeClassList(j, k);
-				document.querySelector(`#keycon${j}_${k}`).classList.add(g_cssObj.keyconfig_Defaultkey);
+				changeKeyConfigColor(j, k, g_cssObj.keyconfig_Defaultkey);
 			}
 		}
 	}
@@ -5613,10 +5635,7 @@ function keyConfigInit(_kcType = g_kcType) {
 					for (let k = 0; k < g_keyObj[`keyCtrl${keyCtrlPtn}`][j].length; k++) {
 						g_keyObj[`keyCtrl${keyCtrlPtn}`][j][k] = setVal(g_keyObj[`keyCtrl${keyCtrlPtn}d`][j][k], 0, C_TYP_NUMBER);
 						document.querySelector(`#keycon${j}_${k}`).textContent = g_kCd[g_keyObj[`keyCtrl${keyCtrlPtn}`][j][k]];
-						removeClassList(j, k);
-						document.querySelector(`#keycon${j}_${k}`).classList.add(
-							g_keyObj.currentPtn === -1 ? g_cssObj.keyconfig_Defaultkey : g_cssObj.title_base
-						);
+						changeKeyConfigColor(j, k, g_keyObj.currentPtn === -1 ? g_cssObj.keyconfig_Defaultkey : g_cssObj.title_base);
 					}
 				}
 				resetCursor(Number(g_kcType === `Replaced`));
@@ -5654,8 +5673,7 @@ function keyConfigInit(_kcType = g_kcType) {
 			}
 			if (g_keyObj[`keyCtrl${keyCtrlPtn}d`][g_currentj][g_currentk] !== setKey) {
 				// 既定キーと異なる場合は色付け
-				removeClassList(g_currentj, g_currentk);
-				keyCdObj.classList.add(g_cssObj.keyconfig_Changekey);
+				changeKeyConfigColor(g_currentj, g_currentk, g_cssObj.keyconfig_Changekey);
 			}
 			keyCdObj.textContent = g_kCd[setKey];
 			g_keyObj[`keyCtrl${keyCtrlPtn}`][g_currentj][g_currentk] = setKey;
@@ -5724,24 +5742,6 @@ function changeSetColor() {
 			g_headerObj[`frz${pattern}Color`][j] = JSON.parse(JSON.stringify(g_headerObj[`frz${pattern}Color${currentTypes[pattern]}`][j]));
 		}
 	});
-}
-
-/**
- * キーコンフィグ画面の対応キー色変更
- * @param {number} _j 
- * @param {number} _k 
- */
-function removeClassList(_j, _k) {
-	const obj = document.querySelector(`#keycon${_j}_${_k}`);
-	if (obj.classList.contains(g_cssObj.keyconfig_Changekey)) {
-		obj.classList.remove(g_cssObj.keyconfig_Changekey);
-	}
-	if (obj.classList.contains(g_cssObj.keyconfig_Defaultkey)) {
-		obj.classList.remove(g_cssObj.keyconfig_Defaultkey);
-	}
-	if (obj.classList.contains(g_cssObj.title_base)) {
-		obj.classList.remove(g_cssObj.title_base);
-	}
 }
 
 /*-----------------------------------------------------------*/

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1868,6 +1868,7 @@ const g_keyObj = {
 
 // 特殊キーのコピー種 (simple: 代入、multiple: 配列ごと代入)
 const g_keyCopyLists = {
+    simpleDef: [`blank`, `scale`],
     simple: [`div`, `blank`, `scale`, `keyRetry`, `keyTitleBack`, `transKey`, `scrollDir`, `assistPos`],
     multiple: [`chara`, `color`, `stepRtn`, `pos`, `shuffle`],
 };


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. キー数周りのコード整理を行いました。
    - 特殊キー作成時、colorX/charaX/stepRtnX/shuffleX/keyCtrlX/posXについて処理が類似しているため
`newKeyMultiParam`関数に処理集約を行っています。
    - blank, scale再設定処理を`updateKeyInfo`関数で集約しました。
    - `newKeySingleParam`, `newKeyPairParam`関数についてアロー関数に変更しました。
2. キーコンフィグ画面のキー割り当て色の変更処理について、
`removeClassList`関数と色割り当て処理を統合し、`changeKeyConfigColor`関数へ移行しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 類似の記述が多かったため。
2. CSSクラスの付け替えは基本、セットで行われるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
