### PR TITLE
[0467/scroll-saving] 他キー移動時でも該当の拡張スクロールがあれば設定を引き継ぐよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4781,6 +4781,8 @@ function createOptionWindow(_sprite) {
 	 */
 	function setDifficulty(_initFlg) {
 
+		const getCurrentNo = (_list, _target) => roundZero(_list.findIndex(item => item === _target));
+
 		// ---------------------------------------------------
 		// 1. キーコンフィグ設定 (KeyConfig)
 
@@ -4803,25 +4805,29 @@ function createOptionWindow(_sprite) {
 			});
 		}
 
+		// ---------------------------------------------------
+		// 2. 初期化設定
+
+		// スクロール設定用の配列を入れ替え
+		g_settings.scrolls = copyArray2d(
+			typeof g_keyObj[`scrollName${g_keyObj.currentKey}`] === C_TYP_OBJECT ?
+				g_keyObj[`scrollName${g_keyObj.currentKey}`] : g_keyObj.scrollName_def
+		);
+
 		// アシスト設定の配列を入れ替え
 		g_settings.autoPlays = (typeof g_keyObj[`assistName${g_keyObj.currentKey}`] === C_TYP_OBJECT ?
 			g_autoPlaysBase.concat(g_keyObj[`assistName${g_keyObj.currentKey}`]) :
 			g_autoPlaysBase.concat());
 
-		// ---------------------------------------------------
-		// 2. 初期化設定
-
 		if (_initFlg) {
 
 			// 速度、ゲージ、リバースの初期設定
 			g_stateObj.speed = g_headerObj.initSpeeds[g_stateObj.scoreId];
-			g_settings.speedNum = roundZero(g_settings.speeds.findIndex(speed => speed === g_stateObj.speed));
+			g_settings.speedNum = getCurrentNo(g_settings.speeds, g_stateObj.speed);
 			g_settings.gaugeNum = 0;
 			if (isNotSameKey) {
-				g_settings.scrollNum = 0;
-				if (!g_settings.autoPlays.includes(g_stateObj.autoPlay)) {
-					g_settings.autoPlayNum = 0;
-				}
+				g_settings.scrollNum = getCurrentNo(g_settings.scrolls, g_stateObj.scroll);
+				g_settings.autoPlayNum = getCurrentNo(g_settings.autoPlays, g_stateObj.autoPlay);
 				g_keycons.shuffleGroupNum = 0;
 			}
 		}
@@ -4907,10 +4913,6 @@ function createOptionWindow(_sprite) {
 
 		// リバース設定 (Reverse, Scroll)
 		if (g_headerObj.scrollUse) {
-			g_settings.scrolls = copyArray2d(
-				typeof g_keyObj[`scrollName${g_keyObj.currentKey}`] === C_TYP_OBJECT ?
-					g_keyObj[`scrollName${g_keyObj.currentKey}`] : g_keyObj.scrollName_def
-			);
 			g_stateObj.scroll = g_settings.scrolls[g_settings.scrollNum];
 			const [visibleScr, hiddenScr] = (g_settings.scrolls.length > 1 ? [`scroll`, `reverse`] : [`reverse`, `scroll`]);
 			spriteList[visibleScr].style.display = C_DIS_INHERIT;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 他キー移動時でも該当の拡張スクロールがあれば設定を引き継ぐよう変更しました。
2. 設定引き継ぎ関連のコードを一部見直しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 利便性向上のため。
2. 処理系が同じものを同じ書き方に見直すことでわかりやすくするため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
