### PR TITLE
[0452/rev-shortcut] ReverseのショートカットをRキー、Scrollのショートカットを上下キーに変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4478,7 +4478,11 @@ function createOptionWindow(_sprite) {
 	// リバース (Reverse) / スクロール (Scroll)
 	// 縦位置: 4
 	createGeneralSetting(spriteList.reverse, `reverse`);
-	g_btnAddFunc.lnkReverseR = _evt => setReverseView(document.getElementById(`btnReverse`));
+	g_btnAddFunc.lnkReverseR = _evt => {
+		if (g_headerObj.scrollUse && g_settings.scrolls.length > 1) {
+			setReverseView(document.getElementById(`btnReverse`));
+		}
+	};
 	if (g_headerObj.scrollUse) {
 		createGeneralSetting(spriteList.scroll, `scroll`, { scLabel: g_lblNameObj.sc_scroll });
 		[$id(`lnkScroll`).left, $id(`lnkScroll`).width] = [
@@ -4493,7 +4497,9 @@ function createOptionWindow(_sprite) {
 				cxtFunc: evt => setReverse(evt.target),
 			}, g_cssObj.button_Default, g_cssObj[`button_Rev${g_stateObj.reverse}`])
 		);
-		spriteList[g_settings.scrolls.length > 1 ? `reverse` : `scroll`].style.visibility = `hidden`;
+		spriteList[g_settings.scrolls.length > 1 ? `reverse` : `scroll`].style.display = C_DIS_NONE;
+	} else {
+		spriteList.scroll.style.pointerEvents = C_DIS_NONE;
 	}
 
 	function setReverse(_btn) {
@@ -4901,8 +4907,8 @@ function createOptionWindow(_sprite) {
 			);
 			g_stateObj.scroll = g_settings.scrolls[g_settings.scrollNum];
 			const [visibleScr, hiddenScr] = (g_settings.scrolls.length > 1 ? [`scroll`, `reverse`] : [`reverse`, `scroll`]);
-			spriteList[visibleScr].style.visibility = `visible`;
-			spriteList[hiddenScr].style.visibility = `hidden`;
+			spriteList[visibleScr].style.display = C_DIS_INHERIT;
+			spriteList[hiddenScr].style.display = C_DIS_NONE;
 			setSetting(0, visibleScr);
 			if (g_settings.scrolls.length > 1) {
 				setReverseView(document.querySelector(`#btnReverse`));

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4478,6 +4478,7 @@ function createOptionWindow(_sprite) {
 	// リバース (Reverse) / スクロール (Scroll)
 	// 縦位置: 4
 	createGeneralSetting(spriteList.reverse, `reverse`);
+	g_btnAddFunc.lnkReverseR = _evt => setReverseView(document.getElementById(`btnReverse`));
 	if (g_headerObj.scrollUse) {
 		createGeneralSetting(spriteList.scroll, `scroll`, { scLabel: g_lblNameObj.sc_scroll });
 		[$id(`lnkScroll`).left, $id(`lnkScroll`).width] = [

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -851,8 +851,7 @@ const g_shortcutObj = {
 
         ShiftLeft_KeyM: { id: `lnkMotionL` },
         KeyM: { id: `lnkMotionR` },
-        ArrowUp: { id: `btnReverse` },
-        ShiftLeft_ArrowDown: { id: `lnkScrollL` },
+        ArrowUp: { id: `lnkScrollL` },
         ArrowDown: { id: `lnkScrollR` },
         KeyR: { id: `lnkReverseR` },
 
@@ -2477,7 +2476,7 @@ const g_lblNameObj = {
     percent: `%`,
 
     sc_speed: `←→`,
-    sc_scroll: `↑/↓`,
+    sc_scroll: `R/↑↓`,
     sc_adjustment: `- +`,
 
     g_start: `Start`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. ReverseのショートカットキーをRキーに統一しました。
2. Scrollのショートカットキーを上下キーに変更しました。
3. Scroll無効時、Reverseの左キーとラベルボタンの一部が押せない問題を修正しました。
4. Scroll有効かつ拡張スクロールが無い（9ikeyや17key）場合、
Reverseの左右キーが押せない問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Scroll設定がある場合、「R」キーを押すと見た目はReverseが変更していないにもかかわらず、
設定上は変更されてしまうため。
2. 1.の変更により「↑」キーに空きができたことと、上下キーでScroll設定とした方がわかりやすいため。
3. `reverseSprite`の上に表示されている`scrollSprite`は見えない状態になっていたが、
存在はしている状態だったため、ボタンが押せない状況になっていた。
4. `scrollSprite`上の左右ボタンが常時可視状態になっていたため。
詳細は下記の「その他コメント」を参照。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/134615250-85c22aaa-e073-4fa7-a35f-440adb8de210.png" width="80%">

<img src="https://user-images.githubusercontent.com/44026291/134618405-2fbf0fa4-e2ea-4ae6-b079-0909efc3c365.png" width="80%">

## :pencil: その他コメント / Other Comments
- Scroll横のショートカット表記が長いため、フォントによっては二段になる。
表示に支障はないため、一旦そのままで様子を見る。
- 3.について、ver10.2.1 ( #530 ) からの既存の問題であることが判明。
ボタン類が無くても、オブジェクト自体は存在していることが考慮されていなかったと推測。
- 4.について、ver23.0.0 ( #1096 )で発生した問題。
makeMiniCssButton関数で明示的にvisibilityを定義するようにしたため、
本来非表示にすべきボタンが、後で子要素のみ表示されてしまったことが原因。
この部分は親要素のdisplay属性を「none」に指定することで親要素配下が最初から存在しないような動きにできるので、今回はそのように対処。
<img src="https://user-images.githubusercontent.com/44026291/134619503-1b2ccd43-81a6-46ed-8241-69464112d0fc.png" width="100%">

- 1～3は、過去バージョンにも影響する問題のため、修正予定です。