### PR TITLE
[ver23.5.0] 譜面変更時、キーが同一の場合に設定を一部引き継ぐよう変更 他

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,11 +15,11 @@ v21の対応終了時期はv24リリース開始時を予定しています。�
 
 | Version | Supported          | Latest Version | Logs | First Release | End of Support |
 | ------- | ------------------ |----------------|------|---------------|----------------|
-| v23     | :heavy_check_mark: |[v23.4.1](https://github.com/cwtickle/danoniplus/releases/tag/v23.4.1)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v23)|2021-09-04|-|
-| v22     | :heavy_check_mark: |[v22.5.4](https://github.com/cwtickle/danoniplus/releases/tag/v22.5.4)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v22)|2021-04-28|(At Release v25)|
-| v21     | :warning:          |[v21.5.4](https://github.com/cwtickle/danoniplus/releases/tag/v21.5.4)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v21)|2021-03-12|(At Release v24)|
+| v23     | :heavy_check_mark: |[v23.5.0](https://github.com/cwtickle/danoniplus/releases/tag/v23.5.0)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v23)|2021-09-04|-|
+| v22     | :heavy_check_mark: |[v22.5.5](https://github.com/cwtickle/danoniplus/releases/tag/v22.5.5)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v22)|2021-04-28|(At Release v25)|
+| v21     | :warning:          |[v21.5.5](https://github.com/cwtickle/danoniplus/releases/tag/v21.5.5)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v21)|2021-03-12|(At Release v24)|
 | v20     | :x:                |[v20.5.4 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v20.5.4)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v20)|2021-02-12|2021-09-04|
-| v19     | :heavy_check_mark: |[v19.5.11](https://github.com/cwtickle/danoniplus/releases/tag/v19.5.11)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v19)|2021-01-17|(At Release v28)|
+| v19     | :heavy_check_mark: |[v19.5.12](https://github.com/cwtickle/danoniplus/releases/tag/v19.5.12)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v19)|2021-01-17|(At Release v28)|
 
 <details>
 <summary>過去バージョン詳細</summary>

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2021/10/04
+ * Revised : 2021/10/14
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 23.4.1`;
-const g_revisedDate = `2021/10/04`;
+const g_version = `Ver 23.5.0`;
+const g_revisedDate = `2021/10/14`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -5,7 +5,7 @@
  *
  * Source by tickle
  * Created : 2019/11/19
- * Revised : 2021/10/02 (v23.4.0)
+ * Revised : 2021/10/14 (v23.5.0)
  *
  * https://github.com/cwtickle/danoniplus
  */


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- #1136 
    - 譜面変更時、キーが同一の場合にReverse/Scroll/AutoPlay/キーパターンを引き継ぐよう変更
    - Display, キーコンフィグ画面から直接開始した場合、プレイ後キーコンフィグ画面に戻ると
キーパターンがデータセーブ有効時、Selfにならない問題を修正
- #1137 

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
