### PR TITLE
[0407/switch-scoredetail] 譜面明細表示の逆回しに対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4105,19 +4105,27 @@ function createOptionWindow(_sprite) {
 			x: 20, y: 90, w: 420, h: 230, visibility: `hidden`,
 		}, g_cssObj.settings_DifSelector);
 		const viewScText = _ => createScText(lnkScoreDetail, `ScoreDetail`, { targetLabel: `lnkScoreDetail`, x: -10 });
+
+		/**
+		 * 譜面明細表示の切替
+		 * @param {number} _val 
+		 */
+		const changeScoreDetail = (_val = 1) => {
+			g_stateObj.scoreDetailViewFlg = true;
+			scoreDetail.style.visibility = `visible`;
+			$id(`detail${g_stateObj.scoreDetail}`).visibility = `hidden`;
+			setSetting(_val, `scoreDetail`);
+			viewScText();
+			$id(`detail${g_stateObj.scoreDetail}`).visibility = `visible`;
+		};
+
 		multiAppend(scoreDetail,
 			createScoreDetail(`Speed`),
 			createScoreDetail(`Density`),
 			createScoreDetail(`ToolDif`, false),
-			makeSettingLblCssButton(`lnkScoreDetail`, `${getStgDetailName(g_stateObj.scoreDetail)}`, 0, _ => {
-				g_stateObj.scoreDetailViewFlg = true;
-				scoreDetail.style.visibility = `visible`;
-				$id(`detail${g_stateObj.scoreDetail}`).visibility = `hidden`;
-				setSetting(1, `scoreDetail`);
-				viewScText();
-				$id(`detail${g_stateObj.scoreDetail}`).visibility = `visible`;
-			}, {
+			makeSettingLblCssButton(`lnkScoreDetail`, `${getStgDetailName(g_stateObj.scoreDetail)}`, 0, _ => changeScoreDetail(), {
 				x: 10, w: 100, borderStyle: `solid`,
+				cxtFunc: _ => changeScoreDetail(-1),
 			}, g_cssObj.button_RevON),
 		);
 		viewScText();

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4123,6 +4123,9 @@ function createOptionWindow(_sprite) {
 			createScoreDetail(`Speed`),
 			createScoreDetail(`Density`),
 			createScoreDetail(`ToolDif`, false),
+			makeSettingLblCssButton(`lnkScoreDetailB`, `- - -`, 0, _ => changeScoreDetail(-1), {
+				x: 10, w: 100, visibility: `hidden`,
+			}, g_cssObj.button_RevON),
 			makeSettingLblCssButton(`lnkScoreDetail`, `${getStgDetailName(g_stateObj.scoreDetail)}`, 0, _ => changeScoreDetail(), {
 				x: 10, w: 100, borderStyle: `solid`,
 				cxtFunc: _ => changeScoreDetail(-1),

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -787,6 +787,7 @@ const g_shortcutObj = {
         KeyV: { id: `lnkVolumeR` },
 
         KeyI: { id: `btnGraph` },
+        ShiftLeft_KeyQ: { id: `lnkScoreDetailB` },
         KeyQ: { id: `lnkScoreDetail` },
         KeyP: { id: `lnkDifInfo` },
         KeyZ: { id: `btnSave` },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 譜面明細表示の逆回しに対応しました。
右クリックで ToolDif -> Density -> Speed の順に移動するようになります。
また、Shift+Qキーでも逆回しが可能です。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 他のボタンの操作方法に合わせるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/115491157-7108d680-a29a-11eb-9127-336bf697a19c.png" width="50%">

## :pencil: その他コメント / Other Comments
- 実装上、「Speed」「Density」などを表示するボタンの裏に
逆回しするボタン(id: lnkScoreDetailB)を非表示で挿入しています。
これはショートカットキーが、実体のボタン操作が無いと動作しないためです。