### PR TITLE
[0487/hidsud-lock] Hidden+/Sudden+の初期位置・ロック機能の実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5347,7 +5347,7 @@ function createSettingsDisplayWindow(_sprite) {
 			x: C_LEN_SETLBL_LEFT, y: 15,
 		}),
 		createCss2Button(`lnklockBtn`, `${getStgDetailName(g_lblNameObj.filterLock)}`, evt => setLockView(evt.target), {
-			x: C_LEN_SETLBL_LEFT + C_LEN_SETLBL_WIDTH - 50, y: 0, w: 50, h: C_LEN_SETLBL_HEIGHT, siz: 12,
+			x: C_LEN_SETLBL_LEFT + C_LEN_SETLBL_WIDTH - 40, y: 0, w: 40, h: C_LEN_SETLBL_HEIGHT, siz: 12,
 			borderStyle: `solid`, cxtFunc: evt => setLockView(evt.target),
 		}, g_cssObj.button_Default, g_cssObj[`button_Rev${g_stateObj.filterLock}`]),
 	);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7796,12 +7796,13 @@ function MainInit() {
 	}
 
 	// Hidden+, Sudden+用のライン、パーセント表示
+	const filterCss = g_stateObj.filterLock === C_FLG_OFF ? g_cssObj.life_Failed : g_cssObj.life_Cleared;
 	[`filterBar0`, `filterBar1`, `borderBar0`, `borderBar1`].forEach(obj => {
 		mainSprite.appendChild(
 			createColorObject2(`${obj}`, {
 				w: g_headerObj.playingWidth - 50, h: 1, styleName: `lifeBar`,
 				opacity: 0.0625,
-			}, g_cssObj.life_Failed)
+			}, filterCss)
 		);
 	});
 	borderBar0.style.top = `${g_posObj.stepDiffY}px`;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -411,6 +411,7 @@ const g_stateObj = {
     d_background: C_FLG_ON,
     d_special: C_FLG_ON,
     appearance: `Visible`,
+    filterLock: C_FLG_OFF,
     opacity: 100,
 
     rotateEnabled: true,
@@ -489,6 +490,9 @@ const g_settings = {
 
     appearances: [`Visible`, `Hidden`, `Hidden+`, `Sudden`, `Sudden+`, `Hid&Sud+`],
     appearanceNum: 0,
+
+    filterLocks: [C_FLG_OFF, C_FLG_ON],
+    filterLockNum: 0,
 
     opacitys: [10, 25, 50, 75, 100],
 
@@ -2550,6 +2554,7 @@ const g_lblNameObj = {
     multi: `x`,
     frame: `f`,
     percent: `%`,
+    filterLock: `Lock`,
 
     sc_speed: `←→`,
     sc_scroll: `R/↑↓`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. Hidden+/Sudden+/Hid&Sud+の初期位置の設定、ロック機能を実装しました。
「Lock」をクリックすると、プレイ中のPageDown/PageUpの操作が無効になります。
また、ロック中はレーンカバーの境界線の色が水色になります。
2. createGeneralSetting関数で真ん中のボタンに対してボタン拡張が行えるようにしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
1. Gitterからの要望より。
https://gitter.im/danonicw/community?at=61b3598ecdb5c1081a57b0d1
2. 今回の1.の変更で必要になったため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
- 左側が従来、右側が変更後のもの。
- レーンカバー位置は微調整するため、1%ごとに変更できるようスライダーを採用しています。

<img src="https://user-images.githubusercontent.com/44026291/145671692-06d87b04-7cff-48fb-9a5b-eae05f861102.png" width="50%"><img src="https://user-images.githubusercontent.com/44026291/145671821-4962fdde-30f7-4255-86f7-9798d33e6269.png" width="50%">

## :pencil: その他コメント / Other Comments
- Appearance設定の位置を若干上に移動しています。
- 変更関数について
    - Add: setLockView, dispAppearanceSlider
    - Mod: createGeneralSetting