### PR TITLE
[0433/right-click] 譜面詳細開閉ボタンで右クリックでも動作するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4076,10 +4076,8 @@ function createOptionWindow(_sprite) {
 	if (g_headerObj.scoreDetailUse) {
 		spriteList.speed.appendChild(
 			createCss2Button(`btnGraph`, `i`, _ => true, {
-				x: 415, y: 0,
-				w: 23, h: 23, siz: C_SIZ_JDGCNTS,
-				title: g_msgObj.graph,
-				resetFunc: _ => setScoreDetail(),
+				x: 415, y: 0, w: 23, h: 23, siz: C_SIZ_JDGCNTS, title: g_msgObj.graph,
+				resetFunc: _ => setScoreDetail(), cxtFunc: _ => setScoreDetail(),
 			}, g_cssObj.button_Mini)
 		);
 		g_stateObj.scoreDetailViewFlg = false;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 譜面詳細開閉ボタンで右クリックでも動作するよう変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 他のボタンとの処理統一のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/121092108-07329500-c826-11eb-8109-840bf8929c9d.png" width="70%">

## :pencil: その他コメント / Other Comments
- 動作の変更はありません。
