### PR TITLE
[0411/switch-right-click] Save切替ボタン、Display切替ボタンの右クリック対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3769,6 +3769,12 @@ function keysConvert(_dosObj) {
 
 const commonSettingBtn = _labelName => {
 
+	const switchSave = evt => {
+		g_stateObj.dataSaveFlg = !g_stateObj.dataSaveFlg;
+		const [from, to] = (g_stateObj.dataSaveFlg ? [C_FLG_OFF, C_FLG_ON] : [C_FLG_ON, C_FLG_OFF]);
+		evt.target.classList.replace(g_cssObj[`button_${from}`], g_cssObj[`button_${to}`]);
+	};
+
 	multiAppend(divRoot,
 
 		// タイトル画面へ戻る
@@ -3793,15 +3799,9 @@ const commonSettingBtn = _labelName => {
 		}, g_cssObj.button_Mini),
 
 		// データセーブフラグの切替
-		createCss2Button(`btnSave`, g_lblNameObj.dataSave, evt => {
-			g_stateObj.dataSaveFlg = !g_stateObj.dataSaveFlg;
-			const [from, to] = (g_stateObj.dataSaveFlg ? [C_FLG_OFF, C_FLG_ON] : [C_FLG_ON, C_FLG_OFF]);
-			evt.target.classList.replace(g_cssObj[`button_${from}`], g_cssObj[`button_${to}`]);
-		}, {
-			x: 0, y: 5,
-			w: g_sWidth / 5, h: 16, siz: 12,
-			title: g_msgObj.dataSave,
-			borderStyle: `solid`,
+		createCss2Button(`btnSave`, g_lblNameObj.dataSave, evt => switchSave(evt), {
+			x: 0, y: 5, w: g_sWidth / 5, h: 16, siz: 12,
+			title: g_msgObj.dataSave, borderStyle: `solid`, cxtFunc: evt => switchSave(evt),
 		}, g_cssObj.button_Default, (g_stateObj.dataSaveFlg ? g_cssObj.button_ON : g_cssObj.button_OFF)),
 	);
 };
@@ -5181,20 +5181,20 @@ function createSettingsDisplayWindow(_sprite) {
 		const linkId = `lnk${_name}`;
 
 		if (g_headerObj[`${_name}Use`]) {
-			displaySprite.appendChild(
-				makeSettingLblCssButton(linkId, g_lblNameObj[`d_${toCapitalize(_name)}`], _heightPos, evt => {
-					const displayFlg = g_stateObj[`d_${_name.toLowerCase()}`];
-					const displayNum = list.findIndex(flg => flg === displayFlg);
-					const nextDisplayFlg = list[(displayNum + 1) % list.length];
-					g_stateObj[`d_${_name.toLowerCase()}`] = nextDisplayFlg;
-					evt.target.classList.replace(g_cssObj[`button_${displayFlg}`], g_cssObj[`button_${nextDisplayFlg}`]);
+			const switchDisplay = evt => {
+				const displayFlg = g_stateObj[`d_${_name.toLowerCase()}`];
+				const displayNum = list.findIndex(flg => flg === displayFlg);
+				const nextDisplayFlg = list[(displayNum + 1) % list.length];
+				g_stateObj[`d_${_name.toLowerCase()}`] = nextDisplayFlg;
+				evt.target.classList.replace(g_cssObj[`button_${displayFlg}`], g_cssObj[`button_${nextDisplayFlg}`]);
 
-					interlockingButton(g_headerObj, _name, nextDisplayFlg, displayFlg, true);
-				}, {
-					x: 30 + 180 * _widthPos,
-					w: 170,
-					title: g_msgObj[`d_${_name.toLowerCase()}`],
-					borderStyle: `solid`,
+				interlockingButton(g_headerObj, _name, nextDisplayFlg, displayFlg, true);
+			};
+			displaySprite.appendChild(
+				makeSettingLblCssButton(linkId, g_lblNameObj[`d_${toCapitalize(_name)}`], _heightPos, evt => switchDisplay(evt), {
+					x: 30 + 180 * _widthPos, w: 170,
+					title: g_msgObj[`d_${_name.toLowerCase()}`], borderStyle: `solid`,
+					cxtFunc: evt => switchDisplay(evt),
 				}, `button_${flg}`)
 			);
 			createScText(document.getElementById(linkId), `${toCapitalize(_name)}`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. Save切替ボタン、Display切替ボタンについて右クリックでも切替できるようにしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 他のボタンと処理を統一するため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
