### PR TITLE
[0457/fontsize] バージョン名のフォントサイズを調整できるよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2430,6 +2430,7 @@ function titleInit() {
 		customVersion += ` / ${g_localVersion2}`;
 	}
 	const releaseDate = (g_headerObj.releaseDate !== `` ? ` @${g_headerObj.releaseDate}` : ``);
+	const versionName = `&copy; 2018-${g_revisedDate.slice(0, 4)} ティックル, CW ${g_version}${g_alphaVersion}${customVersion}${releaseDate}`;
 
 	let reloadFlg = false;
 	const getLinkSiz = _name => getFontSize(_name, g_sWidth / 2 - 20, getBasicFont(), C_LBL_LNKSIZE, 12);
@@ -2499,15 +2500,12 @@ function titleInit() {
 
 		// バージョン描画
 		createCss2Button(
-			`lnkVersion`,
-			`&copy; 2018-${g_revisedDate.slice(0, 4)} ティックル, CW ${g_version}${g_alphaVersion}${customVersion}${releaseDate}`,
-			_ => true,
-			{
-				x: g_sWidth / 4, y: g_sHeight - 20,
-				w: g_sWidth * 3 / 4 - 20, h: 16, siz: 12, align: C_ALIGN_RIGHT,
-				title: g_msgObj.github,
-				resetFunc: _ => openLink(`https://github.com/cwtickle/danoniplus`),
-			},
+			`lnkVersion`, versionName, _ => true, {
+			x: g_sWidth / 4, y: g_sHeight - 20, w: g_sWidth * 3 / 4 - 20, h: 16,
+			siz: getFontSize(versionName, g_sWidth * 3 / 4 - 20, getBasicFont(), 12),
+			align: C_ALIGN_RIGHT, title: g_msgObj.github,
+			resetFunc: _ => openLink(`https://github.com/cwtickle/danoniplus`),
+		},
 			g_cssObj.button_Tweet
 		),
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. バージョン名のフォントサイズを調整できるよう変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #1124 関連の修正です。タイトルのMaker, Artistと同様に枠内に収めるようにしています。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/134775612-0e3501c0-0790-41c8-a384-4906b769516d.png" width="90%">

## :pencil: その他コメント / Other Comments
