### PR TITLE
[0482/default-keyptn] 特殊キーの略記指定に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3771,9 +3771,6 @@ function keysConvert(_dosObj) {
 		// キーの名前 (keyNameX)
 		g_keyObj[`keyName${newKey}`] = setVal(_dosObj[`keyName${newKey}`], newKey, C_TYP_STRING);
 
-		// 元パターンの指定 (basePtnX)
-		newKeySingleParam(newKey, `basePtn`, C_TYP_STRING);
-
 		// 矢印色パターン (colorX_Y)
 		tmpMinPatterns = newKeyMultiParam(newKey, `color`, toNumber, {
 			errCd: `E_0101`,

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3699,7 +3699,8 @@ function keysConvert(_dosObj) {
 				if (existParam(tmpArray[k], `${keyheader}_${k}`)) {
 					continue;
 				}
-				g_keyObj[`${keyheader}_${k}`] = tmpArray[k].split(`,`).map(n => _convFunc(n));
+				g_keyObj[`${keyheader}_${k}`] = g_keyObj[`${_name}${tmpArray[k]}`] !== undefined ?
+					copyArray2d(g_keyObj[`${_name}${tmpArray[k]}`]) : tmpArray[k].split(`,`).map(n => _convFunc(n));
 				if (baseCopyFlg) {
 					g_keyObj[`${keyheader}_${k}d`] = copyArray2d(g_keyObj[`${keyheader}_${k}`]);
 				}
@@ -3722,7 +3723,8 @@ function keysConvert(_dosObj) {
 		if (_dosObj[keyheader] !== undefined) {
 			const tmps = _dosObj[keyheader].split(`$`);
 			for (let k = 0; k < tmps.length; k++) {
-				g_keyObj[`${keyheader}_${k}`] = setVal(tmps[k], ``, _type);
+				g_keyObj[`${keyheader}_${k}`] = setVal(g_keyObj[`${_name}${tmps[k]}`],
+					setVal(tmps[k], ``, _type), C_TYP_STRING);
 			}
 		}
 	};
@@ -3746,13 +3748,17 @@ function keysConvert(_dosObj) {
 					continue;
 				}
 				g_keyObj[pairName] = {};
-				if (_defaultName !== ``) {
-					g_keyObj[pairName][_defaultName] = [...Array(g_keyObj[`color${_key}_${k}`].length)].fill(_defaultVal);
+				if (g_keyObj[`${_pairName}${tmpParams[k]}`] !== undefined) {
+					Object.assign(g_keyObj[pairName], g_keyObj[`${_pairName}${tmpParams[k]}`]);
+				} else {
+					if (_defaultName !== ``) {
+						g_keyObj[pairName][_defaultName] = [...Array(g_keyObj[`color${_key}_${k}`].length)].fill(_defaultVal);
+					}
+					tmpParams[k].split(`/`).forEach(pairs => {
+						const tmpParamPair = pairs.split(`::`);
+						g_keyObj[pairName][tmpParamPair[0]] = tmpParamPair[1].split(`,`).map(n => parseInt(n, 10));
+					});
 				}
-				tmpParams[k].split(`/`).forEach(pairs => {
-					const tmpParamPair = pairs.split(`::`);
-					g_keyObj[pairName][tmpParamPair[0]] = tmpParamPair[1].split(`,`).map(n => parseInt(n, 10));
-				});
 			}
 		}
 	};
@@ -3764,6 +3770,9 @@ function keysConvert(_dosObj) {
 
 		// キーの名前 (keyNameX)
 		g_keyObj[`keyName${newKey}`] = setVal(_dosObj[`keyName${newKey}`], newKey, C_TYP_STRING);
+
+		// 元パターンの指定 (basePtnX)
+		newKeySingleParam(newKey, `basePtn`, C_TYP_STRING);
 
 		// 矢印色パターン (colorX_Y)
 		tmpMinPatterns = newKeyMultiParam(newKey, `color`, toNumber, {
@@ -3790,9 +3799,15 @@ function keysConvert(_dosObj) {
 
 				if (setVal(tmpDivPtn[0], -1, C_TYP_NUMBER) !== -1) {
 					g_keyObj[`div${newKey}_${k}`] = setVal(tmpDivPtn[0], g_keyObj[`chara${newKey}_0`].length, C_TYP_NUMBER);
+				} else if (g_keyObj[`div${tmpDivPtn[0]}`] !== undefined) {
+					// 既定キーパターンが指定された場合、存在すればその値を適用
+					g_keyObj[`div${newKey}_${k}`] = g_keyObj[`div${tmpDivPtn[0]}`];
+					g_keyObj[`divMax${newKey}_${k}`] = setVal(g_keyObj[`divMax${tmpDivPtn[0]}`], undefined, C_TYP_NUMBER);
 				} else if (setVal(g_keyObj[`div${newKey}_${k}`], -1, C_TYP_NUMBER) !== -1) {
+					// すでに定義済みの場合はスキップ
 					continue;
 				} else if (g_keyObj[`chara${newKey}_0`] !== undefined) {
+					// 特に指定が無い場合はcharaX_Yの配列長で決定
 					g_keyObj[`div${newKey}_${k}`] = g_keyObj[`chara${newKey}_0`].length;
 				}
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 特殊キーパターンの設定を一部省略指定できるようにしました。
各設定について、(キー数)_(パターン番号-1) で指定できます。
すでに定義済みであることが条件です。他キーパターンの設定も指定できます。

### 記載例
```
|color6=0,1,0,1,0,2$6_0|
|chara6=arrowA,arrowB,arrowC,arrowD,arrowE,arrowF$6_0|
|div6=6$3|
|stepRtn6=0,45,-90,135,180,onigiri$6_0|
|keyCtrl6=75,79,76,80,187,32/0$6_0|
```

### 同様の指定を従来の方法で記載した場合
```
|color6=0,1,0,1,0,2$0,1,0,1,0,2|
|chara6=arrowA,arrowB,arrowC,arrowD,arrowE,arrowF$arrowA,arrowB,arrowC,arrowD,arrowE,arrowF|
|div6=6$3|
|stepRtn6=0,45,-90,135,180,onigiri$0,45,-90,135,180,onigiri|
|keyCtrl6=75,79,76,80,187,32/0$75,79,76,80,187,32/0|
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Resolves #947 
同様の指定方法を何度も記載するのが手間なため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 今回の設定は、キーコンフィグが異なる場合や、矢印の回転量の設定が違う場合などに
他の設定を流用するためのものです。
- キーの数が違うものを指定した場合、意図した設定にならないことがあります。
- keyExtraListの指定は必要ですが、今は既存キーを上書きしない方法ができるので
その方法を取った方が既存キーに影響することはありません。
    - blank, transKeyのみ、無指定があるため流用できないことがあります。
必要な場合は指定してください。（無指定の場合、デフォルト値が適用されます）
```
|keyExtraList=7N|
|keyName7N=7|
|color7N=7_0$7_1$7_2|
|chara7N=7_0$7_1$7_2|
|div7N=7_0$7_1$7_2|
|pos7N=7_0$7_1$7_2|
|stepRtn7N=7_0$7_1$7_2|
|keyCtrl7N=7_0$7_1$7_2|
|scroll7N=7_0$7_1$7_2|

|blank7N=50$50$50|  // blank、transKeyは必要に応じて設定
|transKey7N=$$7i|
```
