### PR TITLE
[0455/difficulty-name] プレイ画面に譜面名を追加、曲名長に合わせて文字サイズを調整

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2432,7 +2432,7 @@ function titleInit() {
 	const releaseDate = (g_headerObj.releaseDate !== `` ? ` @${g_headerObj.releaseDate}` : ``);
 
 	let reloadFlg = false;
-	const artistSiz = getFontSize(g_headerObj.artistName, g_sWidth / 2 - 20, getBasicFont(), C_LBL_LNKSIZE, 12);
+	const getLinkSiz = _name => getFontSize(_name, g_sWidth / 2 - 20, getBasicFont(), C_LBL_LNKSIZE, 12);
 
 	// ボタン描画
 	multiAppend(divRoot,
@@ -2483,16 +2483,16 @@ function titleInit() {
 
 		// 製作者表示
 		createCss2Button(`lnkMaker`, `${g_lblNameObj.maker}: ${g_headerObj.tuningInit}`, _ => true, {
-			x: 0, y: g_sHeight - 50,
-			w: g_sWidth / 2, h: C_LNK_HEIGHT, siz: C_LBL_LNKSIZE, align: C_ALIGN_LEFT,
+			x: 0, y: g_sHeight - 50, w: g_sWidth / 2, h: C_LNK_HEIGHT,
+			siz: getLinkSiz(`${g_lblNameObj.maker}: ${g_headerObj.tuningInit}`), align: C_ALIGN_LEFT,
 			title: g_headerObj.creatorUrl,
 			resetFunc: _ => openLink(g_headerObj.creatorUrl),
 		}, g_cssObj.button_Default),
 
 		// アーティスト表示
 		createCss2Button(`lnkArtist`, `${g_lblNameObj.artist}: ${g_headerObj.artistName}`, _ => true, {
-			x: g_sWidth / 2, y: g_sHeight - 50,
-			w: g_sWidth / 2, h: C_LNK_HEIGHT, siz: artistSiz, align: C_ALIGN_LEFT,
+			x: g_sWidth / 2, y: g_sHeight - 50, w: g_sWidth / 2, h: C_LNK_HEIGHT,
+			siz: getLinkSiz(`${g_lblNameObj.artist}: ${g_headerObj.artistName}`), align: C_ALIGN_LEFT,
 			title: g_headerObj.artistUrl,
 			resetFunc: _ => openLink(g_headerObj.artistUrl),
 		}, g_cssObj.button_Default),

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7818,6 +7818,8 @@ function MainInit() {
 	// 曲名・アーティスト名表示
 	const musicTitle = g_headerObj.musicTitles[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.musicTitle;
 	const artistName = g_headerObj.artistNames[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.artistName;
+	const assistFlg = (g_autoPlaysBase.includes(g_stateObj.autoPlay) ? `` : `-${g_stateObj.autoPlay}less`);
+	const musicSiz = getFontSize(`${musicTitle} / ${artistName}`, g_headerObj.playingWidth - 125, getBasicFont(), C_SIZ_MAIN);
 
 	multiAppend(infoSprite,
 
@@ -7848,17 +7850,22 @@ function MainInit() {
 
 		// 曲名・アーティスト名表示
 		createDivCss2Label(`lblCredit`, `${musicTitle} / ${artistName}`, {
-			x: 125, y: g_sHeight - 30, w: g_headerObj.playingWidth - 125, h: 20, siz: C_SIZ_MAIN, align: C_ALIGN_LEFT,
+			x: 125, y: g_sHeight - 35, w: g_headerObj.playingWidth - 125, h: 20, siz: musicSiz, align: C_ALIGN_LEFT,
+		}),
+
+		// 曲名・アーティスト名表示
+		createDivCss2Label(`lblDifName`, `[${g_headerObj.keyLabels[g_stateObj.scoreId]} / ${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}]`, {
+			x: 125, y: g_sHeight - 18, w: g_headerObj.playingWidth, h: 20, siz: 12, align: C_ALIGN_LEFT,
 		}),
 
 		// 曲時間表示：現在時間
 		createDivCss2Label(`lblTime1`, `-:--`, {
-			x: 18, y: g_sHeight - 30, w: 40, h: 20, siz: C_SIZ_MAIN, align: C_ALIGN_RIGHT, display: g_workObj.musicinfoDisp,
+			x: 18, y: g_sHeight - 35, w: 40, h: 20, siz: C_SIZ_MAIN, align: C_ALIGN_RIGHT, display: g_workObj.musicinfoDisp,
 		}),
 
 		// 曲時間表示：総時間
 		createDivCss2Label(`lblTime2`, `/ ${fullTime}`, {
-			x: 60, y: g_sHeight - 30, w: 60, h: 20, siz: C_SIZ_MAIN, display: g_workObj.musicinfoDisp,
+			x: 60, y: g_sHeight - 35, w: 60, h: 20, siz: C_SIZ_MAIN, display: g_workObj.musicinfoDisp,
 		}),
 	);
 
@@ -7940,7 +7947,9 @@ function MainInit() {
 
 	// 曲情報OFF
 	if (g_stateObj.d_musicinfo === C_FLG_OFF) {
-		changeStyle(`lblCredit`, { x: 20, animationDuration: `4.0s`, animationName: `leftToRightFade`, animationFillMode: `both` });
+		[`lblCredit`, `lblDifName`].forEach(labelName => {
+			changeStyle(labelName, { x: 20, animationDuration: `4.0s`, animationName: `leftToRightFade`, animationFillMode: `both` });
+		});
 	}
 
 	// ローカル時のみフレーム数を残す

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7850,22 +7850,22 @@ function MainInit() {
 
 		// 曲名・アーティスト名表示
 		createDivCss2Label(`lblCredit`, `${musicTitle} / ${artistName}`, {
-			x: 125, y: g_sHeight - 35, w: g_headerObj.playingWidth - 125, h: 20, siz: musicSiz, align: C_ALIGN_LEFT,
+			x: 125, y: g_sHeight - 33, w: g_headerObj.playingWidth - 125, h: 20, siz: musicSiz, align: C_ALIGN_LEFT,
 		}),
 
 		// 曲名・アーティスト名表示
 		createDivCss2Label(`lblDifName`, `[${g_headerObj.keyLabels[g_stateObj.scoreId]} / ${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}]`, {
-			x: 125, y: g_sHeight - 18, w: g_headerObj.playingWidth, h: 20, siz: 12, align: C_ALIGN_LEFT,
+			x: 125, y: g_sHeight - 16, w: g_headerObj.playingWidth, h: 20, siz: 12, align: C_ALIGN_LEFT,
 		}),
 
 		// 曲時間表示：現在時間
 		createDivCss2Label(`lblTime1`, `-:--`, {
-			x: 18, y: g_sHeight - 35, w: 40, h: 20, siz: C_SIZ_MAIN, align: C_ALIGN_RIGHT, display: g_workObj.musicinfoDisp,
+			x: 18, y: g_sHeight - 33, w: 40, h: 20, siz: C_SIZ_MAIN, align: C_ALIGN_RIGHT, display: g_workObj.musicinfoDisp,
 		}),
 
 		// 曲時間表示：総時間
 		createDivCss2Label(`lblTime2`, `/ ${fullTime}`, {
-			x: 60, y: g_sHeight - 35, w: 60, h: 20, siz: C_SIZ_MAIN, display: g_workObj.musicinfoDisp,
+			x: 60, y: g_sHeight - 33, w: 60, h: 20, siz: C_SIZ_MAIN, display: g_workObj.musicinfoDisp,
 		}),
 	);
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7815,11 +7815,21 @@ function MainInit() {
 		lblInitColor = g_cssObj.life_Failed;
 	}
 
-	// 曲名・アーティスト名表示
+	// 曲名・アーティスト名、譜面名表示
 	const musicTitle = g_headerObj.musicTitles[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.musicTitle;
 	const artistName = g_headerObj.artistNames[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.artistName;
 	const assistFlg = (g_autoPlaysBase.includes(g_stateObj.autoPlay) ? `` : `-${g_stateObj.autoPlay}less`);
-	const musicSiz = getFontSize(`${musicTitle} / ${artistName}`, g_headerObj.playingWidth - 125, getBasicFont(), C_SIZ_MAIN);
+
+	// 曲名・アーティスト名、譜面名のサイズ調整
+	const checkMusicSiz = (_text, _siz) => getFontSize(_text, g_headerObj.playingWidth - 125, getBasicFont(), _siz);
+
+	const makerView = g_headerObj.makerView ? ` (${g_headerObj.creatorNames[g_stateObj.scoreId]})` : ``;
+	let difName = `[${g_headerObj.keyLabels[g_stateObj.scoreId]} / ${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}${makerView}]`;
+	let creditName = `${musicTitle} / ${artistName}`;
+	if (checkMusicSiz(creditName, C_SIZ_MAIN) < 12) {
+		creditName = `${musicTitle}`;
+		difName = `/ ${artistName} ` + difName;
+	}
 
 	multiAppend(infoSprite,
 
@@ -7849,23 +7859,23 @@ function MainInit() {
 		}, g_cssObj.life_Border, g_cssObj.life_BorderColor),
 
 		// 曲名・アーティスト名表示
-		createDivCss2Label(`lblCredit`, `${musicTitle} / ${artistName}`, {
-			x: 125, y: g_sHeight - 33, w: g_headerObj.playingWidth - 125, h: 20, siz: musicSiz, align: C_ALIGN_LEFT,
+		createDivCss2Label(`lblCredit`, creditName, {
+			x: 125, y: g_sHeight - 35, w: g_headerObj.playingWidth - 125, h: 20, siz: checkMusicSiz(creditName, C_SIZ_MAIN), align: C_ALIGN_LEFT,
 		}),
 
-		// 曲名・アーティスト名表示
-		createDivCss2Label(`lblDifName`, `[${g_headerObj.keyLabels[g_stateObj.scoreId]} / ${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}]`, {
-			x: 125, y: g_sHeight - 16, w: g_headerObj.playingWidth, h: 20, siz: 12, align: C_ALIGN_LEFT,
+		// 譜面名表示
+		createDivCss2Label(`lblDifName`, difName, {
+			x: 125, y: g_sHeight - 18, w: g_headerObj.playingWidth, h: 20, siz: checkMusicSiz(difName, 12), align: C_ALIGN_LEFT,
 		}),
 
 		// 曲時間表示：現在時間
 		createDivCss2Label(`lblTime1`, `-:--`, {
-			x: 18, y: g_sHeight - 33, w: 40, h: 20, siz: C_SIZ_MAIN, align: C_ALIGN_RIGHT, display: g_workObj.musicinfoDisp,
+			x: 18, y: g_sHeight - 35, w: 40, h: 20, siz: C_SIZ_MAIN, align: C_ALIGN_RIGHT, display: g_workObj.musicinfoDisp,
 		}),
 
 		// 曲時間表示：総時間
 		createDivCss2Label(`lblTime2`, `/ ${fullTime}`, {
-			x: 60, y: g_sHeight - 33, w: 60, h: 20, siz: C_SIZ_MAIN, display: g_workObj.musicinfoDisp,
+			x: 60, y: g_sHeight - 35, w: 60, h: 20, siz: C_SIZ_MAIN, display: g_workObj.musicinfoDisp,
 		}),
 	);
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -537,15 +537,15 @@ function getStrWidth(_str, _fontsize, _font) {
  * @param {number} _maxWidth 
  * @param {string} _font 
  * @param {number} _maxFontsize
+ * @param {number} _minFontsize
  */
-function getFontSize(_str, _maxWidth, _font = getBasicFont(), _maxFontsize = 64) {
-	const minSiz = 5;
-	for (let siz = _maxFontsize; siz >= minSiz; siz--) {
+function getFontSize(_str, _maxWidth, _font = getBasicFont(), _maxFontsize = 64, _minFontsize = 5) {
+	for (let siz = _maxFontsize; siz >= _minFontsize; siz--) {
 		if (_maxWidth >= getStrWidth(_str, siz, _font)) {
 			return siz;
 		}
 	}
-	return minSiz;
+	return _minFontsize;
 }
 
 /**
@@ -2432,6 +2432,7 @@ function titleInit() {
 	const releaseDate = (g_headerObj.releaseDate !== `` ? ` @${g_headerObj.releaseDate}` : ``);
 
 	let reloadFlg = false;
+	const artistSiz = getFontSize(g_headerObj.artistName, g_sWidth / 2 - 20, getBasicFont(), C_LBL_LNKSIZE, 12);
 
 	// ボタン描画
 	multiAppend(divRoot,
@@ -2455,7 +2456,7 @@ function titleInit() {
 			}
 		}, {
 			x: 0, y: g_sHeight - 20,
-			w: g_sWidth / 5, h: 16, siz: 12,
+			w: g_sWidth / 4, h: 16, siz: 12,
 			title: g_msgObj.dataReset,
 			resetFunc: _ => {
 				if (reloadFlg) {
@@ -2482,16 +2483,16 @@ function titleInit() {
 
 		// 製作者表示
 		createCss2Button(`lnkMaker`, `${g_lblNameObj.maker}: ${g_headerObj.tuningInit}`, _ => true, {
-			x: 20, y: g_sHeight - 45,
-			w: g_sWidth / 2 - 20, h: C_LNK_HEIGHT, siz: C_LBL_LNKSIZE, align: C_ALIGN_LEFT,
+			x: 0, y: g_sHeight - 50,
+			w: g_sWidth / 2, h: C_LNK_HEIGHT, siz: C_LBL_LNKSIZE, align: C_ALIGN_LEFT,
 			title: g_headerObj.creatorUrl,
 			resetFunc: _ => openLink(g_headerObj.creatorUrl),
 		}, g_cssObj.button_Default),
 
 		// アーティスト表示
 		createCss2Button(`lnkArtist`, `${g_lblNameObj.artist}: ${g_headerObj.artistName}`, _ => true, {
-			x: g_sWidth / 2, y: g_sHeight - 45,
-			w: g_sWidth / 2 - 20, h: C_LNK_HEIGHT, siz: C_LBL_LNKSIZE, align: C_ALIGN_LEFT,
+			x: g_sWidth / 2, y: g_sHeight - 50,
+			w: g_sWidth / 2, h: C_LNK_HEIGHT, siz: artistSiz, align: C_ALIGN_LEFT,
 			title: g_headerObj.artistUrl,
 			resetFunc: _ => openLink(g_headerObj.artistUrl),
 		}, g_cssObj.button_Default),
@@ -2503,7 +2504,7 @@ function titleInit() {
 			_ => true,
 			{
 				x: g_sWidth / 4, y: g_sHeight - 20,
-				w: g_sWidth * 3 / 4 - 30, h: 16, siz: 12, align: C_ALIGN_RIGHT,
+				w: g_sWidth * 3 / 4 - 20, h: 16, siz: 12, align: C_ALIGN_RIGHT,
 				title: g_msgObj.github,
 				resetFunc: _ => openLink(`https://github.com/cwtickle/danoniplus`),
 			},
@@ -2512,7 +2513,7 @@ function titleInit() {
 
 		// セキュリティリンク
 		createCss2Button(`lnkComparison`, `&#x1f6e1;`, _ => true, {
-			x: g_sWidth - 30, y: g_sHeight - 20,
+			x: g_sWidth - 20, y: g_sHeight - 20,
 			w: 20, h: 16, siz: 12,
 			title: g_msgObj.security,
 			resetFunc: _ => openLink(`https://github.com/cwtickle/danoniplus/security/policy`),
@@ -3326,6 +3327,9 @@ function headerConvert(_dosObj) {
 
 	// プレイ左上位置(X座標)
 	obj.playingX = setVal(_dosObj.playingX, 0, C_TYP_NUMBER);
+
+	// プレイ中クレジットを表示しないエリアのサイズ(X方向)
+	obj.customViewWidth = setVal(_dosObj.customViewWidth, 0, C_TYP_FLOAT);
 
 	// ジャストフレームの設定 (ローカル: 0フレーム, リモートサーバ上: 1フレーム以内)
 	obj.justFrames = (g_isLocal) ? 0 : 1;
@@ -7821,7 +7825,7 @@ function MainInit() {
 	const assistFlg = (g_autoPlaysBase.includes(g_stateObj.autoPlay) ? `` : `-${g_stateObj.autoPlay}less`);
 
 	// 曲名・アーティスト名、譜面名のサイズ調整
-	const checkMusicSiz = (_text, _siz) => getFontSize(_text, g_headerObj.playingWidth - 125, getBasicFont(), _siz);
+	const checkMusicSiz = (_text, _siz) => getFontSize(_text, g_headerObj.playingWidth - g_headerObj.customViewWidth - 125, getBasicFont(), _siz);
 
 	const makerView = g_headerObj.makerView ? ` (${g_headerObj.creatorNames[g_stateObj.scoreId]})` : ``;
 	let difName = `[${g_headerObj.keyLabels[g_stateObj.scoreId]} / ${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}${makerView}]`;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -27,7 +27,7 @@ const C_LBL_LNKSIZE = 16;
 const C_LBL_BASICFONT = `"Meiryo UI", sans-serif`;
 
 const C_BTN_HEIGHT = 50;
-const C_LNK_HEIGHT = 20;
+const C_LNK_HEIGHT = 30;
 
 // スプライト（ムービークリップ相当）のルート
 const C_SPRITE_ROOT = `divRoot`;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. プレイ画面に譜面名を表示するよう変更しました。
2. プレイ画面の曲名・アーティスト名について、
横長に合わせて文字サイズを調整するよう変更しました。
また、スコアや速度変化表示などカスタムを行っている場合を想定し、
クレジット表示を被せたくない幅をpx単位で設定できるようにしました。
```
|customCreditWidth=150|
```

3. タイトル画面のクレジットリンクサイズを調整しました。
こちらのMaker, Artistについても全体枠に入るようにサイズ調整するようになります。
（最小で12px）

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Gitter要望より。
https://gitter.im/danonicw/community?at=614d9e3363dca81891792046
2. 1.の変更により横幅が足りなくなる可能性があるため。
3. クレジットが長い場合、改行されて崩れる場合があるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/134697279-9c3afc44-a9b2-4728-8b92-b8d6f0f0392b.png" width="60%">

<img src="https://user-images.githubusercontent.com/44026291/134754220-5ea145c9-15fb-4c2b-aee0-6c928c479546.png" width="70%">

- クレジット欄がアーティスト名含め12px未満となる場合は、
アーティスト名を譜面名の行へ移動したうえでそれぞれの行サイズを調整
<img src="https://user-images.githubusercontent.com/44026291/134754140-1f90255d-b2be-42d7-839f-97f814214e6d.png" width="60%">

- タイトル画面（アーティスト名が長い場合）
<img src="https://user-images.githubusercontent.com/44026291/134757424-3cbe9ef4-49f1-4ae2-8c9b-4d8308f3bdb7.png" width="60%">

## :pencil: その他コメント / Other Comments
- 曲名・アーティスト名が長すぎる場合、
フォント最小値の関係で折り返しが発生する可能性があります。
- 曲名・アーティスト名及び曲時間の位置を5pxほど上にしています。
- 譜面名について、Onigiriなしや制作者名（makerView指定時）は表示しますが
別キー表示は行いません。