### PR TITLE
[0519/val-comment] コメント文中に定義済み変数を埋め込む機能を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2562,15 +2562,23 @@ function titleInit() {
 
 	// コメントエリア作成
 	if (g_headerObj.commentVal !== ``) {
+
+		// コメント文の加工
+		const comments = g_headerObj.commentVal.split(`}`).join(`{`).split(`{`);
+		let convCommentVal = ``;
+		for (let j = 0; j < comments.length; j += 2) {
+			convCommentVal += escapeHtmlForEnabledTag(comments[j]);
+			convCommentVal += setVal(comments[j + 1], ``, C_TYP_CALC);
+		}
+
 		if (g_headerObj.commentExternal) {
 			if (document.querySelector(`#commentArea`) !== null) {
-				commentArea.innerHTML = g_headerObj.commentVal;
+				commentArea.innerHTML = convCommentVal;
 			}
 		} else {
-			const tmpComment = g_headerObj.commentVal;
 			multiAppend(divRoot,
 
-				createDivCss2Label(`lblComment`, tmpComment, {
+				createDivCss2Label(`lblComment`, convCommentVal, {
 					x: 0, y: 70, w: g_sWidth, h: g_sHeight - 180, siz: C_SIZ_DIFSELECTOR, align: C_ALIGN_LEFT,
 					overflow: `auto`, background: `#222222`, color: `#cccccc`, display: C_DIS_NONE,
 				}),
@@ -3397,7 +3405,7 @@ function headerConvert(_dosObj) {
 	const newlineTag = setVal(_dosObj.commentAutoBr, true, C_TYP_BOOLEAN) ? `<br>` : ``;
 	let tmpComment = setVal(_dosObj[`commentVal${g_localeObj.val}`] || _dosObj.commentVal, ``, C_TYP_STRING);
 	tmpComment = tmpComment.split(`\r\n`).join(`\n`);
-	obj.commentVal = escapeHtmlForEnabledTag(tmpComment.split(`\n`).join(newlineTag));
+	obj.commentVal = tmpComment.split(`\n`).join(newlineTag);
 
 	// クレジット表示
 	if (document.querySelector(`#webMusicTitle`) !== null) {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2389,7 +2389,7 @@ const g_escapeStr = {
     escapeTag: [
         [`*amp*`, `&amp;`], [`*pipe*`, `|`], [`*dollar*`, `$`], [`*rsquo*`, `&rsquo;`],
         [`*quot*`, `&quot;`], [`*comma*`, `&sbquo;`], [`*squo*`, `&#39;`], [`*bkquo*`, `&#96;`],
-        [`*lt*`, `&lt;`], [`*gt*`, `&gt;`],
+        [`*lt*`, `&lt;`], [`*gt*`, `&gt;`], [`*lbrace*`, `{`], [`*rbrace*`, `}`],
     ],
     unEscapeTag: [
         [`&amp;`, `&`], [`&rsquo;`, `’`], [`&quot;`, `"`], [`&sbquo;`, `,`],


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. コメント文中に定義済み変数を埋め込む機能を追加しました。
次のように、`{定義済み変数}`の形で指定することで定義済み変数から値を取得して表示します。
```
|commentVal=
[7key / Normal]
BPM: 140, ツール値: {g_detailObj.toolDif[0].tool}
|
```
2. 中括弧に対して特殊文字を指定できるようにしました。

|指定文字|変換先|
|----|----|
|{|\*lbrace\*|
|}|\*rbrace\*|

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. コメント文の利便性向上のため。
2. 1.の変更に伴い特殊文字を指定する必要が出てきたため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- この処理はタイトル用カスタム関数（g_customJsObj.title）の実行後に変数を読み込みます。
このためカスタムJsでグローバル変数として定義したものも読み込めます。