### PR TITLE
[0474/judge-posX] 判定キャラクタ位置（X座標）の微調整

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8019,14 +8019,14 @@ function MainInit() {
 
 			// コンボ表示
 			createDivCss2Label(`combo${jdg}`, ``, {
-				x: jdgX[j] + 175, y: jdgY[j],
+				x: jdgX[j] + 170, y: jdgY[j],
 				w: C_LEN_JDGCHARA_WIDTH, h: C_LEN_JDGCHARA_HEIGHT, siz: C_SIZ_JDGCHARA,
 				opacity: g_stateObj.opacity / 100, display: g_workObj.judgmentDisp,
 			}, g_cssObj[`common_${jdgCombos[j]}`]),
 
 			// Fast/Slow表示
 			createDivCss2Label(`diff${jdg}`, ``, {
-				x: jdgX[j] + 175, y: jdgY[j] + 25,
+				x: jdgX[j] + 170, y: jdgY[j] + 25,
 				w: C_LEN_JDGCHARA_WIDTH, h: C_LEN_JDGCHARA_HEIGHT, siz: C_SIZ_MAIN,
 				opacity: g_stateObj.opacity / 100, display: g_workObj.fastslowDisp,
 			}, g_cssObj.common_combo),

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7994,7 +7994,7 @@ function MainInit() {
 	}
 
 	const jdgGroups = [`J`, `FJ`];
-	const jdgX = [g_headerObj.playingWidth / 2 - 210, g_headerObj.playingWidth / 2 - 120];
+	const jdgX = [g_headerObj.playingWidth / 2 - 220, g_headerObj.playingWidth / 2 - 120];
 	const jdgY = [(g_sHeight + g_posObj.stepYR) / 2 - 60, (g_sHeight + g_posObj.stepYR) / 2 + 10];
 	if (g_stateObj.d_background === C_FLG_OFF && g_headerObj.jdgPosReset) {
 	} else {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7994,7 +7994,7 @@ function MainInit() {
 	}
 
 	const jdgGroups = [`J`, `FJ`];
-	const jdgX = [g_headerObj.playingWidth / 2 - 200, g_headerObj.playingWidth / 2 - 100];
+	const jdgX = [g_headerObj.playingWidth / 2 - 210, g_headerObj.playingWidth / 2 - 120];
 	const jdgY = [(g_sHeight + g_posObj.stepYR) / 2 - 60, (g_sHeight + g_posObj.stepYR) / 2 + 10];
 	if (g_stateObj.d_background === C_FLG_OFF && g_headerObj.jdgPosReset) {
 	} else {
@@ -8019,14 +8019,14 @@ function MainInit() {
 
 			// コンボ表示
 			createDivCss2Label(`combo${jdg}`, ``, {
-				x: jdgX[j] + 150, y: jdgY[j],
+				x: jdgX[j] + 175, y: jdgY[j],
 				w: C_LEN_JDGCHARA_WIDTH, h: C_LEN_JDGCHARA_HEIGHT, siz: C_SIZ_JDGCHARA,
 				opacity: g_stateObj.opacity / 100, display: g_workObj.judgmentDisp,
 			}, g_cssObj[`common_${jdgCombos[j]}`]),
 
 			// Fast/Slow表示
 			createDivCss2Label(`diff${jdg}`, ``, {
-				x: jdgX[j] + 150, y: jdgY[j] + 25,
+				x: jdgX[j] + 175, y: jdgY[j] + 25,
 				w: C_LEN_JDGCHARA_WIDTH, h: C_LEN_JDGCHARA_HEIGHT, siz: C_SIZ_MAIN,
 				opacity: g_stateObj.opacity / 100, display: g_workObj.fastslowDisp,
 			}, g_cssObj.common_combo),

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2715,11 +2715,11 @@ const g_lang_lblNameObj = {
         s_printTitle: `Dancing☆Onigiri Level Calculator+++`,
         s_printHeader: `Level\tN-Push\tJack\tAll\tArrow\tFrz\tAPM\tTime`,
 
-        j_ii: ":D PERFECT!!",
-        j_shakin: ":) GREAT!",
-        j_matari: ":| GOOD",
-        j_shobon: ":( BAD",
-        j_uwan: ":_( MISS...",
+        j_ii: ":D Perfect!!",
+        j_shakin: ":) Great!",
+        j_matari: ":| Good",
+        j_shobon: ":( Bad",
+        j_uwan: ":_( Miss...",
 
         j_kita: ":) O.K.",
         j_iknai: ":( N.G.",


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 判定キャラクタ位置（X座標）とコンボ位置の間を少し広げました。
2. 英語時の判定名を大文字のみ⇒小文字混じりに変更しました。

|判定種類|キャラクタ位置<br>(従来との差分)|コンボ位置, Fast/Slow<br>(従来との差分)|
|----|----|----|
|矢印|-20px|0px|
|フリーズアロー|-20px|0px|

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 英語版の場合、判定名が長くコンボ数が10000を超えると重なる可能性があるため。
2. 他の表記と統一するため。判定幅を広く取りすぎないための対策。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/140725301-5742cf4a-6e38-4610-b28c-efea3dacf50f.png" width="60%">
<img src="https://user-images.githubusercontent.com/44026291/140722595-09ceb864-0bcd-412a-ab8b-02f7f28c287d.png" width="60%">
<img src="https://user-images.githubusercontent.com/44026291/140725697-39a1a8a0-6c12-413e-acc3-1f1a1a19ac8b.png" width="60%">

## :pencil: その他コメント / Other Comments
