### PR TITLE
[0465/keyctrl-init] 保存したキーコンフィグが無いときに設定画面で止まることがある問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5112,7 +5112,7 @@ function getKeyCtrl(_localStorage, _extraKeyName = ``) {
 	const basePtn = `${g_keyObj.currentKey}_${baseKeyCtrlPtn}`;
 	const baseKeyNum = g_keyObj[`chara${basePtn}`].length;
 
-	if (_localStorage[`keyCtrl${_extraKeyName}`] !== undefined) {
+	if (_localStorage[`keyCtrl${_extraKeyName}`] !== undefined && _localStorage[`keyCtrl${_extraKeyName}`][0].length > 0) {
 		g_keyObj.currentPtn = -1;
 		const copyPtn = `${g_keyObj.currentKey}_-1`;
 		g_keyObj[`keyCtrl${copyPtn}`] = [];


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 保存したキーコンフィグが無いとき、設定画面で止まることがある問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 保存したキーコンフィグが無いとき、ver23.5.0では`[[]]` という二次元配列を返します。
これまではgetKeyCtrl関数がこの状態の配列を受けることはありませんでしたが、
ver23.5.0でのコード整理により通過することになったため、エラーになることがありました。
`[[]]` は単一配列としてみると`undefined`ではないため（長さ1の配列と解釈）、
添え字[0]のlengthが1以上かどうかを見るように変えています。
https://gitter.im/danonicw/community?at=616a7890fb8ca0572bc5147f

![image](https://github.com/cwtickle/danoniplus/assets/44026291/df79ad84-dfb7-49aa-85c4-75566d812eb7)
![image](https://github.com/cwtickle/danoniplus/assets/44026291/57121f54-5b3e-47bb-97cb-455d18c9ff88)

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- #1136 の修正によるものです。過去バージョンでは発生しません。
