### PR TITLE
[0458/keyname] カスタムキーの名前を変更できる機能を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3625,6 +3625,13 @@ function getGaugeSetting(_dosObj, _name, _difLength, { scoreId = 0 } = {}) {
 }
 
 /**
+ * キー名の取得
+ * @param {string} _key 
+ * @returns 
+ */
+const getKeyName = _key => hasVal(g_keyObj[`keyName${_key}`]) ? g_keyObj[`keyName${_key}`] : _key;
+
+/**
  * 一時的な追加キーの設定
  * @param {object} _dosObj 
  */
@@ -3726,6 +3733,9 @@ function keysConvert(_dosObj) {
 	keyExtraList.forEach(newKey => {
 		let tmpDivPtn = [];
 		let tmpMinPatterns = 1;
+
+		// キーの名前 (keyNameX)
+		g_keyObj[`keyName${newKey}`] = setVal(_dosObj[`keyName${newKey}`], newKey, C_TYP_STRING);
 
 		// 矢印色パターン (colorX_Y)
 		tmpMinPatterns = newKeyMultiParam(newKey, `color`, toNumber, {
@@ -4005,7 +4015,7 @@ function createOptionWindow(_sprite) {
 		let pos = 0;
 		g_headerObj.keyLabels.forEach((keyLabel, j) => {
 			if (_targetKey === `` || keyLabel === _targetKey) {
-				let text = `${keyLabel} / ${g_headerObj.difLabels[j]}`;
+				let text = `${getKeyName(keyLabel)} / ${g_headerObj.difLabels[j]}`;
 				if (g_headerObj.makerView) {
 					text += ` (${g_headerObj.creatorNames[j]})`;
 				}
@@ -4076,7 +4086,7 @@ function createOptionWindow(_sprite) {
 		let pos = 0;
 		g_headerObj.keyLists.forEach((targetKey, m) => {
 			difCover.appendChild(
-				makeDifLblCssButton(`keyFilter${m}`, `${targetKey} key`, m + 2.5, _ => {
+				makeDifLblCssButton(`keyFilter${m}`, `${getKeyName(targetKey)} key`, m + 2.5, _ => {
 					resetDifWindow();
 					g_stateObj.filterKeys = targetKey;
 					createDifWindow(targetKey);
@@ -4883,7 +4893,7 @@ function createOptionWindow(_sprite) {
 
 		// 譜面名設定 (Difficulty)
 		const difWidth = parseFloat(lnkDifficulty.style.width);
-		const difNames = [`${g_keyObj.currentKey} key / ${g_headerObj.difLabels[g_stateObj.scoreId]}`];
+		const difNames = [`${getKeyName(g_keyObj.currentKey)} key / ${g_headerObj.difLabels[g_stateObj.scoreId]}`];
 		lnkDifficulty.style.fontSize = `${getFontSize(difNames[0], difWidth, getBasicFont(), C_SIZ_SETLBL)}px`;
 
 		if (g_headerObj.makerView) {
@@ -7827,7 +7837,7 @@ function MainInit() {
 	const checkMusicSiz = (_text, _siz) => getFontSize(_text, g_headerObj.playingWidth - g_headerObj.customViewWidth - 125, getBasicFont(), _siz);
 
 	const makerView = g_headerObj.makerView ? ` (${g_headerObj.creatorNames[g_stateObj.scoreId]})` : ``;
-	let difName = `[${g_headerObj.keyLabels[g_stateObj.scoreId]} / ${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}${makerView}]`;
+	let difName = `[${getKeyName(g_headerObj.keyLabels[g_stateObj.scoreId])} / ${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}${makerView}]`;
 	let creditName = `${musicTitle} / ${artistName}`;
 	if (checkMusicSiz(creditName, C_SIZ_MUSIC_TITLE) < 12) {
 		creditName = `${musicTitle}`;
@@ -9514,7 +9524,7 @@ function resultInit() {
 	}
 
 	let difData = [
-		`${g_headerObj.keyLabels[g_stateObj.scoreId]}${transKeyData} key / ${g_headerObj.difLabels[g_stateObj.scoreId]}`,
+		`${getKeyName(g_headerObj.keyLabels[g_stateObj.scoreId])}${transKeyData} key / ${g_headerObj.difLabels[g_stateObj.scoreId]}`,
 		`${withOptions(g_autoPlaysBase.includes(g_stateObj.autoPlay), true, `-${g_stateObj.autoPlay}less`)}`,
 		`${withOptions(g_headerObj.makerView, false, `(${g_headerObj.creatorNames[g_stateObj.scoreId]})`)}`,
 		`${withOptions(g_stateObj.shuffle, C_FLG_OFF, `[${getShuffleName()}]`)}`
@@ -9749,7 +9759,7 @@ function resultInit() {
 	// Twitter用リザルト
 	// スコアを上塗りする可能性があるため、カスタムイベント後に配置
 	const hashTag = (g_headerObj.hashTag !== undefined ? ` ${g_headerObj.hashTag}` : ``);
-	let tweetDifData = `${g_headerObj.keyLabels[g_stateObj.scoreId]}${transKeyData}k-${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}`;
+	let tweetDifData = `${getKeyName(g_headerObj.keyLabels[g_stateObj.scoreId])}${transKeyData}k-${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}`;
 	if (g_stateObj.shuffle !== `OFF`) {
 		tweetDifData += `:${getShuffleName()}`;
 	}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. カスタムキーの名前を変更できる機能を追加しました。

```
|keyExtraList=11C|
|keyName11C=11|  // 11Ckeyではなく11keyとして表示
|color11C=...|  // 他の設定は11Cとして設定
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 見た目は既存キーで、中身をカスタムしたい場合に
既存のキー設定に引きずられることがあるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

### 11akeyとして定義するが、キー名は「11」keyとして表示する例
```
|keyExtraList=11a|
|keyName11a=11|
|color11a=3,3,3,3,4,0,1,0,2,0,1,0$4,3,3,3,3,0,1,0,2,0,1,0|
|chara11a=sleft,sdown,sup,sright,oni,left,leftdia,down,space,up,rightdia,right$oni,sleft,sdown,sup,sright,left,leftdia,down,space,up,rightdia,right|
|div11a=7$7|
|stepRtn11a=0,-90,90,180,onigiri,0,-45,-90,onigiri,90,135,180$onigiri,0,-90,90,180,0,-45,-90,onigiri,90,135,180|
|keyCtrl11a=37,40,38/0,39,32,83,68,70,32,74,75,76$32,37,40,38/0,39,83,68,70,32,74,75,76|
|pos11a=2,3,4,5,6,7,8,9,10,11,12,13,14$2,3,4,5,6,7,8,9,10,11,12,13,14|
|transKey11a=$|
|scroll11a=Flat::1,1,1,1,1,-1,-1,-1,-1,-1,-1,-1|
```
<img src="https://user-images.githubusercontent.com/44026291/135465609-76e5e5e3-29b5-4a1f-868f-ed5542058e75.png" width="60%">


## :pencil: その他コメント / Other Comments
