### PR TITLE
[0479/decimal-frame] playbackRate使用時に小数フレーム値が考慮されるよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6438,7 +6438,7 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	g_stateObj.decimalAdjustment = g_stateObj.realAdjustment - g_stateObj.intAdjustment;
 
 	const blankFrame = g_headerObj.blankFrame;
-	const calcFrame = _frame => Math.round((parseInt(_frame) - blankFrame) / g_headerObj.playbackRate + blankFrame + g_stateObj.intAdjustment);
+	const calcFrame = _frame => Math.round((parseFloat(_frame) - blankFrame) / g_headerObj.playbackRate + blankFrame + g_stateObj.intAdjustment);
 
 	for (let j = 0; j < keyNum; j++) {
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. playbackRate使用時に小数フレーム値が考慮されるよう変更しました。
矢印個別のフレーム数は整数に丸められるため、通常時は変わりません。

### 変更前
- Math.round((parseInt(指定フレーム数) - blankFrame) / g_headerObj.playbackRate + adjustment)

### 変更後
- Math.round((parseFloat(指定フレーム数) - blankFrame) / g_headerObj.playbackRate + adjustment)

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. playbackRate（音楽再生速度）を変更した場合、それに応じたフレーム数を計算しますが、
変更前のフレーム数が整数になっていたため、ズレが生じやすくなっていました。
計算上の誤差を少なくするのが目的です。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments