### PR TITLE
[0495/color-motion-init] フェードイン時にそれまでの色変化・モーションデータを保持するように変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -214,6 +214,16 @@ const getNumAttr = (_baseObj, _attrkey) => parseFloat(_baseObj.getAttribute(_att
 const hasVal = _data => _data !== undefined && _data !== ``;
 
 /**
+ * 配列内に存在するかどうかをチェック
+ * @param {string} _val 
+ * @param {array} _array 
+ * @param {integer} _pos 
+ * @returns 
+ */
+const hasValInArray = (_val, _array, _pos = 0) =>
+	_array.findIndex(data => data[_pos] === _val) !== -1;
+
+/**
  * 部分一致検索（リストのいずれかに合致、大小文字問わず）
  * @param {string} _str 検索文字
  * @param {array} _list 検索リスト (英字は小文字にする必要あり)
@@ -7283,7 +7293,9 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 			for (let k = lastk - 3; k >= 0; k -= 3) {
 
 				if (colorData[k] < g_scoreObj.frameNum) {
-					frontData.unshift([colorData[k + 1], colorData[k + 2]]);
+					if (!hasValInArray(colorData[k + 1], frontData)) {
+						frontData.unshift([colorData[k + 1], colorData[k + 2]]);
+					}
 				} else if ((colorData[k] - g_workObj.arrivalFrame[frmPrev] > spdPrev
 					&& colorData[k] < spdNext)) {
 					if (!isFrzHitColor(colorData[k + 1])) {
@@ -7313,7 +7325,9 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 			const frontData = [];
 			for (let k = acolorData.length - 3; k >= 0; k -= 3) {
 				if (acolorData[k] < g_scoreObj.frameNum) {
-					frontData.unshift([acolorData[k + 1], acolorData[k + 2]]);
+					if (!hasValInArray(acolorData[k + 1], frontData)) {
+						frontData.unshift([acolorData[k + 1], acolorData[k + 2]]);
+					}
 				} else {
 					pushColors(`A${_header}`, acolorData[k], acolorData[k + 1], acolorData[k + 2]);
 				}
@@ -7344,7 +7358,9 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 			for (let k = lastk - 4; k >= 0; k -= 4) {
 
 				if (cssMotionData[k] < g_scoreObj.frameNum) {
-					frontData.unshift([cssMotionData[k + 1], cssMotionData[k + 2], cssMotionData[k + 3]]);
+					if (!hasValInArray(cssMotionData[k + 1], frontData)) {
+						frontData.unshift([cssMotionData[k + 1], cssMotionData[k + 2], cssMotionData[k + 3]]);
+					}
 
 				} else if ((cssMotionData[k] - g_workObj.arrivalFrame[frmPrev] > spdPrev
 					&& cssMotionData[k] < spdNext)) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7127,13 +7127,6 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 	/** Motionの適用フレーム数 */
 	g_workObj.motionFrame = [];
 
-	let spdNext = Infinity;
-	let spdPrev = 0;
-	let spdk;
-	let lastk;
-	let tmpObj;
-	let frmPrev;
-
 	const getSpeedPos = _ => {
 		let spdk, spdPrev;
 		if (_dataObj.speedData !== undefined) {
@@ -7170,21 +7163,15 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 
 		const startPoint = [];
 		let spdNext = Infinity;
-		let spdPrev = 0;
-		let spdk;
-		let tmpObj;
-		let arrowArrivalFrm;
-		let frmPrev;
-
-		[spdk, spdPrev] = getSpeedPos();
+		let [spdk, spdPrev] = getSpeedPos();
 
 		// 最後尾のデータから計算して格納
 		const lastk = _data.length - setcnt;
-		arrowArrivalFrm = _data[lastk];
-		tmpObj = getArrowStartFrame(arrowArrivalFrm, _speedOnFrame, _motionOnFrame);
+		let arrowArrivalFrm = _data[lastk];
+		let tmpObj = getArrowStartFrame(arrowArrivalFrm, _speedOnFrame, _motionOnFrame);
 
 		startPoint[lastk] = tmpObj.frm;
-		frmPrev = tmpObj.frm;
+		let frmPrev = tmpObj.frm;
 		g_workObj.initY[frmPrev] = tmpObj.startY;
 		g_workObj.arrivalFrame[frmPrev] = tmpObj.arrivalFrm;
 		g_workObj.motionFrame[frmPrev] = tmpObj.motionFrm;
@@ -7250,6 +7237,7 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 	}
 
 	// 個別加速のタイミング更新
+	let tmpObj;
 	g_workObj.boostData = [];
 	g_workObj.boostData.length = 0;
 	if (hasArrayList(_dataObj.boostData, 2)) {
@@ -7276,13 +7264,13 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 	}
 
 	// 個別・全体色変化、モーションデータのタイミング更新
-	calcColorAndMotionData(`color`, ``, 3, pushColors, { _colorFlg: true });
-	calcColorAndMotionData(`color`, `a`, 3, pushColors);
-	calcColorAndMotionData(`color`, `shadow`, 3, pushColors, { _colorFlg: true });
-	calcColorAndMotionData(`color`, `ashadow`, 3, pushColors);
+	calcDataTiming(`color`, ``, 3, pushColors, { _colorFlg: true });
+	calcDataTiming(`color`, `a`, 3, pushColors);
+	calcDataTiming(`color`, `shadow`, 3, pushColors, { _colorFlg: true });
+	calcDataTiming(`color`, `ashadow`, 3, pushColors);
 
 	[`arrow`, `frz`, `dummyArrow`, `dummyFrz`].forEach(header =>
-		calcColorAndMotionData(`CssMotion`, header, 4, pushCssMotions, { _calcFrameFlg: true }));
+		calcDataTiming(`CssMotion`, header, 4, pushCssMotions, { _calcFrameFlg: true }));
 
 	/**
 	 * 色変化・モーションデータのタイミング更新
@@ -7293,15 +7281,17 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 	 * @param {object} obj _colorFlg: 個別色変化フラグ, _calcFrameFlg: 逆算を無条件で行うかどうかの可否
 	 * @returns 
 	 */
-	function calcColorAndMotionData(_type, _header, _term, _setFunc = _ => true,
+	function calcDataTiming(_type, _header, _term, _setFunc = _ => true,
 		{ _colorFlg = false, _calcFrameFlg = false } = {}) {
 		const baseData = _dataObj[`${_header}${_type}Data`];
 
 		if (!hasArrayList(baseData, _term)) {
 			return;
 		}
-		[spdk, spdPrev] = getSpeedPos();
-		spdNext = Infinity;
+
+		let [spdk, spdPrev] = getSpeedPos();
+		let spdNext = Infinity;
+		let frmPrev, tmpObj;
 
 		const frontData = [];
 		for (let k = baseData.length - _term; k >= 0; k -= _term) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7304,15 +7304,21 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 				}
 				pushColors(`${_header}`, colorData[k], colorData[k + 1], colorData[k + 2]);
 			}
-			frontData.forEach(data => pushColor(_header, 0, data[0], data[1]));
+			frontData.forEach(data => pushColors(_header, g_scoreObj.frameNum, data[0], data[1]));
 		}
 
 		// 全体色変化のタイミング更新
 		if (acolorData !== undefined && acolorData.length >= 3) {
 
+			const frontData = [];
 			for (let k = acolorData.length - 3; k >= 0; k -= 3) {
-				pushColors(`A${_header}`, acolorData[k], acolorData[k + 1], acolorData[k + 2]);
+				if (acolorData[k] < g_scoreObj.frameNum) {
+					frontData.unshift([acolorData[k + 1], acolorData[k + 2]]);
+				} else {
+					pushColors(`A${_header}`, acolorData[k], acolorData[k + 1], acolorData[k + 2]);
+				}
 			}
+			frontData.forEach(data => pushColors(`A${_header}`, g_scoreObj.frameNum, data[0], data[1]));
 		}
 	}
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7279,10 +7279,11 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 			pushColors(``, isFrzHitColor(colorData[lastk + 1]) ? colorData[lastk] : tmpObj.frm,
 				colorData[lastk + 1], colorData[lastk + 2]);
 
