### PR TITLE
[0464/retry-immediate] 曲中リトライキーの猶予フレームを廃止

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8074,8 +8074,8 @@ function MainInit() {
 				clearTimeout(g_timeoutEvtId);
 				titleInit();
 
-			} else if (g_audio.volume >= g_stateObj.volume / 100 && g_scoreObj.frameNum >= g_headerObj.blankFrame) {
-				// 連打対策として指定ボリュームになるまでリトライを禁止
+			} else {
+				// その他の環境では単にRetryに対応するキーのみで適用
 				g_audio.pause();
 				clearTimeout(g_timeoutEvtId);
 				clearWindow();


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 曲中リトライキーの猶予フレームを廃止しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Gitter要望より。
https://gitter.im/danonicw/community?at=6167f968fb8ca0572bbf48d6
PR #810 にて押しっぱなしが禁止になったことで、PR #433 が実質不要になったため。
元々、暫定的な措置でした。

![image](https://github.com/cwtickle/danoniplus/assets/44026291/7cbd0466-c50f-4e1b-adbe-3dcbca957fd5)

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 押しっぱなしはできなくなりましたが、連打はできるのが強いて言えば懸念点です。
押しっぱなしよりは意図的に発生しずらいと思うので、基本問題はないかと思います。