### PR TITLE
[0417/shuffle-name] シャッフルグループが複数の場合のRandom+/S-Random+表記を統一

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9215,11 +9215,19 @@ function resultInit() {
 		transKeyData = `(` + g_keyObj[`transKey${keyCtrlPtn}`] + `)`;
 	}
 
+	const getShuffleName = _ => {
+		let shuffleName = getStgDetailName(g_stateObj.shuffle);
+		if (!g_stateObj.shuffle.endsWith(`+`)) {
+			shuffleName += setScoreIdHeader(g_keycons.shuffleGroupNum);
+		}
+		return shuffleName;
+	}
+
 	let difData = [
 		`${g_headerObj.keyLabels[g_stateObj.scoreId]}${transKeyData} key / ${g_headerObj.difLabels[g_stateObj.scoreId]}`,
 		`${withOptions(g_autoPlaysBase.includes(g_stateObj.autoPlay), true, `-${g_stateObj.autoPlay}less`)}`,
 		`${withOptions(g_headerObj.makerView, false, `(${g_headerObj.creatorNames[g_stateObj.scoreId]})`)}`,
-		`${withOptions(g_stateObj.shuffle, C_FLG_OFF, `[${getStgDetailName(g_stateObj.shuffle)}${setScoreIdHeader(g_keycons.shuffleGroupNum)}]`)}`
+		`${withOptions(g_stateObj.shuffle, C_FLG_OFF, `[${getShuffleName()}]`)}`
 	].filter(value => value !== ``).join(` `);
 
 	let playStyleData = [
@@ -9453,7 +9461,7 @@ function resultInit() {
 	const hashTag = (g_headerObj.hashTag !== undefined ? ` ${g_headerObj.hashTag}` : ``);
 	let tweetDifData = `${g_headerObj.keyLabels[g_stateObj.scoreId]}${transKeyData}k-${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}`;
 	if (g_stateObj.shuffle !== `OFF`) {
-		tweetDifData += `:${getStgDetailName(g_stateObj.shuffle)}${setScoreIdHeader(g_keycons.shuffleGroupNum)}`;
+		tweetDifData += `:${getShuffleName()}`;
 	}
 	const twiturl = new URL(g_localStorageUrl);
 	twiturl.searchParams.append(`scoreId`, g_stateObj.scoreId);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 結果画面に表示するRandom+/S-Random+表記を統一しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. シャッフルグループが変わっても、Random+/S-Random+の内容自体は同じため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
