### PR TITLE
[0408/ctrl-c] タイトル・結果画面でCtrl+Cを使うとショートカットキーが動作する問題を修正

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -748,6 +748,7 @@ const g_shortcutObj = {
         Enter: { id: `btnStart` },
         Slash: { id: `btnHelp`, reset: true },
         F1: { id: `btnHelp`, reset: true },
+        ControlLeft_KeyC: { id: `` },
         KeyC: { id: `btnComment` },
     },
     option: {
@@ -861,6 +862,7 @@ const g_shortcutObj = {
     result: {
         Escape: { id: `btnBack` },
         ShiftLeft_Tab: { id: `btnBack` },
+        ControlLeft_KeyC: { id: `` },
         KeyC: { id: `btnCopy`, reset: true },
         KeyT: { id: `btnTweet`, reset: true },
         KeyG: { id: `btnGitter`, reset: true },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. タイトル・結果画面でCtrl+Cを使うとショートカットキーが動作する問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 不具合というほどでもないが、画面上でテキストコピーしたいときにショートカットキーが使えないため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- danoni_constants.js のみの修正です。
