### PR TITLE
[ver21.5.0] 譜面明細表示の逆回し、右クリックによるON/OFF切替　他

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@
 - 基本的には、同一メジャーバージョンの最新版がサポート対象です。
 - v1～v13, v15～v18は**更新を終了しました。**  
 v14, 20の対応終了時期はv23リリース開始時を予定しています。（変更可能性あり）
-- 各バージョンの概要は[更新情報](../../wiki/UpdateInfo)に記載しています。
+- 各バージョンの概要は[更新情報](https://github.com/cwtickle/danoniplus/wiki/UpdateInfo)に記載しています。
 
 :heavy_check_mark: サポート中 / 
 :warning: 近日中に更新終了予定 / 
@@ -15,40 +15,40 @@ v14, 20の対応終了時期はv23リリース開始時を予定しています�
 
 | Version | Supported          | Latest Version | First Release | End of Support |
 | ------- | ------------------ |----------------|---------------|----------------|
-| v21     | :heavy_check_mark: |[v21.4.2](../../releases/tag/v21.4.2)          |2021-03-12|-|
-| v20     | :heavy_check_mark: |[v20.5.3](../../releases/tag/v20.5.3)          |2021-02-12|(At Release v23)|
-| v19     | :heavy_check_mark: |[v19.5.7](../../releases/tag/v19.5.7)          |2021-01-17|-|
-| v18     | :x:                |[v18.9.6 (final)](../../releases/tag/v18.9.6)  |2020-10-25|2021-03-12|
-| v17     | :x:                |[v17.5.9 (final)](../../releases/tag/v17.5.9)  |2020-09-27|2021-02-12|
-| v16     | :x:                |[v16.4.10 (final)](../../releases/tag/v16.4.10)|2020-08-06|2021-01-17|
-| v15     | :x:                |[v15.7.5 (final)](../../releases/tag/v15.7.5)  |2020-05-13|2020-10-25|
-| v14     | :heavy_check_mark: |[v14.5.20](../../releases/tag/v14.5.20)        |2020-04-29|(At Release v23)|
+| v21     | :heavy_check_mark: |[v21.5.0](https://github.com/cwtickle/danoniplus/releases/tag/v21.5.0)          |2021-03-12|-|
+| v20     | :heavy_check_mark: |[v20.5.3](https://github.com/cwtickle/danoniplus/releases/tag/v20.5.3)          |2021-02-12|(At Release v23)|
+| v19     | :heavy_check_mark: |[v19.5.7](https://github.com/cwtickle/danoniplus/releases/tag/v19.5.7)          |2021-01-17|-|
+| v18     | :x:                |[v18.9.6 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v18.9.6)  |2020-10-25|2021-03-12|
+| v17     | :x:                |[v17.5.9 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v17.5.9)  |2020-09-27|2021-02-12|
+| v16     | :x:                |[v16.4.10 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v16.4.10)|2020-08-06|2021-01-17|
+| v15     | :x:                |[v15.7.5 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v15.7.5)  |2020-05-13|2020-10-25|
+| v14     | :heavy_check_mark: |[v14.5.20](https://github.com/cwtickle/danoniplus/releases/tag/v14.5.20)        |2020-04-29|(At Release v23)|
 
 <details>
 <summary>過去バージョン詳細</summary>
 
 | Version | Supported          | Latest Version | First Release | End of Support |
 | ------- | ------------------ |----------------|---------------|----------------|
-| v13     | :x:                |[v13.6.8 (final)](../../releases/tag/v13.6.8)  |2020-03-29|2020-08-06|
-| v12     | :x:                |[v12.3.6 (final)](../../releases/tag/v12.3.6)  |2020-02-09|2020-05-13|
-| v11     | :x:                |[v11.4.5 (final)](../../releases/tag/v11.4.5)  |2019-12-14|2020-04-18|
-| v10     | :x:                |[v10.5.5 (final)](../../releases/tag/v10.5.5)  |2019-11-04|2020-02-10|
-| v9      | :x::anchor:        |[v9.4.27 (final)](../../releases/tag/v9.4.27)  |2019-10-08|2021-01-17|
-| v8      | :x:                |[v8.7.10 (final)](../../releases/tag/v8.7.10)  |2019-09-08|2019-12-14|
-| v7      | :x:                |[v7.9.13 (final)](../../releases/tag/v7.9.13)  |2019-07-08|2019-11-04|
-| v6      | :x:                |[v6.6.13 (final)](../../releases/tag/v6.6.13)  |2019-06-22|2019-11-04|
-| v5      | :x:                |[v5.12.17 (final)](../../releases/tag/v5.12.17)|2019-05-16|2019-12-14|
-| v4      | :x:                |[v4.10.22 (final)](../../releases/tag/v4.10.22)|2019-04-25|2019-10-08|
-| v3      | :x:                |[v3.13.9 (final)](../../releases/tag/v3.13.9)  |2019-02-25|2019-06-18|
-| v2      | :x:                |[v2.9.11 (final)](../../releases/tag/v2.9.11)  |2019-01-18|2019-06-18|
-| v1      | :x:                |[v1.15.17 (final)](../../releases/tag/v1.15.17)|2018-11-25|2019-10-08|
+| v13     | :x:                |[v13.6.8 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v13.6.8)  |2020-03-29|2020-08-06|
+| v12     | :x:                |[v12.3.6 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v12.3.6)  |2020-02-09|2020-05-13|
+| v11     | :x:                |[v11.4.5 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v11.4.5)  |2019-12-14|2020-04-18|
+| v10     | :x:                |[v10.5.5 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v10.5.5)  |2019-11-04|2020-02-10|
+| v9      | :x::anchor:        |[v9.4.27 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v9.4.27)  |2019-10-08|2021-01-17|
+| v8      | :x:                |[v8.7.10 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v8.7.10)  |2019-09-08|2019-12-14|
+| v7      | :x:                |[v7.9.13 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v7.9.13)  |2019-07-08|2019-11-04|
+| v6      | :x:                |[v6.6.13 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v6.6.13)  |2019-06-22|2019-11-04|
+| v5      | :x:                |[v5.12.17 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v5.12.17)|2019-05-16|2019-12-14|
+| v4      | :x:                |[v4.10.22 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v4.10.22)|2019-04-25|2019-10-08|
+| v3      | :x:                |[v3.13.9 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v3.13.9)  |2019-02-25|2019-06-18|
+| v2      | :x:                |[v2.9.11 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v2.9.11)  |2019-01-18|2019-06-18|
+| v1      | :x:                |[v1.15.17 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v1.15.17)|2018-11-25|2019-10-08|
 
 </details>
 
 ## Reporting a Vulnerability / 脆弱性・不具合情報
 
-- 修正内容の詳細は [Release](../../releases) をご覧ください。
+- 修正内容の詳細は [Release](https://github.com/cwtickle/danoniplus/releases) をご覧ください。
 - 更新終了したバージョンについては、不具合が残っている可能性があります。  
-[アップグレードガイド](../../wiki/MigrationGuide)、[本体のバージョンアップ](../../wiki/HowToUpdate)を参照して、  
+[アップグレードガイド](https://github.com/cwtickle/danoniplus/wiki/MigrationGuide)、[本体のバージョンアップ](https://github.com/cwtickle/danoniplus/wiki/HowToUpdate)を参照して、  
 本体の更新を検討してください。
-- 更新を終了したバージョンの不具合情報は、[Wikiにてまとめています](../../wiki/DeprecatedVersionBugs)。
+- 更新を終了したバージョンの不具合情報は、[Wikiにてまとめています](https://github.com/cwtickle/danoniplus/wiki/DeprecatedVersionBugs)。

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2021/04/07
+ * Revised : 2021/04/22
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 21.4.2`;
-const g_revisedDate = `2021/04/07`;
+const g_version = `Ver 21.5.0`;
+const g_revisedDate = `2021/04/22`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -5,7 +5,7 @@
  *
  * Source by tickle
  * Created : 2019/11/19
- * Revised : 2021/04/07 (v21.4.2)
+ * Revised : 2021/04/22 (v21.5.0)
  *
  * https://github.com/cwtickle/danoniplus
  */


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- #1052 譜面明細表示の逆回しに対応（右クリック or 「Shift」+「Q」キー）
- #1053 タイトル・結果画面で「Ctrl+C」でショートカットキーが反応しないよう修正
- #1054 ローカルストレージの初期値に関するコード見直し
- #1055 共通系処理のコード見直し
- #1056 Save切替ボタン、Display切替ボタンの右クリックでの切替対応

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
