### PR TITLE
[0485/keycon-shortcut] キーコンフィグ画面のPlayボタンにショートカットを追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2262,8 +2262,11 @@ const createScText = (_obj, _settingLabel, { displayName = `option`, dfLabel = `
 const createScTextCommon = _displayName => {
 	Object.keys(g_btnPatterns[_displayName]).filter(target => document.getElementById(`btn${target}`) !== null)
 		.forEach(target =>
-			createScText(document.getElementById(`btn${target}`), target,
-				{ displayName: _displayName, targetLabel: `btn${target}`, x: g_btnPatterns[_displayName][target] }));
+			createScText(document.getElementById(`btn${target}`), target, {
+				displayName: _displayName, targetLabel: `btn${target}`,
+				dfLabel: setVal(g_lblNameObj[`sc_${_displayName}${target}`], ``, C_TYP_STRING),
+				x: g_btnPatterns[_displayName][target]
+			}));
 }
 
 /**

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -972,6 +972,8 @@ const g_shortcutObj = {
     },
     keyConfig: {
         Escape: { id: `btnBack` },
+        Backspace_Enter: { id: `btnPlay` },
+        Backspace_NumpadEnter: { id: `btnPlay` },
     },
     loadingIos: {
         Enter: { id: `btnPlay` },
@@ -1011,7 +1013,7 @@ const g_btnPatterns = {
     difSelector: {},
     settingsDisplay: { Back: 0, KeyConfig: 0, Play: 0, Save: -10, Settings: -5 },
     loadingIos: { Play: 0 },
-    keyConfig: { Back: -3 },
+    keyConfig: { Back: -3, Play: 0 },
     result: { Back: -5, Copy: -5, Tweet: -5, Gitter: -5, Retry: 0 },
 };
 
@@ -2530,6 +2532,7 @@ const g_lblNameObj = {
     sc_speed: `←→`,
     sc_scroll: `R/↑↓`,
     sc_adjustment: `- +`,
+    sc_keyConfigPlay: g_isMac ? `Del+Enter` : `BS+Enter`,
 
     g_start: `Start`,
     g_border: `Border`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. キーコンフィグ画面のPlayボタンにショートカットを追加しました。
「Backspaceキー (MacではDeleteキーと呼ぶ)」＋「Enterキー」の組み合わせで動作します。
※必ず「Backspaceキー」を押してから「Enterキー」を押す必要があります。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. このPlayボタンのみ、ショートカットキーの割り当てが無かったため。
Enterキーは割り当てキーで使用するため、組み合わせにて対処しました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/144560729-8fcc304a-c84a-4898-bc5f-523ebf41ecf9.png" width="60%">

## :pencil: その他コメント / Other Comments
- 「Backspaceキー」＋「Enterキー」を押した場合、カーソルが動く挙動がありますが
基本問題ないため、そのままにします。