### PR TITLE
[0500/multiple-files] js/cssファイルの読み込み方法の見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9353,19 +9353,42 @@ function updateCombo() {
 }
 
 /**
- * 判定処理：イイ
- * @param {number} difFrame 
+ * 回復判定の共通処理
+ * @param {string} _name 
+ * @param {number} _difFrame 
  */
-function judgeIi(difFrame) {
-	changeJudgeCharacter(`ii`, g_lblNameObj.j_ii);
+function judgeRecovery(_name, _difFrame) {
+	changeJudgeCharacter(_name, g_lblNameObj[`j_${_name}`]);
 
 	updateCombo();
-	displayDiff(difFrame, g_headerObj.justFrames);
+	displayDiff(_difFrame, g_headerObj.justFrames);
 
 	lifeRecovery();
 	finishViewing();
 
-	g_customJsObj.judg_ii.forEach(func => func(difFrame));
+	g_customJsObj[`judg_${_name}`].forEach(func => func(_difFrame));
+}
+
+/**
+ * ダメージ系共通処理
+ * @param {string} _name 
+ * @param {number} _difFrame 
+ */
+function judgeDamage(_name, _difFrame) {
+	changeJudgeCharacter(_name, g_lblNameObj[`j_${_name}`]);
+	g_resultObj.combo = 0;
+	comboJ.textContent = ``;
+	diffJ.textContent = ``;
+	lifeDamage();
+	g_customJsObj[`judg_${_name}`].forEach(func => func(_difFrame));
+}
+
+/**
+ * 判定処理：イイ
+ * @param {number} difFrame 
+ */
+function judgeIi(difFrame) {
+	judgeRecovery(`ii`, difFrame);
 }
 
 /**
@@ -9373,15 +9396,7 @@ function judgeIi(difFrame) {
  * @param {number} difFrame 
  */
 function judgeShakin(difFrame) {
-	changeJudgeCharacter(`shakin`, g_lblNameObj.j_shakin);
-
-	updateCombo();
-	displayDiff(difFrame, g_headerObj.justFrames);
-
-	lifeRecovery();
-	finishViewing();
-
-	g_customJsObj.judg_shakin.forEach(func => func(difFrame));
+	judgeRecovery(`shakin`, difFrame);
 }
 
 /**
@@ -9399,24 +9414,11 @@ function judgeMatari(difFrame) {
 }
 
 /**
- * ダメージ系共通処理
- */
-function judgeDamage() {
-	g_resultObj.combo = 0;
-	comboJ.textContent = ``;
-	diffJ.textContent = ``;
-	lifeDamage();
-}
-
-/**
  * 判定処理：ショボーン
  * @param {number} difFrame 
  */
 function judgeShobon(difFrame) {
-	changeJudgeCharacter(`shobon`, g_lblNameObj.j_shobon);
-	judgeDamage();
-
-	g_customJsObj.judg_shobon.forEach(func => func(difFrame));
+	judgeDamage(`shobon`, difFrame);
 }
 
 /**
@@ -9424,10 +9426,7 @@ function judgeShobon(difFrame) {
  * @param {number} difFrame 
  */
 function judgeUwan(difFrame) {
-	changeJudgeCharacter(`uwan`, g_lblNameObj.j_uwan);
-	judgeDamage();
-
-	g_customJsObj.judg_uwan.forEach(func => func(difFrame));
+	judgeDamage(`uwan`, difFrame);
 }
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1547,8 +1547,10 @@ function initAfterDosLoaded() {
 
 		if (g_loadObj.main) {
 			// customjsの読み込み後、譜面詳細情報取得のために譜面をロード
-			loadMultipleFile(0, g_headerObj.jsData, `js`, _ =>
-				loadDos(_ => getScoreDetailData(0), 0, true));
+			loadMultipleFile(0, g_headerObj.jsData, `js`, _ => {
+				loadLegacyCustomFunc();
+				loadDos(_ => getScoreDetailData(0), 0, true);
+			});
 		} else {
 			getScoreDetailData(0);
 			reloadDos(0);
@@ -1923,12 +1925,7 @@ function loadMusic() {
 			lblLoading.textContent = `${g_lblNameObj.nowLoading} ${_event.loaded}Bytes`;
 		}
 		// ユーザカスタムイベント
-		if (typeof customLoadingProgress === C_TYP_FUNCTION) {
-			customLoadingProgress(_event);
-			if (typeof customLoadingProgress2 === C_TYP_FUNCTION) {
-				customLoadingProgress2(_event);
-			}
-		}
+		g_customJsObj.progress.forEach(func => func(_event));
 	});
 
 	// エラー処理
@@ -2454,12 +2451,7 @@ function titleInit() {
 	}
 
 	// ユーザカスタムイベント(初期)
-	if (typeof customTitleInit === C_TYP_FUNCTION) {
-		customTitleInit();
-		if (typeof customTitleInit2 === C_TYP_FUNCTION) {
-			customTitleInit2();
-		}
-	}
+	g_customJsObj.title.forEach(func => func());
 
 	// バージョン情報取得
 	let customVersion = ``;
@@ -2592,12 +2584,7 @@ function titleInit() {
 	function flowTitleTimeline() {
 
 		// ユーザカスタムイベント(フレーム毎)
-		if (typeof customTitleEnterFrame === C_TYP_FUNCTION) {
-			customTitleEnterFrame();
-			if (typeof customTitleEnterFrame2 === C_TYP_FUNCTION) {
-				customTitleEnterFrame2();
-			}
-		}
+		g_customJsObj.titleEnterFrame.forEach(func => func());
 
 		// 背景・マスクモーション
 		drawTitleResultMotion(g_currentPage);
@@ -2619,12 +2606,7 @@ function titleInit() {
 	document.oncontextmenu = _ => true;
 	divRoot.oncontextmenu = _ => false;
 
-	if (typeof skinTitleInit === C_TYP_FUNCTION) {
-		skinTitleInit();
-		if (typeof skinTitleInit2 === C_TYP_FUNCTION) {
-			skinTitleInit2();
-		}
-	}
+	g_skinJsObj.title.forEach(func => func());
 }
 
 /**
@@ -3980,12 +3962,7 @@ function optionInit() {
 	createOptionWindow(divRoot);
 
 	// ユーザカスタムイベント(初期)
-	if (typeof customOptionInit === C_TYP_FUNCTION) {
-		customOptionInit();
-		if (typeof customOptionInit2 === C_TYP_FUNCTION) {
-			customOptionInit2();
-		}
-	}
+	g_customJsObj.option.forEach(func => func());
 
 	// ボタン描画
 	commonSettingBtn(`Display`);
@@ -3995,12 +3972,7 @@ function optionInit() {
 	document.oncontextmenu = _ => true;
 	g_initialFlg = true;
 
-	if (typeof skinOptionInit === C_TYP_FUNCTION) {
-		skinOptionInit();
-		if (typeof skinOptionInit2 === C_TYP_FUNCTION) {
-			skinOptionInit2();
-		}
-	}
+	g_skinJsObj.option.forEach(func => func());
 }
 
 function musicAfterLoaded() {
@@ -5036,12 +5008,7 @@ function createOptionWindow(_sprite) {
 		setGauge(0);
 
 		// ユーザカスタムイベント(初期)
-		if (typeof customSetDifficulty === C_TYP_FUNCTION) {
-			customSetDifficulty(_initFlg, g_canLoadDifInfoFlg);
-			if (typeof customSetDifficulty2 === C_TYP_FUNCTION) {
-				customSetDifficulty2(_initFlg, g_canLoadDifInfoFlg);
-			}
-		}
+		g_customJsObj.difficulty.forEach(func => func(_initFlg, g_canLoadDifInfoFlg));
 
 		// ---------------------------------------------------
 		// 4. 譜面初期情報ロード許可フラグの設定
@@ -5338,12 +5305,7 @@ function settingsDisplayInit() {
 	);
 
 	// ユーザカスタムイベント(初期)
-	if (typeof customSettingsDisplayInit === C_TYP_FUNCTION) {
-		customSettingsDisplayInit();
-		if (typeof customSettingsDisplayInit2 === C_TYP_FUNCTION) {
-			customSettingsDisplayInit2();
-		}
-	}
+	g_customJsObj.settingsDisplay.forEach(func => func());
 
 	// ボタン描画
 	commonSettingBtn(`Settings`);
@@ -5352,12 +5314,7 @@ function settingsDisplayInit() {
 	setShortcutEvent(g_currentPage);
 	document.oncontextmenu = _ => true;
 
-	if (typeof skinSettingsDisplayInit === C_TYP_FUNCTION) {
-		skinSettingsDisplayInit();
-		if (typeof skinSettingsDisplayInit2 === C_TYP_FUNCTION) {
-			skinSettingsDisplayInit2();
-		}
-	}
+	g_skinJsObj.settingsDisplay.forEach(func => func());
 }
 
 /**
@@ -6032,12 +5989,7 @@ function keyConfigInit(_kcType = g_kcType) {
 	};
 
 	// ユーザカスタムイベント(初期)
-	if (typeof customKeyConfigInit === C_TYP_FUNCTION) {
-		customKeyConfigInit();
-		if (typeof customKeyConfigInit2 === C_TYP_FUNCTION) {
-			customKeyConfigInit2();
-		}
-	}
+	g_customJsObj.keyconfig.forEach(func => func());
 
 	// ラベル・ボタン描画
 	multiAppend(divRoot,
@@ -6162,15 +6114,8 @@ function keyConfigInit(_kcType = g_kcType) {
 		}
 	});
 
-	if (typeof skinKeyConfigInit === C_TYP_FUNCTION) {
-		skinKeyConfigInit();
-		if (typeof skinKeyConfigInit2 === C_TYP_FUNCTION) {
-			skinKeyConfigInit2();
-		}
-	}
-
+	g_skinJsObj.keyconfig.forEach(func => func());
 	document.onkeyup = evt => commonKeyUp(evt);
-
 	document.oncontextmenu = _ => false;
 }
 
@@ -6249,18 +6194,8 @@ function loadingScoreInit() {
 		g_headerObj.blankFrame = g_headerObj.blankFrameDef;
 
 		// ユーザカスタムイベント
-		if (typeof customPreloadingInit === C_TYP_FUNCTION) {
-			customPreloadingInit();
-			if (typeof customPreloadingInit2 === C_TYP_FUNCTION) {
-				customPreloadingInit2();
-			}
-		}
-		if (typeof skinPreloadingInit === C_TYP_FUNCTION) {
-			skinPreloadingInit();
-			if (typeof skinPreloadingInit2 === C_TYP_FUNCTION) {
-				skinPreloadingInit2();
-			}
-		}
+		g_customJsObj.preloading.forEach(func => func());
+		g_skinJsObj.preloading.forEach(func => func());
 
 		let dummyIdHeader = ``;
 		if (g_stateObj.dummyId !== ``) {
@@ -6280,7 +6215,7 @@ function loadingScoreInit() {
 
 		// 開始フレーム数の取得(フェードイン加味)
 		g_scoreObj.frameNum = getStartFrame(lastFrame, g_stateObj.fadein);
-		g_scoreObj.baseFrame;
+		g_scoreObj.baseFrame = g_scoreObj.frameNum;
 
 		// フレームごとの速度を取得（配列形式）
 		let speedOnFrame = setSpeedOnFrame(g_scoreObj.speedData, lastFrame);
@@ -6391,12 +6326,7 @@ function loadingScoreInit() {
 		getArrowSettings();
 
 		// ユーザカスタムイベント
-		if (typeof customLoadingInit === C_TYP_FUNCTION) {
-			customLoadingInit();
-			if (typeof customLoadingInit2 === C_TYP_FUNCTION) {
-				customLoadingInit2();
-			}
-		}
+		g_customJsObj.loading.forEach(func => func());
 
 		const tempId = setInterval(() => {
 			const executeMain = _ => {
@@ -8258,13 +8188,7 @@ function MainInit() {
 	}
 
 	// ユーザカスタムイベント(初期)
-	if (typeof customMainInit === C_TYP_FUNCTION) {
-		g_scoreObj.baseFrame = g_scoreObj.frameNum - g_stateObj.intAdjustment;
-		customMainInit();
-		if (typeof customMainInit2 === C_TYP_FUNCTION) {
-			customMainInit2();
-		}
-	}
+	g_customJsObj.main.forEach(func => func());
 
 	/**
 	 * キーを押したときの処理
@@ -8468,12 +8392,7 @@ function MainInit() {
 			if (_cnt === 0) {
 				const stepDivHit = document.querySelector(`#stepHit${_j}`);
 
-				if (typeof customJudgeDummyArrow === C_TYP_FUNCTION) {
-					customJudgeDummyArrow(_cnt);
-					if (typeof customJudgeDummyArrow2 === C_TYP_FUNCTION) {
-						customJudgeDummyArrow2(_cnt);
-					}
-				}
+				g_customJsObj.dummyArrow.forEach(func => func());
 				stepDivHit.style.top = `-15px`;
 				stepDivHit.style.opacity = 1;
 				stepDivHit.classList.value = ``;
@@ -8493,12 +8412,7 @@ function MainInit() {
 
 		// ダミーフリーズアロー(成功時)
 		dummyFrzOK: (_j, _k, _frzName, _cnt) => {
-			if (typeof customJudgeDummyFrz === C_TYP_FUNCTION) {
-				customJudgeDummyFrz(_cnt);
-				if (typeof customJudgeDummyFrz2 === C_TYP_FUNCTION) {
-					customJudgeDummyFrz2(_cnt);
-				}
-			}
+			g_customJsObj.dummyFrz.forEach(func => func());
 			$id(`frzHit${_j}`).opacity = 0;
 			g_attrObj[_frzName].judgEndFlg = true;
 			judgeObjDelete.dummyFrz(_j, _frzName);
@@ -8880,11 +8794,8 @@ function MainInit() {
 		}
 
 		// ユーザカスタムイベント(フレーム毎)
-		if (typeof customMainEnterFrame === C_TYP_FUNCTION) {
-			customMainEnterFrame();
-			if (typeof customMainEnterFrame2 === C_TYP_FUNCTION) {
-				customMainEnterFrame2();
-			}
+		g_customJsObj.mainEnterFrame.forEach(func => func());
+		if (g_customJsObj.mainEnterFrame.length > 0) {
 			g_scoreObj.baseFrame++;
 		}
 
@@ -9454,12 +9365,7 @@ function judgeIi(difFrame) {
 	lifeRecovery();
 	finishViewing();
 
-	if (typeof customJudgeIi === C_TYP_FUNCTION) {
-		customJudgeIi(difFrame);
-		if (typeof customJudgeIi2 === C_TYP_FUNCTION) {
-			customJudgeIi2(difFrame);
-		}
-	}
+	g_customJsObj.judg_ii.forEach(func => func(difFrame));
 }
 
 /**
@@ -9475,12 +9381,7 @@ function judgeShakin(difFrame) {
 	lifeRecovery();
 	finishViewing();
 
-	if (typeof customJudgeShakin === C_TYP_FUNCTION) {
-		customJudgeShakin(difFrame);
-		if (typeof customJudgeShakin2 === C_TYP_FUNCTION) {
-			customJudgeShakin2(difFrame);
-		}
-	}
+	g_customJsObj.judg_shakin.forEach(func => func(difFrame));
 }
 
 /**
@@ -9494,12 +9395,7 @@ function judgeMatari(difFrame) {
 	displayDiff(difFrame, g_headerObj.justFrames);
 	finishViewing();
 
-	if (typeof customJudgeMatari === C_TYP_FUNCTION) {
-		customJudgeMatari(difFrame);
-		if (typeof customJudgeMatari2 === C_TYP_FUNCTION) {
-			customJudgeMatari2(difFrame);
-		}
-	}
+	g_customJsObj.judg_matari.forEach(func => func(difFrame));
 }
 
 /**
@@ -9520,12 +9416,7 @@ function judgeShobon(difFrame) {
 	changeJudgeCharacter(`shobon`, g_lblNameObj.j_shobon);
 	judgeDamage();
 
-	if (typeof customJudgeShobon === C_TYP_FUNCTION) {
-		customJudgeShobon(difFrame);
-		if (typeof customJudgeShobon2 === C_TYP_FUNCTION) {
-			customJudgeShobon2(difFrame);
-		}
-	}
+	g_customJsObj.judg_shobon.forEach(func => func(difFrame));
 }
 
 /**
@@ -9536,12 +9427,7 @@ function judgeUwan(difFrame) {
 	changeJudgeCharacter(`uwan`, g_lblNameObj.j_uwan);
 	judgeDamage();
 
-	if (typeof customJudgeUwan === C_TYP_FUNCTION) {
-		customJudgeUwan(difFrame);
-		if (typeof customJudgeUwan2 === C_TYP_FUNCTION) {
-			customJudgeUwan2(difFrame);
-		}
-	}
+	g_customJsObj.judg_uwan.forEach(func => func(difFrame));
 }
 
 /**
@@ -9560,12 +9446,7 @@ function judgeKita(difFrame) {
 	lifeRecovery();
 	finishViewing();
 
-	if (typeof customJudgeKita === C_TYP_FUNCTION) {
-		customJudgeKita(difFrame);
-		if (typeof customJudgeKita2 === C_TYP_FUNCTION) {
-			customJudgeKita2(difFrame);
-		}
-	}
+	g_customJsObj.judg_kita.forEach(func => func(difFrame));
 }
 
 /**
@@ -9579,12 +9460,7 @@ function judgeIknai(difFrame) {
 
 	lifeDamage();
 
-	if (typeof customJudgeIknai === C_TYP_FUNCTION) {
-		customJudgeIknai(difFrame);
-		if (typeof customJudgeIknai2 === C_TYP_FUNCTION) {
-			customJudgeIknai2(difFrame);
-		}
-	}
+	g_customJsObj.judg_iknai.forEach(func => func(difFrame));
 }
 
 // クリア表示
@@ -9902,12 +9778,7 @@ function resultInit() {
 	}
 
 	// ユーザカスタムイベント(初期)
-	if (typeof customResultInit === C_TYP_FUNCTION) {
-		customResultInit();
-		if (typeof customResultInit2 === C_TYP_FUNCTION) {
-			customResultInit2();
-		}
-	}
+	g_customJsObj.result.forEach(func => func());
 
 	if (highscoreCondition) {
 
@@ -10067,12 +9938,7 @@ function resultInit() {
 	function flowResultTimeline() {
 
 		// ユーザカスタムイベント(フレーム毎)
-		if (typeof customResultEnterFrame === C_TYP_FUNCTION) {
-			customResultEnterFrame();
-			if (typeof customResultEnterFrame2 === C_TYP_FUNCTION) {
-				customResultEnterFrame2();
-			}
-		}
+		g_customJsObj.resultEnterFrame.forEach(func => func());
 
 		// 背景・マスクモーション
 		drawTitleResultMotion(g_currentPage);
@@ -10108,12 +9974,7 @@ function resultInit() {
 	setShortcutEvent(g_currentPage);
 	document.oncontextmenu = _ => true;
 
-	if (typeof skinResultInit === C_TYP_FUNCTION) {
-		skinResultInit();
-		if (typeof skinResultInit2 === C_TYP_FUNCTION) {
-			skinResultInit2();
-		}
-	}
+	g_skinJsObj.result.forEach(func => func());
 }
 
 /**

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2901,3 +2901,243 @@ const g_errMsgObj = {
     main: [],
     result: [],
 };
+
+/**
+ * カスタム関数の定義
+ */
+const g_customJsObj = {
+    title: [],
+    titleEnterFrame: [],
+    option: [],
+    difficulty: [],
+    settingsDisplay: [],
+    keyconfig: [],
+
+    preloading: [],
+    loading: [],
+    progress: [],
+    main: [],
+    dummyArrow: [],
+    dummyFrz: [],
+
+    judg_ii: [],
+    judg_shakin: [],
+    judg_matari: [],
+    judg_shobon: [],
+    judg_uwan: [],
+    judg_kita: [],
+    judg_iknai: [],
+
+    mainEnterFrame: [],
+    result: [],
+    resultEnterFrame: [],
+};
+
+/**
+ * スキン関数の定義
+ */
+const g_skinJsObj = {
+    title: [],
+    option: [],
+    settingsDisplay: [],
+    keyconfig: [],
+
+    preloading: [],
+    loading: [],
+    main: [],
+    result: [],
+};
+
+const loadLegacyCustomFunc = _ => {
+
+    // タイトル
+    if (typeof customTitleInit === C_TYP_FUNCTION) {
+        g_customJsObj.title.push(customTitleInit);
+    }
+    if (typeof customTitleInit2 === C_TYP_FUNCTION) {
+        g_customJsObj.title.push(customTitleInit2);
+    }
+    if (typeof customTitleEnterFrame === C_TYP_FUNCTION) {
+        g_customJsObj.titleEnterFrame.push(customTitleEnterFrame);
+    }
+    if (typeof customTitleEnterFrame2 === C_TYP_FUNCTION) {
+        g_customJsObj.titleEnterFrame.push(customTitleEnterFrame2);
+    }
+    if (typeof skinTitleInit === C_TYP_FUNCTION) {
+        g_skinJsObj.title.push(skinTitleInit);
+    }
+    if (typeof skinTitleInit2 === C_TYP_FUNCTION) {
+        g_skinJsObj.title.push(skinTitleInit2);
+    }
+
+    // 主要設定
+    if (typeof customOptionInit === C_TYP_FUNCTION) {
+        g_customJsObj.option.push(customOptionInit);
+    }
+    if (typeof customOptionInit2 === C_TYP_FUNCTION) {
+        g_customJsObj.option.push(customOptionInit2);
+    }
+    if (typeof skinOptionInit === C_TYP_FUNCTION) {
+        g_skinJsObj.option.push(skinOptionInit);
+    }
+    if (typeof skinOptionInit2 === C_TYP_FUNCTION) {
+        g_skinJsObj.option.push(skinOptionInit2);
+    }
+
+    if (typeof customSetDifficulty === C_TYP_FUNCTION) {
+        g_customJsObj.difficulty.push(customSetDifficulty);
+    }
+    if (typeof customSetDifficulty2 === C_TYP_FUNCTION) {
+        g_customJsObj.difficulty.push(customSetDifficulty2);
+    }
+
+    // ディスプレイ設定
+    if (typeof customSettingsDisplayInit === C_TYP_FUNCTION) {
+        g_customJsObj.settingsDisplay.push(customSettingsDisplayInit);
+    }
+    if (typeof customSettingsDisplayInit2 === C_TYP_FUNCTION) {
+        g_customJsObj.settingsDisplay.push(customSettingsDisplayInit2);
+    }
+    if (typeof skinSettingsDisplayInit === C_TYP_FUNCTION) {
+        g_skinJsObj.settingsDisplay.push(skinSettingsDisplayInit);
+    }
+    if (typeof skinSettingsDisplayInit2 === C_TYP_FUNCTION) {
+        g_skinJsObj.settingsDisplay.push(skinSettingsDisplayInit2);
+    }
+
+    // キーコンフィグ
+    if (typeof customKeyConfigInit === C_TYP_FUNCTION) {
+        g_customJsObj.keyconfig.push(customKeyConfigInit);
+    }
+    if (typeof customKeyConfigInit2 === C_TYP_FUNCTION) {
+        g_customJsObj.keyconfig.push(customKeyConfigInit2);
+    }
+    if (typeof skinKeyConfigInit === C_TYP_FUNCTION) {
+        g_skinJsObj.keyconfig.push(skinKeyConfigInit);
+    }
+    if (typeof skinKeyConfigInit2 === C_TYP_FUNCTION) {
+        g_skinJsObj.keyconfig.push(skinKeyConfigInit2);
+    }
+
+    // ローディング
+    if (typeof customPreloadingInit === C_TYP_FUNCTION) {
+        g_customJsObj.preloading.push(customPreloadingInit);
+    }
+    if (typeof customPreloadingInit2 === C_TYP_FUNCTION) {
+        g_customJsObj.preloading.push(customPreloadingInit2);
+    }
+    if (typeof skinPreloadingInit === C_TYP_FUNCTION) {
+        g_skinJsObj.preloading.push(skinPreloadingInit);
+    }
+    if (typeof skinPreloadingInit2 === C_TYP_FUNCTION) {
+        g_skinJsObj.preloading.push(skinPreloadingInit2);
+    }
+    if (typeof customLoadingInit === C_TYP_FUNCTION) {
+        g_customJsObj.loading.push(customLoadingInit);
+    }
+    if (typeof customLoadingInit2 === C_TYP_FUNCTION) {
+        g_customJsObj.loading.push(customLoadingInit2);
+    }
+    if (typeof customLoadingProgress === C_TYP_FUNCTION) {
+        g_customJsObj.progress.push(customLoadingProgress);
+    }
+    if (typeof customLoadingProgress2 === C_TYP_FUNCTION) {
+        g_customJsObj.progress.push(customLoadingProgress2);
+    }
+
+    // メイン
+    if (typeof customMainInit === C_TYP_FUNCTION) {
+        g_customJsObj.main.push(customMainInit);
+    }
+    if (typeof customMainInit2 === C_TYP_FUNCTION) {
+        g_customJsObj.main.push(customMainInit2);
+    }
+    if (typeof customJudgeDummyArrow === C_TYP_FUNCTION) {
+        g_customJsObj.dummyArrow.push(customJudgeDummyArrow);
+    }
+    if (typeof customJudgeDummyArrow2 === C_TYP_FUNCTION) {
+        g_customJsObj.dummyArrow.push(customJudgeDummyArrow2);
+    }
+    if (typeof customJudgeDummyFrz === C_TYP_FUNCTION) {
+        g_customJsObj.dummyFrz.push(customJudgeDummyFrz);
+    }
+    if (typeof customJudgeDummyFrz2 === C_TYP_FUNCTION) {
+        g_customJsObj.dummyFrz.push(customJudgeDummyFrz2);
+    }
+    if (typeof customMainEnterFrame === C_TYP_FUNCTION) {
+        g_customJsObj.mainEnterFrame.push(customMainEnterFrame);
+    }
+    if (typeof customMainEnterFrame2 === C_TYP_FUNCTION) {
+        g_customJsObj.mainEnterFrame.push(customMainEnterFrame2);
+    }
+    if (typeof skinMainInit === C_TYP_FUNCTION) {
+        g_skinJsObj.main.push(skinMainInit);
+    }
+    if (typeof skinMainInit2 === C_TYP_FUNCTION) {
+        g_skinJsObj.main.push(skinMainInit2);
+    }
+
+    // 判定
+    if (typeof customJudgeIi === C_TYP_FUNCTION) {
+        g_customJsObj.judg_ii.push(customJudgeIi);
+    }
+    if (typeof customJudgeIi2 === C_TYP_FUNCTION) {
+        g_customJsObj.judg_ii.push(customJudgeIi2);
+    }
+    if (typeof customJudgeShakin === C_TYP_FUNCTION) {
+        g_customJsObj.judg_shakin.push(customJudgeShakin);
+    }
+    if (typeof customJudgeShakin2 === C_TYP_FUNCTION) {
+        g_customJsObj.judg_shakin.push(customJudgeShakin2);
+    }
+    if (typeof customJudgeMatari === C_TYP_FUNCTION) {
+        g_customJsObj.judg_matari.push(customJudgeMatari);
+    }
+    if (typeof customJudgeMatari2 === C_TYP_FUNCTION) {
+        g_customJsObj.judg_matari.push(customJudgeMatari2);
+    }
+    if (typeof customJudgeShobon === C_TYP_FUNCTION) {
+        g_customJsObj.judg_shobon.push(customJudgeShobon);
+    }
+    if (typeof customJudgeShobon2 === C_TYP_FUNCTION) {
+        g_customJsObj.judg_shobon.push(customJudgeShobon2);
+    }
+    if (typeof customJudgeUwan === C_TYP_FUNCTION) {
+        g_customJsObj.judg_uwan.push(customJudgeUwan);
+    }
+    if (typeof customJudgeUwan2 === C_TYP_FUNCTION) {
+        g_customJsObj.judg_uwan.push(customJudgeUwan2);
+    }
+    if (typeof customJudgeKita === C_TYP_FUNCTION) {
+        g_customJsObj.judg_kita.push(customJudgeKita);
+    }
+    if (typeof customJudgeKita2 === C_TYP_FUNCTION) {
+        g_customJsObj.judg_kita.push(customJudgeKita2);
+    }
+    if (typeof customJudgeIknai === C_TYP_FUNCTION) {
+        g_customJsObj.judg_iknai.push(customJudgeIknai);
+    }
+    if (typeof customJudgeIknai2 === C_TYP_FUNCTION) {
+        g_customJsObj.judg_iknai.push(customJudgeIknai2);
+    }
+
+    // リザルト
+    if (typeof customResultInit === C_TYP_FUNCTION) {
+        g_customJsObj.result.push(customResultInit);
+    }
+    if (typeof customResultInit2 === C_TYP_FUNCTION) {
+        g_customJsObj.result.push(customResultInit2);
+    }
+    if (typeof customResultEnterFrame === C_TYP_FUNCTION) {
+        g_customJsObj.resultEnterFrame.push(customResultEnterFrame);
+    }
+    if (typeof customResultEnterFrame2 === C_TYP_FUNCTION) {
+        g_customJsObj.resultEnterFrame.push(customResultEnterFrame2);
+    }
+    if (typeof skinResultInit === C_TYP_FUNCTION) {
+        g_skinJsObj.result.push(skinResultInit);
+    }
+    if (typeof skinResultInit2 === C_TYP_FUNCTION) {
+        g_skinJsObj.result.push(skinResultInit2);
+    }
+};

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2904,6 +2904,7 @@ const g_errMsgObj = {
 
 /**
  * カスタム関数の定義
+ * - 挿入場所ごとに名前を分けて定義
  */
 const g_customJsObj = {
     title: [],
@@ -2935,6 +2936,7 @@ const g_customJsObj = {
 
 /**
  * スキン関数の定義
+ * - 挿入場所ごとに名前を分けて定義
  */
 const g_skinJsObj = {
     title: [],
@@ -2948,6 +2950,10 @@ const g_skinJsObj = {
     result: [],
 };
 
+/**
+ * 従来のカスタム関数をg_customJsObj, g_skinJsObjへ追加
+ * - customjsファイルを読み込んだ直後にこの関数を呼び出している
+ */
 const loadLegacyCustomFunc = _ => {
 
     // タイトル


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. js/cssファイルの読み込み方法を見直しました。
これによりcustomjs、skinTypeが3つ以上指定できるようになります。
2. カスタム関数の呼び出し方法を変更しました。
customjsの場合は「g_customJsObj.画面名」、skinTypeの場合は「g_skinJsObj.画面名」に
関数を追加していく形になります。
    - 互換のため、従来の関数も呼び出しできるようにしています。
    - この変更により、3つ目以降のファイルについて新たなカスタム関数を呼び出すことが可能になりますが、
呼び出し方法が変わりますので、ご注意ください。
3. カスタム関数 （XXXInit, XXXInit2 など）について、XXXInitが無くてもXXXInit2の直接呼び出しが可能になりました。

### 従来の呼び出し方法 (メインのフレーム毎処理の場合)
```javascript
function customMainEnterFrame2() {
    // 省略
}
```

### 今後の呼び出し方法１ (任意の関数を追加)
- カスタムファイル中、追加したい箇所へ記述することで可能です。
- 添え字を使わないため、これまでのやり方に近いと思います。
```javascript
function anotherCustomFunction() {

}
// anotherCustomFunctionをメインのフレーム毎処理に追加
g_customJsObj.mainEnterFrame.push(anotherCustomFunction); 
```

### 今後の呼び出し方法２ (直接配列へ関数を追加)
- g_customJsObjもしくはg_skinJsObjに直接関数を追加します。
- 既存関数を置き換える場合や、順序性を重視する場合はこちらの方が良いかもしれません。
※現状、既存関数を廃止する予定はありません。
```javascript
// 配列の添え字は0番目が1つ目、1番目が2つ目の関数となる
// 3つ目以降を指定したい場合は、添え字の数を増やすことで可能
g_customJsObj.mainEnterFrame[1] = _ => {
    // 省略
}
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 従来の2ファイルを前提とした読込方法だと無理があるため。
2. 3ファイル以上のカスタムファイルの呼び出しが必要になる可能性があるため。
3. 2.の変更に伴い、制限を撤廃しました。
事前にカスタム関数があるかどうかを見る形式に変わったためです。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 従来関数の互換対応は、danoni_constants.js 側にまとめています。
カスタムファイル読込後にloadLegacyCustomFuncを呼び出すことで従来カスタム関数の有効化処理を行います。
- danoni_setting.js の「g_presetCustomJs」「g_presetSkinType」は、
カンマ区切りで記載することで複数指定が可能です。
配列化を検討しましたが、利用頻度が高いと思われ安易に廃止できないためこの形とします。
```javascript
// カンマの前後は半角スペースを入れないこと
const g_presetCustomJs = `danoni_custom.js,danoni_original_setting.js`;
const g_presetSkinType = `default,background`;
```