### PR TITLE
[0517/skinjs] メイン画面のスキン拡張が利いていない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9079,12 +9079,7 @@ function MainInit() {
 			g_timeoutEvtId = setTimeout(_ => flowTimeline(), 1000 / g_fps - buffTime);
 		}
 	}
-	if (typeof skinMainInit === C_TYP_FUNCTION) {
-		skinMainInit();
-		if (typeof skinMainInit2 === C_TYP_FUNCTION) {
-			skinMainInit2();
-		}
-	}
+	g_skinJsObj.main.forEach(func => func());
 
 	g_audio.currentTime = firstFrame / g_fps * g_headerObj.playbackRate;
 	g_audio.playbackRate = g_headerObj.playbackRate;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. メイン画面のスキン拡張が利いていない問題を修正しました。
※従来のカスタム関数は変更前でも使用できます。拡張できていなかったというだけです。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 他の機能との整合のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 不具合ではありませんが、機能不十分となるためv24には変更差分を適用する予定です。
