### PR TITLE
[ver21.4.2] 総矢印数、総フリーズアロー数のカウント方法を従来の方法に戻す

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ v14, 20の対応終了時期はv23リリース開始時を予定しています�
 
 | Version | Supported          | Latest Version | First Release | End of Support |
 | ------- | ------------------ |----------------|---------------|----------------|
-| v21     | :heavy_check_mark: |[v21.4.1](../../releases/tag/v21.4.1)          |2021-03-12|-|
+| v21     | :heavy_check_mark: |[v21.4.2](../../releases/tag/v21.4.2)          |2021-03-12|-|
 | v20     | :heavy_check_mark: |[v20.5.3](../../releases/tag/v20.5.3)          |2021-02-12|(At Release v23)|
 | v19     | :heavy_check_mark: |[v19.5.7](../../releases/tag/v19.5.7)          |2021-01-17|-|
 | v18     | :x:                |[v18.9.6 (final)](../../releases/tag/v18.9.6)  |2020-10-25|2021-03-12|

--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -4,7 +4,7 @@
   本体cssファイル
 
   Created : 2018/10/08
-  Revised : 2021/04/07 (v21.4.1)
+  Revised : 2021/04/07 (v21.4.2)
 
   https://github.com/cwtickle/danoniplus
 ------------------------------------------ */

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,7 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 21.4.1`;
+const g_version = `Ver 21.4.2`;
 const g_revisedDate = `2021/04/07`;
 const g_alphaVersion = ``;
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -5,7 +5,7 @@
  *
  * Source by tickle
  * Created : 2019/11/19
- * Revised : 2021/04/07 (v21.4.1)
+ * Revised : 2021/04/07 (v21.4.2)
  *
  * https://github.com/cwtickle/danoniplus
  */

--- a/skin/danoni_skin_default.css
+++ b/skin/danoni_skin_default.css
@@ -4,7 +4,7 @@
   スキンcssファイル (default)
 
   Created : 2019/11/04
-  Revised : 2021/04/07 (v21.4.1)
+  Revised : 2021/04/07 (v21.4.2)
 
   https://github.com/cwtickle/danoniplus
 ------------------------------------------ */

--- a/skin/danoni_skin_light.css
+++ b/skin/danoni_skin_light.css
@@ -4,7 +4,7 @@
   スキンcssファイル (light)
 
   Created : 2019/11/04
-  Revised : 2021/04/07 (v21.4.1)
+  Revised : 2021/04/07 (v21.4.2)
 
   https://github.com/cwtickle/danoniplus
 ------------------------------------------ */

--- a/skin/danoni_skin_skyblue.css
+++ b/skin/danoni_skin_skyblue.css
@@ -4,7 +4,7 @@
   スキンcssファイル (skyblue)
 
   Created : 2019/11/04
-  Revised : 2021/04/07 (v21.4.1)
+  Revised : 2021/04/07 (v21.4.2)
 
   https://github.com/cwtickle/danoniplus
 ------------------------------------------ */


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- #1050 総矢印数、総フリーズアロー数のカウント方法を従来の方法に戻す

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- #1047 , #1049 の変更を含みます。
