### PR TITLE
[0414/temp-color-change] 一時的に初期矢印色の割当先を変更できる機能を実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5360,27 +5360,45 @@ function keyConfigInit(_kcType = g_kcType) {
 		const posj = g_keyObj[`pos${keyCtrlPtn}`][j];
 		const stdPos = posj - ((posj > divideCnt ? posMax : 0) + divideCnt) / 2;
 
-		// キーコンフィグ表示用の矢印・おにぎりを表示
 		const keyconX = g_keyObj.blank * stdPos + (kWidth - C_ARW_WIDTH) / 2;
 		const keyconY = C_KYC_HEIGHT * (Number(posj > divideCnt));
 		const colorPos = g_keyObj[`color${keyCtrlPtn}`][j];
 		const arrowColor = getKeyConfigColor(j, colorPos);
 
+		/**
+		 * 一時的に矢印色を変更
+		 * @param {number} _scrollNum 
+		 */
+		const changeTmpColor = (_scrollNum = 1) => {
+			const baseKeyCtrlPtn = !g_stateObj.extraKeyFlg ? g_localKeyStorage.keyCtrlPtn : g_localStorage[`keyCtrlPtn${g_keyObj.currentKey}`];
+			const basePtn = `${g_keyObj.currentKey}_${baseKeyCtrlPtn}`;
+
+			const setColorLen = g_headerObj.setColor.length;
+			g_keyObj[`color${keyCtrlPtn}`][j] = (g_keyObj[`color${keyCtrlPtn}`][j] + setColorLen + _scrollNum) % setColorLen;
+			g_keyObj[`color${basePtn}`][j] = g_keyObj[`color${keyCtrlPtn}`][j];
+			document.getElementById(`arrow${j}`).style.background = g_headerObj.setColor[g_keyObj[`color${keyCtrlPtn}`][j]];
+		};
+		keyconSprite.appendChild(
+			createCss2Button(`color${j}`, ``, _ => changeTmpColor(), {
+				x: keyconX, y: keyconY, w: C_ARW_WIDTH, h: C_ARW_WIDTH,
+				cxtFunc: _ => changeTmpColor(-1),
+			}, g_cssObj.button_Default_NoColor, g_cssObj.title_base)
+		);
+
+		// キーコンフィグ表示用の矢印・おにぎりを表示
 		if (g_headerObj.setShadowColor[colorPos] !== ``) {
 			// 矢印の塗り部分
 			const shadowColor = (g_headerObj.setShadowColor[colorPos] === `Default` ? arrowColor :
 				g_headerObj.setShadowColor[colorPos]);
 			keyconSprite.appendChild(
 				createColorObject2(`arrowShadow${j}`, {
-					x: keyconX, y: keyconY,
-					background: shadowColor, rotate: g_keyObj[`stepRtn${keyCtrlPtn}`][j], styleName: `Shadow`,
-					opacity: 0.5,
+					x: keyconX, y: keyconY, background: shadowColor, rotate: g_keyObj[`stepRtn${keyCtrlPtn}`][j],
+					styleName: `Shadow`, opacity: 0.5, pointerEvents: `none`,
 				})
 			);
 		}
 		keyconSprite.appendChild(createColorObject2(`arrow${j}`, {
-			x: keyconX, y: keyconY,
-			background: arrowColor, rotate: g_keyObj[`stepRtn${keyCtrlPtn}`][j],
+			x: keyconX, y: keyconY, background: arrowColor, rotate: g_keyObj[`stepRtn${keyCtrlPtn}`][j], pointerEvents: `none`,
 		}));
 		if (g_headerObj.shuffleUse && g_keyObj[`shuffle${keyCtrlPtn}`] !== undefined) {
 			keyconSprite.appendChild(
@@ -5390,6 +5408,7 @@ function keyConfigInit(_kcType = g_kcType) {
 			);
 		}
 
+		// 割り当て先のキー名を表示
 		for (let k = 0; k < g_keyObj[`keyCtrl${keyCtrlPtn}`][j].length; k++) {
 			g_keyObj[`keyCtrl${keyCtrlPtn}`][j][k] = setVal(g_keyObj[`keyCtrl${keyCtrlPtn}`][j][k], 0, C_TYP_NUMBER);
 			g_keyObj[`keyCtrl${keyCtrlPtn}d`][j][k] = setVal(g_keyObj[`keyCtrl${keyCtrlPtn}d`][j][k], 0, C_TYP_NUMBER);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 一時的に初期矢印色の割当先を変更できる機能を実装しました。
キーコンフィグ画面にて矢印本体を左クリック or 右クリックで他の割り当て色に切り替えます。

### 仕様
- 割り当て対象は初期矢印色（と、それに対応する初期フリーズアロー色）のみです。
- 保存期間はリロードするまでです。ローカルストレージへの保存は行いません。
- 割り当てできる色は、設定中のColorTypeに対応したsetColor（5色）から選べます。
- 色変化した場合は上書きされます。必要に応じてDisplayオプションからColorをOFFにする必要があります。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
- 一部のキー種について、プレイヤーにより特定の割り当てキーのみ色を変えたい場合がありますが、
個別に対応することが難しいため、一時的に色を割り当てられるようにしました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/116385286-9cb82d80-a853-11eb-98ee-a7855381117a.png" width="60%">

## :pencil: その他コメント / Other Comments
