### PR TITLE
[0510/dupli-definition] 二重定義箇所を見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2276,8 +2276,7 @@ function drawTitleResultMotion(_displayName) {
  * ショートカットキー表示
  * @param {object} _obj
  * @param {string} _settingLabel 
- * @param {string} displayName 
- * @param {string} dfLabel 
+ * @param {object} objectList 
  */
 const createScText = (_obj, _settingLabel, { displayName = `option`, dfLabel = ``, targetLabel = `lnk${_settingLabel}R`,
 	x = g_scViewObj.x, y = g_scViewObj.y, w = g_scViewObj.w, siz = g_scViewObj.siz } = {}) => {
@@ -2669,9 +2668,10 @@ function makeInfoWindow(_text, _animationName = ``, _backColor = `#ccccff`) {
 
 /**
  * 警告ウィンドウのスタイル設定
- * @param {string} _lbl 
+ * @param {string} _text 
  * @param {string} _bkColor 
  * @param {string} _textColor 
+ * @param {string} _align
  */
 function setWindowStyle(_text, _bkColor, _textColor, _align = C_ALIGN_LEFT) {
 
@@ -3435,7 +3435,7 @@ function headerConvert(_dosObj) {
 
 /**
  * ゲージ設定リストへの追加
- * @param {string} _obj
+ * @param {object} _obj
  */
 function addGaugeFulls(_obj) {
 	_obj.map(key => g_gaugeOptionObj.customFulls[key] = false);
@@ -3512,9 +3512,10 @@ function resetBaseColorList(_baseObj, _dosObj, { scoreId = `` } = {}) {
 
 /**
  * 矢印・フリーズアロー色のデータ展開
- * @param {array} _data 
+ * @param {string} _data 
  * @param {array} _colorInit 
- * @param {object} _options 
+ * @param {number} _colorInitLength
+ * @param {object} objectList
  */
 function setColorList(_data, _colorInit, _colorInitLength,
 	{ _defaultColorgrd = g_headerObj.defaultColorgrd, _colorCdPaddingUse = false,
@@ -3626,6 +3627,7 @@ function resetCustomGauge(_dosObj, { scoreId = 0 } = {}) {
  * @param {object} _dosObj 
  * @param {string} _name 
  * @param {number} _difLength
+ * @param {object} objectList
  */
 function getGaugeSetting(_dosObj, _name, _difLength, { scoreId = 0 } = {}) {
 
@@ -3766,7 +3768,7 @@ function keysConvert(_dosObj) {
 				loopFunc(k, keyheader);
 			}
 		} else if (errCd !== `` && g_keyObj[`${keyheader}_0`] === undefined) {
-			makeWarningWindow(g_msgInfoObj[_errCd].split(`{0}`).join(_key));
+			makeWarningWindow(g_msgInfoObj[errCd].split(`{0}`).join(_key));
 		}
 		return tmpMinPatterns;
 	};
@@ -4463,7 +4465,7 @@ function createOptionWindow(_sprite) {
 
 	/**
 	 * グラフの縦軸を描画
-	 * @param {context} _context 
+	 * @param {object} _context 
 	 * @param {number} _resolution 
 	 */
 	function drawBaseLine(_context, _resolution = 10) {
@@ -5264,8 +5266,7 @@ function getKeyCtrl(_localStorage, _extraKeyName = ``) {
  * @param {string} _name 初期設定文字
  * @param {number} _heightPos 上からの配置順
  * @param {function} _func 通常ボタン処理
- * @param {function} _cxtFunc 右クリック時の処理
- * @param {object} _overridePos 座標設定(既定を上書き)
+ * @param {object} objectList 座標設定(既定を上書き)
  * @param {...any} _classes 追加するクラス
  */
 function makeSettingLblCssButton(_id, _name, _heightPos, _func, { x, y, w, h, siz, cxtFunc = _ => true, ...rest } = {}, ..._classes) {
@@ -5551,7 +5552,7 @@ function keyConfigInit(_kcType = g_kcType) {
 
 		createDivCss2Label(`kcDesc`, g_lblNameObj.kcDesc.split(`{0}`).join(g_kCd[C_KEY_RETRY])
 			.split(`{1}:`).join(g_isMac ? `` : `Delete:`), {
-			x: 0, y: 68, w: g_sWidth, h: 20, siz: C_SIZ_MAIN,
+			x: 0, y: 68, w: g_sWidth, h: 20,
 			siz: getFontSize(g_lblNameObj.kcDesc, g_sWidth, getBasicFont(), C_SIZ_MAIN),
 		}),
 
@@ -5967,7 +5968,6 @@ function keyConfigInit(_kcType = g_kcType) {
 
 	/**
 	 * ConfigTypeの制御
-	 * @param {event} _evt 
 	 * @param {number} _scrollNum 
 	 */
 	const setConfigType = (_scrollNum = 1) => {
@@ -6580,7 +6580,7 @@ function scoreConvert(_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 
 	/**
 	 * 矢印データの格納
-	 * @param {array} _data 
+	 * @param {string} _data 
 	 */
 	function storeArrowData(_data) {
 		let arrowData = [];
@@ -7608,7 +7608,8 @@ function pushColors(_header, _frame, _val, _colorCd, _allFlg) {
  * @param {string} _header 
  * @param {number} _frame 
  * @param {number} _val 
- * @param {string} _colorCd 
+ * @param {string} _styleName
+ * @param {string} _styleNameRev
  */
 function pushCssMotions(_header, _frame, _val, _styleName, _styleNameRev) {
 
@@ -8647,7 +8648,7 @@ function MainInit() {
 	 * @param {number} _j 
 	 * @param {number} _arrowCnt 
 	 * @param {string} _name 
-	 * @param {string} _normalcolor
+	 * @param {string} _normalColor
 	 * @param {string} _barColor 
 	 */
 	function makeFrzArrow(_j, _arrowCnt, _name, _normalColor, _barColor) {
@@ -9325,7 +9326,7 @@ function countFastSlow(_difFrame, _justFrames = 0) {
 
 /**
  * ライフゲージバーの色、数値を変更
- * @param {strint} _state 
+ * @param {string} _state 
  */
 function changeLifeColor(_state = ``) {
 	const lblLife = document.querySelector(`#lblLife`);
@@ -10032,7 +10033,7 @@ const getShuffleName = _ => {
  * @param {number} _x
  * @param {string} _class 
  * @param {number} _heightPos 
- * @param {string, number} _text
+ * @param {string} _text
  * @param {string} _align
  */
 function makeCssResultPlayData(_id, _x, _class, _heightPos, _text, _align = C_ALIGN_CENTER, { w = 400, siz = C_SIZ_MAIN } = {}) {
@@ -10047,7 +10048,7 @@ function makeCssResultPlayData(_id, _x, _class, _heightPos, _text, _align = C_AL
  * @param {number} _x
  * @param {string} _class
  * @param {number} _heightPos 
- * @param {string, number} _text
+ * @param {string} _text
  * @param {string} _align
  */
 function makeCssResultSymbol(_id, _x, _class, _heightPos, _text, _align = C_ALIGN_LEFT) {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -560,10 +560,6 @@ let g_sHeight;
 
 const g_hidSudObj = {
     filterPos: 10,
-    pgDown: {},
-    pgUp: {},
-    std: {},
-    filterPosDefault: {},
 
     'Visible': 1,
     'Hidden': 0,

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,6 @@
 ﻿{
     "compilerOptions": {
-        "target": "es6",
+        "target": "es2021",
         "baseUrl": "./"
     },
     "exclude": [

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,6 @@
 ﻿{
     "compilerOptions": {
-        "target": "es2021",
+        "target": "es2020",
         "baseUrl": "./"
     },
     "exclude": [


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. オブジェクト内で二重定義している箇所を見直しました。
2. カスタムキー定義に誤りがある場合にメッセージが表示されない問題を修正しました。
3. jsconfig.json の target属性を `es6`から`es2020`に変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. エラーにはならないが、厳密にはやめた方が良い記述のため。
2. 引数の割り当て誤りのため。
3. es6以降で適用された機能を一部使用しているため。
https://code.visualstudio.com/docs/languages/jsconfig

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 2.について優先度は低いが過去バージョンにも適用する予定。