### PR TITLE
[0443/imgtype-org] ImgType: Original の位置を自由な位置に入れられるよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2766,14 +2766,16 @@ function headerConvert(_dosObj) {
 			tmpImgTypes.forEach((tmpImgType, j) => {
 				const imgTypes = tmpImgType.split(`,`);
 				obj.imgType[j] = [imgTypes[0], imgTypes[1] || `svg`];
-				g_keycons.imgTypes[j] = imgTypes[0];
+				g_keycons.imgTypes[j] = (imgTypes[0] === `` ? `Original` : imgTypes[0]);
 			});
 		}
 	}
 
 	// 末尾にデフォルト画像セットが入るよう追加
-	obj.imgType.push([``]);
-	g_keycons.imgTypes.push(`Original`);
+	if (obj.imgType.findIndex(imgSets => imgSets[0] === ``) === -1) {
+		obj.imgType.push([``]);
+		g_keycons.imgTypes.push(`Original`);
+	}
 	g_imgType = g_keycons.imgTypes[0];
 
 	// サーバ上の場合、画像セットを再読込（ローカルファイル時は読込済みのためスキップ）

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -124,7 +124,7 @@ const g_presetFrzStartjdgUse = `false`;
 	下記の場合は[classic]フォルダに[png]形式の画像一式をデフォルト画像セットとして使用する
 	拡張子は、未指定の場合`svg`形式
 */
-// const g_presetImageSets = [`classic,png`, `classic-thin,png`];
+// const g_presetImageSets = [``, `classic,png`, `classic-thin,png`];
 
 // デフォルト画像セット (C_IMG_XXXX, 厳密にはg_imgObj) に対して拡張子の上書きを行うか設定
 // 文字列の後ろ3文字をカットして、下記の値を適用する。コメントアウトした場合は、上書きを行わない。


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. ImgType: Original の位置を自由な位置に入れられるよう変更しました。
空文字で挟むことで対応します。

### 譜面ヘッダーで対応する場合
```
|imgType=$classic,png$classic-thin,png|　// Original, classic, classic-thinの順
|imgType=classic,png$$classic-thin,png|   // classic, Original, classic-thinの順
```

### danoni_setting.js で対応する場合
```javascript
const g_presetImageSets = [``, `classic,png`, `classic-thin,png`];　// Original, classic, classic-thinの順
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. デフォルトの画像セットを最初に持ってくるといった場合に対応するため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
