### PR TITLE
[0418/shuffle-group] shuffle設定でシャッフルグループのみ選択可のオプションを追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3143,6 +3143,12 @@ function headerConvert(_dosObj) {
 	// 譜面名に制作者名を付加するかどうかのフラグ
 	obj.makerView = setVal(_dosObj.makerView, false, C_TYP_BOOLEAN);
 
+	// shuffleUse=group 時のみshuffle用配列を組み替える
+	if (_dosObj.shuffleUse === `group`) {
+		_dosObj.shuffleUse = true;
+		g_settings.shuffles = g_settings.shuffles.filter(val => !val.endsWith(`+`));
+	}
+
 	// オプション利用可否設定
 	g_canDisabledSettings.forEach(option => {
 		obj[`${option}Use`] = setVal(_dosObj[`${option}Use`],


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 譜面ヘッダーで |shuffleUse=group| と指定することで、
「OFF」「Mirror」「Random」「S-Random」のみ選択できるように制御する設定を追加しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Resolves #1065 

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 従来の |shuffleUse=false|や|shuffleUse=true|はそのまま使えます。
- 現状、Shuffle設定は設定名末尾に「+」が入っているものが
シャッフルグループを跨いでシャッフルされるため、
設定名末尾に「+」が入っているものを除外しています。
これに沿わない設定が今後追加された場合は注意が必要です。