### PR TITLE
[0405/white-keycon-color] 明背景時、キーコンフィグ画面の文字が薄い問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5389,7 +5389,7 @@ function keyConfigInit(_kcType = g_kcType) {
 				}, {
 					x: keyconX, y: 50 + C_KYC_REPHEIGHT * k + keyconY,
 					w: C_ARW_WIDTH, h: C_LNK_HEIGHT, siz: C_SIZ_JDGCNTS,
-				}, g_cssObj.button_Default_NoColor)
+				}, g_cssObj.button_Default_NoColor, g_cssObj.title_base)
 			);
 
 			// キーに色付け


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 明背景時、キーコンフィグ画面の文字が薄い問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. キーコンフィグ画面の割り当てキー表示をボタン化した際、color属性を定義できていませんでした。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
