### PR TITLE
[0442/decimal-adjustment] 譜面データが極端に小さいフレーム数のときにAdjが一部利かない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6108,9 +6108,6 @@ function loadingScoreInit() {
 			}
 		}
 
-		const headerAdjustment = parseFloat(g_headerObj.adjustment[g_stateObj.scoreId] || g_headerObj.adjustment[0]);
-		g_stateObj.realAdjustment = parseFloat(g_stateObj.adjustment) + headerAdjustment + preblankFrame;
-
 		// シャッフルグループ未定義の場合
 		if (g_keyObj[`shuffle${keyCtrlPtn}`] === undefined) {
 			g_keyObj[`shuffle${keyCtrlPtn}`] = [...Array(keyNum)].fill(0);
@@ -6343,8 +6340,14 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	obj.dummyArrowData = [];
 	obj.dummyFrzData = [];
 
+	// allAdjustment: 全体, realAdjustment: 整数値のみ(切り捨て), decimalAdjustment: 小数値のみ
+	const headerAdjustment = parseFloat(g_headerObj.adjustment[g_stateObj.scoreId] || g_headerObj.adjustment[0]);
+	g_stateObj.allAdjustment = parseFloat(g_stateObj.adjustment) + headerAdjustment + _preblankFrame;
+	g_stateObj.realAdjustment = Math.floor(g_stateObj.allAdjustment);
+	g_stateObj.decimalAdjustment = g_stateObj.allAdjustment - g_stateObj.realAdjustment;
+
 	const blankFrame = g_headerObj.blankFrame;
-	const calcFrame = _frame => Math.round((parseInt(_frame) - blankFrame) / g_headerObj.playbackRate + blankFrame);
+	const calcFrame = _frame => Math.round((parseInt(_frame) - blankFrame) / g_headerObj.playbackRate + blankFrame + g_stateObj.realAdjustment);
 
 	for (let j = 0; j < keyNum; j++) {
 
@@ -7698,7 +7701,7 @@ function MainInit() {
 
 	// 開始位置、楽曲再生位置の設定
 	const firstFrame = g_scoreObj.frameNum;
-	const musicStartFrame = firstFrame + g_headerObj.blankFrame - Math.floor(g_stateObj.realAdjustment);
+	const musicStartFrame = firstFrame + g_headerObj.blankFrame;
 	const fadeFlgs = { fadein: [`In`, `Out`], fadeout: [`Out`, `In`] };
 	g_audio.volume = (firstFrame === 0 ? g_stateObj.volume / 100 : 0);
 
@@ -7928,7 +7931,7 @@ function MainInit() {
 
 	// ユーザカスタムイベント(初期)
 	if (typeof customMainInit === C_TYP_FUNCTION) {
-		g_scoreObj.baseFrame = g_scoreObj.frameNum;
+		g_scoreObj.baseFrame = g_scoreObj.frameNum - g_stateObj.realAdjustment;
 		customMainInit();
 		if (typeof customMainInit2 === C_TYP_FUNCTION) {
 			customMainInit2();
@@ -8768,7 +8771,7 @@ function MainInit() {
 	g_audio.playbackRate = g_headerObj.playbackRate;
 
 	if (g_audio instanceof AudioPlayer) {
-		const musicStartAdjustment = (g_headerObj.blankFrame - g_stateObj.realAdjustment + 1) / g_fps;
+		const musicStartAdjustment = (g_headerObj.blankFrame - g_stateObj.decimalAdjustment + 1) / g_fps;
 		musicStartTime = performance.now() + musicStartAdjustment * 1000;
 		g_audio.play(musicStartAdjustment);
 	}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8523,6 +8523,8 @@ function MainInit() {
 
 		if (currentFrame === musicStartFrame) {
 			musicStartFlg = true;
+
+			// ローカルかつBase64エンコード無し(WebAudioAPI使用不可)のときは従来通り再生
 			if (!(g_audio instanceof AudioPlayer)) {
 				musicStartTime = performance.now();
 				g_audio.play();
@@ -8770,6 +8772,7 @@ function MainInit() {
 	g_audio.currentTime = firstFrame / g_fps * g_headerObj.playbackRate;
 	g_audio.playbackRate = g_headerObj.playbackRate;
 
+	// WebAudioAPIが使用できる場合は小数フレーム分だけ音源位置を調整
 	if (g_audio instanceof AudioPlayer) {
 		const musicStartAdjustment = (g_headerObj.blankFrame - g_stateObj.decimalAdjustment + 1) / g_fps;
 		musicStartTime = performance.now() + musicStartAdjustment * 1000;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6340,14 +6340,14 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	obj.dummyArrowData = [];
 	obj.dummyFrzData = [];
 
-	// allAdjustment: 全体, realAdjustment: 整数値のみ(切り捨て), decimalAdjustment: 小数値のみ
+	// realAdjustment: 全体, intAdjustment: 整数値のみ(切り捨て), decimalAdjustment: 小数値のみ
 	const headerAdjustment = parseFloat(g_headerObj.adjustment[g_stateObj.scoreId] || g_headerObj.adjustment[0]);
-	g_stateObj.allAdjustment = parseFloat(g_stateObj.adjustment) + headerAdjustment + _preblankFrame;
-	g_stateObj.realAdjustment = Math.floor(g_stateObj.allAdjustment);
-	g_stateObj.decimalAdjustment = g_stateObj.allAdjustment - g_stateObj.realAdjustment;
+	g_stateObj.realAdjustment = parseFloat(g_stateObj.adjustment) + headerAdjustment + _preblankFrame;
+	g_stateObj.intAdjustment = Math.floor(g_stateObj.realAdjustment);
+	g_stateObj.decimalAdjustment = g_stateObj.realAdjustment - g_stateObj.intAdjustment;
 
 	const blankFrame = g_headerObj.blankFrame;
-	const calcFrame = _frame => Math.round((parseInt(_frame) - blankFrame) / g_headerObj.playbackRate + blankFrame + g_stateObj.realAdjustment);
+	const calcFrame = _frame => Math.round((parseInt(_frame) - blankFrame) / g_headerObj.playbackRate + blankFrame + g_stateObj.intAdjustment);
 
 	for (let j = 0; j < keyNum; j++) {
 
@@ -7931,7 +7931,7 @@ function MainInit() {
 
 	// ユーザカスタムイベント(初期)
 	if (typeof customMainInit === C_TYP_FUNCTION) {
-		g_scoreObj.baseFrame = g_scoreObj.frameNum - g_stateObj.realAdjustment;
+		g_scoreObj.baseFrame = g_scoreObj.frameNum - g_stateObj.intAdjustment;
 		customMainInit();
 		if (typeof customMainInit2 === C_TYP_FUNCTION) {
 			customMainInit2();


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. blankFrameや譜面データが極端に小さいフレーム数のとき、Adjustmentが一部利かない問題を修正しました。
対処方針として、Adjustmentの整数値部分は従来のやり方に戻し、
小数部分のみ音源位置調整に委ねる方法を取っています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Resolves #1101 

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- v23.0.0のみ発生する事象です。
