### PR TITLE
[0512/frz-with-arrowcolor] 矢印色変化に対するフリーズアローの追従設定を一部分離

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3070,8 +3070,8 @@ function headerConvert(_dosObj) {
 	if (!obj.defaultFrzColorUse) {
 		const tmpFrzScope = [];
 
-		if (hasVal(_dosObj.frzScopeFromArrowColors)) {
-			tmpFrzScope.push(..._dosObj.frzScopeFromArrowColors.split(`,`));
+		if (hasVal(_dosObj.frzScopeFromAC)) {
+			tmpFrzScope.push(..._dosObj.frzScopeFromAC.split(`,`));
 		} else if (typeof g_presetFrzScopeFromArrowColors === C_TYP_OBJECT) {
 			tmpFrzScope.push(...g_presetFrzScopeFromArrowColors);
 		}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3063,6 +3063,18 @@ function headerConvert(_dosObj) {
 		obj.defaultFrzColorUse = true;
 	}
 
+	// 矢印色変化に対応してフリーズアロー色を追随する範囲の設定
+	obj.frzScopeFromArrowColors = [];
+	const tmpFrzScope = [];
+
+	if (hasVal(_dosObj.frzScopeFromArrowColors)) {
+		tmpFrzScope.push(..._dosObj.frzScopeFromArrowColors.split(`,`));
+	} else if (typeof g_presetFrzScopeFromArrowColors === C_TYP_OBJECT) {
+		tmpFrzScope.push(...g_presetFrzScopeFromArrowColors);
+	}
+	tmpFrzScope.filter(type => [`Normal`, `Hit`].includes(type))
+		.forEach(data => obj.frzScopeFromArrowColors.push(data));
+
 	// 初期色情報
 	Object.keys(g_dfColorObj).forEach(key => obj[key] = g_dfColorObj[key].concat());
 	if (obj.baseBrightFlg) {
@@ -7546,13 +7558,16 @@ function pushColors(_header, _frame, _val, _colorCd, _allFlg) {
 	if (_val < 30 || _val >= 1000) {
 		const baseHeaders = [`mk${_header}Color`];
 		allUseTypes.push(`Arrow`);
-		if (!g_headerObj.defaultFrzColorUse) {
-			baseHeaders.push(`mkF${_header}ColorNormal`, `mkF${_header}ColorNormalBar`,
-				`mkF${_header}ColorHit`, `mkF${_header}ColorHitBar`);
+
+		// フリーズアロー色の追随設定がある場合、対象を追加
+		g_headerObj.frzScopeFromArrowColors.forEach(type => {
+			baseHeaders.push(`mkF${_header}Color${type}`, `mkF${_header}Color${type}Bar`);
+		});
+		if (g_headerObj.frzScopeFromArrowColors.length > 0) {
 			allUseTypes.push(`Frz`);
 		}
 
-		// 矢印の色変化 (defaultFrzColorUse=falseのときはフリーズアローも色変化)
+		// 矢印の色変化 (追随指定時はフリーズアローも色変化)
 		baseHeaders.forEach(baseHeader => {
 			initialize(baseHeader);
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3072,8 +3072,8 @@ function headerConvert(_dosObj) {
 
 		if (hasVal(_dosObj.frzScopeFromAC)) {
 			tmpFrzScope.push(..._dosObj.frzScopeFromAC.split(`,`));
-		} else if (typeof g_presetFrzScopeFromArrowColors === C_TYP_OBJECT) {
-			tmpFrzScope.push(...g_presetFrzScopeFromArrowColors);
+		} else if (typeof g_presetFrzScopeFromAC === C_TYP_OBJECT) {
+			tmpFrzScope.push(...g_presetFrzScopeFromAC);
 		}
 		tmpFrzScope.filter(type => [`Normal`, `Hit`].includes(type))
 			.forEach(data => obj.frzScopeFromArrowColors.push(data));

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3064,16 +3064,20 @@ function headerConvert(_dosObj) {
 	}
 
 	// 矢印色変化に対応してフリーズアロー色を追随する範囲の設定
+	// (defaultFrzColorUse=false時のみ)
 	obj.frzScopeFromArrowColors = [];
-	const tmpFrzScope = [];
 
-	if (hasVal(_dosObj.frzScopeFromArrowColors)) {
-		tmpFrzScope.push(..._dosObj.frzScopeFromArrowColors.split(`,`));
-	} else if (typeof g_presetFrzScopeFromArrowColors === C_TYP_OBJECT) {
-		tmpFrzScope.push(...g_presetFrzScopeFromArrowColors);
+	if (!obj.defaultFrzColorUse) {
+		const tmpFrzScope = [];
+
+		if (hasVal(_dosObj.frzScopeFromArrowColors)) {
+			tmpFrzScope.push(..._dosObj.frzScopeFromArrowColors.split(`,`));
+		} else if (typeof g_presetFrzScopeFromArrowColors === C_TYP_OBJECT) {
+			tmpFrzScope.push(...g_presetFrzScopeFromArrowColors);
+		}
+		tmpFrzScope.filter(type => [`Normal`, `Hit`].includes(type))
+			.forEach(data => obj.frzScopeFromArrowColors.push(data));
 	}
-	tmpFrzScope.filter(type => [`Normal`, `Hit`].includes(type))
-		.forEach(data => obj.frzScopeFromArrowColors.push(data));
 
 	// 初期色情報
 	Object.keys(g_dfColorObj).forEach(key => obj[key] = g_dfColorObj[key].concat());

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -39,6 +39,8 @@ const g_presetGauge = {
 const g_presetFrzColors = true;
 
 // 矢印色変化に対応してフリーズアロー色を追随する範囲の設定 (Normal: 通常時、Hit: ヒット時)
+// ※この設定は、g_presetFrzColors = false もしくは 
+//   譜面ヘッダー：defaultFrzColorUse=false のときにのみ有効です。
 // const g_presetFrzScopeFromArrowColors = [`Normal`, `Hit`];
 
 // ゲージ設定（デフォルト以外）

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -38,9 +38,11 @@ const g_presetGauge = {
 // フリーズアローのデフォルト色セットの利用有無 (true: 使用, false: 矢印色を優先してセット)
 const g_presetFrzColors = true;
 
-// 矢印色変化に対応してフリーズアロー色を追随する範囲の設定 (Normal: 通常時、Hit: ヒット時)
-// ※この設定は、g_presetFrzColors = false もしくは 
-//   譜面ヘッダー：defaultFrzColorUse=false のときにのみ有効です。
+/**
+	矢印色変化に対応してフリーズアロー色を追随する範囲の設定 (Normal: 通常時、Hit: ヒット時)
+	※この設定は、g_presetFrzColors = false もしくは 
+	譜面ヘッダー：defaultFrzColorUse=false のときにのみ有効です。
+*/
 // const g_presetFrzScopeFromArrowColors = [`Normal`, `Hit`];
 
 // ゲージ設定（デフォルト以外）

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -43,7 +43,7 @@ const g_presetFrzColors = true;
 	※この設定は、g_presetFrzColors = false もしくは 
 	譜面ヘッダー：defaultFrzColorUse=false のときにのみ有効です。
 */
-// const g_presetFrzScopeFromArrowColors = [`Normal`, `Hit`];
+// const g_presetFrzScopeFromAC = [`Normal`, `Hit`];
 
 // ゲージ設定（デフォルト以外）
 const g_presetGaugeCustom = {

--- a/js/danoni_setting.js
+++ b/js/danoni_setting.js
@@ -38,6 +38,9 @@ const g_presetGauge = {
 // フリーズアローのデフォルト色セットの利用有無 (true: 使用, false: 矢印色を優先してセット)
 const g_presetFrzColors = true;
 
+// 矢印色変化に対応してフリーズアロー色を追随する範囲の設定 (Normal: 通常時、Hit: ヒット時)
+// const g_presetFrzScopeFromArrowColors = [`Normal`, `Hit`];
+
 // ゲージ設定（デフォルト以外）
 const g_presetGaugeCustom = {
 	Easy: {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. フリーズアローのデフォルト色セットの利用有無（defaultFrzColorUse / g_presetFrzColors）と
矢印色変化に対するフリーズアローの追従設定（frzScopeFromAC / g_presetFrzScopeFromAC）
を一部分離しました。
#1187 関連の変更です。
追従範囲を「Normal（通常時）」「Hit（ヒット時）」から選択して設定します。（未指定も可能）

### 譜面ヘッダーでの設定
```
|defaultFrzColorUse=false|  // フリーズアロー初期色(frzColor)が未定義のときは矢印初期色(setColor)から取得

|frzScopeFromAC=Normal|        // 通常時のみ追従
|frzScopeFromAC=Normal,Hit|    // 通常時、ヒット時両方追従
```
### danoni_setting.jsでの設定
```javascript
// 通常時、ヒット時両方追従（ g_presetFrzColors を定義しないときは  |defaultFrzColorUse=false| を譜面側で定義）
const g_presetFrzScopeFromAC = [`Normal`, `Hit`];
```

デフォルトは「いずれにも追従しない」設定にします。
なお、この設定は `defaultFrzColorUse=false` もしくは `g_presetFrzColors=false` の**場合にのみ有効**です。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Gitter要望より。機能が異なるため分けて管理する必要がありました。
https://gitter.im/danonicw/community?at=61f0389c9a335454063e2e1d

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- ver25.1.0～ver25.4.1のように、矢印色変化に対するフリーズアローを追従するには
`|frzScopeFromAC=Normal,Hit| `の追加もしくは
danoni_setting.js側で下記の設定が必要です。
```javascript
const g_presetFrzScopeFromAC = [`Normal`, `Hit`];
```