### PR TITLE
[0477/lang-data] 歌詞表示、背景・マスクモーションにおいて多言語化に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6665,9 +6665,9 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 
 		[g_localeObj.val, ``].forEach(lang => {
 			if (g_stateObj.scroll !== `---`) {
-				wordDataList.push(_dosObj[`wordAlt${_scoreNo}${lang}_data`], _dosObj[`wordAlt${lang}_data`]);
+				wordDataList.push(_dosObj[`wordAlt${lang}${_scoreNo}_data`], _dosObj[`wordAlt${lang}_data`]);
 			} else if (g_stateObj.reverse === C_FLG_ON) {
-				wordDataList.push(_dosObj[`wordRev${_scoreNo}${lang}_data`], _dosObj[`wordRev${lang}_data`]);
+				wordDataList.push(_dosObj[`wordRev${lang}${_scoreNo}_data`], _dosObj[`wordRev${lang}_data`]);
 
 				// wordRev_dataが指定されている場合はそのままの位置を採用
 				// word_dataのみ指定されている場合、下記ルールに従って設定
@@ -6680,7 +6680,7 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 					}
 				}
 			}
-			wordDataList.push(_dosObj[`word${_scoreNo}${lang}_data`], _dosObj[`word${lang}_data`]);
+			wordDataList.push(_dosObj[`word${lang}${_scoreNo}_data`], _dosObj[`word${lang}_data`]);
 		});
 
 		const inputWordData = wordDataList.find((v) => v !== undefined);
@@ -6751,11 +6751,11 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 		const dataList = [];
 		[g_localeObj.val, ``].forEach(lang => {
 			if (g_stateObj.scroll !== `---`) {
-				dataList.push(_dosObj[`${_header}Alt${_scoreNo}${lang}_data`], _dosObj[`${_header}Alt${lang}_data`]);
+				dataList.push(_dosObj[`${_header}Alt${lang}${_scoreNo}_data`], _dosObj[`${_header}Alt${lang}_data`]);
 			} else if (g_stateObj.reverse === C_FLG_ON) {
-				dataList.push(_dosObj[`${_header}Rev${_scoreNo}${lang}_data`], _dosObj[`${_header}Rev${lang}_data`]);
+				dataList.push(_dosObj[`${_header}Rev${lang}${_scoreNo}_data`], _dosObj[`${_header}Rev${lang}_data`]);
 			}
-			dataList.push(_dosObj[`${_header}${_scoreNo}${lang}_data`], _dosObj[`${_header}${lang}_data`]);
+			dataList.push(_dosObj[`${_header}${lang}${_scoreNo}_data`], _dosObj[`${_header}${lang}_data`]);
 		});
 
 		const data = dataList.find((v) => v !== undefined);
@@ -6771,9 +6771,9 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	function makeBackgroundResultData(_header, _scoreNo, _defaultHeader = ``) {
 		const dataList = [];
 		[g_localeObj.val, ``].forEach(lang => {
-			dataList.push(_dosObj[`${_header}${_scoreNo}${lang}_data`], _dosObj[`${_header}${lang}_data`]);
+			dataList.push(_dosObj[`${_header}${lang}${_scoreNo}_data`], _dosObj[`${_header}${lang}_data`]);
 			if (_defaultHeader !== ``) {
-				dataList.push(_dosObj[`${_defaultHeader}${_scoreNo}${lang}_data`], _dosObj[`${_defaultHeader}${lang}_data`]);
+				dataList.push(_dosObj[`${_defaultHeader}${lang}${_scoreNo}_data`], _dosObj[`${_defaultHeader}${lang}_data`]);
 			}
 		});
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6755,7 +6755,6 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 			} else if (g_stateObj.reverse === C_FLG_ON) {
 				dataList.push(_dosObj[`${_header}Rev${_scoreNo}${lang}_data`], _dosObj[`${_header}Rev${lang}_data`]);
 			}
-			console.log(`${_header}${_scoreNo}${lang}_data`);
 			dataList.push(_dosObj[`${_header}${_scoreNo}${lang}_data`], _dosObj[`${_header}${lang}_data`]);
 		});
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3308,8 +3308,11 @@ function headerConvert(_dosObj) {
 		obj[`${sprite}TitleData`] = [];
 		obj[`${sprite}TitleData`].length = 0;
 		obj[`${sprite}TitleMaxDepth`] = -1;
-		if (hasVal(_dosObj[`${sprite}title_data`])) {
-			[obj[`${sprite}TitleData`], obj[`${sprite}TitleMaxDepth`]] = makeSpriteData(_dosObj[`${sprite}title_data`]);
+
+		const dataList = [_dosObj[`${sprite}title${g_localeObj.val}_data`], _dosObj[`${sprite}title_data`]];
+		const data = dataList.find((v) => v !== undefined);
+		if (hasVal(data)) {
+			[obj[`${sprite}TitleData`], obj[`${sprite}TitleMaxDepth`]] = makeSpriteData(data);
 		}
 	});
 
