### PR TITLE
[0447/adj-1frame] 設定画面のAdjustment（外側）の間隔値を±1frameにする

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4704,7 +4704,7 @@ function createOptionWindow(_sprite) {
 	// タイミング調整 (Adjustment)
 	// 縦位置: 10  短縮ショートカットあり
 	createGeneralSetting(spriteList.adjustment, `adjustment`, {
-		skipTerm: 5, skipTerm2: 30, scLabel: g_lblNameObj.sc_adjustment, roundNum: 5,
+		skipTerm: 5, skipTerm2: 10, scLabel: g_lblNameObj.sc_adjustment, roundNum: 5,
 		unitName: `${getStgDetailName(g_lblNameObj.frame)}`,
 	});
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 設定画面のAdjustment（外側）の間隔値を±1frameにしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. Gitterでの議論より。
https://gitter.im/danonicw/community?at=6147dde6f428f97a9f95ef24

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/133969534-3123c3fd-2f46-4235-a2b8-fe6fc51bdf78.png" width="60%">

## :pencil: その他コメント / Other Comments
