### PR TITLE
[0425/change-tmp-shuffle] 一時的にシャッフルグループ番号を変更する機能を実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5355,6 +5355,24 @@ function keyConfigInit(_kcType = g_kcType) {
 		$id(`arrowShadow${_j}`).background = getShadowColor(g_keyObj[`color${keyCtrlPtn}`][_j], arrowColor);
 	};
 
+	/**
+	 * 一時的にシャッフルグループ番号を変更
+	 * @param {number} _j 
+	 * @param {number} _scrollNum 
+	 */
+	const changeTmpShuffleNum = (_j, _scrollNum = 1) => {
+		const baseKeyCtrlPtn = !g_stateObj.extraKeyFlg ? g_localKeyStorage.keyCtrlPtn : g_localStorage[`keyCtrlPtn${g_keyObj.currentKey}`];
+		const basePtn = `${g_keyObj.currentKey}_${baseKeyCtrlPtn}`;
+
+		const tmpShuffle = (g_keyObj[`shuffle${keyCtrlPtn}`][_j] + 10 + _scrollNum) % 10;
+		document.getElementById(`sArrow${_j}`).textContent = tmpShuffle + 1;
+		g_keyObj[`shuffle${keyCtrlPtn}`][_j] = g_keyObj[`shuffle${basePtn}`][_j] = tmpShuffle;
+		if (g_keyObj[`shuffle${keyCtrlPtn}_1`] !== undefined) {
+			g_keyObj[`shuffle${keyCtrlPtn}_${g_keycons.shuffleGroupNum}`][_j] =
+				g_keyObj[`shuffle${basePtn}_${g_keycons.shuffleGroupNum}`][_j] = tmpShuffle;
+		}
+	};
+
 	for (let j = 0; j < keyNum; j++) {
 
 		const posj = g_keyObj[`pos${keyCtrlPtn}`][j];
@@ -5385,9 +5403,10 @@ function keyConfigInit(_kcType = g_kcType) {
 		);
 		if (g_headerObj.shuffleUse && g_keyObj[`shuffle${keyCtrlPtn}`] !== undefined) {
 			keyconSprite.appendChild(
-				createDivCss2Label(`sArrow${j}`, ``, {
-					x: keyconX, y: keyconY - 12, w: C_ARW_WIDTH, h: 15, siz: 12, align: C_ALIGN_CENTER, fontWeight: `bold`,
-				})
+				createCss2Button(`sArrow${j}`, ``, _ => changeTmpShuffleNum(j), {
+					x: keyconX, y: keyconY - 12, w: C_ARW_WIDTH, h: 15, siz: 12, fontWeight: `bold`,
+					cxtFunc: _ => changeTmpShuffleNum(j, -1),
+				}, g_cssObj.button_Default_NoColor, g_cssObj.title_base)
 			);
 		}
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 一時的にシャッフルグループ番号を変更する機能を実装しました。
仕様は矢印色の場合 ( PR  #1060 ) と同じで、リロードするまでの間有効です。
キーコンフィグ画面のシャッフルグループ番号をクリックして変更します。
グループ番号は1～10まで割り当て可能です。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. シャッフルグループがすでにありますが、それに当てはまらないケースに柔軟に対応するため。
従来のシャッフルグループは良く使用するグループとして保持しておくこととします。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/117895428-4ccc7280-b2f9-11eb-8949-f6796259f1fb.png" width="50%">

## :pencil: その他コメント / Other Comments
- ラベルをボタン化しただけなので、ID名は変わりません。
- 変更した場合、矢印色とは異なり譜面内容が変わるため、
カスタムしたことがわかるようにした方が良いかどうかは検討中です。→一旦そのままにしました。