### PR TITLE
[0515/group-change] シャッフル・カラーグループを変更した際にその内容が反映されない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5799,6 +5799,7 @@ function keyConfigInit(_kcType = g_kcType) {
 			}
 			g_keycons[`${_type}GroupNum`] = j + _scrollNum;
 		}
+		g_keyObj[`${_type}${keyCtrlPtn}`] = [...g_keyObj[`${_type}${keyCtrlPtn}_${g_keycons[`${_type}GroupNum`]}`]];
 		viewGroup(_type);
 	};
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. シャッフル・カラーグループを変更した際にその内容が反映されない問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. ver24.5.1でコード整理を行った際、シャッフル・カラーグループ変更処理 (setGroup) で
実際の設定を反映する処理が抜けていたため。
Gitterより報告がありました。
https://gitter.im/danonicw/community?at=61f42696bfe2f54b2e3f0422

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 矢印やAAを直接選択して変更するパターンでは問題なく動作します。
