### PR TITLE
[0497/stock-animation] 歌詞表示、背景・マスク表示においてフェードイン時に前のデータを蓄積するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3394,16 +3394,16 @@ function headerConvert(_dosObj) {
 		setVal(g_presetResultFormat, resultFormatDefault, C_TYP_STRING) : resultFormatDefault), C_TYP_STRING));
 
 	// フェードイン時にそれ以前のデータをプリロードしない種別(word, back, mask)を指定
-	obj.unpreloadCategories = setVal(_dosObj.unpreloadCategory, ``, C_TYP_STRING).split(`,`);
-	g_fadeinStockList = g_fadeinStockList.filter(cg => obj.unpreloadCategories.indexOf(cg) === -1);
+	obj.unStockCategories = setVal(_dosObj.unStockCategory, ``, C_TYP_STRING).split(`,`);
+	g_fadeinStockList = g_fadeinStockList.filter(cg => obj.unStockCategories.indexOf(cg) === -1);
 
 	// フェードイン時にそれ以前のデータをプリロードしないパターンを指定
-	if (typeof g_presetPreloadForceDelList === C_TYP_OBJECT) {
-		Object.assign(g_preloadForceDelList, g_presetPreloadForceDelList);
+	if (typeof g_presetStockForceDelList === C_TYP_OBJECT) {
+		Object.assign(g_stockForceDelList, g_presetStockForceDelList);
 	}
 	g_fadeinStockList.forEach(type => {
-		if (hasVal(_dosObj[`${type}ForceDel`])) {
-			g_preloadForceDelList[type] = Array.from((new Set([...g_preloadForceDelList[type], ..._dosObj[`${type}ForceDel`].split(`,`)])).values());
+		if (hasVal(_dosObj[`${type}StockForceDel`])) {
+			g_stockForceDelList[type] = Array.from((new Set([...g_stockForceDelList[type], ..._dosObj[`${type}StockForceDel`].split(`,`)])).values());
 		}
 	})
 
@@ -7376,9 +7376,9 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 				}
 			}
 		}
-		// g_preloadForceDelList に合致する消去対象データを検索し、削除
+		// g_stockForceDelList に合致する消去対象データを検索し、削除
 		for (let j = getLength(_data[startNum]) - 1; j >= 0; j--) {
-			if (_data[startNum][j] !== undefined && isExceptData[_type](g_preloadForceDelList, j)) {
+			if (_data[startNum][j] !== undefined && isExceptData[_type](g_stockForceDelList, j)) {
 				_data[startNum][j] = undefined;
 			}
 		}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7308,6 +7308,35 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 		frontData.forEach(data => _setFunc(toCapitalize(_header), g_scoreObj.frameNum, ...data));
 	}
 
+	[`word`, `back`, `mask`].forEach(type =>
+		[_dataObj[`${type}Data`], _dataObj[`${type}MaxDepth`]] =
+		calcAnimationData(_dataObj[`${type}Data`], _dataObj[`${type}MaxDepth`]));
+
+	/**
+	 * 歌詞表示、背景・マスク表示のフェードイン時調整処理
+	 * @param {object} _data 
+	 * @param {integer} _maxDepth 
+	 * @returns 
+	 */
+	function calcAnimationData(_data, _maxDepth) {
+
+		const startNum = g_scoreObj.frameNum;
+		let maxDepth = _maxDepth;
+
+		if (startNum > 0 && _data[startNum] === undefined) {
+			_data[startNum] = [];
+		}
+		for (let j = _data.length - 1; j >= 0; j--) {
+			if (_data[j] !== undefined && j < g_scoreObj.frameNum) {
+				_data[startNum].unshift(..._data[j]);
+				_data[j] = undefined;
+
+				maxDepth = Math.max(maxDepth, _data[startNum].length);
+			}
+		}
+		return [_data, maxDepth];
+	}
+
 	// 実際に処理させる途中変速配列を作成
 	g_workObj.speedData = [];
 	g_workObj.speedData.length = 0;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7269,7 +7269,7 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 	calcDataTiming(`color`, `shadow`, 3, pushColors, { _colorFlg: true });
 	calcDataTiming(`color`, `ashadow`, 3, pushColors);
 
