### PR TITLE
[0492/sc-group2] シャッフルグループ・カラーグループの処理見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5184,8 +5184,9 @@ function getKeyCtrl(_localStorage, _extraKeyName = ``) {
 			}
 		}
 
+		const isUpdate = prevPtn !== -1 && g_keyObj.prevKey !== g_keyObj.currentKey;
 		g_keyCopyLists.multiple.forEach(header => {
-			if (g_keyObj[`${header}${basePtn}`] !== undefined && prevPtn !== -1) {
+			if (g_keyObj[`${header}${basePtn}`] !== undefined && isUpdate) {
 				g_keyObj[`${header}${copyPtn}`] = copyArray2d(g_keyObj[`${header}${basePtn}`]);
 			}
 		});
@@ -5582,18 +5583,13 @@ function keyConfigInit(_kcType = g_kcType) {
 	 * @returns 
 	 */
 	const changeTmpData = (_type, _len, _j, _scrollNum) => {
-		const basePtn = getBasePtn();
 		const tmpNo = nextPos(g_keyObj[`${_type}${keyCtrlPtn}_${g_keycons[`${_type}GroupNum`]}`][_j], _scrollNum, _len);
-
 		const setTmpData = _ptn => {
 			g_keyObj[`${_type}${_ptn}`][_j] = tmpNo;
 			g_keyObj[`${_type}${_ptn}_${g_keycons[`${_type}GroupNum`]}`][_j] = tmpNo;
 		};
 
 		setTmpData(keyCtrlPtn);
-		if (keyCtrlPtn === basePtn) {
-			setTmpData(`${g_keyObj.currentKey}_-1`);
-		}
 		return tmpNo;
 	};
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5195,7 +5195,7 @@ function getKeyCtrl(_localStorage, _extraKeyName = ``) {
 		});
 
 		[`color`, `shuffle`].forEach(type => {
-			if (prevPtn !== -1 && g_keyObj.prevKey !== g_keyObj.currentKey) {
+			if (isUpdate) {
 				let maxPtn = 0;
 				while (g_keyObj[`${type}${basePtn}_${maxPtn}`] !== undefined) {
 					maxPtn++;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5575,8 +5575,6 @@ function keyConfigInit(_kcType = g_kcType) {
 	 */
 	const changeTmpData = (_type, _len, _j, _scrollNum) => {
 		const basePtn = getBasePtn();
-		console.log(`${_type}${keyCtrlPtn}_${g_keycons[`${_type}GroupNum`]}`);
-		console.log(g_keyObj[`${_type}${keyCtrlPtn}_${g_keycons[`${_type}GroupNum`]}`])
 		const tmpNo = nextPos(g_keyObj[`${_type}${keyCtrlPtn}_${g_keycons[`${_type}GroupNum`]}`][_j], _scrollNum, _len);
 
 		const setTmpData = _ptn => {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3766,6 +3766,14 @@ function keysConvert(_dosObj) {
 		}
 	};
 
+	/**
+	 * 子構成配列へのコピー
+	 * @param {number} _k 
+	 * @param {string} _header 
+	 * @returns 
+	 */
+	const copyChildArray = (_k, _header) => g_keyObj[`${_header}_${_k}_0`] = copyArray2d(g_keyObj[`${_header}_${_k}`]);
+
 	// 対象キー毎に処理
 	keyExtraList.forEach(newKey => {
 		let tmpDivPtn = [];
@@ -3777,7 +3785,7 @@ function keysConvert(_dosObj) {
 		// 矢印色パターン (colorX_Y)
 		tmpMinPatterns = newKeyMultiParam(newKey, `color`, toNumber, {
 			errCd: `E_0101`,
-			loopFunc: (k, keyheader) => g_keyObj[`${keyheader}_${k}_0`] = copyArray2d(g_keyObj[`${keyheader}_${k}`]),
+			loopFunc: (k, keyheader) => copyChildArray(k, keyheader),
 		});
 
 		// 読込変数の接頭辞 (charaX_Y)
@@ -3850,7 +3858,7 @@ function keysConvert(_dosObj) {
 
 		// シャッフルグループ (shuffleX_Y)
 		newKeyMultiParam(newKey, `shuffle`, toNumber, {
-			loopFunc: (k, keyheader) => g_keyObj[`${keyheader}_${k}_0`] = copyArray2d(g_keyObj[`${keyheader}_${k}`]),
+			loopFunc: (k, keyheader) => copyChildArray(k, keyheader),
 		});
 
 		// スクロールパターン (scrollX_Y)


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. シャッフルグループ・カラーグループの処理を見直し、
`shuffleX_Y_Z`や`colorX_Y_Z`の番号配列をベースとしたやり方に変更しました。
2. KeyPattern: selfとそれ以外の設定を独立させるようにしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 部分的に`shuffleX_Y`や`colorX_Y`を使っていたことで処理が複雑になっていたため。
2. これまで、保存元のシャッフルグループ・カラーグループが変更された場合、
KeyPattern: self のシャッフルグループ・カラーグループも合わせて変更するようになっていたが、他の設定はそのような仕様になっていないため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- PR #1176 の処理整理版です。
キーを変更すると設定が戻る件については仕様です。