### PR TITLE
[0520/density-expantion] 譜面密度グラフで二重押し/多重押し状況を表示するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4495,6 +4495,21 @@ function createOptionWindow(_sprite) {
 			context.stroke();
 		}
 
+		const lineNames = [`1Push`, `2Push`, `3Push+`];
+		Object.keys(g_graphColorObj).filter(val => val.indexOf(`max`) !== -1).forEach((val, j) => {
+			const lineX = 70 + j * 70;
+
+			context.beginPath();
+			context.lineWidth = 3;
+			context.fillStyle = g_rankObj.rankColorAllPerfect;
+			context.strokeStyle = g_graphColorObj[val];
+			context.moveTo(lineX, 215);
+			context.lineTo(lineX + 20, 215);
+			context.stroke();
+			context.font = `${C_SIZ_DIFSELECTOR}px ${getBasicFont()}`;
+			context.fillText(lineNames[j], lineX + 20, 218);
+		});
+
 		const obj = getScoreBaseData(_scoreId);
 		updateScoreDetailLabel(`Density`, g_lblNameObj.s_apm, obj.apm, 0);
 		updateScoreDetailLabel(`Density`, g_lblNameObj.s_time, obj.playingTime, 1);

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -246,11 +246,11 @@ const C_CLR_DENSITY_DEFAULT = `#999999cc`;
 const C_LEN_DENSITY_DIVISION = 16;
 
 const g_graphColorObj = {
-    max: `#990000cc`,
+    max: `#993333cc`,
     default: `#999999cc`,
-    max2Push: `#660000cc`,
+    max2Push: `#9933cccc`,
     default2Push: `#777777cc`,
-    max3Push: `#330000cc`,
+    max3Push: `#003399cc`,
     default3Push: `#555555cc`,
 };
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -245,6 +245,15 @@ const C_CLR_DENSITY_MAX = `#990000cc`;
 const C_CLR_DENSITY_DEFAULT = `#999999cc`;
 const C_LEN_DENSITY_DIVISION = 16;
 
+const g_graphColorObj = {
+    max: `#990000cc`,
+    default: `#999999cc`,
+    max2Push: `#660000cc`,
+    default2Push: `#777777cc`,
+    max3Push: `#330000cc`,
+    default3Push: `#555555cc`,
+};
+
 const g_settingBtnObj = {
     chara: {
         L: `<`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 譜面密度グラフで二重押し/多重押し状況を表示するよう変更しました。
濃い色が二重押しの割合、さらに濃い色が3つ押し以上の割合を表します。
また、最大密度のときはピンクが二重押し、青が多重押しを表します。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 譜面密度傾向を細かく見ることができるため。
※実装に当たり、Tarwilさんのコードを一部参考にしました。
 
## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/152635989-119a6537-f35d-49de-9060-699c9ccb0083.png" width="50%"><img src="https://user-images.githubusercontent.com/44026291/152636016-6802b87d-5f15-4c8f-8cfc-22f943f9d313.png" width="50%">


## :pencil: その他コメント / Other Comments
- 二重押し、多重押しの判断は矢印とフリーズ始点を基準にカウントしています。
このため、フリーズ中の矢印や始点位置の異なる多重フリーズアローはカウントしていません。