### PR TITLE
[ver23.3.1] Reverse, Scroll周りのボタンの問題を修正

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,8 +3,8 @@
 要望・不具合報告がある場合、以下のいずれかの方法で行うことができます。
 
 - リポジトリをForkして編集した後、Pull Requestを「cwtickle/danoniplus」の「develop」ブランチへ送る。
-- 当リポジトリのIssueもしくは[GitLabのIssue](https://gitlab.com/cwtickle/danonicw-issue/-/issues), もしくは[Gitter](https://gitter.im/danonicw/community)に要望・不具合内容を報告する。  
-※GitLab及びGitterは「Twitterアカウント」を持っている方でも参加可能です。  
+- 当リポジトリのIssueもしくは[Gitter](https://gitter.im/danonicw/community)に要望・不具合内容を報告する。  
+※Gitterは「Twitterアカウント」を持っている方でも参加可能です。  
 　Gitter内では、Github同様のmarkdownが使えます。お気軽にどうぞ！
 - 要望・不具合内容をティックル宛([@cw_tickle](https://twitter.com/cw_tickle))へ直接連絡する。
 
@@ -32,8 +32,8 @@ forループを除き、danoni_main.js内は極力const/letで宣言する。
 |カテゴリ|命名ルール|
 |----|----|
 |定数|"C_(カテゴリ)_(名前)"の形式。全て英大文字、数字、アンダースコアのみを使用。|
-|グローバル変数|変数の頭に"g_"をつける。|
-|関数の引数|アンダースコア始まりのキャメル表記。 例)_count, _folderName|
+|グローバルオブジェクト|変数の頭に"g_"をつける。<br>極力単独のグローバル変数を作成せず、既存カテゴリのオブジェクトのプロパティとして定義する。|
+|関数の引数|アンダースコア始まりのキャメル表記。 例)_count, _folderName<br>デフォルト引数も検討する。<br>引数が増える場合は、(構造体)オブジェクトとして定義することを検討。|
 
 ## ソース構造
 ### [Japanese]
@@ -49,13 +49,13 @@ forループを除き、danoni_main.js内は極力const/letで宣言する。
 - Make detailed settings and logic separate functions so that you can see screen sketches, and clarify the contents of execution.
 
 ## 画面の構成
-・[タイトル]-[設定・オプション]-[キーコンフィグ]-[譜面読込]-[メイン]-[リザルト]  
-・各画面に Init がついたものが画面の基本構成(ルート)を表す。  
+- [タイトル]-[設定・オプション]-[キーコンフィグ]-[譜面読込]-[メイン]-[リザルト]  
+- 各画面に Init がついたものが画面の基本構成(ルート)を表す。  
 
 ## スプライトの親子関係
-・基本的にdiv要素で管理。最下層を[difRoot]とし、createSprite()でdiv子要素を作成していく。  
-・clearWindow()で[difRoot]以外の全てのスプライトを削除できる。  
-・特定のスプライトに限り削除する場合は deleteChildspriteAll() で実現。  
+- 基本的にdiv要素で管理。最下層を[difRoot]とし、createSprite()でdiv子要素を作成していく。  
+- clearWindow()で[difRoot]以外の全てのスプライトを削除できる。  
+- 特定のスプライトに限り削除する場合は deleteChildspriteAll() で実現。  
 
 ## インデント、改行
-・タグ区切り、Java/ActionScript(K&Rスタイルの改版)
+- タグ区切り、Java/ActionScript(K&Rスタイルの改版)

--- a/README.md
+++ b/README.md
@@ -11,14 +11,12 @@
 Dancing☆Onigiri (CW Edition)は、ブラウザで動作するキーボードを使ったリズムゲームです。  
 公開しているソース一式と、音楽ファイル・譜面データ(テキスト)を組み合わせることで  
 オリジナルのゲームデータを作ることができます。詳細は[Wiki](https://github.com/cwtickle/danoniplus/wiki)をご覧ください。  
-(Dancing Onigiri "CW Edition" is a rhythm game. 
-By combining a set of published sources with music files and sequences (text file)
-You can create original game data. See the [wiki](../../wiki/Sidebar-En) for details.
+*Dancing Onigiri "CW Edition"* is a rhythm game. 
+You can create original game data by combining a set of published sources with music files and sequences (text file). See the [wiki](../../wiki/Sidebar-En) for details.
 
-ここで公開しているソースは、Flashとして公開されているリズムゲーム  
-「Dancing☆Onigiri」の**HTML5**版です。  
-ParaFla版の譜面データに準拠し、ParaFla!ソースで作成した作品の後継、  
-置き換え先の受け皿として作成しています。  
+ここで公開しているソースは、以前Flashとして公開していたリズムゲーム  
+「Dancing☆Onigiri」の**HTML5 (HTML Living Standard)**版です。  
+これまでのParaFla版に比べ、さまざまな機能強化を行っています。  
 
 ## Demo
 - [Demo1](http://cw7.sakura.ne.jp/danoni/2013/0237_Cllema.html) クレマ / 木下たまき  
@@ -28,9 +26,9 @@ ParaFla版の譜面データに準拠し、ParaFla!ソースで作成した作�
 ## How to Play / 遊び方
 リズムに合わせてやってくる矢印・フリーズアローを、ステップゾーン上で押すリズムゲームです。  
 キーボードを使って遊びます。  
-(This is a rhythm game, using Keyboard on the website. )  
+This is a rhythm game, using Keyboard on the website.   
 下記は7keyの例ですが、他にも5keyや11keyなど多様なプレイスタイルがあります。  
-(There are many playstyles in the Dancing-Onigiri. For example, 5keys, 7keys, 11keys, etc.)
+There are many playstyles in the *Dancing Onigiri*. For example, 5keys, 7keys, 11keys, etc.
 
 詳細は下記をご覧ください。(The details are as follows.)  
 -> [How to Play](../../wiki/AboutGameSystem)
@@ -42,9 +40,9 @@ ParaFla版の譜面データに準拠し、ParaFla!ソースで作成した作�
 タイミング良くキーボードを押すと(・∀・)ｲｲ!!や(ﾟ∀ﾟ)ｷﾀｰ!!となり、ライフが上がります。  
 一方、タイミングを外すと(´・ω・\`)ｼｮﾎﾞｰﾝ、(\`Д´)ｳﾜｧﾝ、(・A・)ｲｸﾅｲとなり、ライフが下がります。  
 ゲーム終了までにライフゲージのライフが残っているか、ノルマ以上であればゲームクリアです。  
-(When you press the keyboard with good timing (・∀・)ｲｲ!! (ﾟ∀ﾟ)ｷﾀｰ!! and life will go up.
+When you press the keyboard with good timing (・∀・)ｲｲ!! (ﾟ∀ﾟ)ｷﾀｰ!! and life will go up.
 On the other hand, if you remove the timing (´・ω・\`)ｼｮﾎﾞｰﾝ, (\`Д´)ｳﾜｧﾝ, (・A・)ｲｸﾅｲ will be, life falls.
-If the life of the life gauge remains by the end of the game or it is over the quota, the game is cleared.)
+If the life of the life gauge remains by the end of the game or it is over the quota, the game is cleared.
 
 ## Works / 公開作品
 - [Dancing☆Onigiri 難易度表 for.js](http://dodl4.g3.xrea.com/) 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,12 +30,12 @@ v21の対応終了時期はv24リリース開始時を予定しています。�
 | v17     | :x:                |[v17.5.9 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v17.5.9)  |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v17)|2020-09-27|2021-02-12|
 | v16     | :x:                |[v16.4.10 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v16.4.10)|[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v16)|2020-08-06|2021-01-17|
 | v15     | :x:                |[v15.7.5 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v15.7.5)  |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v15)|2020-05-13|2020-10-25|
-| v14     | :x::anchor:        |[v14.5.21 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v14.5.21)|[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v14)|2020-04-29|2021-09-04|
+| v14     | :x: :anchor:       |[v14.5.21 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v14.5.21)|[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v14)|2020-04-29|2021-09-04|
 | v13     | :x:                |[v13.6.8 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v13.6.8)  |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v13)|2020-03-29|2020-08-06|
 | v12     | :x:                |[v12.3.6 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v12.3.6)  |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v12)|2020-02-09|2020-05-13|
 | v11     | :x:                |[v11.4.5 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v11.4.5)  |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v11)|2019-12-14|2020-04-18|
 | v10     | :x:                |[v10.5.5 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v10.5.5)  |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v10)|2019-11-04|2020-02-10|
-| v9      | :x::anchor:        |[v9.4.27 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v9.4.27)  |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v9)|2019-10-08|2021-01-17|
+| v9      | :x: :anchor:       |[v9.4.27 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v9.4.27)  |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v9)|2019-10-08|2021-01-17|
 | v8      | :x:                |[v8.7.10 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v8.7.10)  |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v8)|2019-09-08|2019-12-14|
 | v7      | :x:                |[v7.9.13 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v7.9.13)  |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v7)|2019-07-08|2019-11-04|
 | v6      | :x:                |[v6.6.13 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v6.6.13)  |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v6)|2019-06-22|2019-11-04|

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,11 +15,11 @@ v21の対応終了時期はv24リリース開始時を予定しています。�
 
 | Version | Supported          | Latest Version | Logs | First Release | End of Support |
 | ------- | ------------------ |----------------|------|---------------|----------------|
-| v23     | :heavy_check_mark: |[v23.3.0](https://github.com/cwtickle/danoniplus/releases/tag/v23.3.0)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v23)|2021-09-04|-|
-| v22     | :heavy_check_mark: |[v22.5.2](https://github.com/cwtickle/danoniplus/releases/tag/v22.5.2)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v22)|2021-04-28|(At Release v25)|
-| v21     | :warning:          |[v21.5.2](https://github.com/cwtickle/danoniplus/releases/tag/v21.5.2)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v21)|2021-03-12|(At Release v24)|
+| v23     | :heavy_check_mark: |[v23.3.1](https://github.com/cwtickle/danoniplus/releases/tag/v23.3.1)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v23)|2021-09-04|-|
+| v22     | :heavy_check_mark: |[v22.5.3](https://github.com/cwtickle/danoniplus/releases/tag/v22.5.3)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v22)|2021-04-28|(At Release v25)|
+| v21     | :warning:          |[v21.5.3](https://github.com/cwtickle/danoniplus/releases/tag/v21.5.3)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v21)|2021-03-12|(At Release v24)|
 | v20     | :x:                |[v20.5.4 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v20.5.4)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v20)|2021-02-12|2021-09-04|
-| v19     | :heavy_check_mark: |[v19.5.9](https://github.com/cwtickle/danoniplus/releases/tag/v19.5.9)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v19)|2021-01-17|(At Release v28)|
+| v19     | :heavy_check_mark: |[v19.5.10](https://github.com/cwtickle/danoniplus/releases/tag/v19.5.10)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v19)|2021-01-17|(At Release v28)|
 
 <details>
 <summary>過去バージョン詳細</summary>

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4478,6 +4478,11 @@ function createOptionWindow(_sprite) {
 	// リバース (Reverse) / スクロール (Scroll)
 	// 縦位置: 4
 	createGeneralSetting(spriteList.reverse, `reverse`);
+	g_btnAddFunc.lnkReverseR = _evt => {
+		if (g_headerObj.scrollUse && g_settings.scrolls.length > 1) {
+			setReverseView(document.getElementById(`btnReverse`));
+		}
+	};
 	if (g_headerObj.scrollUse) {
 		createGeneralSetting(spriteList.scroll, `scroll`, { scLabel: g_lblNameObj.sc_scroll });
 		[$id(`lnkScroll`).left, $id(`lnkScroll`).width] = [
@@ -4492,7 +4497,9 @@ function createOptionWindow(_sprite) {
 				cxtFunc: evt => setReverse(evt.target),
 			}, g_cssObj.button_Default, g_cssObj[`button_Rev${g_stateObj.reverse}`])
 		);
-		spriteList[g_settings.scrolls.length > 1 ? `reverse` : `scroll`].style.visibility = `hidden`;
+		spriteList[g_settings.scrolls.length > 1 ? `reverse` : `scroll`].style.display = C_DIS_NONE;
+	} else {
+		spriteList.scroll.style.pointerEvents = C_DIS_NONE;
 	}
 
 	function setReverse(_btn) {
@@ -4900,8 +4907,8 @@ function createOptionWindow(_sprite) {
 			);
 			g_stateObj.scroll = g_settings.scrolls[g_settings.scrollNum];
 			const [visibleScr, hiddenScr] = (g_settings.scrolls.length > 1 ? [`scroll`, `reverse`] : [`reverse`, `scroll`]);
-			spriteList[visibleScr].style.visibility = `visible`;
-			spriteList[hiddenScr].style.visibility = `hidden`;
+			spriteList[visibleScr].style.display = C_DIS_INHERIT;
+			spriteList[hiddenScr].style.display = C_DIS_NONE;
 			setSetting(0, visibleScr);
 			if (g_settings.scrolls.length > 1) {
 				setReverseView(document.querySelector(`#btnReverse`));

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2021/09/23
+ * Revised : 2021/09/24
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 23.3.0`;
-const g_revisedDate = `2021/09/23`;
+const g_version = `Ver 23.3.1`;
+const g_revisedDate = `2021/09/24`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4477,12 +4477,13 @@ function createOptionWindow(_sprite) {
 	// ---------------------------------------------------
 	// リバース (Reverse) / スクロール (Scroll)
 	// 縦位置: 4
-	createGeneralSetting(spriteList.reverse, `reverse`);
-	g_btnAddFunc.lnkReverseR = _evt => {
-		if (g_headerObj.scrollUse && g_settings.scrolls.length > 1) {
-			setReverseView(document.getElementById(`btnReverse`));
+	createGeneralSetting(spriteList.reverse, `reverse`, {
+		addRFunc: _ => {
+			if (g_headerObj.scrollUse && g_settings.scrolls.length > 1) {
+				setReverseView(document.getElementById(`btnReverse`));
+			}
 		}
-	};
+	});
 	if (g_headerObj.scrollUse) {
 		createGeneralSetting(spriteList.scroll, `scroll`, { scLabel: g_lblNameObj.sc_scroll });
 		[$id(`lnkScroll`).left, $id(`lnkScroll`).width] = [
@@ -4955,7 +4956,7 @@ function createOptionWindow(_sprite) {
  * @param {object} _options
  */
 function createGeneralSetting(_obj, _settingName, { unitName = ``,
-	skipTerms = [...Array(3)].fill(1), hiddenBtn = false,
+	skipTerms = [...Array(3)].fill(1), hiddenBtn = false, addRFunc = _ => { }, addLFunc = _ => { },
 	settingLabel = _settingName, displayName = `option`, scLabel = ``, roundNum = 0 } = {}) {
 
 	const settingUpper = toCapitalize(_settingName);
@@ -4971,10 +4972,14 @@ function createGeneralSetting(_obj, _settingName, { unitName = ``,
 				{ cxtFunc: _ => setSetting(skipTerms[1] * (-1), _settingName, unitName, roundNum) }),
 
 			// 右回し・左回しボタン（外側）
-			makeMiniCssButton(linkId, `R`, 0, _ => setSetting(
-				skipTerms[0], _settingName, unitName, roundNum)),
-			makeMiniCssButton(linkId, `L`, 0, _ => setSetting(
-				skipTerms[0] * (-1), _settingName, unitName, roundNum)),
+			makeMiniCssButton(linkId, `R`, 0, _ => {
+				setSetting(skipTerms[0], _settingName, unitName, roundNum);
+				addRFunc();
+			}),
+			makeMiniCssButton(linkId, `L`, 0, _ => {
+				setSetting(skipTerms[0] * (-1), _settingName, unitName, roundNum);
+				addLFunc();
+			}),
 		)
 
 		// 右回し・左回しボタン（内側）

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -5,7 +5,7 @@
  *
  * Source by tickle
  * Created : 2019/11/19
- * Revised : 2021/09/23 (v23.3.0)
+ * Revised : 2021/09/24 (v23.3.1)
  *
  * https://github.com/cwtickle/danoniplus
  */

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -851,8 +851,7 @@ const g_shortcutObj = {
 
         ShiftLeft_KeyM: { id: `lnkMotionL` },
         KeyM: { id: `lnkMotionR` },
-        ArrowUp: { id: `btnReverse` },
-        ShiftLeft_ArrowDown: { id: `lnkScrollL` },
+        ArrowUp: { id: `lnkScrollL` },
         ArrowDown: { id: `lnkScrollR` },
         KeyR: { id: `lnkReverseR` },
 
@@ -2477,7 +2476,7 @@ const g_lblNameObj = {
     percent: `%`,
 
     sc_speed: `←→`,
-    sc_scroll: `↑/↓`,
+    sc_scroll: `R/↑↓`,
     sc_adjustment: `- +`,
 
     g_start: `Start`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- #1120 
    - ReverseのショートカットキーをRキーに統一
    - Scrollのショートカットキーを上下キーに変更
    - Scroll無効時、Reverseの左キーとラベルボタンの一部が押せない問題を修正
    - Scroll有効かつ拡張スクロールが無い（9ikeyや17key）場合、
Reverseの左右キーが押せない問題を修正
- #1121 

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
