### PR TITLE
[0489/keyptn-groupset] カラーグループが複数あるときの挙動誤りを修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4856,7 +4856,7 @@ function createOptionWindow(_sprite) {
 		// ローカルストレージで保存した設定を呼び出し
 		if ((g_canLoadDifInfoFlg && (isNotSameKey && g_stateObj.dataSaveFlg)) || _initFlg) {
 
-			if (isNotSameKey) {
+			if (isNotSameKey && g_keyObj.prevKey !== `Dummy`) {
 				// キーパターン、シャッフルグループ初期化
 				g_keyObj.currentPtn = 0;
 				g_keycons.shuffleGroupNum = 0;
@@ -5563,18 +5563,39 @@ function keyConfigInit(_kcType = g_kcType) {
 	};
 
 	/**
+	 * 一時的に矢印色・シャッフルグループを変更（共通処理）
+	 * @param {string} _type 
+	 * @param {number} _len 
+	 * @param {number} _j 
+	 * @param {number} _scrollNum 
+	 * @returns 
+	 */
+	const changeTmpData = (_type, _len, _j, _scrollNum) => {
+		const basePtn = getBasePtn();
+		const hasMultiGroup = g_keyObj[`${_type}${keyCtrlPtn}_1`] !== undefined;
+		const tmpNo = nextPos(g_keyObj[`${_type}${keyCtrlPtn}`][_j], _scrollNum, _len);
+
+		const setTmpData = _ptn => {
+			g_keyObj[`${_type}${_ptn}`][_j] = tmpNo;
+			if (hasMultiGroup) {
+				g_keyObj[`${_type}${_ptn}_${g_keycons[`${_type}GroupNum`]}`][_j] = tmpNo;
+			}
+		};
+
+		setTmpData(keyCtrlPtn);
+		if (keyCtrlPtn === basePtn) {
+			setTmpData(`${g_keyObj.currentKey}_-1`);
+		}
+		return tmpNo;
+	};
+
+	/**
 	 * 一時的に矢印色を変更
 	 * @param {number} _j
 	 * @param {number} _scrollNum 
 	 */
 	const changeTmpColor = (_j, _scrollNum = 1) => {
-		const setColorLen = g_headerObj.setColor.length;
-		const tmpColors = nextPos(g_keyObj[`color${keyCtrlPtn}`][_j], _scrollNum, setColorLen);
-		g_keyObj[`color${keyCtrlPtn}`][_j] = tmpColors;
-		if (g_keyObj[`color${keyCtrlPtn}_1`] !== undefined) {
-			g_keyObj[`color${keyCtrlPtn}_${g_keycons.colorGroupNum}`][_j] = tmpColors;
-		}
-
+		changeTmpData(`color`, g_headerObj.setColor.length, _j, _scrollNum);
 		const arrowColor = getKeyConfigColor(_j, g_keyObj[`color${keyCtrlPtn}`][_j]);
 		$id(`arrow${_j}`).background = arrowColor;
 		$id(`arrowShadow${_j}`).background = getShadowColor(g_keyObj[`color${keyCtrlPtn}`][_j], arrowColor);
@@ -5586,13 +5607,8 @@ function keyConfigInit(_kcType = g_kcType) {
 	 * @param {number} _scrollNum 
 	 */
 	const changeTmpShuffleNum = (_j, _scrollNum = 1) => {
-		const basePtn = getBasePtn();
-		const tmpShuffle = nextPos(g_keyObj[`shuffle${keyCtrlPtn}`][_j], _scrollNum, 10);
+		const tmpShuffle = changeTmpData(`shuffle`, 10, _j, _scrollNum);
 		document.getElementById(`sArrow${_j}`).textContent = tmpShuffle + 1;
-		g_keyObj[`shuffle${keyCtrlPtn}`][_j] = g_keyObj[`shuffle${basePtn}`][_j] = tmpShuffle;
-		if (g_keyObj[`shuffle${keyCtrlPtn}_1`] !== undefined) {
-			g_keyObj[`shuffle${keyCtrlPtn}_${g_keycons.shuffleGroupNum}`][_j] = tmpShuffle;
-		}
 	};
 
 	for (let j = 0; j < keyNum; j++) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5569,8 +5569,11 @@ function keyConfigInit(_kcType = g_kcType) {
 	 */
 	const changeTmpColor = (_j, _scrollNum = 1) => {
 		const setColorLen = g_headerObj.setColor.length;
-		g_keyObj[`color${keyCtrlPtn}`][_j] = nextPos(g_keyObj[`color${keyCtrlPtn}`][_j], _scrollNum, setColorLen);
-		g_keyObj[`color${getBasePtn()}`][_j] = g_keyObj[`color${keyCtrlPtn}`][_j];
+		const tmpColors = nextPos(g_keyObj[`color${keyCtrlPtn}`][_j], _scrollNum, setColorLen);
+		g_keyObj[`color${keyCtrlPtn}`][_j] = tmpColors;
+		if (g_keyObj[`color${keyCtrlPtn}_1`] !== undefined) {
+			g_keyObj[`color${keyCtrlPtn}_${g_keycons.colorGroupNum}`][_j] = tmpColors;
+		}
 
 		const arrowColor = getKeyConfigColor(_j, g_keyObj[`color${keyCtrlPtn}`][_j]);
 		$id(`arrow${_j}`).background = arrowColor;
@@ -5588,8 +5591,7 @@ function keyConfigInit(_kcType = g_kcType) {
 		document.getElementById(`sArrow${_j}`).textContent = tmpShuffle + 1;
 		g_keyObj[`shuffle${keyCtrlPtn}`][_j] = g_keyObj[`shuffle${basePtn}`][_j] = tmpShuffle;
 		if (g_keyObj[`shuffle${keyCtrlPtn}_1`] !== undefined) {
-			g_keyObj[`shuffle${keyCtrlPtn}_${g_keycons.shuffleGroupNum}`][_j] =
-				g_keyObj[`shuffle${basePtn}_${g_keycons.shuffleGroupNum}`][_j] = tmpShuffle;
+			g_keyObj[`shuffle${keyCtrlPtn}_${g_keycons.shuffleGroupNum}`][_j] = tmpShuffle;
 		}
 	};
 
@@ -5702,7 +5704,7 @@ function keyConfigInit(_kcType = g_kcType) {
 			if (g_keyObj[`${_type}${keyCtrlPtn}_1`] !== undefined) {
 				document.getElementById(`lnk${toCapitalize(_type)}Group`).textContent =
 					getStgDetailName(`${g_keycons[`${_type}GroupNum`] + 1}`);
-				g_keyObj[`${_type}${keyCtrlPtn}`] = g_keyObj[`${_type}${getBasePtn()}`] = g_keyObj[`${_type}${keyCtrlPtn}_${g_keycons[`${_type}GroupNum`]}`].concat();
+				g_keyObj[`${_type}${keyCtrlPtn}`] = g_keyObj[`${_type}${keyCtrlPtn}_${g_keycons[`${_type}GroupNum`]}`].concat();
 			}
 			viewGroupObj[_type](`_${g_keycons[`${_type}GroupNum`]}`);
 		}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5720,7 +5720,6 @@ function keyConfigInit(_kcType = g_kcType) {
 			if (g_keyObj[`${_type}${keyCtrlPtn}_1`] !== undefined) {
 				document.getElementById(`lnk${toCapitalize(_type)}Group`).textContent =
 					getStgDetailName(`${g_keycons[`${_type}GroupNum`] + 1}`);
-				g_keyObj[`${_type}${keyCtrlPtn}`] = g_keyObj[`${_type}${keyCtrlPtn}_${g_keycons[`${_type}GroupNum`]}`].concat();
 			}
 			viewGroupObj[_type](`_${g_keycons[`${_type}GroupNum`]}`);
 		}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. カラーグループが複数あるパターンAが保存済みのパターンBで無いとき、
保存済みのパターンBの色情報をパターンAで上書きしてしまう問題を修正しました。
2. データ保存有効時、シャッフルグループを変更してもタイトルに戻った後シャッフルグループが元に戻ってしまう問題を修正しました。
3. シャッフルグループ・カラーグループが複数ある場合、保存済みのキーパターン（Self）から保存元のキーパターンに反映されてしまう問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Gitterでの指摘より。仕様誤りと思われます。
https://gitter.im/danonicw/community?at=61b5b044abdd6644e3d30f14
2. データ保存時の挙動について、シャッフルグループは他の情報と異なり
ローカルストレージの保存対象で無いため、既存の情報を保持する必要がありました。
3. 保存済みのキーパターン（Self）と保存元のキーパターンは別であるため、
反映させない動きが正しい。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- シャッフルグループにも似たような問題がありそうなので、合わせて確認します。
