### PR TITLE
[0496/cr-data-timing] 色変化計算部分について計算スキップを廃止

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7291,34 +7291,26 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 
 		let [spdk, spdPrev] = getSpeedPos();
 		let spdNext = Infinity;
-		let frmPrev, tmpObj;
+		let tmpObj;
 
 		const frontData = [];
 		for (let k = baseData.length - _term; k >= 0; k -= _term) {
+			const calcFrameFlg = (_colorFlg && !isFrzHitColor(baseData[k + 1])) || _calcFrameFlg;
 
 			if (baseData[k] < g_scoreObj.frameNum) {
 				if (!hasValInArray(baseData[k + 1], frontData)) {
 					frontData.unshift(baseData.slice(k + 1, k + _term));
 				}
 			} else {
-				const calcFrameFlg = (_colorFlg && !isFrzHitColor(baseData[k + 1])) || _calcFrameFlg;
-				if ((baseData[k] - g_workObj.arrivalFrame[frmPrev] > spdPrev
-					&& baseData[k] < spdNext)) {
-					if (calcFrameFlg) {
-						baseData[k] -= g_workObj.arrivalFrame[frmPrev];
-					}
-				} else {
+				if (calcFrameFlg) {
 					while (baseData[k] < spdPrev) {
 						spdk -= 2;
 						spdNext = spdPrev;
 						spdPrev = _dataObj.speedData[spdk];
 					}
 					tmpObj = getArrowStartFrame(baseData[k], _speedOnFrame, _motionOnFrame);
-					frmPrev = tmpObj.frm;
-					g_workObj.arrivalFrame[frmPrev] = tmpObj.arrivalFrm;
-					if (calcFrameFlg) {
-						baseData[k] = tmpObj.frm;
-					}
+					g_workObj.arrivalFrame[tmpObj.frm] = tmpObj.arrivalFrm;
+					baseData[k] = tmpObj.frm;
 				}
 				_setFunc(toCapitalize(_header), ...baseData.slice(k, k + _term));
 			}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 色変化計算部分について計算スキップを廃止しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. コード整理の一環です。
また、矢印やフリーズアローに対して色変化回数は基本的に少なく、
毎回再計算しても大きな問題になることは少ないためです。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
