### PR TITLE
[0511/adjustment-view] 適正Adjを表示する機能を実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7657,6 +7657,7 @@ function getArrowSettings() {
 	g_workObj.stepHitRtn = copyArray2d(g_keyObj[`stepRtn${keyCtrlPtn}`]);
 	g_workObj.arrowRtn = copyArray2d(g_keyObj[`stepRtn${keyCtrlPtn}`]);
 	g_workObj.keyCtrl = copyArray2d(g_keyObj[`keyCtrl${keyCtrlPtn}`]);
+	g_workObj.diffList = [];
 
 	const keyCtrlLen = g_workObj.keyCtrl.length;
 	g_workObj.keyCtrlN = [...Array(keyCtrlLen)].map(_ => []);
@@ -9302,6 +9303,7 @@ function judgeArrow(_j) {
  */
 function displayDiff(_difFrame, _justFrames = 0) {
 	let diffJDisp = ``;
+	g_workObj.diffList.push(_difFrame);
 	const difCnt = Math.abs(_difFrame);
 	if (_difFrame > _justFrames) {
 		diffJDisp = `<span class="common_matari">Fast ${difCnt} Frames</span>`;
@@ -9581,6 +9583,13 @@ function resultInit() {
 		}
 	}
 
+	// diffListから適正Adjを算出（20個以下の場合は算出しない）
+	const getSign = _val => (_val > 0 ? `+` : ``);
+	const getDiffFrame = _val => `${getSign(_val)}${_val}${g_lblNameObj.frame}`;
+	const diffAdj = (g_workObj.diffList.length <= 20 ?
+		`` : (-1) * Math.round(g_workObj.diffList.reduce((x, y) => x + y, 0) / g_workObj.diffList.length * 10) / 10);
+	const expectedAdj = Math.round((g_stateObj.adjustment + diffAdj) * 10) / 10;
+
 	// 背景スプライトを作成
 	createMultipleSprite(`backResultSprite`, g_headerObj.backResultMaxDepth);
 
@@ -9738,6 +9747,13 @@ function resultInit() {
 			makeCssResultSymbol(`lblFastS`, 260, g_cssObj.score, 1, g_resultObj.fast, C_ALIGN_RIGHT),
 			makeCssResultSymbol(`lblSlowS`, 260, g_cssObj.score, 3, g_resultObj.slow, C_ALIGN_RIGHT),
 		);
+		if (diffAdj !== ``) {
+			multiAppend(resultWindow,
+				makeCssResultSymbol(`lblAdj`, 350, g_cssObj.common_shakin, 4, g_lblNameObj.j_adj),
+				makeCssResultSymbol(`lblAdjS`, 260, g_cssObj.score, 5, `${getDiffFrame(expectedAdj)}`, C_ALIGN_RIGHT),
+				makeCssResultSymbol(`lblAdjS`, 260, g_cssObj.score, 6, `(${getDiffFrame(diffAdj)})`, C_ALIGN_RIGHT, { siz: 12 }),
+			);
+		}
 	}
 
 	// ランク描画
@@ -10051,8 +10067,8 @@ function makeCssResultPlayData(_id, _x, _class, _heightPos, _text, _align = C_AL
  * @param {string} _text
  * @param {string} _align
  */
-function makeCssResultSymbol(_id, _x, _class, _heightPos, _text, _align = C_ALIGN_LEFT) {
-	return makeCssResultPlayData(_id, _x, _class, _heightPos, _text, _align, { w: 150, siz: C_SIZ_JDGCNTS });
+function makeCssResultSymbol(_id, _x, _class, _heightPos, _text, _align = C_ALIGN_LEFT, { siz = C_SIZ_JDGCNTS } = {}) {
+	return makeCssResultPlayData(_id, _x, _class, _heightPos, _text, _align, { w: 150, siz: siz });
 }
 
 // ライセンス原文、以下は削除しないでください

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9586,9 +9586,8 @@ function resultInit() {
 	// diffListから適正Adjを算出（20個以下の場合は算出しない）
 	const getSign = _val => (_val > 0 ? `+` : ``);
 	const getDiffFrame = _val => `${getSign(_val)}${_val}${g_lblNameObj.frame}`;
-	const diffAdj = (g_workObj.diffList.length <= 20 ?
-		`` : (-1) * Math.round(g_workObj.diffList.reduce((x, y) => x + y, 0) / g_workObj.diffList.length * 10) / 10);
-	const expectedAdj = Math.round((g_stateObj.adjustment + diffAdj) * 10) / 10;
+	const estimatedAdj = (g_workObj.diffList.length <= 20 ?
+		`` : Math.round(g_stateObj.adjustment - g_workObj.diffList.reduce((x, y) => x + y, 0) / g_workObj.diffList.length * 10) / 10);
 
 	// 背景スプライトを作成
 	createMultipleSprite(`backResultSprite`, g_headerObj.backResultMaxDepth);
@@ -9747,11 +9746,10 @@ function resultInit() {
 			makeCssResultSymbol(`lblFastS`, 260, g_cssObj.score, 1, g_resultObj.fast, C_ALIGN_RIGHT),
 			makeCssResultSymbol(`lblSlowS`, 260, g_cssObj.score, 3, g_resultObj.slow, C_ALIGN_RIGHT),
 		);
-		if (diffAdj !== ``) {
+		if (estimatedAdj !== ``) {
 			multiAppend(resultWindow,
 				makeCssResultSymbol(`lblAdj`, 350, g_cssObj.common_shakin, 4, g_lblNameObj.j_adj),
-				makeCssResultSymbol(`lblAdjS`, 260, g_cssObj.score, 5, `${getDiffFrame(expectedAdj)}`, C_ALIGN_RIGHT),
-				makeCssResultSymbol(`lblAdjS`, 260, g_cssObj.score, 6, `(${getDiffFrame(diffAdj)})`, C_ALIGN_RIGHT, { siz: 12 }),
+				makeCssResultSymbol(`lblAdjS`, 260, g_cssObj.score, 5, `${getDiffFrame(estimatedAdj)}`, C_ALIGN_RIGHT),
 			);
 		}
 	}
@@ -10067,8 +10065,8 @@ function makeCssResultPlayData(_id, _x, _class, _heightPos, _text, _align = C_AL
  * @param {string} _text
  * @param {string} _align
  */
-function makeCssResultSymbol(_id, _x, _class, _heightPos, _text, _align = C_ALIGN_LEFT, { siz = C_SIZ_JDGCNTS } = {}) {
-	return makeCssResultPlayData(_id, _x, _class, _heightPos, _text, _align, { w: 150, siz: siz });
+function makeCssResultSymbol(_id, _x, _class, _heightPos, _text, _align = C_ALIGN_LEFT) {
+	return makeCssResultPlayData(_id, _x, _class, _heightPos, _text, _align, { w: 150, siz: C_SIZ_JDGCNTS });
 }
 
 // ライセンス原文、以下は削除しないでください

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2691,7 +2691,6 @@ const g_lblNameObj = {
 
     j_fast: `Fast`,
     j_slow: `Slow`,
-    j_adj: `C.Adj.`,
 
     allPerfect: `All Perfect!!`,
     perfect: `Perfect!!`,
@@ -2748,6 +2747,8 @@ const g_lang_lblNameObj = {
 
         j_kita: "(ﾟ∀ﾟ)ｷﾀ-!!",
         j_iknai: "(・A・)ｲｸﾅｲ",
+
+        j_adj: `推定Adj`,
     },
     En: {
         kcDesc: `[{0}:Skip / {1}:Key invalidation (Alternate keys only)]`,
@@ -2774,6 +2775,8 @@ const g_lang_lblNameObj = {
 
         j_kita: ":) O.K.",
         j_iknai: ":( N.G.",
+
+        j_adj: `Est-Adj.`,
     },
 };
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2691,6 +2691,7 @@ const g_lblNameObj = {
 
     j_fast: `Fast`,
     j_slow: `Slow`,
+    j_adj: `C.Adj.`,
 
     allPerfect: `All Perfect!!`,
     perfect: `Perfect!!`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. fast/slowを呼び出している関数を使って、結果画面に適正Adjustment値を表示する機能を実装しました。
イイ～マターリの判定領域に引っ掛かったジャストからの差分値を蓄積して、
その平均値から適正Adjustment値を0.1フレーム単位で表示します。
括弧無しが設定すべきAdjustment、括弧付が現在のAdjustmentからの差分を表します。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Fast/Slowである程度どちらに向ければ良いかはわかるが、具体的な補正先がわかりにくいため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/150981097-a67e12aa-2f40-4885-a363-307547847f3a.png" width="50%"><img src="https://user-images.githubusercontent.com/44026291/150981670-1edfa318-16eb-42ba-88ff-9876c3edf946.png" width="50%">


## :pencil: その他コメント / Other Comments
- 適正Adjustment値を、0.1フレーム単位にするのか、0.5フレーム単位にするのかは判断が要りそうです。
- わかりやすい略名が思いつかないため、一旦仮の名前を入れています。
    - 日本語名：推定Adj、英語名：Est-Adj. (Estimated Adjustmentの略)と表記するようにしました。
    差分値については、表示するメリットが薄い（推定Adjで事足りる）ことから表記を見送る予定です。