### PR TITLE
[0503/baseframe] g_scoreObj.baseFrameの設定誤りを修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6226,7 +6226,7 @@ function loadingScoreInit() {
 
 		// 開始フレーム数の取得(フェードイン加味)
 		g_scoreObj.frameNum = getStartFrame(lastFrame, g_stateObj.fadein);
-		g_scoreObj.baseFrame = g_scoreObj.frameNum;
+		g_scoreObj.baseFrame = g_scoreObj.frameNum - g_stateObj.intAdjustment;
 
 		// フレームごとの速度を取得（配列形式）
 		let speedOnFrame = setSpeedOnFrame(g_scoreObj.speedData, lastFrame);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. g_scoreObj.baseFrameの設定誤りを修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Resolves #1196 
`g_scoreObj.baseFrame`の設定について、従来はcustomMainInitの前に定義されていたが、
ver25.3.0のコード整理の際に消してしまったため。
g_scoreObj.frameNum - g_stateObj.intAdjustment が正しい。
(g_stateObj.intAdjustment = preblankFrame + ヘッダのAdjustment + 設定でのAdjustmentの整数値) 

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- ver25.3.0でのみ発生します。