### PR TITLE
フリーズアローの挙動見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8931,6 +8931,11 @@ function changeCssMotions(_mkCssMotion, _mkCssMotionName, _name) {
 function changeHitFrz(_j, _k, _name) {
 	const frzNo = `${_j}_${_k}`;
 	const frzName = `${_name}${frzNo}`;
+
+	if (g_attrObj[frzName].keyUpFrame !== 0) {
+		return;
+	}
+
 	const styfrzBar = $id(`${_name}Bar${frzNo}`);
 	const styfrzBtm = $id(`${_name}Btm${frzNo}`);
 	const styfrzBtmShadow = $id(`${_name}BtmShadow${frzNo}`);
@@ -8943,6 +8948,7 @@ function changeHitFrz(_j, _k, _name) {
 	g_attrObj[frzName].frzBarLength -= delFrzLength * g_attrObj[frzName].dir;
 	g_attrObj[frzName].barY -= delFrzLength * g_attrObj[frzName].dividePos;
 	g_attrObj[frzName].btmY -= delFrzLength;
+	g_attrObj[frzName].y += delFrzLength;
 	g_attrObj[frzName].isMoving = false;
 
 	styfrzBar.top = `${g_attrObj[frzName].barY}px`;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8495,6 +8495,18 @@ function MainInit() {
 				// フリーズアローがヒット中の処理
 				if (g_attrObj[frzName].frzBarLength > 0) {
 
+					// 早押ししたフレーム分終端の位置を動かす
+					if (g_attrObj[frzName].cnt > 0) {
+						if (g_workObj.currentSpeed !== 0) {
+							const delFrzLength = g_workObj.motionOnFrames[g_attrObj[frzName].boostCnt] * g_attrObj[frzName].boostSpd;
+							g_attrObj[frzName].btmY -= delFrzLength;
+							g_attrObj[frzName].barY -= delFrzLength * g_attrObj[frzName].dividePos;
+							g_attrObj[frzName].frzBarLength -= delFrzLength * g_attrObj[frzName].dir;
+							g_attrObj[frzName].boostCnt--;
+						}
+						g_attrObj[frzName].cnt--;
+					}
+
 					g_attrObj[frzName].frzBarLength -= movY * g_attrObj[frzName].dir;
 					g_attrObj[frzName].barY -= movY * g_attrObj[frzName].dividePos;
 					g_attrObj[frzName].btmY -= movY;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8495,18 +8495,6 @@ function MainInit() {
 				// フリーズアローがヒット中の処理
 				if (g_attrObj[frzName].frzBarLength > 0) {
 
-					// 早押ししたフレーム分終端の位置を動かす
-					if (g_attrObj[frzName].cnt > 0) {
-						if (g_workObj.currentSpeed !== 0) {
-							const delFrzLength = g_workObj.motionOnFrames[g_attrObj[frzName].boostCnt] * g_attrObj[frzName].boostSpd;
-							g_attrObj[frzName].btmY -= delFrzLength;
-							g_attrObj[frzName].barY -= delFrzLength * g_attrObj[frzName].dividePos;
-							g_attrObj[frzName].frzBarLength -= delFrzLength * g_attrObj[frzName].dir;
-							g_attrObj[frzName].boostCnt--;
-						}
-						g_attrObj[frzName].cnt--;
-					}
-
 					g_attrObj[frzName].frzBarLength -= movY * g_attrObj[frzName].dir;
 					g_attrObj[frzName].barY -= movY * g_attrObj[frzName].dividePos;
 					g_attrObj[frzName].btmY -= movY;
@@ -8957,9 +8945,17 @@ function changeHitFrz(_j, _k, _name) {
 	const delFrzLength = parseFloat($id(`stepRoot${_j}`).top) - g_attrObj[frzName].y;
 	document.getElementById(frzName).style.top = $id(`stepRoot${_j}`).top;
 
-	g_attrObj[frzName].frzBarLength -= delFrzLength * g_attrObj[frzName].dir;
-	g_attrObj[frzName].barY -= delFrzLength * g_attrObj[frzName].dividePos;
-	g_attrObj[frzName].btmY -= delFrzLength;
+	let delFrzMotionLength = 0;
+	if (g_attrObj[frzName].cnt > 0) {
+		const fastFrame = g_attrObj[frzName].cnt;
+		for (let i = 0; i < fastFrame; i++) {
+			delFrzMotionLength += g_workObj.motionOnFrames[g_attrObj[frzName].boostCnt - i] * g_attrObj[frzName].boostSpd;
+		}
+	}
+
+	g_attrObj[frzName].frzBarLength -= (delFrzLength + delFrzMotionLength) * g_attrObj[frzName].dir;
+	g_attrObj[frzName].barY -= (delFrzLength + delFrzMotionLength) * g_attrObj[frzName].dividePos;
+	g_attrObj[frzName].btmY -= (delFrzLength + delFrzMotionLength);
 	g_attrObj[frzName].y += delFrzLength;
 	g_attrObj[frzName].isMoving = false;
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8246,17 +8246,21 @@ function MainInit() {
 			if (g_workObj.judgFrzCnt[_j] !== _k && _cnt <= g_judgObj.frzJ[g_judgPosObj.sfsf] + 1) {
 				const prevFrzName = `frz${_j}_${g_workObj.judgFrzCnt[_j]}`;
 
-				if (g_attrObj[prevFrzName].cnt >= (-1) * g_judgObj.frzJ[g_judgPosObj.kita]) {
-				} else {
+				// フリーズアロー押下中の場合は削除しない
+				if (g_attrObj[prevFrzName].isMoving) {
 
-					// 枠外判定前の場合、このタイミングで枠外判定を行う
-					if (g_attrObj[prevFrzName].cnt >= (-1) * g_judgObj.frzJ[g_judgPosObj.iknai]) {
-						judgeIknai(_cnt);
-						if (g_headerObj.frzStartjdgUse) {
-							judgeUwan(_cnt);
+					if (g_attrObj[prevFrzName].cnt >= (-1) * g_judgObj.frzJ[g_judgPosObj.kita]) {
+					} else {
+
+						// 枠外判定前の場合、このタイミングで枠外判定を行う
+						if (g_attrObj[prevFrzName].cnt >= (-1) * g_judgObj.frzJ[g_judgPosObj.iknai]) {
+							judgeIknai(_cnt);
+							if (g_headerObj.frzStartjdgUse) {
+								judgeUwan(_cnt);
+							}
 						}
+						judgeObjDelete.frz(_j, prevFrzName);
 					}
-					judgeObjDelete.frz(_j, prevFrzName);
 				}
 			}
 		},
@@ -8945,17 +8949,15 @@ function changeHitFrz(_j, _k, _name) {
 	const delFrzLength = parseFloat($id(`stepRoot${_j}`).top) - g_attrObj[frzName].y;
 	document.getElementById(frzName).style.top = $id(`stepRoot${_j}`).top;
 
+	// 早押ししたboostCnt分のフリーズアロー終端位置の修正
 	let delFrzMotionLength = 0;
-	if (g_attrObj[frzName].cnt > 0) {
-		const fastFrame = g_attrObj[frzName].cnt;
-		for (let i = 0; i < fastFrame; i++) {
-			delFrzMotionLength += g_workObj.motionOnFrames[g_attrObj[frzName].boostCnt - i] * g_attrObj[frzName].boostSpd;
-		}
+	for (let i = 0; i < g_attrObj[frzName].cnt; i++) {
+		delFrzMotionLength += g_workObj.motionOnFrames[g_attrObj[frzName].boostCnt - i] * g_attrObj[frzName].boostSpd;
 	}
 
 	g_attrObj[frzName].frzBarLength -= (delFrzLength + delFrzMotionLength) * g_attrObj[frzName].dir;
 	g_attrObj[frzName].barY -= (delFrzLength + delFrzMotionLength) * g_attrObj[frzName].dividePos;
-	g_attrObj[frzName].btmY -= (delFrzLength + delFrzMotionLength);
+	g_attrObj[frzName].btmY -= delFrzLength + delFrzMotionLength;
 	g_attrObj[frzName].y += delFrzLength;
 	g_attrObj[frzName].isMoving = false;
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8241,26 +8241,22 @@ function MainInit() {
 		frzOFF: (_j, _k, _cnt) => {
 
 			// フリーズアローの判定領域に入った場合、前のフリーズアローを強制的に削除
-			// ただし、前のフリーズアローの判定領域がジャスト付近(キター領域)の場合は削除しない
+			// ただし、前のフリーズアローが押下中または判定領域がジャスト付近(キター領域)の場合は削除しない
 			// 削除する場合、前のフリーズアローの判定はイクナイ(＆ウワァン)扱い
 			if (g_workObj.judgFrzCnt[_j] !== _k && _cnt <= g_judgObj.frzJ[g_judgPosObj.sfsf] + 1) {
 				const prevFrzName = `frz${_j}_${g_workObj.judgFrzCnt[_j]}`;
 
-				// フリーズアロー押下中の場合は削除しない
-				if (g_attrObj[prevFrzName].isMoving) {
+				if (g_attrObj[prevFrzName].cnt >= (-1) * g_judgObj.frzJ[g_judgPosObj.kita] || !g_attrObj[prevFrzName].isMoving) {
+				} else {
 
-					if (g_attrObj[prevFrzName].cnt >= (-1) * g_judgObj.frzJ[g_judgPosObj.kita]) {
-					} else {
-
-						// 枠外判定前の場合、このタイミングで枠外判定を行う
-						if (g_attrObj[prevFrzName].cnt >= (-1) * g_judgObj.frzJ[g_judgPosObj.iknai]) {
-							judgeIknai(_cnt);
-							if (g_headerObj.frzStartjdgUse) {
-								judgeUwan(_cnt);
-							}
+					// 枠外判定前の場合、このタイミングで枠外判定を行う
+					if (g_attrObj[prevFrzName].cnt >= (-1) * g_judgObj.frzJ[g_judgPosObj.iknai]) {
+						judgeIknai(_cnt);
+						if (g_headerObj.frzStartjdgUse) {
+							judgeUwan(_cnt);
 						}
-						judgeObjDelete.frz(_j, prevFrzName);
 					}
+					judgeObjDelete.frz(_j, prevFrzName);
 				}
 			}
 		},

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8246,8 +8246,8 @@ function MainInit() {
 			if (g_workObj.judgFrzCnt[_j] !== _k && _cnt <= g_judgObj.frzJ[g_judgPosObj.sfsf] + 1) {
 				const prevFrzName = `frz${_j}_${g_workObj.judgFrzCnt[_j]}`;
 
-				if (g_attrObj[prevFrzName].cnt >= (-1) * g_judgObj.frzJ[g_judgPosObj.kita] || !g_attrObj[prevFrzName].isMoving) {
-				} else {
+				if (g_attrObj[prevFrzName].isMoving &&
+					g_attrObj[prevFrzName].cnt < (-1) * g_judgObj.frzJ[g_judgPosObj.kita]) {
 
 					// 枠外判定前の場合、このタイミングで枠外判定を行う
 					if (g_attrObj[prevFrzName].cnt >= (-1) * g_judgObj.frzJ[g_judgPosObj.iknai]) {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. フリーズアローを押し直したとき終端がズレる問題を修正
2. フリーズアローを離したとき全体の位置がズレる問題を修正

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. フリーズアローを押し直すたびに changeHitFrz が実行されていたため、初回のみ実行するようにしました
2. ステップゾーンと実際にフリーズアローを押し始めた位置のズレ幅（delFrzLength）を
g_attrObj[frzName].y に対しても反映するようにしました

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
以下のバグも見つかっていますが、現時点では良い解決法が見つかっていません

3. boost, brake 使用時に、早めにフリーズアローを押し始めると終端の位置がズレる
4. 遅めにフリーズアローを押し始めると、終端の直後に次のフリーズアローが存在する場合にのみ、
最後まで押し切ってもイクナイ判定となってしまう（#341 からのバグ）

3は対応したいですが、4は根が深そうなので別件としたほうがいいかもしれません