### PR TITLE
[0446/boost-frames] Boost時の軌道計算を見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6896,7 +6896,7 @@ function setMotionOnFrame() {
 	} else if (g_stateObj.motion === `Boost`) {
 		// ステップゾーンに近づくにつれて加速量を大きくする (16 → 85)
 		for (let j = C_MOTION_STD_POS + 1; j < C_MOTION_STD_POS + 70; j++) {
-			motionOnFrame[j] = (C_MOTION_STD_POS + 70 - j) * g_stateObj.speed * 2 / 50;
+			motionOnFrame[j] = (C_MOTION_STD_POS + 70 - j) * 3 / 50;
 		}
 	} else if (g_stateObj.motion === `Brake`) {
 		// 初期は+2x、ステップゾーンに近づくにつれて加速量を下げる (20 → 34)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6906,11 +6906,6 @@ function setMotionOnFrame() {
 		for (let j = C_MOTION_STD_POS + 19; j <= brakeLastFrame; j++) {
 			motionOnFrame[j] = 4;
 		}
-	} else if (g_stateObj.motion === `Compress`) {
-		// ステップゾーンに近づくにつれて加速量を負数にする (16 → 85)
-		for (let j = C_MOTION_STD_POS + 1; j < C_MOTION_STD_POS + 70; j++) {
-			motionOnFrame[j] = -(C_MOTION_STD_POS + 70 - j) * 2.5 * g_stateObj.speed / 100;
-		}
 	}
 
 	return motionOnFrame;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6906,6 +6906,11 @@ function setMotionOnFrame() {
 		for (let j = C_MOTION_STD_POS + 19; j <= brakeLastFrame; j++) {
 			motionOnFrame[j] = 4;
 		}
+	} else if (g_stateObj.motion === `Compress`) {
+		// ステップゾーンに近づくにつれて加速量を負数にする (16 → 85)
+		for (let j = C_MOTION_STD_POS + 1; j < C_MOTION_STD_POS + 70; j++) {
+			motionOnFrame[j] = -(C_MOTION_STD_POS + 70 - j) * 2.5 * g_stateObj.speed / 100;
+		}
 	}
 
 	return motionOnFrame;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -448,7 +448,7 @@ const g_settings = {
     speeds: [...Array((C_MAX_SPEED - C_MIN_SPEED) * 20 + 1).keys()].map(i => C_MIN_SPEED + i / 20),
     speedNum: 0,
 
-    motions: [C_FLG_OFF, `Boost`, `Brake`, `Compress`],
+    motions: [C_FLG_OFF, `Boost`, `Brake`],
     motionNum: 0,
 
     reverses: [C_FLG_OFF, C_FLG_ON],
@@ -2311,7 +2311,6 @@ const g_lblNameObj = {
     'u_ON': `ON`,
     'u_Boost': `Boost`,
     'u_Brake': `Brake`,
-    'u_Comprees': `Compress`,
 
     'u_Cross': `Cross`,
     'u_Split': `Split`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -448,7 +448,7 @@ const g_settings = {
     speeds: [...Array((C_MAX_SPEED - C_MIN_SPEED) * 20 + 1).keys()].map(i => C_MIN_SPEED + i / 20),
     speedNum: 0,
 
-    motions: [C_FLG_OFF, `Boost`, `Brake`],
+    motions: [C_FLG_OFF, `Boost`, `Brake`, `Compress`],
     motionNum: 0,
 
     reverses: [C_FLG_OFF, C_FLG_ON],
@@ -2311,6 +2311,7 @@ const g_lblNameObj = {
     'u_ON': `ON`,
     'u_Boost': `Boost`,
     'u_Brake': `Brake`,
+    'u_Comprees': `Compress`,
 
     'u_Cross': `Cross`,
     'u_Split': `Split`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. Boostオプション付加時の起動計算を見直しました。
（変化イメージはスクリーンショットを参照）

従来のBoostと比較した場合の差異は下記の通りです。
- 従来：ステップゾーンの到達時速度＝Speedで設定した倍速× 2.4
- 今後：ステップゾーンの到達時速度＝Speedで設定した倍速＋2x 程度

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 従来の計算方法では加算値の振れ幅が速度成分に比例するため、
ほとんどのケースで常時高速となり、低速Boostしか使えていない状況でした。
Brakeと同じ振れ幅に制限することで本来のBoostらしい、
徐々に加速する動きになると思います。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/133342567-5962d281-5825-4b8c-bac4-0c879cfbbba1.png" width="70%">

## :pencil: その他コメント / Other Comments
- 試験的に自サイトの作品に適用しています。
https://cw7.sakura.ne.jp/danoni/2013/0237_Cllema.html