### PR TITLE
[0483/key-copylist] 保存済みキー数設定の一部設定誤りを修正

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2204,7 +2204,7 @@ keyCtrlName.forEach(property => g_keyObj[`${property}d`] = copyArray2d(g_keyObj[
 const g_keyCopyLists = {
     simpleDef: [`blank`, `scale`],
     simple: [`div`, `blank`, `scale`, `keyRetry`, `keyTitleBack`, `transKey`, `scrollDir`, `assistPos`],
-    multiple: [`chara`, `color`, `stepRtn`, `pos`, `shuffle`, `scrollDir`, `assistPos`],
+    multiple: [`chara`, `color`, `stepRtn`, `pos`, `shuffle`],
 };
 
 // タイトル画面関連のリスト群


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 保存済みキー数設定の一部設定誤りを修正しました。
 `g_keyCopyLists`の項目をver24.2.1以前の状態に戻しています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. ver24.3.0にて `g_keyCopyLists`の項目を一部修正したが、結果的に修正不要だったため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- この部分は修正しなくても不具合にはつながらないため、次回更新時に反映する方向とします。
