### PR TITLE
[0508/get-name] 冗長な名称呼び出しを取り止め、key名の変更に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4211,7 +4211,7 @@ function createOptionWindow(_sprite) {
 	// 縦位置: 2  短縮ショートカットあり
 	createGeneralSetting(spriteList.speed, `speed`, {
 		skipTerms: [20, 5, 1], hiddenBtn: true, scLabel: g_lblNameObj.sc_speed, roundNum: 5,
-		unitName: ` ${getStgDetailName(g_lblNameObj.multi)}`,
+		unitName: ` ${g_lblNameObj.multi}`,
 	});
 
 	if (g_headerObj.scoreDetailUse) {
@@ -4799,7 +4799,7 @@ function createOptionWindow(_sprite) {
 	// 縦位置: 10  短縮ショートカットあり
 	createGeneralSetting(spriteList.adjustment, `adjustment`, {
 		skipTerms: [50, 10, 5], hiddenBtn: true, scLabel: g_lblNameObj.sc_adjustment, roundNum: 5,
-		unitName: `${getStgDetailName(g_lblNameObj.frame)}`,
+		unitName: g_lblNameObj.frame,
 	});
 
 	// ---------------------------------------------------
@@ -4807,7 +4807,7 @@ function createOptionWindow(_sprite) {
 	// 縦位置: 11 スライダーあり
 	spriteList.fadein.appendChild(createLblSetting(`Fadein`));
 
-	const lnkFadein = createDivCss2Label(`lnkFadein`, `${g_stateObj.fadein}${getStgDetailName(g_lblNameObj.percent)}`, {
+	const lnkFadein = createDivCss2Label(`lnkFadein`, `${g_stateObj.fadein}${g_lblNameObj.percent}`, {
 		x: C_LEN_SETLBL_LEFT, y: 0,
 	}, g_cssObj.settings_FadeinBar);
 	spriteList.fadein.appendChild(lnkFadein);
@@ -4815,7 +4815,7 @@ function createOptionWindow(_sprite) {
 	const setFadein = _sign => {
 		g_stateObj.fadein = nextPos(g_stateObj.fadein, _sign, 100);
 		fadeinSlider.value = g_stateObj.fadein;
-		lnkFadein.textContent = `${g_stateObj.fadein}${getStgDetailName(g_lblNameObj.percent)}`;
+		lnkFadein.textContent = `${g_stateObj.fadein}${g_lblNameObj.percent}`;
 	};
 
 	multiAppend(spriteList.fadein,
@@ -4834,13 +4834,13 @@ function createOptionWindow(_sprite) {
 	const fadeinSlider = document.querySelector(`#fadeinSlider`);
 	fadeinSlider.addEventListener(`input`, _ => {
 		g_stateObj.fadein = parseInt(fadeinSlider.value);
-		lnkFadein.textContent = `${g_stateObj.fadein}${getStgDetailName(g_lblNameObj.percent)}`;
+		lnkFadein.textContent = `${g_stateObj.fadein}${g_lblNameObj.percent}`;
 	}, false);
 
 	// ---------------------------------------------------
 	// ボリューム (Volume) 
 	// 縦位置: 12
-	createGeneralSetting(spriteList.volume, `volume`, { unitName: getStgDetailName(g_lblNameObj.percent) });
+	createGeneralSetting(spriteList.volume, `volume`, { unitName: g_lblNameObj.percent });
 
 	/**
 	 * 譜面初期化処理
@@ -4961,7 +4961,7 @@ function createOptionWindow(_sprite) {
 
 		// 譜面名設定 (Difficulty)
 		const difWidth = parseFloat(lnkDifficulty.style.width);
-		const difNames = [`${getKeyName(g_keyObj.currentKey)} key / ${g_headerObj.difLabels[g_stateObj.scoreId]}`];
+		const difNames = [`${getKeyName(g_keyObj.currentKey)} ${getStgDetailName('key')} / ${g_headerObj.difLabels[g_stateObj.scoreId]}`];
 		lnkDifficulty.style.fontSize = `${getFontSize(difNames[0], difWidth, getBasicFont(), C_SIZ_SETLBL)}px`;
 
 		if (g_headerObj.makerView) {
@@ -4974,7 +4974,7 @@ function createOptionWindow(_sprite) {
 		lnkDifficulty.innerHTML = difNames.join(``);
 
 		// 速度設定 (Speed)
-		setSetting(0, `speed`, ` ${getStgDetailName(g_lblNameObj.multi)}`);
+		setSetting(0, `speed`, ` ${g_lblNameObj.multi}`);
 		if (g_headerObj.scoreDetailUse) {
 			drawSpeedGraph(g_stateObj.scoreId);
 			drawDensityGraph(g_stateObj.scoreId);
@@ -5357,13 +5357,13 @@ function createSettingsDisplayWindow(_sprite) {
 
 	// Hidden+/Sudden+初期値用スライダー、ロックボタン
 	multiAppend(spriteList.appearance,
-		createDivCss2Label(`lblAppearancePos`, `${g_hidSudObj.filterPos}${getStgDetailName(g_lblNameObj.percent)}`, {
+		createDivCss2Label(`lblAppearancePos`, `${g_hidSudObj.filterPos}${g_lblNameObj.percent}`, {
 			x: C_LEN_SETLBL_LEFT, y: 20, siz: 12, align: C_ALIGN_CENTER,
 		}),
 		createDivCss2Label(`lblAppearanceBar`, `<input id="appearanceSlider" type="range" value="${g_hidSudObj.filterPos}" min="0" max="100" step="1">`, {
 			x: C_LEN_SETLBL_LEFT, y: 15,
 		}),
-		createCss2Button(`lnkLockBtn`, `${getStgDetailName(g_lblNameObj.filterLock)}`, evt => setLockView(evt.target), {
+		createCss2Button(`lnkLockBtn`, g_lblNameObj.filterLock, evt => setLockView(evt.target), {
 			x: C_LEN_SETLBL_LEFT + C_LEN_SETLBL_WIDTH - 40, y: 0, w: 40, h: C_LEN_SETLBL_HEIGHT, siz: 12,
 			borderStyle: `solid`, cxtFunc: evt => setLockView(evt.target),
 		}, g_cssObj.button_Default, g_cssObj[`button_Rev${g_stateObj.filterLock}`]),
@@ -5381,7 +5381,7 @@ function createSettingsDisplayWindow(_sprite) {
 	const appearanceSlider = document.querySelector(`#appearanceSlider`);
 	appearanceSlider.addEventListener(`input`, _ => {
 		g_hidSudObj.filterPos = parseInt(appearanceSlider.value);
-		lblAppearancePos.textContent = `${g_hidSudObj.filterPos}${getStgDetailName(g_lblNameObj.percent)}`;
+		lblAppearancePos.textContent = `${g_hidSudObj.filterPos}${g_lblNameObj.percent}`;
 	}, false);
 
 	const dispAppearanceSlider = _ => {
@@ -5395,7 +5395,7 @@ function createSettingsDisplayWindow(_sprite) {
 	// ---------------------------------------------------
 	// 判定表示系の不透明度 (Opacity)
 	// 縦位置: 9
-	createGeneralSetting(spriteList.opacity, `opacity`, { unitName: getStgDetailName(g_lblNameObj.percent), displayName: g_currentPage });
+	createGeneralSetting(spriteList.opacity, `opacity`, { unitName: g_lblNameObj.percent, displayName: g_currentPage });
 
 	/**
 	 * Display表示/非表示ボタン
@@ -9611,14 +9611,14 @@ function resultInit() {
 	}
 
 	let difData = [
-		`${getKeyName(g_headerObj.keyLabels[g_stateObj.scoreId])}${transKeyData} key / ${g_headerObj.difLabels[g_stateObj.scoreId]}`,
+		`${getKeyName(g_headerObj.keyLabels[g_stateObj.scoreId])}${transKeyData} ${getStgDetailName('key')} / ${g_headerObj.difLabels[g_stateObj.scoreId]}`,
 		`${withOptions(g_autoPlaysBase.includes(g_stateObj.autoPlay), true, `-${getStgDetailName(g_stateObj.autoPlay)}${getStgDetailName('less')}`)}`,
 		`${withOptions(g_headerObj.makerView, false, `(${g_headerObj.creatorNames[g_stateObj.scoreId]})`)}`,
 		`${withOptions(g_stateObj.shuffle, C_FLG_OFF, `[${getShuffleName()}]`)}`
 	].filter(value => value !== ``).join(` `);
 
 	let playStyleData = [
-		`${g_stateObj.speed}${getStgDetailName(g_lblNameObj.multi)}`,
+		`${g_stateObj.speed}${g_lblNameObj.multi}`,
 		`${withOptions(g_stateObj.motion, C_FLG_OFF)}`,
 		`${withOptions(g_stateObj.reverse, C_FLG_OFF,
 			getStgDetailName(g_stateObj.scroll !== '---' ? 'R-' : 'Reverse'))}${withOptions(g_stateObj.scroll, '---')}`,
@@ -9749,7 +9749,7 @@ function resultInit() {
 
 	// ハイスコア差分計算
 	const assistFlg = (g_autoPlaysBase.includes(g_stateObj.autoPlay) ? `` : `-${g_stateObj.autoPlay}less`);
-	let scoreName = `${g_headerObj.keyLabels[g_stateObj.scoreId]}k-${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}`;
+	let scoreName = `${g_headerObj.keyLabels[g_stateObj.scoreId]}${getStgDetailName('k-')}${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}`;
 	if (g_headerObj.makerView) {
 		scoreName += `-${g_headerObj.creatorNames[g_stateObj.scoreId]}`;
 	}
@@ -9833,7 +9833,7 @@ function resultInit() {
 	// Twitter用リザルト
 	// スコアを上塗りする可能性があるため、カスタムイベント後に配置
 	const hashTag = (g_headerObj.hashTag !== undefined ? ` ${g_headerObj.hashTag}` : ``);
-	let tweetDifData = `${getKeyName(g_headerObj.keyLabels[g_stateObj.scoreId])}${transKeyData}k-${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}`;
+	let tweetDifData = `${getKeyName(g_headerObj.keyLabels[g_stateObj.scoreId])}${transKeyData}${getStgDetailName('k-')}${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}`;
 	if (g_stateObj.shuffle !== `OFF`) {
 		tweetDifData += `:${getShuffleName()}`;
 	}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4024,6 +4024,18 @@ const createOptionSprite = _sprite => createEmptySprite(_sprite, `optionsprite`,
 });
 
 /**
+ * スライダー共通処理
+ * @param {object} _slider 
+ * @param {object} _link 
+ * @returns 
+ */
+const inputSlider = (_slider, _link) => {
+	const value = parseInt(_slider.value);
+	_link.textContent = `${value}${g_lblNameObj.percent}`;
+	return value;
+}
+
+/**
  * 設定・オプション画面のラベル・ボタン処理の描画
  * @param {Object} _sprite 基準とするスプライト(ここで指定する座標は、そのスプライトからの相対位置)
  */
@@ -4832,10 +4844,8 @@ function createOptionWindow(_sprite) {
 	)
 
 	const fadeinSlider = document.querySelector(`#fadeinSlider`);
-	fadeinSlider.addEventListener(`input`, _ => {
-		g_stateObj.fadein = parseInt(fadeinSlider.value);
-		lnkFadein.textContent = `${g_stateObj.fadein}${g_lblNameObj.percent}`;
-	}, false);
+	fadeinSlider.addEventListener(`input`, _ =>
+		g_stateObj.fadein = inputSlider(fadeinSlider, lnkFadein), false);
 
 	// ---------------------------------------------------
 	// ボリューム (Volume) 
@@ -5379,10 +5389,8 @@ function createSettingsDisplayWindow(_sprite) {
 	}
 
 	const appearanceSlider = document.querySelector(`#appearanceSlider`);
-	appearanceSlider.addEventListener(`input`, _ => {
-		g_hidSudObj.filterPos = parseInt(appearanceSlider.value);
-		lblAppearancePos.textContent = `${g_hidSudObj.filterPos}${g_lblNameObj.percent}`;
-	}, false);
+	appearanceSlider.addEventListener(`input`, _ =>
+		g_hidSudObj.filterPos = inputSlider(appearanceSlider, lblAppearancePos), false);
 
 	const dispAppearanceSlider = _ => {
 		[`lblAppearancePos`, `lblAppearanceBar`, `lnkLockBtn`].forEach(obj =>

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2620,6 +2620,8 @@ const g_lblNameObj = {
 
     'u_x': `x`,
     'u_%': `%`,
+    'u_key': `key`,
+    'u_k-': `k-`,
 
     'u_OFF': `OFF`,
     'u_ON': `ON`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. getStgDetailName関数における冗長な名称呼び出しを取り止めました。
2. `key`や`k-`のような部分についても `g_lblNamesObj` で変更できるようにしました。
3. スライダーの入力処理を共通化しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. getStgDetailName関数は、g_lblNameObj['u_(名前)']の変数を呼び出すためのものだが、
`x`や`f`などの単位についてはすでに`multi`や`frame`が定義されているため。
2. キー数部分はボタン部分にあり、これまで置き換える方法が無かったため。
3. CodeClimateからの指摘より。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
