### PR TITLE
[0507/back-current-path] back/maskデータで画像パスのカレントディレクトリ指定に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1143,8 +1143,10 @@ function makeSpriteData(_data, _calcFrame = _frame => _frame) {
 			};
 			if (g_headerObj.autoPreload) {
 				if (checkImage(tmpObj.path)) {
-					const [file, dir] = getFilePath(tmpObj.path, `./`);
-					tmpObj.path = `${dir}/${file}`;
+					if (g_headerObj.syncBackPath) {
+						const [file, dir] = getFilePath(tmpObj.path, `./`);
+						tmpObj.path = `${dir}/${file}`;
+					}
 					preloadFile(`image`, tmpObj.path);
 				}
 			}
@@ -2767,6 +2769,10 @@ function preheaderConvert(_dosObj) {
 			(typeof g_presetCustomDesignUse === C_TYP_OBJECT && (objName in g_presetCustomDesignUse) ?
 				setVal(g_presetCustomDesignUse[objName], false, C_TYP_BOOLEAN) : false), C_TYP_BOOLEAN);
 	});
+
+	// 背景・マスクモーションのパス指定方法を他の設定に合わせる設定
+	const tmpSyncBackPath = (typeof g_presetSyncBackPath === C_TYP_BOOLEAN ? g_presetSyncBackPath : false);
+	obj.syncBackPath = setVal(_dosObj.syncBackPath, tmpSyncBackPath, C_TYP_BOOLEAN);
 
 	return obj;
 }

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1145,7 +1145,7 @@ function makeSpriteData(_data, _calcFrame = _frame => _frame) {
 				if (checkImage(tmpObj.path)) {
 					if (g_headerObj.syncBackPath) {
 						const [file, dir] = getFilePath(tmpObj.path, `./`);
-						tmpObj.path = `${dir}/${file}`;
+						tmpObj.path = `${dir}${file}`;
 					}
 					preloadFile(`image`, tmpObj.path);
 				}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1143,6 +1143,8 @@ function makeSpriteData(_data, _calcFrame = _frame => _frame) {
 			};
 			if (g_headerObj.autoPreload) {
 				if (checkImage(tmpObj.path)) {
+					const [file, dir] = getFilePath(tmpObj.path, `./`);
+					tmpObj.path = `${dir}/${file}`;
 					preloadFile(`image`, tmpObj.path);
 				}
 			}

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -24,6 +24,9 @@ const g_presetSkinType = `default`;
 // 既定カスタムCss (デフォルトは指定なし、cssフォルダを参照)
 //const g_presetCustomCss = `danoni_custom.css`;
 
+// 背景・マスクモーションで使用する画像パスの指定方法を他の設定に合わせる設定 (trueで有効化)
+// const g_presetSyncBackPath = true;
+
 // ゲージ設定（デフォルト）
 const g_presetGauge = {
 	//	Border: 70,  // ノルマ制でのボーダーライン、ライフ制にしたい場合は `x` を指定


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. back/maskデータで画像パスのカレントディレクトリ指定に対応しました。
別のフォルダに作品ファイルを移動しても、danoni_main.jsの場所が適切に指定されていればそれに追随します。
2. 1.を設定で切り替えられるようにしました。
譜面ヘッダーでは「syncBackPath」、danoni_setting.jsでは「g_presetSyncBackPath」で指定します。
「true」にすると有効化します。デフォルトは「false」です。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. このデータのみ、他と違ってフォルダの追随設定・カレントディレクトリ指定ができなかったため。
2. 既存作品に影響を与える可能性があるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 最初からサブディレクトリなど違う場所に作品ページを置いている場合、
今回の変更を適用すると画像が反映されない可能性があります。
念のため、譜面ヘッダーかdanoni_setting.jsでの代替手段を用意する方向で考えます。