### PR TITLE
[ver25.1.0] 条件付きで矢印と同時にフリーズアローに色変化を適用　他

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ v23の対応終了時期はv26リリース開始時を予定しています。�
 
 | Version | Supported          | Latest Version | Logs | First Release | End of Support |
 | ------- | ------------------ |----------------|------|---------------|----------------|
-| v25     | :heavy_check_mark: |[v25.0.0](https://github.com/cwtickle/danoniplus/releases/tag/v25.0.0)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v25)|2022-01-04|-|
+| v25     | :heavy_check_mark: |[v25.1.0](https://github.com/cwtickle/danoniplus/releases/tag/v25.1.0)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v25)|2022-01-04|-|
 | v24     | :heavy_check_mark: |[v24.6.0](https://github.com/cwtickle/danoniplus/releases/tag/v24.6.0)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v24)|2021-10-24|(At Release v33)|
 | v23     | :warning:          |[v23.5.4](https://github.com/cwtickle/danoniplus/releases/tag/v23.5.4)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v23)|2021-09-04|(At Release v26)|
 | v22     | :x:                |[v22.5.6 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v22.5.6)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v22)|2021-04-28|2022-01-04|

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2022/01/04
+ * Revised : 2022/01/07
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 25.0.0`;
-const g_revisedDate = `2022/01/04`;
+const g_version = `Ver 25.1.0`;
+const g_revisedDate = `2022/01/07`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -5,7 +5,7 @@
  *
  * Source by tickle
  * Created : 2019/11/19
- * Revised : 2022/01/04 (v25.0.0)
+ * Revised : 2022/01/07 (v25.1.0)
  *
  * https://github.com/cwtickle/danoniplus
  */


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- #1187 
    - defaultFrzColorUse=false のとき、矢印の色変化に追随してフリーズアローにも色変化を適用する機能を実装
    - フェードイン時に個別色変化と全体色変化が混在している場合に色変化が反映されない問題を改善

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
