### PR TITLE
[0432/unrepeat-key] メイン画面以外でキーリピート禁止を緩和

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -315,7 +315,7 @@ const blockCode = _setCode => !C_BLOCK_KEYS.map(key => g_kCdN[key]).includes(_se
  */
 const commonKeyDown = (_evt, _displayName, _func = _code => { }) => {
 	const setCode = transCode(_evt.code);
-	if (_evt.repeat) {
+	if (_evt.repeat && g_unrepeatKey.includes(setCode)) {
 		return blockCode(setCode);
 	}
 	g_inputKeyBuffer[setCode] = true;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7883,7 +7883,7 @@ function MainInit() {
 		evt.preventDefault();
 		const setCode = transCode(evt.code);
 
-		if (evt.repeat) {
+		if (evt.repeat && !g_mainRepeatObj.key.includes(setCode)) {
 			return blockCode(setCode);
 		}
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -315,7 +315,7 @@ const blockCode = _setCode => !C_BLOCK_KEYS.map(key => g_kCdN[key]).includes(_se
  */
 const commonKeyDown = (_evt, _displayName, _func = _code => { }) => {
 	const setCode = transCode(_evt.code);
-	if (_evt.repeat && g_unrepeatKey.includes(setCode)) {
+	if (_evt.repeat && (g_unrepeatObj.page.includes(_displayName) || g_unrepeatObj.key.includes(setCode))) {
 		return blockCode(setCode);
 	}
 	g_inputKeyBuffer[setCode] = true;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -920,6 +920,9 @@ const g_btnPatterns = {
     result: { Back: -5, Copy: -5, Tweet: -5, Gitter: -5, Retry: 0 },
 };
 
+// メイン画面以外でキーリピートを許可しないキーを設定
+const g_unrepeatKey = [`Enter`, `Backspace`, `Delete`, `Escape`];
+
 // CSS名称
 const g_cssObj = {
     title_base: `title_base`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -921,7 +921,10 @@ const g_btnPatterns = {
 };
 
 // メイン画面以外でキーリピートを許可しないキーを設定
-const g_unrepeatKey = [`Enter`, `Backspace`, `Delete`, `Escape`];
+const g_unrepeatObj = {
+    key: [`Enter`, `Backspace`, `Delete`, `Escape`, `NumpadEnter`, `Tab`],
+    page: [`keyConfig`, `loading`, `loadingIos`],
+};
 
 // CSS名称
 const g_cssObj = {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -926,6 +926,11 @@ const g_unrepeatObj = {
     page: [`keyConfig`, `loading`, `loadingIos`],
 };
 
+// メイン画面でキーリピートを許可するキーを設定
+const g_mainRepeatObj = {
+    key: [`PageDown`, `PageUp`],
+};
+
 // CSS名称
 const g_cssObj = {
     title_base: `title_base`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. メイン画面以外でキーリピート禁止を緩和しました。
引き続き禁止するキーはKeyBoardEvent.codeの指定に従い、danoni_constants.jsで定義します。
※ただし、キーコンフィグ画面、ロード画面は引き続きリピート禁止にします。
```javascript
// メイン画面以外でキーリピートを許可しないキーを設定
const g_unrepeatObj = {
    key: [`Enter`, `Backspace`, `Delete`, `Escape`, `NumpadEnter`, `Tab`],
    page: [`keyConfig`, `loading`, `loadingIos`],
};
```

```javascript
/**
 * キーを押したときの動作（汎用）
 * @param {object} _evt 
 * @param {string} _displayName 
 * @param {function} _func
 */
const commonKeyDown = (_evt, _displayName, _func = _code => { }) => {
	const setCode = transCode(_evt.code);
	if (_evt.repeat && (g_unrepeatObj.page.includes(_displayName) || g_unrepeatObj.key.includes(setCode))) {
		return blockCode(setCode);
	}
	g_inputKeyBuffer[setCode] = true;

```

2. メイン画面で、PageUp/PageDownボタンのみキーリピートを許可しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 過去、PR #810 でキーリピートを禁止しましたが、メイン画面の一部キーで起こる事象であり、
他の画面については画面遷移系のキーをブロックできれば十分と思われるため。
2. Hid+, Sud+のカバー変更に使用するキーであり、連打で調整するのが手間のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments