### PR TITLE
Adjustmentを0.1単位で設定できる機能の追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4671,7 +4671,7 @@ function createOptionWindow(_sprite) {
 	// ---------------------------------------------------
 	// タイミング調整 (Adjustment)
 	// 縦位置: 10  短縮ショートカットあり
-	createGeneralSetting(spriteList.adjustment, `adjustment`, { skipTerm: 10, skipTerm2: 50, scLabel: g_lblNameObj.sc_adjustment });
+	createGeneralSetting(spriteList.adjustment, `adjustment`, { skipTerm: 5, skipTerm2: 30, scLabel: g_lblNameObj.sc_adjustment, roundNum: 5 });
 
 	// ---------------------------------------------------
 	// フェードイン (Fadein)
@@ -4912,7 +4912,7 @@ function createOptionWindow(_sprite) {
  * @param {object} _options
  */
 function createGeneralSetting(_obj, _settingName, { unitName = ``, skipTerm = 0, skipTerm2 = 0,
-	settingLabel = _settingName, displayName = `option`, scLabel = `` } = {}) {
+	settingLabel = _settingName, displayName = `option`, scLabel = ``, roundNum = 0 } = {}) {
 
 	const settingUpper = toCapitalize(_settingName);
 	const linkId = `lnk${settingUpper}`;
@@ -4923,29 +4923,29 @@ function createGeneralSetting(_obj, _settingName, { unitName = ``, skipTerm = 0,
 
 		multiAppend(_obj,
 			makeSettingLblCssButton(linkId, `${initName}${g_localStorage[_settingName] === g_stateObj[_settingName] ? ' *' : ''}`, 0,
-				_ => setSetting(1, _settingName, unitName),
-				{ cxtFunc: _ => setSetting(-1, _settingName, unitName) }),
+				_ => setSetting(1, _settingName, unitName, roundNum),
+				{ cxtFunc: _ => setSetting(-1, _settingName, unitName, roundNum) }),
 
 			// 右回し・左回しボタン（外側）
 			makeMiniCssButton(linkId, `R`, 0, _ => setSetting(
-				skipTerm2 > 0 ? skipTerm2 : (skipTerm > 0 ? skipTerm : 1), _settingName, unitName)),
+				skipTerm2 > 0 ? skipTerm2 : (skipTerm > 0 ? skipTerm : 1), _settingName, unitName, roundNum)),
 			makeMiniCssButton(linkId, `L`, 0, _ => setSetting(
-				skipTerm2 > 0 ? skipTerm2 * (-1) : (skipTerm > 0 ? skipTerm * (-1) : -1), _settingName, unitName)),
+				skipTerm2 > 0 ? skipTerm2 * (-1) : (skipTerm > 0 ? skipTerm * (-1) : -1), _settingName, unitName, roundNum)),
 		)
 
 		// 右回し・左回しボタン（内側）
 		if (skipTerm > 0) {
 			multiAppend(_obj,
-				makeMiniCssButton(linkId, `RR`, 0, _ => setSetting(skipTerm2 > 0 ? skipTerm : 1, _settingName, unitName)),
-				makeMiniCssButton(linkId, `LL`, 0, _ => setSetting(skipTerm2 > 0 ? skipTerm * (-1) : -1, _settingName, unitName)),
+				makeMiniCssButton(linkId, `RR`, 0, _ => setSetting(skipTerm2 > 0 ? skipTerm : 1, _settingName, unitName, roundNum)),
+				makeMiniCssButton(linkId, `LL`, 0, _ => setSetting(skipTerm2 > 0 ? skipTerm * (-1) : -1, _settingName, unitName, roundNum)),
 			);
 		}
 
-		// 右回し・左回しボタン（最内側）
+		// 右回し・左回しボタン（最内側,不可視）
 		if (skipTerm2 > 0) {
 			multiAppend(_obj,
-				makeMiniCssButton(linkId, `RRR`, 0, _ => setSetting(1, _settingName, unitName), { visibility: `hidden` }),
-				makeMiniCssButton(linkId, `LLL`, 0, _ => setSetting(-1, _settingName, unitName), { visibility: `hidden` }),
+				makeMiniCssButton(linkId, `RRR`, 0, _ => setSetting(1, _settingName, unitName, roundNum), { visibility: `hidden` }),
+				makeMiniCssButton(linkId, `LLL`, 0, _ => setSetting(-1, _settingName, unitName, roundNum), { visibility: `hidden` }),
 			);
 		}
 
