### PR TITLE
[0471/warning-window] Firefox時、警告ウィンドウが最小化される問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2668,8 +2668,8 @@ function setWindowStyle(_text, _bkColor, _textColor, _align = C_ALIGN_LEFT) {
 	range.selectNode(tmplbl);
 
 	// ウィンドウ枠の行を元に縦の長さを決定(150pxを超えた場合は縦スクロールバーを付与)
-	const warnHeight = Math.min(150, (Math.max(range.getClientRects().length,
-		_text.split(`<br>`).length + _text.split(`<p>`).length - 1)) * 21);
+	const warnHeight = Math.min(150, Math.max(range.getClientRects().length,
+		_text.split(`<br>`).length + _text.split(`<p>`).length - 1) * 21);
 	const lbl = createDivCss2Label(`lblWarning`, _text, {
 		x: 0, y: 70, w: g_sWidth, h: warnHeight, siz: C_SIZ_MAIN, backgroundColor: _bkColor,
 		opacity: 0.9, lineHeight: `15px`, color: _textColor, align: _align, fontFamily: getBasicFont(),

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2668,8 +2668,8 @@ function setWindowStyle(_text, _bkColor, _textColor, _align = C_ALIGN_LEFT) {
 	range.selectNode(tmplbl);
 
 	// ウィンドウ枠の行を元に縦の長さを決定(150pxを超えた場合は縦スクロールバーを付与)
-	const len = (Math.max(range.getClientRects().length, _text.split(`<br>`).length + _text.split(`<p>`).length - 1)) * 21;
-	const warnHeight = (len < 150 ? len : 150);
+	const warnHeight = Math.min(150, (Math.max(range.getClientRects().length,
+		_text.split(`<br>`).length + _text.split(`<p>`).length - 1)) * 21);
 	const lbl = createDivCss2Label(`lblWarning`, _text, {
 		x: 0, y: 70, w: g_sWidth, h: warnHeight, siz: C_SIZ_MAIN, backgroundColor: _bkColor,
 		opacity: 0.9, lineHeight: `15px`, color: _textColor, align: _align, fontFamily: getBasicFont(),

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2668,7 +2668,7 @@ function setWindowStyle(_text, _bkColor, _textColor, _align = C_ALIGN_LEFT) {
 	range.selectNode(tmplbl);
 
 	// ウィンドウ枠の行を元に縦の長さを決定(150pxを超えた場合は縦スクロールバーを付与)
-	const len = (range.getClientRects().length) * 21;
+	const len = (Math.max(range.getClientRects().length, _text.split(`<br>`).length + _text.split(`<p>`).length - 1)) * 21;
 	const warnHeight = (len < 150 ? len : 150);
 	const lbl = createDivCss2Label(`lblWarning`, _text, {
 		x: 0, y: 70, w: g_sWidth, h: warnHeight, siz: C_SIZ_MAIN, backgroundColor: _bkColor,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. Firefox時、警告ウィンドウの高さが最小化される問題を修正しました。
`range.getClientRects().length`(ver24以降採用)と
`_text.split('<br>').length + _text.split('<p>').length - 1`(ver23以前)を比較して
大きい方を採用する方式に変えています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Firefoxの場合、警告ウィンドウの行数を取得する`range.getClientRects().length`が常に1となり
正しい高さが取得できないため。
https://developer.mozilla.org/ja/docs/Web/API/Element/getClientRects

## :camera: スクリーンショット / Screenshot
### 変更前 (左がFirefox, 右がChrome)
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/139524674-c835e45d-fcf7-4ae2-bd9b-ff0991136c6a.png" width="50%"><img src="https://user-images.githubusercontent.com/44026291/139524701-d353bb29-fb9e-47c7-b3f4-4663046b55d3.png" width="40%">

### 変更後 (左がFirefox, 右がChrome)
<img src="https://user-images.githubusercontent.com/44026291/139524689-1386fb1d-cc6f-41cf-912c-c9162abef6d2.png" width="50%"><img src="https://user-images.githubusercontent.com/44026291/139524724-5ed83b94-d19c-4a39-933b-59ac12d4b807.png" width="40%">

## :pencil: その他コメント / Other Comments
- Firefoxで、自動改行かつ高さが150pxに満たない場合に問題となる可能性がありますが
大半の問題は解消できるため、一旦この内容でPull Requestを出します。
- ver24.0.0 #1144 の項番2に起因する問題です。