### PR TITLE
[0490/shuffle-group] シャッフルグループが利かない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5681,10 +5681,10 @@ function keyConfigInit(_kcType = g_kcType) {
 	cursor.style.transitionDuration = `0.125s`;
 
 	const viewGroupObj = {
-		shuffle: _ => {
+		shuffle: (_type = ``) => {
 			if (g_keyObj[`shuffle${keyCtrlPtn}`] !== undefined) {
 				for (let j = 0; j < keyNum; j++) {
-					document.getElementById(`sArrow${j}`).textContent = g_keyObj[`shuffle${keyCtrlPtn}`][j] + 1;
+					document.getElementById(`sArrow${j}`).textContent = g_keyObj[`shuffle${keyCtrlPtn}${_type}`][j] + 1;
 				}
 			}
 		},


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. シャッフルグループが利かない問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #1174 の変更による不具合の修正です。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- この修正により、保存済みのキーパターン（Self）のシャッフルグループを変更すると
保存元のキーパターンに反映される問題が出ますが、
微細な問題で保存対象でも無いため、今回は対応保留します。