### PR TITLE
[0453/rev-shortcut2] main側ではbtnAddFuncを明示的に使わないよう修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4477,12 +4477,13 @@ function createOptionWindow(_sprite) {
 	// ---------------------------------------------------
 	// リバース (Reverse) / スクロール (Scroll)
 	// 縦位置: 4
-	createGeneralSetting(spriteList.reverse, `reverse`);
-	g_btnAddFunc.lnkReverseR = _evt => {
-		if (g_headerObj.scrollUse && g_settings.scrolls.length > 1) {
-			setReverseView(document.getElementById(`btnReverse`));
+	createGeneralSetting(spriteList.reverse, `reverse`, {
+		addRFunc: _ => {
+			if (g_headerObj.scrollUse && g_settings.scrolls.length > 1) {
+				setReverseView(document.getElementById(`btnReverse`));
+			}
 		}
-	};
+	});
 	if (g_headerObj.scrollUse) {
 		createGeneralSetting(spriteList.scroll, `scroll`, { scLabel: g_lblNameObj.sc_scroll });
 		[$id(`lnkScroll`).left, $id(`lnkScroll`).width] = [
@@ -4955,7 +4956,7 @@ function createOptionWindow(_sprite) {
  * @param {object} _options
  */
 function createGeneralSetting(_obj, _settingName, { unitName = ``,
-	skipTerms = [...Array(3)].fill(1), hiddenBtn = false,
+	skipTerms = [...Array(3)].fill(1), hiddenBtn = false, addRFunc = _ => { }, addLFunc = _ => { },
 	settingLabel = _settingName, displayName = `option`, scLabel = ``, roundNum = 0 } = {}) {
 
 	const settingUpper = toCapitalize(_settingName);
@@ -4971,10 +4972,14 @@ function createGeneralSetting(_obj, _settingName, { unitName = ``,
 				{ cxtFunc: _ => setSetting(skipTerms[1] * (-1), _settingName, unitName, roundNum) }),
 
 			// 右回し・左回しボタン（外側）
-			makeMiniCssButton(linkId, `R`, 0, _ => setSetting(
-				skipTerms[0], _settingName, unitName, roundNum)),
-			makeMiniCssButton(linkId, `L`, 0, _ => setSetting(
-				skipTerms[0] * (-1), _settingName, unitName, roundNum)),
+			makeMiniCssButton(linkId, `R`, 0, _ => {
+				setSetting(skipTerms[0], _settingName, unitName, roundNum);
+				addRFunc();
+			}),
+			makeMiniCssButton(linkId, `L`, 0, _ => {
+				setSetting(skipTerms[0] * (-1), _settingName, unitName, roundNum);
+				addLFunc();
+			}),
 		)
 
 		// 右回し・左回しボタン（内側）


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. PR #1120 の修正で、main側でbtnAddFuncを使わず、別引数にて実現するよう変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. カスタム側でbtnAddFuncを使って処理追加するケースに対応するため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- createGeneralSetting に引数を追加する方法で実現しています。
これは共用関数であり、またショートカット文字を表示するための条件の中で
指定したidの形式が`lnk_____R`の形式であるという制約があるため、このような対処にしています。
本来は`addRFunc`があれば十分ですが、今後左側カーソルの処理を入れないとも限らないため、
今回は使用しないものの、`addLFunc`を追加しています。
- 過去バージョン適用時、同様の考慮が必要なためマークを入れています。