@@ -4986,11 +4986,19 @@ function getStgDetailName(_name) {
  * @param {number} _scrollNum 
  * @param {string} _settingName
  * @param {string} _unitName
+ * @param {number} _roundNum
  */
-function setSetting(_scrollNum, _settingName, _unitName = ``) {
+function setSetting(_scrollNum, _settingName, _unitName = ``, _roundNum = 0) {
 	let settingNum = g_settings[`${_settingName}Num`];
 	const settingList = g_settings[`${_settingName}s`];
 	const settingMax = settingList.length - 1;
+
+	// _roundNum単位で丸める
+	if (_roundNum > 0 && _scrollNum >= _roundNum) {
+		settingNum = Math.floor(settingNum / _roundNum) * _roundNum;
+	} else if (_roundNum > 0 && -_scrollNum >= _roundNum) {
+		settingNum = Math.ceil(settingNum / _roundNum) * _roundNum;
+	}
 
 	if (_scrollNum > 0) {
 		settingNum = (settingNum === settingMax ?

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4944,8 +4944,8 @@ function createGeneralSetting(_obj, _settingName, { unitName = ``, skipTerm = 0,
 		// 右回し・左回しボタン（最内側）
 		if (skipTerm2 > 0) {
 			multiAppend(_obj,
-				makeMiniCssButton(linkId, `RRR`, 0, _ => setSetting(1, _settingName, unitName), { dw: -C_LEN_SETMINI_WIDTH / 2, dx: C_LEN_SETMINI_WIDTH / 2 }),
-				makeMiniCssButton(linkId, `LLL`, 0, _ => setSetting(-1, _settingName, unitName), { dw: -C_LEN_SETMINI_WIDTH / 2 }),
+				makeMiniCssButton(linkId, `RRR`, 0, _ => setSetting(1, _settingName, unitName), { visibility: `hidden` }),
+				makeMiniCssButton(linkId, `LLL`, 0, _ => setSetting(-1, _settingName, unitName), { visibility: `hidden` }),
 			);
 		}
 
@@ -5108,11 +5108,12 @@ function makeDifLblCssButton(_id, _name, _heightPos, _func, { x = 0, w = C_LEN_D
  * @param {number} _heightPos 上からの配置順
  * @param {function} _func 
  */
-function makeMiniCssButton(_id, _directionFlg, _heightPos, _func, { dx = 0, dy = 0, dw = 0, dh = 0, dsiz = 0 } = {}) {
+function makeMiniCssButton(_id, _directionFlg, _heightPos, _func, { dx = 0, dy = 0, dw = 0, dh = 0, dsiz = 0, visibility = `visible` } = {}) {
 	return createCss2Button(`${_id}${_directionFlg}`, g_settingBtnObj.chara[_directionFlg], _func, {
 		x: g_settingBtnObj.pos[_directionFlg] + dx,
 		y: C_LEN_SETLBL_HEIGHT * _heightPos + dy,
 		w: C_LEN_SETMINI_WIDTH + dw, h: C_LEN_SETLBL_HEIGHT + dh, siz: C_SIZ_SETLBL + dsiz,
+		visibility: visibility
 	}, g_cssObj.button_Mini);
 }
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8737,7 +8737,7 @@ function MainInit() {
 	g_audio.playbackRate = g_headerObj.playbackRate;
 
 	if (g_audio instanceof AudioPlayer) {
-		const musicStartAdjustment = (g_headerObj.blankFrame - g_stateObj.realAdjustment) / g_fps;
+		const musicStartAdjustment = (g_headerObj.blankFrame - g_stateObj.realAdjustment + 1) / g_fps;
 		musicStartTime = performance.now() + musicStartAdjustment * 1000;
 		g_audio.play(musicStartAdjustment);
 	}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -953,13 +953,13 @@ class AudioPlayer {
 		}
 	}
 
-	play() {
+	play(_adjustmentTime = 0) {
 		this._source = this._context.createBufferSource();
 		this._source.buffer = this._buffer;
 		this._source.playbackRate.value = this.playbackRate;
 		this._source.connect(this._gain);
 		this._startTime = this._context.currentTime;
-		this._source.start(this._context.currentTime, this._fadeinPosition);
+		this._source.start(this._context.currentTime + _adjustmentTime, this._fadeinPosition);
 	}
 
 	pause() {
@@ -1265,7 +1265,7 @@ function loadLocalStorage() {
 		g_localStorage = JSON.parse(checkStorage);
 
 		// Adjustment, Volume, Appearance, Opacity初期値設定
-		checkLocalParam(`adjustment`, C_TYP_NUMBER, C_MAX_ADJUSTMENT);
+		checkLocalParam(`adjustment`, C_TYP_FLOAT, C_MAX_ADJUSTMENT);
 		checkLocalParam(`volume`, C_TYP_NUMBER, g_settings.volumes.length - 1);
 		checkLocalParam(`appearance`);
 		checkLocalParam(`opacity`, C_TYP_NUMBER, g_settings.opacitys.length - 1);
@@ -4671,7 +4671,7 @@ function createOptionWindow(_sprite) {
 	// ---------------------------------------------------
 	// タイミング調整 (Adjustment)
 	// 縦位置: 10  短縮ショートカットあり
-	createGeneralSetting(spriteList.adjustment, `adjustment`, { skipTerm: 5, scLabel: g_lblNameObj.sc_adjustment });
+	createGeneralSetting(spriteList.adjustment, `adjustment`, { skipTerm: 10, skipTerm2: 50, scLabel: g_lblNameObj.sc_adjustment });
 
 	// ---------------------------------------------------
 	// フェードイン (Fadein)
@@ -4911,7 +4911,7 @@ function createOptionWindow(_sprite) {
  * @param {string} _settingName 
  * @param {object} _options
  */
-function createGeneralSetting(_obj, _settingName, { unitName = ``, skipTerm = 0,
+function createGeneralSetting(_obj, _settingName, { unitName = ``, skipTerm = 0, skipTerm2 = 0,
 	settingLabel = _settingName, displayName = `option`, scLabel = `` } = {}) {
 
 	const settingUpper = toCapitalize(_settingName);
@@ -4927,15 +4927,25 @@ function createGeneralSetting(_obj, _settingName, { unitName = ``, skipTerm = 0,
 				{ cxtFunc: _ => setSetting(-1, _settingName, unitName) }),
 
 			// 右回し・左回しボタン（外側）
-			makeMiniCssButton(linkId, `R`, 0, _ => setSetting(skipTerm > 0 ? skipTerm : 1, _settingName, unitName)),
-			makeMiniCssButton(linkId, `L`, 0, _ => setSetting(skipTerm > 0 ? skipTerm * (-1) : -1, _settingName, unitName)),
+			makeMiniCssButton(linkId, `R`, 0, _ => setSetting(
+				skipTerm2 > 0 ? skipTerm2 : (skipTerm > 0 ? skipTerm : 1), _settingName, unitName)),
+			makeMiniCssButton(linkId, `L`, 0, _ => setSetting(
+				skipTerm2 > 0 ? skipTerm2 * (-1) : (skipTerm > 0 ? skipTerm * (-1) : -1), _settingName, unitName)),
 		)
 
 		// 右回し・左回しボタン（内側）
 		if (skipTerm > 0) {
 			multiAppend(_obj,
-				makeMiniCssButton(linkId, `RR`, 0, _ => setSetting(1, _settingName, unitName)),
-				makeMiniCssButton(linkId, `LL`, 0, _ => setSetting(-1, _settingName, unitName)),
+				makeMiniCssButton(linkId, `RR`, 0, _ => setSetting(skipTerm2 > 0 ? skipTerm : 1, _settingName, unitName)),
+				makeMiniCssButton(linkId, `LL`, 0, _ => setSetting(skipTerm2 > 0 ? skipTerm * (-1) : -1, _settingName, unitName)),
+			);
+		}
+
+		// 右回し・左回しボタン（最内側）
+		if (skipTerm2 > 0) {
+			multiAppend(_obj,
+				makeMiniCssButton(linkId, `RRR`, 0, _ => setSetting(1, _settingName, unitName), { dw: -C_LEN_SETMINI_WIDTH / 2, dx: C_LEN_SETMINI_WIDTH / 2 }),
+				makeMiniCssButton(linkId, `LLL`, 0, _ => setSetting(-1, _settingName, unitName), { dw: -C_LEN_SETMINI_WIDTH / 2 }),
 			);
 		}
 
@@ -6067,6 +6077,9 @@ function loadingScoreInit() {
 			}
 		}
 
+		const headerAdjustment = parseFloat(g_headerObj.adjustment[g_stateObj.scoreId] || g_headerObj.adjustment[0]);
+		g_stateObj.realAdjustment = parseFloat(g_stateObj.adjustment) + headerAdjustment + preblankFrame;
+
 		// シャッフルグループ未定義の場合
 		if (g_keyObj[`shuffle${keyCtrlPtn}`] === undefined) {
 			g_keyObj[`shuffle${keyCtrlPtn}`] = [...Array(keyNum)].fill(0);
@@ -6298,11 +6311,9 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	obj.frzData = [];
 	obj.dummyArrowData = [];
 	obj.dummyFrzData = [];
-	const headerAdjustment = parseInt(g_headerObj.adjustment[_scoreId] || g_headerObj.adjustment[0]);
-	const realAdjustment = parseInt(g_stateObj.adjustment) + headerAdjustment + _preblankFrame;
-	g_stateObj.realAdjustment = realAdjustment;
+
 	const blankFrame = g_headerObj.blankFrame;
-	const calcFrame = _frame => Math.round((parseInt(_frame) - blankFrame) / g_headerObj.playbackRate + blankFrame + realAdjustment);
+	const calcFrame = _frame => Math.round((parseInt(_frame) - blankFrame) / g_headerObj.playbackRate + blankFrame);
 
 	for (let j = 0; j < keyNum; j++) {
 
@@ -7656,7 +7667,7 @@ function MainInit() {
 
 	// 開始位置、楽曲再生位置の設定
 	const firstFrame = g_scoreObj.frameNum;
-	const musicStartFrame = firstFrame + g_headerObj.blankFrame;
+	const musicStartFrame = firstFrame + g_headerObj.blankFrame - Math.floor(g_stateObj.realAdjustment);
 	const fadeFlgs = { fadein: [`In`, `Out`], fadeout: [`Out`, `In`] };
 	g_audio.volume = (firstFrame === 0 ? g_stateObj.volume / 100 : 0);
 
@@ -7886,7 +7897,7 @@ function MainInit() {
 
 	// ユーザカスタムイベント(初期)
 	if (typeof customMainInit === C_TYP_FUNCTION) {
-		g_scoreObj.baseFrame = g_scoreObj.frameNum - g_stateObj.realAdjustment;
+		g_scoreObj.baseFrame = g_scoreObj.frameNum;
 		customMainInit();
 		if (typeof customMainInit2 === C_TYP_FUNCTION) {
 			customMainInit2();
@@ -8478,11 +8489,11 @@ function MainInit() {
 
 		if (currentFrame === musicStartFrame) {
 			musicStartFlg = true;
-			g_audio.currentTime = firstFrame / g_fps * g_headerObj.playbackRate;
-			g_audio.playbackRate = g_headerObj.playbackRate;
-			g_audio.play();
-			musicStartTime = performance.now();
-			g_audio.dispatchEvent(new CustomEvent(`timeupdate`));
+			if (!(g_audio instanceof AudioPlayer)) {
+				musicStartTime = performance.now();
+				g_audio.play();
+				g_audio.dispatchEvent(new CustomEvent(`timeupdate`));
+			}
 		}
 
 		// 背景・マスクモーション
@@ -8707,7 +8718,7 @@ function MainInit() {
 			// 60fpsから遅延するため、その差分を取って次回のタイミングで遅れをリカバリする
 			thisTime = performance.now();
 			buffTime = 0;
-			if (currentFrame >= musicStartFrame) {
+			if (g_audio instanceof AudioPlayer || currentFrame >= musicStartFrame) {
 				buffTime = (thisTime - musicStartTime - (currentFrame - musicStartFrame) * 1000 / g_fps);
 			}
 			g_scoreObj.frameNum++;
@@ -8721,6 +8732,16 @@ function MainInit() {
 			skinMainInit2();
 		}
 	}
+
+	g_audio.currentTime = firstFrame / g_fps * g_headerObj.playbackRate;
+	g_audio.playbackRate = g_headerObj.playbackRate;
+
+	if (g_audio instanceof AudioPlayer) {
+		const musicStartAdjustment = (g_headerObj.blankFrame - g_stateObj.realAdjustment) / g_fps;
+		musicStartTime = performance.now() + musicStartAdjustment * 1000;
+		g_audio.play(musicStartAdjustment);
+	}
+
 	g_timeoutEvtId = setTimeout(_ => flowTimeline(), 1000 / g_fps);
 }
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -239,16 +239,20 @@ const g_settingBtnObj = {
     chara: {
         L: `<`,
         LL: `<`,
+        LLL: `<`,
         R: `>`,
         RR: `>`,
+        RRR: `>`,
         D: `↓`,
         U: `↑`,
     },
     pos: {
         L: C_LEN_SETLBL_LEFT - C_LEN_SETMINI_WIDTH,
         LL: C_LEN_SETLBL_LEFT,
+        LLL: C_LEN_SETLBL_LEFT + C_LEN_SETMINI_WIDTH,
         R: C_LEN_SETLBL_LEFT + C_LEN_SETLBL_WIDTH,
         RR: C_LEN_SETLBL_LEFT + C_LEN_SETLBL_WIDTH - C_LEN_SETMINI_WIDTH,
+        RRR: C_LEN_SETLBL_LEFT + C_LEN_SETLBL_WIDTH - C_LEN_SETMINI_WIDTH * 2,
     }
 };
 
@@ -459,8 +463,8 @@ const g_settings = {
     autoPlays: [C_FLG_OFF, C_FLG_ALL],
     autoPlayNum: 0,
 
-    adjustments: [...Array(C_MAX_ADJUSTMENT * 2 + 1).keys()].map(i => i - C_MAX_ADJUSTMENT),
-    adjustmentNum: C_MAX_ADJUSTMENT,
+    adjustments: [...Array(C_MAX_ADJUSTMENT * 20 + 1).keys()].map(i => (i - C_MAX_ADJUSTMENT * 10) / 10),
+    adjustmentNum: C_MAX_ADJUSTMENT * 10,
 
     volumes: [0, 0.5, 1, 2, 5, 10, 25, 50, 75, 100],
 
@@ -850,13 +854,17 @@ const g_shortcutObj = {
         KeyG: { id: `lnkGaugeR` },
 
         ShiftLeft_Semicolon: { id: `lnkAdjustmentR` },
+        AltLeft_Semicolon: { id: `lnkAdjustmentRRR` },
         Semicolon: { id: `lnkAdjustmentRR` },
         ShiftLeft_Minus: { id: `lnkAdjustmentL` },
+        AltLeft_Minus: { id: `lnkAdjustmentLLL` },
         Minus: { id: `lnkAdjustmentLL` },
 
         ShiftLeft_NumpadAdd: { id: `lnkAdjustmentR` },
+        AltLeft_NumpadAdd: { id: `lnkAdjustmentRRR` },
         NumpadAdd: { id: `lnkAdjustmentRR` },
         ShiftLeft_NumpadSubtract: { id: `lnkAdjustmentL` },
+        AltLeft_NumpadSubtract: { id: `lnkAdjustmentLLL` },
         NumpadSubtract: { id: `lnkAdjustmentLL` },
 
         ShiftLeft_KeyV: { id: `lnkVolumeL` },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- 曲開始位置をWebAudioAPIで微調整することでAdjustmentを0.1単位で設定できるようにしました

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- [Adjustmentが小数点以下で合わない](https://twitter.com/vdos2643/status/1429445149143146503)と感じる場合があるようです

## :camera: スクリーンショット / Screenshot

## :pencil: その他コメント / Other Comments
- 私は1f未満の差は正直よく分かりません
  - [自サイトに適用済](https://suzume.kirara.st/atmosphere/)なので分かる方に試していただけるとありがたいです
- WebAudioAPIが利用できない条件では小数点以下切り捨てで動作します
