### PR TITLE
[0459/sample-html] サンプルhtmlの画像リンク間違いを修正

### DIFF
--- a/danoni/danoni1.html
+++ b/danoni/danoni1.html
@@ -112,30 +112,30 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 1050,0,[loop],200:700:700
 
 1200,-,＜これ以後はループ終了後の処理＞
-1200,0,../img/giko.png,,220,220,200,200,1,spinX,120
+1200,0,../img/classic/giko.png,,220,220,200,200,1,spinX,120
 1300,0
 |
 
 |maskfailedS_data=
-0,0,../img/frzbar.png,,0,250,500,250,1
+0,0,../img/classic/frzbar.png,,0,250,500,250,1
 700,0
 |
 
 |maskresult_data=
-0,0,../img/frzbar.png,,0,0,500,250,1
+0,0,../img/classic/frzbar.png,,0,0,500,250,1
 200,0
 |
 
 |mask_data=
-0,0,../img/frzbar.png,,0,250,500,250,1
+0,0,../img/classic/frzbar.png,,0,250,500,250,1
 700,0
 |
 
 |back_data=
-200,0,../img/c.png,,20,20,200,200,0.5,leftToRightFade,120
-200,1,../img/iyo.png,,220,220,200,200,1,spinY,120
+200,0,../img/classic/c.png,,20,20,200,200,0.5,leftToRightFade,120
+200,1,../img/classic/iyo.png,,220,220,200,200,1,spinY,120
 300,0
-320,1,../img/iyo.png,,220,220,200,200,0,leftToRightFade,120
+320,1,../img/classic/iyo.png,,220,220,200,200,0,leftToRightFade,120
 400,2,文字のフローテスト,,100,140,36,0,0,fromBig,100
 500,2,文字のフローテスト,,100,140,36,0,0,upToDown,100
 600,2,文字のフローテスト,,100,140,36,0,1,spinX,100


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. サンプルhtml (danoni1.html)の画像リンク間違いを修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. classicフォルダへの移動に伴い、リンク切れとなっていたため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 本体ソースに影響するものではないため、過去バージョンには反映しません。
