### PR TITLE
[0491/sc-group] シャッフルグループ、カラーグループが初期化されない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5164,6 +5164,7 @@ function getKeyCtrl(_localStorage, _extraKeyName = ``) {
 	const baseKeyNum = g_keyObj[`chara${basePtn}`].length;
 
 	if (_localStorage[`keyCtrl${_extraKeyName}`] !== undefined && _localStorage[`keyCtrl${_extraKeyName}`][0].length > 0) {
+		const prevPtn = g_keyObj.currentPtn;
 		g_keyObj.currentPtn = -1;
 		const copyPtn = `${g_keyObj.currentKey}_-1`;
 		g_keyObj[`keyCtrl${copyPtn}`] = [...Array(baseKeyNum)].map(_ => []);
@@ -5176,7 +5177,7 @@ function getKeyCtrl(_localStorage, _extraKeyName = ``) {
 		}
 
 		g_keyCopyLists.multiple.forEach(header => {
-			if (g_keyObj[`${header}${basePtn}`] !== undefined) {
+			if (g_keyObj[`${header}${basePtn}`] !== undefined && prevPtn !== -1) {
 				g_keyObj[`${header}${copyPtn}`] = copyArray2d(g_keyObj[`${header}${basePtn}`]);
 			}
 		});
@@ -5720,8 +5721,10 @@ function keyConfigInit(_kcType = g_kcType) {
 			if (g_keyObj[`${_type}${keyCtrlPtn}_1`] !== undefined) {
 				document.getElementById(`lnk${toCapitalize(_type)}Group`).textContent =
 					getStgDetailName(`${g_keycons[`${_type}GroupNum`] + 1}`);
+				viewGroupObj[_type](`_${g_keycons[`${_type}GroupNum`]}`);
+			} else {
+				viewGroupObj[_type]();
 			}
-			viewGroupObj[_type](`_${g_keycons[`${_type}GroupNum`]}`);
 		}
 	}
 	const setGroup = (_type, _scrollNum = 1) => {
@@ -5936,7 +5939,7 @@ function keyConfigInit(_kcType = g_kcType) {
 			g_stateObj.d_color = g_keycons.colorDefs[nextNum];
 		}
 		changeSetColor();
-		viewGroupObj.color();
+		viewGroupObj.color(g_keyObj[`color${keyCtrlPtn}_1`] !== undefined ? `_${g_keycons.colorGroupNum}` : ``);
 		lnkColorType.textContent = `${getStgDetailName(g_colorType)}${g_localStorage.colorType === g_colorType ? ' *' : ''}`;
 	};
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. シャッフルグループ、カラーグループが単一のとき、初期化されない問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 以下の問題が発生し、うまく初期化できていませんでした。
    - 設定画面に入ったときsetDifficulty関数を通過しますが、
このときに保存済みのキー設定を読み出す処理があります（getKeyCtrl関数）。
この中にg_keyObjの「shuffle」や「color」の番号配列が含まれていたため、
一時的にこれらの番号を変更しても、元に戻る挙動になっていました。
⇒ 前にプレイした状態が「KeyPattern : Self」の場合は、g_keyObjの「shuffle」「color」「chara」「pos」「stepRtn」を変更しないようにしました。
    - キーコンフィグ画面に入ったとき、setColorType関数を通過する処理があります。
このとき、「color」の番号配列の1番目（ColorGroup: 1）を適用するようになっていました。
これだと、ColorGroup: 2 などを指定してプレイし、元に戻った際にColorGroup: 1が呼び出されてしまう問題があります。
⇒ カラーグループが複数ある際は、現在のカラーグループに対するg_keyObjの「color」の番号配列を取得するように変更しました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- これらの修正を行っても、以下の挙動になりますがこれは仕様とします。
    - シャッフルグループやカラーグループが単一のキーパターンの場合、
キーを変えると設定が元に戻る。

### 理由補足
- これは、シャッフルグループやカラーグループが複数保持しているパターンでは
グループ内で個別に設定を保持している（shuffleX_Y_Z：Zはグループ個別番号）のに対して、
グループが単一の場合、1つしか設定を持っていないためである（shuffleX_Y）。
- 厳密にはすべて「shuffleX_Y_Z」のような形式に揃えるべきかもしれないが、
現状カスタムキーではシャッフルグループやカラーグループに対応していないため、
現在の状況下ではこの仕様に留める。