### PR TITLE
[0518/comment-select\] コメントエリアを選択できるように変更、ボタンサイズ調整

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2567,7 +2567,7 @@ function titleInit() {
 				commentArea.innerHTML = g_headerObj.commentVal;
 			}
 		} else {
-			let tmpComment = g_headerObj.commentVal;
+			const tmpComment = g_headerObj.commentVal;
 			multiAppend(divRoot,
 
 				createDivCss2Label(`lblComment`, tmpComment, {
@@ -2579,10 +2579,11 @@ function titleInit() {
 					const lblCommentDef = lblComment.style.display;
 					lblComment.style.display = (lblCommentDef === C_DIS_NONE ? C_DIS_INHERIT : C_DIS_NONE);
 				}, {
-					x: g_sWidth - 180, y: (g_sHeight / 2) + 150, w: 150, h: 50, siz: 20, border: `solid 1px #999999`,
+					x: g_sWidth - 160, y: (g_sHeight / 2) + 150, w: 140, h: 50, siz: 20, border: `solid 1px #999999`,
 				}, g_cssObj.button_Default),
 
 			);
+			setUserSelect(lblComment.style, `text`);
 		}
 	}
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. コメントエリアを選択できるように変更しました。
2. コメントボタンの位置、サイズを調整しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. コメント部分を選択するケースが考えられるため。
2. 横幅500pxのとき、コメントボタンとClick Here!!の文字が隠れてしまうため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/152154194-2f30298d-448f-4fbe-be03-eb2723f8e7b4.png" width="50%"><img src="https://user-images.githubusercontent.com/44026291/152154335-f3aa1f3e-d891-4758-84df-cb499c96da0f.png" width="50%">


## :pencil: その他コメント / Other Comments
