### PR TITLE
[ver22.3.1] シャッフルグループ番号の一時変更、9A/11ikeyのシャッフルグループ追加　他（再）

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ v14, 20の対応終了時期はv23リリース開始時を予定しています�
 
 | Version | Supported          | Latest Version | First Release | End of Support |
 | ------- | ------------------ |----------------|---------------|----------------|
-| v22     | :heavy_check_mark: |[v22.3.0](https://github.com/cwtickle/danoniplus/releases/tag/v22.3.0)          |2021-04-28|-|
+| v22     | :heavy_check_mark: |[v22.3.1](https://github.com/cwtickle/danoniplus/releases/tag/v22.3.1)          |2021-04-28|-|
 | v21     | :heavy_check_mark: |[v21.5.0](https://github.com/cwtickle/danoniplus/releases/tag/v21.5.0)          |2021-03-12|(At Release v24)|
 | v20     | :warning:          |[v20.5.3](https://github.com/cwtickle/danoniplus/releases/tag/v20.5.3)          |2021-02-12|(At Release v23)|
 | v19     | :heavy_check_mark: |[v19.5.7](https://github.com/cwtickle/danoniplus/releases/tag/v19.5.7)          |2021-01-17|-|

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,7 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 22.3.0`;
+const g_version = `Ver 22.3.1`;
 const g_revisedDate = `2021/05/12`;
 const g_alphaVersion = ``;
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -5,7 +5,7 @@
  *
  * Source by tickle
  * Created : 2019/11/19
- * Revised : 2021/05/12 (v22.3.0)
+ * Revised : 2021/05/12 (v22.3.1)
  *
  * https://github.com/cwtickle/danoniplus
  */


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- #1074 9A/11ikeyにおいてシャッフルグループを追加
- #1075 一時的にシャッフルグループ番号を変更する機能を追加
- #1076 デフォルトキーコンフィグ配列の二重記載を廃止（コード見直し）
- #1077 カーソル処理の処理集約
- #1079 shuffleUse=group時にシャッフルグループ番号が変更できないよう修正

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
