### PR TITLE
[0461/lyrics-white] word_dataの初期色をCSSに任せる設定に変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7906,7 +7906,7 @@ function MainInit() {
 		const wordY = (j % 2 === 0 ? 10 : (g_headerObj.bottomWordSetFlg ? g_posObj.distY + 10 : g_sHeight - 60));
 		wordSprite.appendChild(createDivCss2Label(`lblword${j}`, ``, {
 			x: 100, y: wordY, w: g_headerObj.playingWidth - 200, h: 50,
-			siz: C_SIZ_MAIN, align: C_ALIGN_LEFT, color: `#ffffff`, fontFamily: getBasicFont(),
+			siz: C_SIZ_MAIN, align: C_ALIGN_LEFT, fontFamily: getBasicFont(),
 			display: `block`, margin: `auto`,
 		}));
 	}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. word_data（歌詞表示）の初期色をCSSに任せる設定に変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 明背景のとき、初期色が白なので強制的に色を変える必要がありました。
今後はCSSに従うので、`skinType=white`とすれば文字色のデフォルトが黒になります。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/135697998-5c02a997-9e31-44d7-a3e8-7417e68c951c.png" width="70%">
<img src="https://user-images.githubusercontent.com/44026291/135697983-c59372d2-f26b-4094-8f05-f79aaa0b0cb5.png" width="60%">
<img src="https://user-images.githubusercontent.com/44026291/135697944-2d1da577-b2da-4689-acb2-bd781d6837f4.png" width="60%">

## :pencil: その他コメント / Other Comments