### PR TITLE
[0466/shuffle-info] プレイ画面の譜面名にシャッフル名称を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7861,12 +7861,13 @@ function MainInit() {
 	const musicTitle = g_headerObj.musicTitles[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.musicTitle;
 	const artistName = g_headerObj.artistNames[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.artistName;
 	const assistFlg = (g_autoPlaysBase.includes(g_stateObj.autoPlay) ? `` : `-${g_stateObj.autoPlay}less`);
+	const shuffleName = (g_stateObj.shuffle !== C_FLG_OFF ? `: ${getShuffleName()}` : ``);
 
 	// 曲名・アーティスト名、譜面名のサイズ調整
 	const checkMusicSiz = (_text, _siz) => getFontSize(_text, g_headerObj.playingWidth - g_headerObj.customViewWidth - 125, getBasicFont(), _siz);
 
 	const makerView = g_headerObj.makerView ? ` (${g_headerObj.creatorNames[g_stateObj.scoreId]})` : ``;
-	let difName = `[${getKeyName(g_headerObj.keyLabels[g_stateObj.scoreId])} / ${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}${makerView}]`;
+	let difName = `[${getKeyName(g_headerObj.keyLabels[g_stateObj.scoreId])} / ${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}${shuffleName}${makerView}]`;
 	let creditName = `${musicTitle} / ${artistName}`;
 	if (checkMusicSiz(creditName, C_SIZ_MUSIC_TITLE) < 12) {
 		creditName = `${musicTitle}`;
@@ -9544,14 +9545,6 @@ function resultInit() {
 		transKeyData = `(` + g_keyObj[`transKey${keyCtrlPtn}`] + `)`;
 	}
 
-	const getShuffleName = _ => {
-		let shuffleName = getStgDetailName(g_stateObj.shuffle);
-		if (!g_stateObj.shuffle.endsWith(`+`)) {
-			shuffleName += setScoreIdHeader(g_keycons.shuffleGroupNum);
-		}
-		return shuffleName;
-	}
-
 	let difData = [
 		`${getKeyName(g_headerObj.keyLabels[g_stateObj.scoreId])}${transKeyData} key / ${g_headerObj.difLabels[g_stateObj.scoreId]}`,
 		`${withOptions(g_autoPlaysBase.includes(g_stateObj.autoPlay), true, `-${g_stateObj.autoPlay}less`)}`,
@@ -9945,6 +9938,18 @@ function resultInit() {
 			skinResultInit2();
 		}
 	}
+}
+
+/**
+ * シャッフル名称の取得
+ * @returns 
+ */
+const getShuffleName = _ => {
+	let shuffleName = getStgDetailName(g_stateObj.shuffle);
+	if (!g_stateObj.shuffle.endsWith(`+`)) {
+		shuffleName += setScoreIdHeader(g_keycons.shuffleGroupNum);
+	}
+	return shuffleName;
 }
 
 /**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. プレイ画面の譜面名にシャッフル名称を追加しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 本質的には元の譜面と別の譜面であるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/137667140-fb0fbf84-3b57-4e33-af9c-52075dc6fd93.png" width="60%">

## :pencil: その他コメント / Other Comments
