### PR TITLE
[0454/AP-rank] ランクAPの実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2965,6 +2965,7 @@ function headerConvert(_dosObj) {
 		obj.defaultColorgrd[0] = setVal(obj.defaultColorgrd[0], false, C_TYP_BOOLEAN);
 		obj.defaultColorgrd[1] = setVal(obj.defaultColorgrd[1], intermediateColor, C_TYP_STRING);
 	}
+	g_rankObj.rankColorAllPerfect = intermediateColor;
 
 	// カラーコードのゼロパディング有無設定
 	obj.colorCdPaddingUse = setVal(_dosObj.colorCdPaddingUse, false, C_TYP_BOOLEAN);
@@ -9457,9 +9458,9 @@ function resultInit() {
 		if (g_resultObj.spState === ``) {
 			g_resultObj.spState = `cleared`;
 		}
-		if (g_resultObj.matari + g_resultObj.shobon + g_resultObj.uwan + g_resultObj.sfsf + g_resultObj.iknai === 0) {
-			rankMark = g_rankObj.rankMarkPF;
-			rankColor = g_rankObj.rankColorPF;
+		if (g_resultObj.spState === `perfect` || g_resultObj.spState === `allPerfect`) {
+			rankMark = g_rankObj[`rankMark${toCapitalize(g_resultObj.spState)}`];
+			rankColor = g_rankObj[`rankColor${toCapitalize(g_resultObj.spState)}`];
 		} else {
 			const rPos = g_rankObj.rankRate.findIndex(rate => resultScore * 100 / g_maxScore >= rate);
 			rankMark = g_rankObj.rankMarks[rPos];

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -332,8 +332,10 @@ const g_rankObj = {
     rankRate: [97, 90, 85, 80, 75, 70, 50, 0],
     rankColor: [`#00ccff`, `#6600ff`, `#ff9900`, `#ff0000`, `#00ff00`, `#ff00ff`, `#cc00ff`, `#cc9933`],
 
-    rankMarkPF: `PF`,
-    rankColorPF: `#cccc00`,
+    rankMarkAllPerfect: `AP`,
+    rankColorAllPerfect: ``,
+    rankMarkPerfect: `PF`,
+    rankColorPerfect: `#cccc00`,
     rankMarkC: `C`,
     rankColorC: `#cc9933`,
     rankMarkF: `F`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. All Perfect達成時のランクをAPに変更しました。
    - 黒背景時は白、白背景時に黒になるように設定しています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Discordサーバーでの要望より。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/134688577-ed5d350e-895a-4df7-a9d8-f4a3e1eef940.png" width="50%"><img src="https://user-images.githubusercontent.com/44026291/134688685-aaabdf88-5956-4aad-b3ed-b6b0fc541f75.png" width="50%">

## :pencil: その他コメント / Other Comments
- 変数名を一部変更しています。
    - g_rankObj.rankColorPF -> g_rankObj.rankColorPerfect
    - g_rankObj.rankMarkPF -> g_rankObj.rankMarkPerfect