-	[`arrow`, `frz`, `dummyArrow`, `dummyFrz`].forEach(header =>
+	g_typeLists.arrow.forEach(header =>
 		calcDataTiming(`CssMotion`, header, 4, pushCssMotions, { _calcFrameFlg: true }));
 
 	/**
@@ -7309,21 +7309,18 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 	}
 
 	[`word`, `back`, `mask`].forEach(type =>
-		[_dataObj[`${type}Data`], _dataObj[`${type}MaxDepth`]] =
-		calcAnimationData(type, _dataObj[`${type}Data`], _dataObj[`${type}MaxDepth`]));
+		_dataObj[`${type}Data`] = calcAnimationData(type, _dataObj[`${type}Data`]));
 
 	/**
 	 * 歌詞表示、背景・マスク表示のフェードイン時調整処理
 	 * @param {string} _type
 	 * @param {object} _data 
-	 * @param {integer} _maxDepth 
 	 * @returns 
 	 */
-	function calcAnimationData(_type, _data, _maxDepth) {
+	function calcAnimationData(_type, _data) {
 
 		const startNum = g_scoreObj.frameNum;
 		const cgArrays = [`word`];
-		let maxDepth = _maxDepth;
 
 		const isSameDepth = (_j, _k, _type) =>
 			_data[startNum][_j] !== undefined &&
@@ -7357,13 +7354,12 @@ function pushArrows(_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 			}
 		}
 
-		// 深度の最大長を更新
+		// カットした箇所をリストから削除
 		if (getLength(_data[startNum], _type) > 0) {
 			_data[startNum] = _data[startNum].filter(list => getLength(list, _type) > 0);
-			maxDepth = Math.max(maxDepth, getLength(_data[startNum], _type));
 		}
 
-		return [_data, maxDepth];
+		return _data;
 	}
 
 	// 実際に処理させる途中変速配列を作成

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3403,7 +3403,7 @@ function headerConvert(_dosObj) {
 	}
 	g_fadeinStockList.forEach(type => {
 		if (hasVal(_dosObj[`${type}ForceDel`])) {
-			g_preloadForceDelList[_type] = new Set([...g_preloadForceDelList[_type], ..._dosObj[`${type}ForceDel`].split(`,`)]);
+			g_preloadForceDelList[type] = Array.from((new Set([...g_preloadForceDelList[type], ..._dosObj[`${type}ForceDel`].split(`,`)])).values());
 		}
 	})
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -232,6 +232,15 @@ const hasValInArray = (_val, _array, _pos = 0) =>
 const hasArrayList = (_data, _length = 1) => _data !== undefined && _data.length >= _length;
 
 /**
+ * 重複を排除した配列の生成
+ * @param {array} _array1 
+ * @param {array} _array2 
+ * @returns 
+ */
+const makeDedupliArray = (_array1, _array2) =>
+	Array.from((new Set([..._array1, ..._array2])).values());
+
+/**
  * 部分一致検索（リストのいずれかに合致、大小文字問わず）
  * @param {string} _str 検索文字
  * @param {array} _list 検索リスト (英字は小文字にする必要あり)
@@ -3393,19 +3402,22 @@ function headerConvert(_dosObj) {
 	obj.resultFormat = escapeHtmlForEnabledTag(setVal(_dosObj.resultFormat, (typeof g_presetResultFormat === C_TYP_STRING ?
 		setVal(g_presetResultFormat, resultFormatDefault, C_TYP_STRING) : resultFormatDefault), C_TYP_STRING));
 
-	// フェードイン時にそれ以前のデータをプリロードしない種別(word, back, mask)を指定
+	// フェードイン時にそれ以前のデータを蓄積しない種別(word, back, mask)を指定
 	obj.unStockCategories = setVal(_dosObj.unStockCategory, ``, C_TYP_STRING).split(`,`);
+	if (typeof g_presetUnStockCategories === C_TYP_OBJECT) {
+		obj.unStockCategories = makeDedupliArray(obj.unStockCategories, g_presetUnStockCategories);
+	}
 	g_fadeinStockList = g_fadeinStockList.filter(cg => obj.unStockCategories.indexOf(cg) === -1);
 
-	// フェードイン時にそれ以前のデータをプリロードしないパターンを指定
+	// フェードイン時にそれ以前のデータを蓄積しないパターンを指定
 	if (typeof g_presetStockForceDelList === C_TYP_OBJECT) {
 		Object.assign(g_stockForceDelList, g_presetStockForceDelList);
 	}
 	g_fadeinStockList.forEach(type => {
 		if (hasVal(_dosObj[`${type}StockForceDel`])) {
-			g_stockForceDelList[type] = Array.from((new Set([...g_stockForceDelList[type], ..._dosObj[`${type}StockForceDel`].split(`,`)])).values());
+			g_stockForceDelList[type] = makeDedupliArray(g_stockForceDelList[type], _dosObj[`${type}StockForceDel`].split(`,`));
 		}
-	})
+	});
 
 	return obj;
 }

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -233,3 +233,10 @@ const g_lblRenames = {
 	keyConfig: true,
 	result: true,
 };
+
+/** フェードイン時、プリロードを強制削除するリスト（英字は小文字で指定） */
+const g_presetPreloadForceDelList = {
+	word: [],
+	back: [],
+	mask: [],
+};

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -234,7 +234,10 @@ const g_lblRenames = {
 	result: true,
 };
 
-/** フェードイン時、プリロードを強制削除するリスト（英字は小文字で指定） */
+/** 
+ * フェードイン時、プリロードを強制削除するリスト（英字は小文字で指定）
+ * 指定例) back: [`fade`]   ※back_dataでアニメーション名に'fade'や'Fade'を含む
+ */
 const g_presetPreloadForceDelList = {
 	word: [],
 	back: [],

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -238,7 +238,7 @@ const g_lblRenames = {
  * フェードイン時、プリロードを強制削除するリスト（英字は小文字で指定）
  * 指定例) back: [`fade`]   ※back_dataでアニメーション名に'fade'や'Fade'を含む
  */
-const g_presetPreloadForceDelList = {
+const g_presetStockForceDelList = {
 	word: [],
 	back: [],
 	mask: [],

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -234,6 +234,11 @@ const g_lblRenames = {
 	result: true,
 };
 
+/**
+ * フェードイン時にそれ以前のデータを蓄積しない種別(word, back, mask)を指定
+ */
+const g_presetUnStockCategories = [];
+
 /** 
  * フェードイン時、プリロードを強制削除するリスト（英字は小文字で指定）
  * 指定例) back: [`fade`]   ※back_dataでアニメーション名に'fade'や'Fade'を含む

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2254,6 +2254,13 @@ const g_titleLists = {
 
 const g_animationData = [`back`, `mask`];
 
+let g_fadeinStockList = [`word`, `back`, `mask`];
+const g_preloadExceptList = {
+    word: [`[left]`, `[center]`, `[right]`],
+    back: [],
+    mask: [],
+};
+
 /**
  * データ種, 最小データ長のセット
  */

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2264,7 +2264,7 @@ const g_preloadExceptList = {
 };
 
 /** フェードイン時、プリロードを強制削除するリスト（初期値は空） */
-const g_preloadForceDelList = {
+const g_stockForceDelList = {
     word: [],
     back: [],
     mask: [],

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2255,8 +2255,17 @@ const g_titleLists = {
 const g_animationData = [`back`, `mask`];
 
 let g_fadeinStockList = [`word`, `back`, `mask`];
+
+/** フェードイン時でもプリロードを除外しないリスト */
 const g_preloadExceptList = {
     word: [`[left]`, `[center]`, `[right]`],
+    back: [],
+    mask: [],
+};
+
+/** フェードイン時、プリロードを強制削除するリスト（初期値は空） */
+const g_preloadForceDelList = {
+    word: [],
     back: [],
     mask: [],
 };


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 歌詞表示、背景・マスク表示において、フェードイン時に
フェードインより前のデータを蓄積（＝プリロード）するよう変更しました。
#1181 の歌詞表示、背景・マスク表示版です。

### 関連設定（譜面ヘッダー）
- フェードイン時にそれ以前のデータを蓄積しない種別(word, back, mask)を作品別に指定できる設定を追加しました。
追加すると、従来通りフェードイン以前のデータは蓄積（プリロード）しません。
```
|unStockCategory=back,mask|  // back_data, mask_dataはプリロード対象外
```

- フェードイン時にそれ以前のデータをプリロードする条件を指定できるようにしました。
例えば下記の場合、back_dataやmask_dataに「fade」や「Fade」、「FADE」といった文字列がフェードイン直前に含まれているとプリロードしません。
カンマ区切りで複数指定が可能です。英字は「小文字」で指定が必要です。
```
|wordStockForceDel=|         // 無指定のため、除外条件なし
|backStockForceDel=fade|  // leftToRightFade、fadeoutなどのアニメーションが除外対象
|maskStockForceDel=fade,disappear|
```

### 関連設定（共通設定ファイル：danoni_setting.js）
#### g_presetUnStockCategories
- `unStockCategory`の共通設定ファイル版です。
配列形式で指定できます。指定するとまとめて今回の変更を無効にできます。
```javascript
const g_presetUnStockCategories = [`word`, `back`, `mask`];
```

#### g_presetStockForceDelList
- `wordStockForceDel`, `backStockForceDel`, `maskStockForceDel`と同じで、プリロードの対象外にする文字パターンを配列形式で記述します。共通設定ファイルの適用作品全てに反映されます。
```javascript
const g_presetStockForceDelList = {
	word: [],
	back: [`fade`, `out`],
	mask: [],
};
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 既存背景など、継承したいものをフェードイン時にも引き継ぎできるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 背景、マスク表示使用時にCSS側で自然消滅するようなアニメーションを行っている場合、
フェードインで蓄積されたデータを吐き出すことで
意図しない挙動を引き起こす可能性があります。