### PR TITLE
プレイ開始ボタンなどのショートカットにテンキーエンターを割り当て

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -825,6 +825,7 @@ g_kCdN[240] = `CapsLock`;
 const g_shortcutObj = {
     title: {
         Enter: { id: `btnStart` },
+        NumpadEnter: { id: `btnStart` },
         Slash: { id: `btnHelp`, reset: true },
         F1: { id: `btnHelp`, reset: true },
         ControlLeft_KeyC: { id: `` },
@@ -879,6 +880,7 @@ const g_shortcutObj = {
         Escape: { id: `btnBack` },
         Space: { id: `btnKeyConfig` },
         Enter: { id: `btnPlay` },
+        NumpadEnter: { id: `btnPlay` },
         ShiftLeft_Tab: { id: `btnBack` },
         Tab: { id: `btnDisplay` },
     },
@@ -893,6 +895,7 @@ const g_shortcutObj = {
         Escape: { id: `btnBack` },
         Space: { id: `btnKeyConfig` },
         Enter: { id: `lnkDifficulty` },
+        NumpadEnter: { id: `lnkDifficulty` },
         ShiftLeft_Tab: { id: `btnBack` },
         Tab: { id: `btnDisplay` },
     },
@@ -934,6 +937,7 @@ const g_shortcutObj = {
         Escape: { id: `btnBack` },
         Space: { id: `btnKeyConfig` },
         Enter: { id: `btnPlay` },
+        NumpadEnter: { id: `btnPlay` },
         ShiftLeft_Tab: { id: `btnBack` },
         Tab: { id: `btnSettings` },
     },
@@ -942,6 +946,7 @@ const g_shortcutObj = {
     },
     loadingIos: {
         Enter: { id: `btnPlay` },
+        NumpadEnter: { id: `btnPlay` },
     },
     result: {
         Escape: { id: `btnBack` },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- タイトル画面からのスタートやプレイ開始ボタンなど、ショートカットにエンターキーが割り当てられていた動作に対してテンキーエンターも追加しました

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- 利便性向上およびFlash版ソースと仕様統一のため

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 特になし