+			const frontData = [];
 			for (let k = lastk - 3; k >= 0; k -= 3) {
 
 				if (colorData[k] < g_scoreObj.frameNum) {
-					break;
+					frontData.unshift([colorData[k + 1], colorData[k + 2]]);
 				} else if ((colorData[k] - g_workObj.arrivalFrame[frmPrev] > spdPrev
 					&& colorData[k] < spdNext)) {
 					if (!isFrzHitColor(colorData[k + 1])) {
@@ -7303,6 +7304,7 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 				}
 				pushColors(`${_header}`, colorData[k], colorData[k + 1], colorData[k + 2]);
 			}
+			frontData.forEach(data => pushColor(_header, 0, data[0], data[1]));
 		}
 
 		// 全体色変化のタイミング更新
@@ -7332,10 +7334,12 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 			g_workObj.arrivalFrame[frmPrev] = tmpObj.arrivalFrm;
 			pushCssMotions(_header, tmpObj.frm, cssMotionData[lastk + 1], cssMotionData[lastk + 2], cssMotionData[lastk + 3]);
 
+			const frontData = [];
 			for (let k = lastk - 4; k >= 0; k -= 4) {
 
 				if (cssMotionData[k] < g_scoreObj.frameNum) {
-					break;
+					frontData.unshift([cssMotionData[k + 1], cssMotionData[k + 2], cssMotionData[k + 3]]);
+
 				} else if ((cssMotionData[k] - g_workObj.arrivalFrame[frmPrev] > spdPrev
 					&& cssMotionData[k] < spdNext)) {
 					cssMotionData[k] -= g_workObj.arrivalFrame[frmPrev];
@@ -7352,6 +7356,7 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 				}
 				pushCssMotions(_header, cssMotionData[k], cssMotionData[k + 1], cssMotionData[k + 2], cssMotionData[k + 3]);
 			}
