### PR TITLE
[0502/custom-css] cssファイルを追加で外部読込できる機能を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1809,6 +1809,11 @@ function calcLevel(_scoreObj) {
 function loadMultipleFile(_j, _fileData, _loadType, _afterFunc = _ => true) {
 	if (_j < _fileData.length) {
 		const filePath = `${_fileData[_j][1]}${_fileData[_j][0]}?${new Date().getTime()}`;
+		if (_fileData[_j][0].endsWith(`.css`)) {
+			_loadType = `css`;
+		}
+
+		// jsファイル、cssファイルにより呼び出す関数を切替
 		if (_loadType === `js`) {
 			loadScript(filePath, _ =>
 				loadMultipleFile(_j + 1, _fileData, _loadType, _afterFunc), false);
@@ -2743,8 +2748,10 @@ function preheaderConvert(_dosObj) {
 
 	const setJsFiles = (_files, _defaultDir, _type = `custom`) => {
 		_files.forEach(file => {
-			const [jsFile, jsDir] = getFilePath(file, _defaultDir);
-			obj.jsData.push([_type === `skin` ? `danoni_skin_${jsFile}.js` : jsFile, jsDir]);
+			if (hasVal(file)) {
+				const [jsFile, jsDir] = getFilePath(file, _defaultDir);
+				obj.jsData.push([_type === `skin` ? `danoni_skin_${jsFile}.js` : jsFile, jsDir]);
+			}
 		});
 	};
 
@@ -2755,6 +2762,10 @@ function preheaderConvert(_dosObj) {
 	// 外部jsファイルの指定
 	const tmpCustomjs = _dosObj.customjs || (typeof g_presetCustomJs === C_TYP_STRING ? g_presetCustomJs : C_JSF_CUSTOM);
 	setJsFiles(tmpCustomjs.split(`,`), C_DIR_JS);
+
+	// 外部cssファイルの指定
+	const tmpCustomcss = _dosObj.customcss || (typeof g_presetCustomCss === C_TYP_STRING ? g_presetCustomCsJs : ``);
+	setJsFiles(tmpCustomcss.split(`,`), C_DIR_CSS);
 
 	// デフォルト曲名表示、背景、Ready表示の利用有無
 	g_titleLists.init.forEach(objName => {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1482,7 +1482,7 @@ function initAfterDosLoaded() {
 
 	// CSSファイルの読み込み
 	const skinList = g_headerObj.jsData.filter(file => file[0].indexOf(`danoni_skin`) !== -1);
-	loadMultipleFile(0, skinList, `css`, _ => initAfterCssLoaded());
+	loadMultipleFiles(0, skinList, `css`, _ => initAfterCssLoaded());
 
 	/**
 	 * スキンCSSファイルを読み込んだ後の処理
@@ -1547,7 +1547,7 @@ function initAfterDosLoaded() {
 
 		if (g_loadObj.main) {
 			// customjsの読み込み後、譜面詳細情報取得のために譜面をロード
-			loadMultipleFile(0, g_headerObj.jsData, `js`, _ => {
+			loadMultipleFiles(0, g_headerObj.jsData, `js`, _ => {
 				loadLegacyCustomFunc();
 				loadDos(_ => getScoreDetailData(0), 0, true);
 			});
@@ -1806,7 +1806,7 @@ function calcLevel(_scoreObj) {
  * @param {string} _loadType
  * @param {function} _afterFunc 
  */
-function loadMultipleFile(_j, _fileData, _loadType, _afterFunc = _ => true) {
+function loadMultipleFiles(_j, _fileData, _loadType, _afterFunc = _ => true) {
 	if (_j < _fileData.length) {
 		const filePath = `${_fileData[_j][1]}${_fileData[_j][0]}?${new Date().getTime()}`;
 		if (_fileData[_j][0].endsWith(`.css`)) {
@@ -1816,11 +1816,11 @@ function loadMultipleFile(_j, _fileData, _loadType, _afterFunc = _ => true) {
 		// jsファイル、cssファイルにより呼び出す関数を切替
 		if (_loadType === `js`) {
 			loadScript(filePath, _ =>
-				loadMultipleFile(_j + 1, _fileData, _loadType, _afterFunc), false);
+				loadMultipleFiles(_j + 1, _fileData, _loadType, _afterFunc), false);
 		} else if (_loadType === `css`) {
 			const cssPath = filePath.split(`.js`).join(`.css`);
 			importCssFile(cssPath, _ =>
-				loadMultipleFile(_j + 1, _fileData, _loadType, _afterFunc));
+				loadMultipleFiles(_j + 1, _fileData, _loadType, _afterFunc));
 		}
 	} else {
 		_afterFunc();

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2764,7 +2764,7 @@ function preheaderConvert(_dosObj) {
 	setJsFiles(tmpCustomjs.split(`,`), C_DIR_JS);
 
 	// 外部cssファイルの指定
-	const tmpCustomcss = _dosObj.customcss || (typeof g_presetCustomCss === C_TYP_STRING ? g_presetCustomCsJs : ``);
+	const tmpCustomcss = _dosObj.customcss || (typeof g_presetCustomCss === C_TYP_STRING ? g_presetCustomCss : ``);
 	setJsFiles(tmpCustomcss.split(`,`), C_DIR_CSS);
 
 	// デフォルト曲名表示、背景、Ready表示の利用有無

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -19,7 +19,10 @@ const g_presetTuningUrl = `https://www.google.co.jp/`;
 const g_presetSkinType = `default`;
 
 // 既定カスタムJs (デフォルトは danoni_custom.js)
-//const g_presetCustomJs = `danoni_custom.js`;
+//const g_presetCustomJs = `danoni_custom.js,danoni_init.js`;
+
+// 既定カスタムCss (デフォルトは指定なし、cssフォルダを参照)
+//const g_presetCustomCss = `danoni_custom.css`;
 
 // ゲージ設定（デフォルト）
 const g_presetGauge = {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. cssファイルを追加で外部読込できる機能を追加しました。
使い方はcustomjs、g_presetCustomJsと同じです。
    - 譜面側：customcss
    - danoni_setting.js：g_presetCustomCss
2. loadMultipleFile -> loadMultipleFiles に関数名を変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. アニメーションなどの格納にcssファイルを外部で持たせる場合があるため。
2. 他の関数との名称整合のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
