### PR TITLE
[ver23.1.1] フリーズアローの挙動見直し、Boost時の軌道計算見直し

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,11 +15,11 @@ v21の対応終了時期はv24リリース開始時を予定しています。�
 
 | Version | Supported          | Latest Version | Logs | First Release | End of Support |
 | ------- | ------------------ |----------------|------|---------------|----------------|
-| v23     | :heavy_check_mark: |[v23.1.0](https://github.com/cwtickle/danoniplus/releases/tag/v23.1.0)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v23)|2021-09-04|-|
-| v22     | :heavy_check_mark: |[v22.5.1](https://github.com/cwtickle/danoniplus/releases/tag/v22.5.1)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v22)|2021-04-28|(At Release v25)|
-| v21     | :warning:          |[v21.5.1](https://github.com/cwtickle/danoniplus/releases/tag/v21.5.1)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v21)|2021-03-12|(At Release v24)|
+| v23     | :heavy_check_mark: |[v23.1.1](https://github.com/cwtickle/danoniplus/releases/tag/v23.1.1)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v23)|2021-09-04|-|
+| v22     | :heavy_check_mark: |[v22.5.2](https://github.com/cwtickle/danoniplus/releases/tag/v22.5.2)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v22)|2021-04-28|(At Release v25)|
+| v21     | :warning:          |[v21.5.2](https://github.com/cwtickle/danoniplus/releases/tag/v21.5.2)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v21)|2021-03-12|(At Release v24)|
 | v20     | :x:                |[v20.5.4 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v20.5.4)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v20)|2021-02-12|2021-09-04|
-| v19     | :heavy_check_mark: |[v19.5.8](https://github.com/cwtickle/danoniplus/releases/tag/v19.5.8)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v19)|2021-01-17|(At Release v28)|
+| v19     | :heavy_check_mark: |[v19.5.9](https://github.com/cwtickle/danoniplus/releases/tag/v19.5.9)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v19)|2021-01-17|(At Release v28)|
 
 <details>
 <summary>過去バージョン詳細</summary>

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2021/09/11
+ * Revised : 2021/09/16
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 23.1.0`;
-const g_revisedDate = `2021/09/11`;
+const g_version = `Ver 23.1.1`;
+const g_revisedDate = `2021/09/16`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- #1110 
    - フリーズアローを押し直したとき終端がズレる問題を修正
    - フリーズアローを離したとき全体の位置がズレる問題を修正
    - boost, brake 使用時に、早めにフリーズアローを押し始めると終端の位置がズレる問題を修正
    - 遅めにフリーズアローを押し始めると、終端の直後に次のフリーズアローが存在する場合にのみ、
最後まで押し切ってもイクナイ判定となってしまう問題を修正
- #1111

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