+			frontData.forEach(data => pushCssMotions(_header, 0, data[0], data[1], data[2]));
 		}
 	}
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -224,6 +224,14 @@ const hasValInArray = (_val, _array, _pos = 0) =>
 	_array.findIndex(data => data[_pos] === _val) !== -1;
 
 /**
+ * 配列が既定長以上かどうかをチェック
+ * @param {array} _data 
+ * @param {integer} _length 
+ * @returns 
+ */
+const hasArrayList = (_data, _length = 1) => _data !== undefined && _data.length >= _length;
+
+/**
  * 部分一致検索（リストのいずれかに合致、大小文字問わず）
  * @param {string} _str 検索文字
  * @param {array} _list 検索リスト (英字は小文字にする必要あり)
@@ -6237,7 +6245,7 @@ function loadingScoreInit() {
 		convertreplaceNums();
 
 		const setData = (_data, _minLength = 1) => {
-			return (_data !== undefined && _data.length >= _minLength ? _data.concat() : []);
+			return (hasArrayList(_data, _minLength) ? _data.concat() : []);
 		}
 
 		// フレーム・曲開始位置調整
@@ -7244,7 +7252,7 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 	// 個別加速のタイミング更新
 	g_workObj.boostData = [];
 	g_workObj.boostData.length = 0;
-	if (_dataObj.boostData !== undefined && _dataObj.boostData.length >= 2) {
+	if (hasArrayList(_dataObj.boostData, 2)) {
 		let delBoostIdx = 0;
 		for (let k = _dataObj.boostData.length - 2; k >= 0; k -= 2) {
 			if (_dataObj.boostData[k] < g_scoreObj.frameNum) {
@@ -7278,7 +7286,7 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 
 		// 個別色変化のタイミング更新
 		// フリーズアロー(ヒット時)の場合のみ、逆算をしない
-		if (colorData !== undefined && colorData.length >= 3) {
+		if (hasArrayList(colorData, 3)) {
 			[spdk, spdPrev] = getSpeedPos();
 			spdNext = Infinity;
 
@@ -7296,31 +7304,33 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 					if (!hasValInArray(colorData[k + 1], frontData)) {
 						frontData.unshift([colorData[k + 1], colorData[k + 2]]);
 					}
-				} else if ((colorData[k] - g_workObj.arrivalFrame[frmPrev] > spdPrev
-					&& colorData[k] < spdNext)) {
-					if (!isFrzHitColor(colorData[k + 1])) {
-						colorData[k] -= g_workObj.arrivalFrame[frmPrev];
-					}
 				} else {
-					if (colorData[k] < spdPrev) {
-						spdk -= 2;
-						spdNext = spdPrev;
-						spdPrev = _dataObj.speedData[spdk];
+					if ((colorData[k] - g_workObj.arrivalFrame[frmPrev] > spdPrev
+						&& colorData[k] < spdNext)) {
+						if (!isFrzHitColor(colorData[k + 1])) {
+							colorData[k] -= g_workObj.arrivalFrame[frmPrev];
+						}
+					} else {
+						if (colorData[k] < spdPrev) {
+							spdk -= 2;
+							spdNext = spdPrev;
+							spdPrev = _dataObj.speedData[spdk];
+						}
+						tmpObj = getArrowStartFrame(colorData[k], _speedOnFrame, _motionOnFrame);
+						frmPrev = tmpObj.frm;
+						if (!isFrzHitColor(colorData[k + 1])) {
+							colorData[k] = tmpObj.frm;
+						}
+						g_workObj.arrivalFrame[frmPrev] = tmpObj.arrivalFrm;
 					}
-					tmpObj = getArrowStartFrame(colorData[k], _speedOnFrame, _motionOnFrame);
-					frmPrev = tmpObj.frm;
-					if (!isFrzHitColor(colorData[k + 1])) {
-						colorData[k] = tmpObj.frm;
-					}
-					g_workObj.arrivalFrame[frmPrev] = tmpObj.arrivalFrm;
+					pushColors(`${_header}`, colorData[k], colorData[k + 1], colorData[k + 2]);
 				}
-				pushColors(`${_header}`, colorData[k], colorData[k + 1], colorData[k + 2]);
 			}
 			frontData.forEach(data => pushColors(_header, g_scoreObj.frameNum, data[0], data[1]));
 		}
 
 		// 全体色変化のタイミング更新
-		if (acolorData !== undefined && acolorData.length >= 3) {
+		if (hasArrayList(acolorData, 3)) {
 
 			const frontData = [];
 			for (let k = acolorData.length - 3; k >= 0; k -= 3) {
@@ -7344,7 +7354,7 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 
 	function calcCssMotion(_header) {
 		const cssMotionData = _dataObj[`${_header}CssMotionData`];
-		if (cssMotionData !== undefined && cssMotionData.length >= 4) {
+		if (hasArrayList(cssMotionData, 4)) {
 			[spdk, spdPrev] = getSpeedPos();
 			spdNext = Infinity;
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. フェードイン時にそれまでの色変化・モーションデータを保持するようにしました。
フェードイン以前の色変化(color_data, acolor_data)とモーションデータ(arrowMotion_data, frzMotion_data)を溜め込んでおき、開始時に全て適用するようにします。
開始順に溜め込むようにしているため、後のものが適用されるようにしています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. フェードイン時でも色変化データやモーションデータを保持させるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- モーションデータについて、タイマーは現状を引き継ぎます。
アニメーションが掛かっている場合は矢印、フリーズアロー出現時から適用されます。
- このプルリクエストでは対応しませんが、今後背景、マスクに対して同様の措置を取る場合、フェードインかつアニメーションが途中にあるときの扱いを考える必要がありそうです。