### PR TITLE
[0509/clipboard-http] http環境でクリップボードコピーに失敗する問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -585,9 +585,26 @@ function getFontSize(_str, _maxWidth, _font = getBasicFont(), _maxFontsize = 64,
 async function copyTextToClipboard(_textVal, _msg) {
 	try {
 		await navigator.clipboard.writeText(_textVal);
-		makeInfoWindow(_msg, `leftToRightFade`);
+
 	} catch (error) {
-		makeInfoWindow(g_msgInfoObj.W_0021, `leftToRightFade`, `#ffffcc`);
+		// http環境では navigator.clipboard が使えないため、従来の方法を実行
+		// テキストエリアを用意し、値をセット
+		const copyFrom = document.createElement(`textarea`);
+		copyFrom.textContent = _textVal;
+
+		// bodyタグの要素を取得
+		const bodyElm = document.getElementsByTagName(`body`)[0];
+		// 子要素にテキストエリアを配置
+		bodyElm.appendChild(copyFrom);
+
+		// テキストエリアの値を選択し、コピーコマンド発行
+		copyFrom.select();
+		document.execCommand(`copy`);
+		// 追加テキストエリアを削除
+		bodyElm.removeChild(copyFrom);
+
+	} finally {
+		makeInfoWindow(_msg, `leftToRightFade`);
 	}
 }
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. http環境でクリップボードコピーに失敗する問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. ver25.4.0で使用した navigator.clipboard.writeText はローカル及びhttps環境で無いと使用できないため、
http環境の場合は従来のクリップボードコピーを使用する必要がありました。
https://propg.ee-mall.info/%E3%83%97%E3%83%AD%E3%82%B0%E3%83%A9%E3%83%9F%E3%83%B3%E3%82%B0/javascript/js-http%E7%92%B0%E5%A2%83%E3%81%A7%E3%81%AFnavigator-clipboard-writetext%E3%81%8C%E3%82%A8%E3%83%A9%E3%83%BC%E3%81%AB%E3%81%AA%E3%82%8B/

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
