### PR TITLE
[0506/clipboard-api] クリップボードコピーの方法を変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -578,28 +578,17 @@ function getFontSize(_str, _maxWidth, _font = getBasicFont(), _maxFontsize = 64,
 
 /**
  * クリップボードコピー関数
- * 入力値をクリップボードへコピーする
+ * 入力値をクリップボードへコピーし、メッセージを表示
  * @param {string} _textVal 入力値
+ * @param {string} _msg
  */
-function copyTextToClipboard(_textVal) {
-	// テキストエリアを用意する
-	const copyFrom = document.createElement(`textarea`);
-	// テキストエリアへ値をセット
-	copyFrom.textContent = _textVal;
-
-	// bodyタグの要素を取得
-	const bodyElm = document.getElementsByTagName(`body`)[0];
-	// 子要素にテキストエリアを配置
-	bodyElm.appendChild(copyFrom);
-
-	// テキストエリアの値を選択
-	copyFrom.select();
-	// コピーコマンド発行
-	const retVal = document.execCommand(`copy`);
-	// 追加テキストエリアを削除
-	bodyElm.removeChild(copyFrom);
-	// 処理結果を返却
-	return retVal;
+async function copyTextToClipboard(_textVal, _msg) {
+	try {
+		await navigator.clipboard.writeText(_textVal);
+		makeInfoWindow(_msg, `leftToRightFade`);
+	} catch (error) {
+		makeInfoWindow(g_msgInfoObj.W_0021, `leftToRightFade`, `#ffffcc`);
+	}
 }
 
 /**
@@ -2644,8 +2633,8 @@ function makeWarningWindow(_text = ``, { resetFlg = false, backBtnUse = false } 
  * お知らせウィンドウ（汎用）を表示
  * @param {string} _text 
  */
-function makeInfoWindow(_text, _animationName = ``) {
-	const lblWarning = setWindowStyle(`<p>${_text}</p>`, `#ccccff`, `#000066`, C_ALIGN_CENTER);
+function makeInfoWindow(_text, _animationName = ``, _backColor = `#ccccff`) {
+	const lblWarning = setWindowStyle(`<p>${_text}</p>`, _backColor, `#000066`, C_ALIGN_CENTER);
 	lblWarning.style.pointerEvents = C_DIS_NONE;
 
 	if (_animationName !== ``) {
@@ -4533,9 +4522,8 @@ function createOptionWindow(_sprite) {
 			makeSettingLblCssButton(`lnkDifInfo`, g_lblNameObj.s_print, 0, _ => {
 				copyTextToClipboard(
 					`****** ${g_lblNameObj.s_printTitle} [${g_version}] ******\r\n\r\n`
-					+ `\t${g_lblNameObj.s_printHeader}\r\n\r\n${printData}`
+					+ `\t${g_lblNameObj.s_printHeader}\r\n\r\n${printData}`, g_msgInfoObj.I_0003
 				);
-				makeInfoWindow(g_msgInfoObj.I_0003, `leftToRightFade`);
 			}, {
 				x: 10, y: 30, w: 100, borderStyle: `solid`
 			}, g_cssObj.button_RevON),
@@ -9896,8 +9884,7 @@ function resultInit() {
 
 		// リザルトデータをクリップボードへコピー
 		createCss2Button(`btnCopy`, g_lblNameObj.b_copy, _ => {
-			copyTextToClipboard(resultText);
-			makeInfoWindow(g_msgInfoObj.I_0001, `leftToRightFade`);
+			copyTextToClipboard(resultText, g_msgInfoObj.I_0001);
 		}, {
 			x: g_sWidth / 4,
 			w: g_sWidth / 2,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2436,6 +2436,7 @@ const g_lang_msgInfoObj = {
         W_0012: `現在の設定では音源再生方法により小数の Adjustment が利用できません。<br>
         また、Fadein を使用した場合は通常よりズレが発生することがあります。<br>
         音源ファイルを js/txt 化するか、サーバー上動作とすれば解消します。(W-0012)`,
+        W_0021: `クリップボードのコピーに失敗しました。`,
 
         E_0011: `アーティスト名が未入力です。(E-0011)`,
         E_0012: `曲名情報が未設定です。(E-0012)<br>
@@ -2482,6 +2483,7 @@ const g_lang_msgInfoObj = {
         Also, if you use "Fadein", it may be out of alignment.<br>
         It can be solved by converting the sound source file to encoded data (js, txt) or 
         operating it on the server. (W-0012)`,
+        W_0021: `Failed to copy the clipboard.`,
 
         E_0011: `The artist name is not set. (E-0011)`,
         E_0012: `The song title information is not set. (E-0012)<br>


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. クリップボードコピーの方法を変更しました。
2. copyTextToClipboard関数の中にmakeInfoWindow関数を内包するようにしました。
3. makeInfoWindow関数の引数に _backColor を追加しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. `document.execCommand`が非推奨になっているため。
代替として、Clipboard APIを使用します。
https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText
2. 現状、クリップボードコピーが完了した場合にメッセージを表示しているため。
3. クリップボードコピーに失敗することがあり、そのときのメッセージカラーを変える必要が出てきたため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments