### PR TITLE
[0516/norecord-view] No Recordの文字が推定Adjと重なる問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9844,9 +9844,9 @@ function resultInit() {
 		});
 
 	} else {
-		resultWindow.appendChild(makeCssResultSymbol(`lblAutoView`, 230, g_cssObj.result_noRecord, 4, `(No Record)`));
+		resultWindow.appendChild(makeCssResultSymbol(`lblAutoView`, 215, g_cssObj.result_noRecord, 4, `(No Record)`));
 		const lblAutoView = document.querySelector(`#lblAutoView`);
-		lblAutoView.style.fontSize = `24px`;
+		lblAutoView.style.fontSize = `20px`;
 	}
 
 	// ユーザカスタムイベント(初期)


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 結果画面のNo Recordの文字が推定Adjと重なる問題を修正しました。
(No Record)の文字サイズを24px -> 20px に変更し、位置を15px左へずらしています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Mirror/Randomなどでプレイしたときに発生します。
Gitterより報告がありました。
https://gitter.im/danonicw/community?at=61f4147fd41a5853f9728967

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
- 右側が変更後イメージです。

<img src="https://user-images.githubusercontent.com/44026291/151640103-704b8ef8-8e76-4d0c-8ac9-7d694aa640cb.png" width="50%"><img src="https://user-images.githubusercontent.com/44026291/151640021-d0c34d81-44a3-46d0-9606-0d951b94924c.png" width="50%">

## :pencil: その他コメント / Other Comments