### PR TITLE
[0499/cr-setting] キーコンフィグが隠れる場合に横スクロールできるよう対応、コード整理

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5719,7 +5719,6 @@ function keyConfigInit(_kcType = g_kcType) {
 		}
 	}
 	const posj = g_keyObj[`pos${keyCtrlPtn}`][0];
-	keyconSprite.scrollLeft = -maxLeftX;
 
 	// カーソルの作成
 	const cursor = keyconSprite.appendChild(createImg(`cursor`, g_imgObj.cursor,
@@ -5915,12 +5914,22 @@ function keyConfigInit(_kcType = g_kcType) {
 		const posj = g_keyObj[`pos${keyCtrlPtn}`][g_currentj];
 		const stdPos = posj - ((posj > divideCnt ? posMax : 0) + divideCnt) / 2;
 
-		cursor.style.left = `${(kWidth - C_ARW_WIDTH) / 2 + g_keyObj.blank * stdPos - maxLeftX - 10}px`;
+		const nextLeft = (kWidth - C_ARW_WIDTH) / 2 + g_keyObj.blank * stdPos - maxLeftX - 10;
+		cursor.style.left = `${nextLeft}px`;
 		const baseY = C_KYC_HEIGHT * Number(posj > divideCnt) + 57;
 		cursor.style.top = `${baseY + C_KYC_REPHEIGHT * g_currentk}px`;
 		if (g_currentk === 0 && g_kcType === `Replaced`) {
 			g_kcType = C_FLG_ALL;
 			lnkKcType.textContent = getStgDetailName(g_kcType);
+		}
+
+		// 次の位置が見えなくなったらkeyconSpriteの位置を調整する
+		if (maxLeftX !== 0) {
+			if (nextLeft > keyconSprite.scrollLeft + g_sWidth - C_ARW_WIDTH) {
+				keyconSprite.scrollLeft = Math.min(keyconSprite.scrollLeft + C_ARW_WIDTH, -maxLeftX * 2);
+			} else if (nextLeft < keyconSprite.scrollLeft) {
+				keyconSprite.scrollLeft = maxLeftX;
+			}
 		}
 	};
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5925,11 +5925,7 @@ function keyConfigInit(_kcType = g_kcType) {
 
 		// 次の位置が見えなくなったらkeyconSpriteの位置を調整する
 		if (maxLeftX !== 0) {
-			if (nextLeft > keyconSprite.scrollLeft + g_sWidth - C_ARW_WIDTH) {
-				keyconSprite.scrollLeft = Math.min(keyconSprite.scrollLeft + C_ARW_WIDTH, -maxLeftX * 2);
-			} else if (nextLeft < keyconSprite.scrollLeft) {
-				keyconSprite.scrollLeft = maxLeftX;
-			}
+			keyconSprite.scrollLeft = Math.max(0, nextLeft - g_sWidth / 2);
 		}
 	};
 
@@ -5999,6 +5995,7 @@ function keyConfigInit(_kcType = g_kcType) {
 	// ConfigType, ColorTypeの初期設定
 	setConfigType(0);
 	setColorType(0);
+	keyconSprite.scrollLeft = - maxLeftX;
 
 	// キーパターン表示
 	const lblTransKey = hasVal(g_keyObj[`transKey${keyCtrlPtn}`]) ?
@@ -6080,6 +6077,7 @@ function keyConfigInit(_kcType = g_kcType) {
 					}
 				}
 				resetCursor(Number(g_kcType === `Replaced`));
+				keyconSprite.scrollLeft = - maxLeftX;
 			}
 		}, {
 			x: 0, y: g_sHeight - 75,

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5576,6 +5576,9 @@ function keyConfigInit(_kcType = g_kcType) {
 	const kWidth = parseInt(keyconSprite.style.width);
 	changeSetColor();
 
+	const maxLeftPos = Math.max(divideCnt, posMax - divideCnt - 2) / 2;
+	const maxLeftX = Math.min(0, (kWidth - C_ARW_WIDTH) / 2 - maxLeftPos * g_keyObj.blank);
+
 	/**
 	 * keyconSpriteのスクロール位置調整
 	 * @param {number} _targetX 
@@ -5666,9 +5669,6 @@ function keyConfigInit(_kcType = g_kcType) {
 
 		adjustScrollPoint(parseFloat($id(`arrow${_j}`).left));
 	};
-
-	const maxLeftPos = Math.max(divideCnt, posMax - divideCnt - 2) / 2;
-	const maxLeftX = Math.min(0, (kWidth - C_ARW_WIDTH) / 2 - maxLeftPos * g_keyObj.blank);
 
 	for (let j = 0; j < keyNum; j++) {
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5577,6 +5577,16 @@ function keyConfigInit(_kcType = g_kcType) {
 	changeSetColor();
 
 	/**
+	 * keyconSpriteのスクロール位置調整
+	 * @param {number} _targetX 
+	 */
+	const adjustScrollPoint = _targetX => {
+		if (maxLeftX !== 0) {
+			keyconSprite.scrollLeft = Math.max(0, _targetX - g_sWidth / 2);
+		}
+	};
+
+	/**
 	 * キーコンフィグ用の矢印色を取得
 	 * @param {number} _colorPos 
 	 */
@@ -5641,6 +5651,8 @@ function keyConfigInit(_kcType = g_kcType) {
 		const arrowColor = getKeyConfigColor(_j, g_keyObj[`color${keyCtrlPtn}`][_j]);
 		$id(`arrow${_j}`).background = arrowColor;
 		$id(`arrowShadow${_j}`).background = getShadowColor(g_keyObj[`color${keyCtrlPtn}`][_j], arrowColor);
+
+		adjustScrollPoint(parseFloat($id(`arrow${_j}`).left));
 	};
 
 	/**
@@ -5651,6 +5663,8 @@ function keyConfigInit(_kcType = g_kcType) {
 	const changeTmpShuffleNum = (_j, _scrollNum = 1) => {
 		const tmpShuffle = changeTmpData(`shuffle`, 10, _j, _scrollNum);
 		document.getElementById(`sArrow${_j}`).textContent = tmpShuffle + 1;
+
+		adjustScrollPoint(parseFloat($id(`arrow${_j}`).left));
 	};
 
 	const maxLeftPos = Math.max(divideCnt, posMax - divideCnt - 2) / 2;
@@ -5924,9 +5938,7 @@ function keyConfigInit(_kcType = g_kcType) {
 		}
 
 		// 次の位置が見えなくなったらkeyconSpriteの位置を調整する
-		if (maxLeftX !== 0) {
-			keyconSprite.scrollLeft = Math.max(0, nextLeft - g_sWidth / 2);
-		}
+		adjustScrollPoint(nextLeft);
 	};
 
 	/**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1553,11 +1553,7 @@ function initAfterDosLoaded() {
 
 		if (g_loadObj.main) {
 			// customjsの読み込み後、譜面詳細情報取得のために譜面をロード
-			loadCustomjs(_ => {
-				loadDos(_ => {
-					getScoreDetailData(0);
-				}, 0, true);
-			});
+			loadCustomjs(_ => loadDos(_ => getScoreDetailData(0), 0, true));
 		} else {
 			getScoreDetailData(0);
 			reloadDos(0);
@@ -3949,7 +3945,7 @@ const commonSettingBtn = _labelName => {
 		createCss2Button(`btn${_labelName}`, `>`, _ => true, {
 			x: g_sWidth / 2 + 175 - C_LEN_SETMINI_WIDTH / 2, y: 25,
 			w: C_LEN_SETMINI_WIDTH, h: 40, title: g_msgObj[`to${_labelName}`],
-			resetFunc: _ => (_labelName === `Display` ? settingsDisplayInit() : optionInit()),
+			resetFunc: _ => g_jumpSettingWindow[g_currentPage](),
 		}, g_cssObj.button_Mini),
 
 		// データセーブフラグの切替
@@ -5570,7 +5566,7 @@ function keyConfigInit(_kcType = g_kcType) {
 	);
 
 	// キーの一覧を表示
-	const keyconSprite = createEmptySprite(divRoot, `keyconSprite`, { y: 100 + (g_sHeight - 500) / 2, h: 300 });
+	const keyconSprite = createEmptySprite(divRoot, `keyconSprite`, { y: 88 + (g_sHeight - 500) / 2, h: g_sHeight, overflow: `auto` });
 	const tkObj = getKeyInfo();
 	const [keyCtrlPtn, keyNum, posMax, divideCnt] =
 		[tkObj.keyCtrlPtn, tkObj.keyNum, tkObj.posMax, tkObj.divideCnt];
@@ -5657,13 +5653,16 @@ function keyConfigInit(_kcType = g_kcType) {
 		document.getElementById(`sArrow${_j}`).textContent = tmpShuffle + 1;
 	};
 
+	const maxLeftPos = Math.max(divideCnt, posMax - divideCnt - 2) / 2;
+	const maxLeftX = Math.min(0, (kWidth - C_ARW_WIDTH) / 2 - maxLeftPos * g_keyObj.blank);
+
 	for (let j = 0; j < keyNum; j++) {
 
 		const posj = g_keyObj[`pos${keyCtrlPtn}`][j];
 		const stdPos = posj - ((posj > divideCnt ? posMax : 0) + divideCnt) / 2;
 
-		const keyconX = g_keyObj.blank * stdPos + (kWidth - C_ARW_WIDTH) / 2;
-		const keyconY = C_KYC_HEIGHT * (Number(posj > divideCnt));
+		const keyconX = g_keyObj.blank * stdPos + (kWidth - C_ARW_WIDTH) / 2 - maxLeftX;
+		const keyconY = C_KYC_HEIGHT * (Number(posj > divideCnt)) + 12;
 		const colorPos = g_keyObj[`color${keyCtrlPtn}`][j];
 		const arrowColor = getKeyConfigColor(j, colorPos);
 
@@ -5720,10 +5719,11 @@ function keyConfigInit(_kcType = g_kcType) {
 		}
 	}
 	const posj = g_keyObj[`pos${keyCtrlPtn}`][0];
+	keyconSprite.scrollLeft = -maxLeftX;
 
 	// カーソルの作成
 	const cursor = keyconSprite.appendChild(createImg(`cursor`, g_imgObj.cursor,
-		(kWidth - C_ARW_WIDTH) / 2 + g_keyObj.blank * (posj - divideCnt / 2) - 10, 45, 15, 30));
+		(kWidth - C_ARW_WIDTH) / 2 + g_keyObj.blank * (posj - divideCnt / 2) - 10, 57, 15, 30));
 	cursor.style.transitionDuration = `0.125s`;
 
 	const viewGroupObj = {
@@ -5915,8 +5915,8 @@ function keyConfigInit(_kcType = g_kcType) {
 		const posj = g_keyObj[`pos${keyCtrlPtn}`][g_currentj];
 		const stdPos = posj - ((posj > divideCnt ? posMax : 0) + divideCnt) / 2;
 
-		cursor.style.left = `${(kWidth - C_ARW_WIDTH) / 2 + g_keyObj.blank * stdPos - 10}px`;
-		const baseY = C_KYC_HEIGHT * Number(posj > divideCnt) + 45;
+		cursor.style.left = `${(kWidth - C_ARW_WIDTH) / 2 + g_keyObj.blank * stdPos - maxLeftX - 10}px`;
+		const baseY = C_KYC_HEIGHT * Number(posj > divideCnt) + 57;
 		cursor.style.top = `${baseY + C_KYC_REPHEIGHT * g_currentk}px`;
 		if (g_currentk === 0 && g_kcType === `Replaced`) {
 			g_kcType = C_FLG_ALL;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -504,6 +504,15 @@ g_settings.volumeNum = g_settings.volumes.length - 1;
 g_settings.opacityNum = g_settings.opacitys.length - 1;
 
 /**
+ * 設定画面間移動
+ */
+const g_jumpSettingWindow = {
+    option: _ => settingsDisplayInit(),
+    difSelector: _ => settingsDisplayInit(),
+    settingsDisplay: _ => optionInit(),
+};
+
+/**
  * シャッフル適用関数
  */
 const g_shuffleFunc = {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. キーコンフィグが隠れる場合に横スクロールできるよう対応しました。
ドラッグボールで動かせる他、カーソルの移動に合わせて画面もスライドします。
※タイトルやボタンはスライドしません。
2. 設定画面間のページ移動を関数化しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 必要となるケースは通常ありませんが、疑似キリズマなど一部のキーが隠れるケースがありえるため。
またキーの割り当て以外に一時的な色変更など、キーコンフィグの位置づけが変わってきているためです。
2. 今後、画面が増えた場合に備えた対応です。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/149237817-24c5881d-adbb-4690-bea1-f008bace1639.png" width="50%"><img src="https://user-images.githubusercontent.com/44026291/149237878-7fe4732e-e8ff-4692-abf0-e57964a18afa.png" width="50%">

## :pencil: その他コメント / Other Comments
- 1.の変更に合わせ、keyconSpriteの位置をY方向に12px下に移動し、
高さを300px -> 500px（ウィンドウの縦の長さ）に変更しています。
横スクロールを有効にすると、枠外のものが見えなくなってしまうのと、
横スクロールバーが見えてしまうと画面デザインに影響を与えるためです。
- 初期表示、リセット時は中央になるように表示されます。
何かキーを押したり、カーソル位置やシャッフルグループ番号を押すとスクロール位置を自動調整します。