@@ -6656,27 +6659,29 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 * @param {string} _scoreNo 
 	 */
 	function makeWordData(_scoreNo) {
-		let wordDataList = [];
+		const wordDataList = [];
 		let wordReverseFlg = false;
 		const divideCnt = getKeyInfo().divideCnt;
 
-		if (g_stateObj.scroll !== `---`) {
-			wordDataList = [_dosObj[`wordAlt${_scoreNo}_data`], _dosObj.wordAlt_data];
-		} else if (g_stateObj.reverse === C_FLG_ON) {
-			wordDataList = [_dosObj[`wordRev${_scoreNo}_data`], _dosObj.wordRev_data];
+		[g_localeObj.val, ``].forEach(lang => {
+			if (g_stateObj.scroll !== `---`) {
+				wordDataList.push(_dosObj[`wordAlt${_scoreNo}${lang}_data`], _dosObj[`wordAlt${lang}_data`]);
+			} else if (g_stateObj.reverse === C_FLG_ON) {
+				wordDataList.push(_dosObj[`wordRev${_scoreNo}${lang}_data`], _dosObj[`wordRev${lang}_data`]);
 
-			// wordRev_dataが指定されている場合はそのままの位置を採用
-			// word_dataのみ指定されている場合、下記ルールに従って設定
-			if (wordDataList.find((v) => v !== undefined) === undefined) {
-				// Reverse時の歌詞の自動反転制御設定
-				if (g_headerObj.wordAutoReverse !== `auto`) {
-					wordReverseFlg = g_headerObj.wordAutoReverse === C_FLG_ON;
-				} else if (keyNum === divideCnt + 1) {
-					wordReverseFlg = true;
+				// wordRev_dataが指定されている場合はそのままの位置を採用
+				// word_dataのみ指定されている場合、下記ルールに従って設定
+				if (wordDataList.find((v) => v !== undefined) === undefined) {
+					// Reverse時の歌詞の自動反転制御設定
+					if (g_headerObj.wordAutoReverse !== `auto`) {
+						wordReverseFlg = g_headerObj.wordAutoReverse === C_FLG_ON;
+					} else if (keyNum === divideCnt + 1) {
+						wordReverseFlg = true;
+					}
 				}
 			}
-		}
-		wordDataList.push(_dosObj[`word${_scoreNo}_data`], _dosObj.word_data);
+			wordDataList.push(_dosObj[`word${_scoreNo}${lang}_data`], _dosObj[`word${lang}_data`]);
+		});
 
 		const inputWordData = wordDataList.find((v) => v !== undefined);
 		return (inputWordData !== undefined ? makeSpriteWordData(inputWordData, wordReverseFlg) : [[], -1]);
@@ -6743,13 +6748,16 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 * @param {string} _scoreNo
 	 */
 	function makeBackgroundData(_header, _scoreNo) {
-		let dataList = [];
-		if (g_stateObj.scroll !== `---`) {
-			dataList = [_dosObj[`${_header}Alt${_scoreNo}_data`], _dosObj[`${_header}Alt_data`]];
-		} else if (g_stateObj.reverse === C_FLG_ON) {
-			dataList = [_dosObj[`${_header}Rev${_scoreNo}_data`], _dosObj[`${_header}Rev_data`]];
-		}
-		dataList.push(_dosObj[`${_header}${_scoreNo}_data`], _dosObj[`${_header}_data`]);
+		const dataList = [];
+		[g_localeObj.val, ``].forEach(lang => {
+			if (g_stateObj.scroll !== `---`) {
+				dataList.push(_dosObj[`${_header}Alt${_scoreNo}${lang}_data`], _dosObj[`${_header}Alt${lang}_data`]);
+			} else if (g_stateObj.reverse === C_FLG_ON) {
+				dataList.push(_dosObj[`${_header}Rev${_scoreNo}${lang}_data`], _dosObj[`${_header}Rev${lang}_data`]);
+			}
+			console.log(`${_header}${_scoreNo}${lang}_data`);
+			dataList.push(_dosObj[`${_header}${_scoreNo}${lang}_data`], _dosObj[`${_header}${lang}_data`]);
+		});
 
 		const data = dataList.find((v) => v !== undefined);
 		return (data !== undefined ? makeSpriteData(data, calcFrame) : [[], -1]);
@@ -6762,10 +6770,13 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 * @param {string} _defaultHeader 
 	 */
 	function makeBackgroundResultData(_header, _scoreNo, _defaultHeader = ``) {
-		const dataList = [_dosObj[`${_header}${_scoreNo}_data`], _dosObj[`${_header}_data`]];
-		if (_defaultHeader !== ``) {
-			dataList.push(_dosObj[`${_defaultHeader}${_scoreNo}_data`], _dosObj[`${_defaultHeader}_data`]);
-		}
+		const dataList = [];
+		[g_localeObj.val, ``].forEach(lang => {
+			dataList.push(_dosObj[`${_header}${_scoreNo}${lang}_data`], _dosObj[`${_header}${lang}_data`]);
+			if (_defaultHeader !== ``) {
+				dataList.push(_dosObj[`${_defaultHeader}${_scoreNo}${lang}_data`], _dosObj[`${_defaultHeader}${lang}_data`]);
+			}
+		});
 
 		const data = dataList.find((v) => v !== undefined);
 		return (data !== undefined ? makeSpriteData(data) : [[], -1]);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 歌詞表示、背景・マスクモーションにおいて多言語化に対応しました。
以下のように言語分けができます。
未指定時は言語指定なしのものが優先されます。

|言語指定なし|日本語指定|英語指定|用途|
|----|----|----|----|
|word_data|word**Ja**_data|word**En**_data|歌詞表示|
|back_data|back**Ja**_data|back**En**_data|背景データ|
|mask_data|mask**Ja**_data|mask**En**_data|マスクデータ|

- backtitle_data, backresult_data, back2_data なども同様に使えます。
- (言語指定) > (言語指定なし) の順に適用されます。
    - maskJa_data と mask2_data の場合、maskJa_data が優先されます。 
- 2譜面目の指定方法は maskJa2_data や backEn2_data のように指定します。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 言語により表示内容を変える場合があるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
