### PR TITLE
[0473/silence-mode] デフォルト音源利用時、無音であることをプレイ画面で表示するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8087,6 +8087,10 @@ function MainInit() {
 		);
 	}
 
+	if (getMusicUrl(g_stateObj.scoreId) === `nosound.mp3`) {
+		makeInfoWindow(g_msgInfoObj.I_0004, `leftToRightFade`);
+	}
+
 	// ユーザカスタムイベント(初期)
 	if (typeof customMainInit === C_TYP_FUNCTION) {
 		g_scoreObj.baseFrame = g_scoreObj.frameNum - g_stateObj.intAdjustment;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2424,6 +2424,7 @@ const g_lang_msgInfoObj = {
         I_0001: `リザルトデータをクリップボードにコピーしました！`,
         I_0002: `入力したキーは割り当てできません。他のキーを指定してください。`,
         I_0003: `各譜面の明細情報をクリップボードにコピーしました！`,
+        I_0004: `musicUrlが設定されていないため、無音モードで再生します`,
     },
     En: {
         W_0001: `Your browser is not guaranteed to work.<br>
@@ -2469,6 +2470,7 @@ const g_lang_msgInfoObj = {
         I_0001: `Your result data is copied to the clipboard!`,
         I_0002: `The specified key cannot be assigned. Please specify another key.`,
         I_0003: `Charts information is copied to the clipboard!`,
+        I_0004: `Play in silence mode because "musicUrl" is not set`,
     },
 }
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. デフォルト音源利用時、無音であることをプレイ画面で表示するようにしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. musicUrlが無指定であることを明示的にわかるようにするため。
#1151 の変更により、musicUrlが無指定でもプレイできるようになったため、無指定もしくはデフォルト音源を使用していることがわかるように明示する必要がありました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/140709828-305ef25c-e1fb-4fbd-a810-542362f456ae.png" width="50%"><img src="https://user-images.githubusercontent.com/44026291/140709909-a5363931-92b6-4ffb-8914-c62ff99f9314.png" width="50%">

## :pencil: その他コメント / Other Comments
