### PR TITLE
オプション画面のボタン動作見直し、速度設定細分化

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2842,8 +2842,7 @@ function headerConvert(_dosObj) {
 		obj.minSpeed = C_MIN_SPEED;
 		obj.maxSpeed = C_MAX_SPEED;
 	}
-	g_settings.speeds = [...Array((obj.maxSpeed - obj.minSpeed) * 4 + 1).keys()].map(i => obj.minSpeed + i / 4);
-
+	g_settings.speeds = [...Array((obj.maxSpeed - obj.minSpeed) * 20 + 1).keys()].map(i => obj.minSpeed + i / 20);
 
 	// プレイ中のショートカットキー
 	obj.keyRetry = setVal(_dosObj.keyRetry, C_KEY_RETRY, C_TYP_NUMBER);
@@ -4111,7 +4110,10 @@ function createOptionWindow(_sprite) {
 	// ---------------------------------------------------
 	// 速度(Speed)
 	// 縦位置: 2  短縮ショートカットあり
-	createGeneralSetting(spriteList.speed, `speed`, { unitName: ` ${getStgDetailName(g_lblNameObj.multi)}`, skipTerm: 4, scLabel: g_lblNameObj.sc_speed });
+	createGeneralSetting(spriteList.speed, `speed`, {
+		skipTerm: 5, skipTerm2: 20, scLabel: g_lblNameObj.sc_speed, roundNum: 5,
+		unitName: ` ${getStgDetailName(g_lblNameObj.multi)}`,
+	});
 
 	if (g_headerObj.scoreDetailUse) {
 		spriteList.speed.appendChild(
@@ -4944,8 +4946,8 @@ function createGeneralSetting(_obj, _settingName, { unitName = ``, skipTerm = 0,
 
 		multiAppend(_obj,
 			makeSettingLblCssButton(linkId, `${initName}${g_localStorage[_settingName] === g_stateObj[_settingName] ? ' *' : ''}`, 0,
-				_ => setSetting(1, _settingName, unitName, roundNum),
-				{ cxtFunc: _ => setSetting(-1, _settingName, unitName, roundNum) }),
+				_ => setSetting(skipTerm2 > 0 ? skipTerm : 1, _settingName, unitName, roundNum),
+				{ cxtFunc: _ => setSetting(skipTerm2 > 0 ? skipTerm * (-1) : -1, _settingName, unitName, roundNum) }),
 
 			// 右回し・左回しボタン（外側）
 			makeMiniCssButton(linkId, `R`, 0, _ => setSetting(

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -442,7 +442,7 @@ let g_appearanceRanges = [`Hidden+`, `Sudden+`, `Hid&Sud+`];
 
 // 設定系全般管理
 const g_settings = {
-    speeds: [...Array((C_MAX_SPEED - C_MIN_SPEED) * 4 + 1).keys()].map(i => C_MIN_SPEED + i / 4),
+    speeds: [...Array((C_MAX_SPEED - C_MIN_SPEED) * 20 + 1).keys()].map(i => C_MIN_SPEED + i / 20),
     speedNum: 0,
 
     motions: [C_FLG_OFF, `Boost`, `Brake`],
@@ -835,8 +835,10 @@ const g_shortcutObj = {
         ShiftLeft_KeyD: { id: `lnkDifficultyL` },
         KeyD: { id: `lnkDifficultyR` },
         ShiftLeft_ArrowRight: { id: `lnkSpeedR` },
+        AltLeft_ArrowRight: { id: `lnkSpeedRRR` },
         ArrowRight: { id: `lnkSpeedRR` },
         ShiftLeft_ArrowLeft: { id: `lnkSpeedL` },
+        AltLeft_ArrowLeft: { id: `lnkSpeedLLL` },
         ArrowLeft: { id: `lnkSpeedLL` },
         KeyL: { id: `lnkDifficulty` },
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- オプション項目の最内側に不可視ボタンがあるとき、中央のラベルボタンの動作を最内側ではなく内側ボタンと同じにするよう修正
- Alt+←or→のショートカットでスピードをx0.05単位で変更できる機能を追加

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- #1096 にてAdjustmentボタンの仕様が変わりましたが、
他のオプション項目とは違い中央ボタンのみ独自の動作をするのは統一性がなく違和感があるため
- より正確な適正倍速でプレイできるようにするため

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- g_btnAddFunc などでボタンをカスタムしているときに影響を与える可能性があります
