### PR TITLE
[0462/chart-sorting] 矢印データが昇順で無い場合の問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6458,7 +6458,7 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 				if (isNaN(parseFloat(arrowData[0]))) {
 					return [];
 				} else {
-					arrowData = arrowData.map(data => calcFrame(data));
+					arrowData = arrowData.map(data => calcFrame(data)).sort((_a, _b) => _a - _b);
 				}
 			}
 		}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6553,7 +6553,7 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 					}
 					speedData[speedIdx] = {
 						frame: calcFrame(setVal(tmpSpeedData[k], ``, C_TYP_CALC)),
-						speed: setVal(tmpSpeedData[k + 1], 1, C_TYP_CALC)
+						speed: setVal(tmpSpeedData[k + 1], 1, C_TYP_CALC),
 					};
 					speedIdx++;
 				}
@@ -6586,14 +6586,20 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 					} else if (tmpColorData[k + 1] === `-`) {
 						break;
 					}
-					colorData[colorIdx] = calcFrame(setVal(tmpColorData[k], ``, C_TYP_CALC));
-					colorData[colorIdx + 1] = setVal(tmpColorData[k + 1], 0, C_TYP_CALC);
-					colorData[colorIdx + 2] = tmpColorData[k + 2];
-					colorIdx += 3;
+					colorData[colorIdx] = {
+						frame: calcFrame(setVal(tmpColorData[k], ``, C_TYP_CALC)),
+						colorNum: setVal(tmpColorData[k + 1], 0, C_TYP_CALC),
+						colorCd: tmpColorData[k + 2],
+					};
+					colorIdx++;
 				}
 			});
+			colorData.sort((_a, _b) => _a.frame - _b.frame);
 		}
-		return colorData;
+		const sortedColorData = [];
+		colorData.forEach(data => sortedColorData.push(data.frame, data.colorNum, data.colorCd));
+
+		return sortedColorData;
 	}
 
 	/**
@@ -6619,14 +6625,20 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 				if (isNaN(parseInt(tmpcssMotionData[0]))) {
 					return;
 				}
-				cssMotionData[motionIdx] = calcFrame(tmpcssMotionData[0]);
-				cssMotionData[motionIdx + 1] = parseFloat(tmpcssMotionData[1]);
-				cssMotionData[motionIdx + 2] = (tmpcssMotionData[2] === `none` ? `` : tmpcssMotionData[2]);
-				cssMotionData[motionIdx + 3] = (tmpcssMotionData[3] === `none` ? `` : setVal(tmpcssMotionData[3], cssMotionData[motionIdx + 2], C_TYP_STRING));
-				motionIdx += 4;
+				cssMotionData[motionIdx] = {
+					frame: calcFrame(tmpcssMotionData[0]),
+					arrowNum: parseFloat(tmpcssMotionData[1]),
+					styleUp: (tmpcssMotionData[2] === `none` ? `` : tmpcssMotionData[2]),
+					styleDown: (tmpcssMotionData[3] === `none` ? `` : setVal(tmpcssMotionData[3], cssMotionData[motionIdx + 2], C_TYP_STRING)),
+				};
+				motionIdx++;
 			});
+			cssMotionData.sort((_a, _b) => _a.frame - _b.frame);
 		}
-		return cssMotionData;
+		const sortedCssMotionData = [];
+		cssMotionData.forEach(data => sortedCssMotionData.push(data.frame, data.arrowNum, data.styleUp, data.styleDown));
+
+		return sortedCssMotionData;
 	}
 
 	/**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6551,14 +6551,19 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 					} else if (tmpSpeedData[k + 1] === `-`) {
 						break;
 					}
-					speedData[speedIdx] = calcFrame(setVal(tmpSpeedData[k], ``, C_TYP_CALC));
-					speedData[speedIdx + 1] = setVal(tmpSpeedData[k + 1], 1, C_TYP_CALC);
-					speedIdx += 2;
+					speedData[speedIdx] = {
+						frame: calcFrame(setVal(tmpSpeedData[k], ``, C_TYP_CALC)),
+						speed: setVal(tmpSpeedData[k + 1], 1, C_TYP_CALC)
+					};
+					speedIdx++;
 				}
 			});
+			speedData.sort((_a, _b) => _a.frame - _b.frame);
 		}
+		const sortedSpeedData = [];
+		speedData.forEach(data => sortedSpeedData.push(data.frame, data.speed));
 
-		return speedData;
+		return sortedSpeedData;
 	}
 
 	/**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 矢印データが昇順で無い（厳密には最初の矢印データのフレーム数より小さいフレーム数がデータの真ん中に存在する）場合に矢印が出てこない問題を修正しました。

```
|left_data=200,300,400,500,600,700,800,50,55,60,65,70,75,80|
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Gitterからの報告より。
https://gitter.im/danonicw/community?at=61595d062197144e84443743
本来はエディター側で並び替えが行われるため、本体側で考慮していませんでしたが
簡易的にできる範囲で対応します。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 矢印データ、速度変化、色変化、矢印モーションデータに対して並び替え処理を追加しています。
極力、今のコード構成を壊さないように修正しました。
- 歌詞表示、背景・マスク表示は元々順序系には依存しないため、そのままです。