### PR TITLE
[0402/extra-keys] 特殊キーのキーコンフィグのリセットに失敗する問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3617,7 +3617,7 @@ function keysConvert(_dosObj) {
 				}
 				g_keyObj[`${keyheader}_${k}`] = tmpArray[k].split(`,`).map(n => _convFunc(n));
 				if (baseCopyFlg) {
-					g_keyObj[`${keyheader}_${k}d`] = g_keyObj[`${keyheader}_${k}`].concat();
+					g_keyObj[`${keyheader}_${k}d`] = JSON.parse(JSON.stringify(g_keyObj[`${keyheader}_${k}`]));
 				}
 				loopFunc(k, keyheader);
 			}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 特殊キーのキーコンフィグのリセットに失敗する問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #1041 にてコード集約を行った影響で、デフォルト配列作成時にシャローコピーを行っていたため。
`JSON.parse(JSON.stringify(多次元配列));`の形式に変更しました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
