### PR TITLE
[0406/real-arrowcnts] 総矢印数、総フリーズアロー数のカウント方法を従来の方法に戻す

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5887,8 +5887,10 @@ function loadingScoreInit() {
 		}
 
 		// 矢印・フリーズアロー数をカウント
-		g_allArrow = sumData(g_detailObj.arrowCnt[g_stateObj.scoreId]);
-		g_allFrz = sumData(g_detailObj.frzCnt[g_stateObj.scoreId]) * 2;
+		g_allArrow = 0;
+		g_allFrz = 0;
+		g_scoreObj.arrowData.forEach(data => g_allArrow += data.length);
+		g_scoreObj.frzData.forEach(data => g_allFrz += data.length);
 
 		// ライフ回復・ダメージ量の計算
 		// フリーズ始点でも通常判定させる場合は総矢印数を水増しする


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 総矢印数、総フリーズアロー数のカウント方法を従来の方法に戻しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 譜面ファイルが外部データで、かつ譜面が更新されリロードを行わなかった場合、
総矢印数、総フリーズアロー数が更新されないため総数が合致しない場合があります。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- v21.4.1のみ発生します。