### PR TITLE
fix: Reverse時のarrowMotionDataが正しく反映されない問題の修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6663,27 +6663,23 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 		}
 
 		let cssMotionData = [];
+		let sortedCssMotionData = [];
 
 		if (hasVal(dosCssMotionData) && g_stateObj.d_arroweffect === C_FLG_ON) {
-			let motionIdx = 0;
-
 			splitLF(dosCssMotionData).filter(data => hasVal(data)).forEach(tmpData => {
 				const tmpcssMotionData = tmpData.split(`,`);
 				if (isNaN(parseInt(tmpcssMotionData[0]))) {
 					return;
 				}
-				cssMotionData[motionIdx] = {
-					frame: calcFrame(tmpcssMotionData[0]),
-					arrowNum: parseFloat(tmpcssMotionData[1]),
-					styleUp: (tmpcssMotionData[2] === `none` ? `` : tmpcssMotionData[2]),
-					styleDown: (tmpcssMotionData[3] === `none` ? `` : setVal(tmpcssMotionData[3], cssMotionData[motionIdx + 2], C_TYP_STRING)),
-				};
-				motionIdx++;
+				const frame = calcFrame(tmpcssMotionData[0]);
+				const arrowNum = parseFloat(tmpcssMotionData[1]);
+				const styleUp = (tmpcssMotionData[2] === `none` ? `` : tmpcssMotionData[2]);
+				const styleDown = (tmpcssMotionData[3] === `none` ? `` : setVal(tmpcssMotionData[3], styleUp, C_TYP_STRING));
+
+				cssMotionData.push([frame, arrowNum, styleUp, styleDown]);
 			});
-			cssMotionData.sort((_a, _b) => _a.frame - _b.frame);
+			sortedCssMotionData = cssMotionData.sort((_a, _b) => _a[0] - _b[0]).flat();
 		}
-		const sortedCssMotionData = [];
-		cssMotionData.forEach(data => sortedCssMotionData.push(data.frame, data.arrowNum, data.styleUp, data.styleDown));
 
 		return sortedCssMotionData;
 	}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- Reverse時(下向き)のarrowMotionDataが正しく反映されない問題の修正
  - `motionIdx` の役割が 1fb988b526e7c55f6f0848a799984ebc8b9a622e で変わったが、この箇所だけ修正されていなかったのが原因と思われます
- 一部コードリファクタ

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 変更必須な箇所は 6679行目のみと思うので、それ以外は適宜変えていただいて大丈夫です。 
