### PR TITLE
空の矢印データを含む譜面にS-Ranをかけるとフルコン演出が通常より早く出てしまう問題の修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6127,11 +6127,12 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	function storeArrowData(_data) {
 		let arrowData = [];
 
-		if (_data !== undefined) {
+		if (_data !== undefined && _data !== ``) {
 			const tmpData = splitLF(_data).join(``);
 			if (tmpData !== undefined) {
 				arrowData = tmpData.split(`,`);
 				if (isNaN(parseFloat(arrowData[0]))) {
+					return []
 				} else {
 					arrowData = arrowData.map(data => calcFrame(data));
 				}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- 矢印データが空または不正なときarrowDataを空の配列にするようにします

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- [izkdicさんのツイート](https://twitter.com/vdos2643/status/1379451476024561670)
- `|frzSpace_data=|`のような空データではarrowDataの中身が`[""]`となり、S-Ran時この`""`が残ってしまいます
- これにより、`g_allArrow`を数えるときそのキーを無視する条件を満たしてしまいます
  - `parseFloat("")`がNaNなので`isNaN(parseFloat(g_scoreObj.arrowData[j][0]))` がtrue
- 総ノート数が足りないため通常より早くフルコン演出が発動します

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments

