### PR TITLE
[0419/asym-mirror] 非対称ミラーの実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6044,9 +6044,19 @@ function applyShuffle(_keyNum, _shuffleGroup, _style) {
  * @param {number} _keyNum
  * @param {array} _shuffleGroup
  */
-function applyMirror(_keyNum, _shuffleGroup) {
+function applyMirror(_keyNum, _shuffleGroup, _asymFlg = false) {
 	// シャッフルグループごとにミラー
 	const style = copyArray2d(_shuffleGroup).map(_group => _group.reverse());
+	if (_asymFlg) {
+		// グループが4の倍数のとき、4n+1, 4n+2のみ入れ替える
+		style.forEach((group, i) => {
+			if (group.length % 4 === 0) {
+				for (let k = 0; k < group.length / 4; k++) {
+					[style[i][4 * k + 1], style[i][4 * k + 2]] = [style[i][4 * k + 2], style[i][4 * k + 1]];
+				}
+			}
+		});
+	}
 	applyShuffle(_keyNum, _shuffleGroup, style);
 }
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -400,7 +400,7 @@ const g_settings = {
     scrolls: [],
     scrollNum: 0,
 
-    shuffles: [C_FLG_OFF, `Mirror`, `A-Mirror`, `Random`, `Random+`, `S-Random`, `S-Random+`],
+    shuffles: [C_FLG_OFF, `Mirror`, `Asym-Mirror`, `Random`, `Random+`, `S-Random`, `S-Random+`],
     shuffleNum: 0,
 
     gauges: [],
@@ -432,7 +432,7 @@ g_settings.opacityNum = g_settings.opacitys.length - 1;
 const g_shuffleFunc = {
     'OFF': _ => true,
     'Mirror': (keyNum, shuffleGroup) => applyMirror(keyNum, shuffleGroup),
-    'A-Mirror': (keyNum, shuffleGroup) => applyMirror(keyNum, shuffleGroup, true),
+    'Asym-Mirror': (keyNum, shuffleGroup) => applyMirror(keyNum, shuffleGroup, true),
     'Random': (keyNum, shuffleGroup) => applyRandom(keyNum, shuffleGroup),
     'Random+': keyNum => applyRandom(keyNum, [[...Array(keyNum).keys()]]),
     'S-Random': (keyNum, shuffleGroup) => {
@@ -2257,7 +2257,7 @@ const g_lblNameObj = {
     'u_Reverse': `Reverse`,
 
     'u_Mirror': `Mirror`,
-    'u_A-Mirror': `A-Mirror`,
+    'u_Asym-Mirror': `Asym-Mirror`,
     'u_Random': `Random`,
     'u_Random+': `Random+`,
     'u_S-Random': `S-Random`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -400,7 +400,7 @@ const g_settings = {
     scrolls: [],
     scrollNum: 0,
 
-    shuffles: [C_FLG_OFF, `Mirror`, `Random`, `Random+`, `S-Random`, `S-Random+`],
+    shuffles: [C_FLG_OFF, `Mirror`, `A-Mirror`, `Random`, `Random+`, `S-Random`, `S-Random+`],
     shuffleNum: 0,
 
     gauges: [],
@@ -432,6 +432,7 @@ g_settings.opacityNum = g_settings.opacitys.length - 1;
 const g_shuffleFunc = {
     'OFF': _ => true,
     'Mirror': (keyNum, shuffleGroup) => applyMirror(keyNum, shuffleGroup),
+    'A-Mirror': (keyNum, shuffleGroup) => applyMirror(keyNum, shuffleGroup, true),
     'Random': (keyNum, shuffleGroup) => applyRandom(keyNum, shuffleGroup),
     'Random+': keyNum => applyRandom(keyNum, [[...Array(keyNum).keys()]]),
     'S-Random': (keyNum, shuffleGroup) => {
@@ -2256,6 +2257,7 @@ const g_lblNameObj = {
     'u_Reverse': `Reverse`,
 
     'u_Mirror': `Mirror`,
+    'u_A-Mirror': `A-Mirror`,
     'u_Random': `Random`,
     'u_Random+': `Random+`,
     'u_S-Random': `S-Random`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. Shuffle設定に「Asym-Mirror」（非対称ミラー、Asymmetric-Mirror）を実装しました。
反転した後、「↓」と「↑」のみさらに反転するイメージです。
※個別のシャッフルグループが4の倍数のみ有効です。それ以外の場合は「Mirror」と同じです。

### 通常のミラー（Mirror）
```
[0, 1, 2, 3] -> [3, 2, 1, 0]
[0, 1, 2, 3, 4, 5, 6, 7] -> [7, 6, 5, 4, 3, 2, 1, 0]
```
### 非対称ミラー（Asym-Mirror）
<pre>
[0, 1, 2, 3] -> [3, <b>1, 2, </b>0]
[0, 1, 2, 3, 4, 5, 6, 7] -> [7, <b>5, 6, </b>4, 3, <b>1, 2, </b>0]
</pre>


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 9Akey, 11ikeyのミラー反転時、上下が逆になり操作しにくいケースがあるため。
また、このケースの対応のために多くのシャッフルグループを作るのは非効率のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/116858281-175cc080-ac39-11eb-8fb4-bd1d1d19f327.png" width="70%">

## :pencil: その他コメント / Other Comments
- 上下左右の反転を目的とするため、下記の事象が発生しますが仕様とします。
    - 7, 8, 14keyでは「Mirror」と「Asym-Mirror」が同一になる。
    - 17keyの場合、上下左右の棲み分けが無いがシャッフルグループが4の倍数のため、
「Asym-Mirror」は設定できるが想定した反転にはならない。
- 元々「A-Mirror」とする予定でしたが、わかりにくいため「Asym-Mirror」に変更しました。