### PR TITLE
[0449/msg-setting] Adjustmentのオンマウス説明文の修正、コード修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4981,8 +4981,8 @@ function createGeneralSetting(_obj, _settingName, { unitName = ``,
 		// 右回し・左回しボタン（最内側）
 		if (skipTerms[2] > 1) {
 			multiAppend(_obj,
-				makeMiniCssButton(linkId, `RRR`, 0, _ => setSetting(skipTerms[2], _settingName, unitName, roundNum), { dx: C_LEN_SETMINI_WIDTH / 2 - 1, dw: -C_LEN_SETMINI_WIDTH / 2 }),
-				makeMiniCssButton(linkId, `LLL`, 0, _ => setSetting(skipTerms[2] * (-1), _settingName, unitName, roundNum), { dx: 1, dw: -C_LEN_SETMINI_WIDTH / 2 }),
+				makeMiniCssButton(linkId, `RRR`, 0, _ => setSetting(skipTerms[2], _settingName, unitName, roundNum), { dw: -C_LEN_SETMINI_WIDTH / 2 }),
+				makeMiniCssButton(linkId, `LLL`, 0, _ => setSetting(skipTerms[2] * (-1), _settingName, unitName, roundNum), { dw: -C_LEN_SETMINI_WIDTH / 2 }),
 			);
 		}
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -251,10 +251,12 @@ const g_settingBtnObj = {
     pos: {
         L: C_LEN_SETLBL_LEFT - C_LEN_SETMINI_WIDTH,
         LL: C_LEN_SETLBL_LEFT,
-        LLL: C_LEN_SETLBL_LEFT + C_LEN_SETMINI_WIDTH,
+        LLL: C_LEN_SETLBL_LEFT + C_LEN_SETMINI_WIDTH + 1,
+        HL: C_LEN_SETLBL_LEFT,
         R: C_LEN_SETLBL_LEFT + C_LEN_SETLBL_WIDTH,
         RR: C_LEN_SETLBL_LEFT + C_LEN_SETLBL_WIDTH - C_LEN_SETMINI_WIDTH,
-        RRR: C_LEN_SETLBL_LEFT + C_LEN_SETLBL_WIDTH - C_LEN_SETMINI_WIDTH * 2,
+        RRR: C_LEN_SETLBL_LEFT + C_LEN_SETLBL_WIDTH - C_LEN_SETMINI_WIDTH * 3 / 2 - 1,
+        HR: C_LEN_SETLBL_LEFT + C_LEN_SETLBL_WIDTH - C_LEN_SETMINI_WIDTH,
     }
 };
 
@@ -2442,7 +2444,7 @@ const g_msgObj = {
     shuffle: `譜面を左右反転したり、ランダムにします。\nランダムにした場合は別譜面扱いとなり、ハイスコアは保存されません。`,
     autoPlay: `オートプレイや一部キーを自動で打たせる設定を行います。\nオートプレイ時はハイスコアを保存しません。`,
     gauge: `クリア条件を設定します。\n[Start] ゲージ初期値, [Border] クリア条件(ハイフン時は0),\n[Recovery] 回復量, [Damage] ダメージ量`,
-    adjustment: `タイミングにズレを感じる場合、\n数値を変えることでフレーム単位のズレを直すことができます。\n外側のボタンは3f刻み、内側は0.5f刻みで調整できます。`,
+    adjustment: `タイミングにズレを感じる場合、\n数値を変えることでフレーム単位のズレを直すことができます。\n外側のボタンは5f刻み、真ん中は1f刻み、内側は0.5f刻みで調整できます。`,
     fadein: `譜面を途中から再生します。\n途中から開始した場合はハイスコアを保存しません。`,
     volume: `ゲーム内の音量を設定します。`,
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. Adjustmentのオンマウス説明文（ボタンの仕様）が一部間違っていたのを修正しました。
2. 設定画面の前/次ボタンのコードを一部見直しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. ver23.2.0よりボタンの刻み幅が再度変わっているため。
2. 意味合いは同じですが、できるだけ初期思想に合わせた実装にしました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 機能的な不具合ではなく、軽微なものです。