### PR TITLE
[0521/estimated-adj] 推定Adjの計算方法を単純平均から正規分布ベースに変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9706,8 +9706,16 @@ function resultInit() {
 	// diffListから適正Adjを算出（20個以下の場合は算出しない）
 	const getSign = _val => (_val > 0 ? `+` : ``);
 	const getDiffFrame = _val => `${getSign(_val)}${_val}${g_lblNameObj.frame}`;
-	const estimatedAdj = (g_workObj.diffList.length <= 20 ?
-		`` : Math.round((g_stateObj.adjustment - g_workObj.diffList.reduce((x, y) => x + y, 0) / g_workObj.diffList.length) * 10) / 10);
+	const diffLength = g_workObj.diffList.length;
+	const bayesFunc = (_offset, _length) => {
+		let result = 0;
+		for (let j = _offset; j < _length; j++) {
+			result += (_length - j) * (j + 1) * g_workObj.diffList[j];
+		}
+		return result;
+	};
+	const bayesExVal = 3 * bayesFunc(0, diffLength) / (diffLength * (diffLength + 1) * (diffLength + 2));
+	const estimatedAdj = (diffLength <= 20 ? `` : Math.round((g_stateObj.adjustment - bayesExVal) * 100) / 100);
 
 	// 背景スプライトを作成
 	createMultipleSprite(`backResultSprite`, g_headerObj.backResultMaxDepth);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9715,7 +9715,7 @@ function resultInit() {
 		return result;
 	};
 	const bayesExVal = 3 * bayesFunc(0, diffLength) / (diffLength * (diffLength + 1) * (diffLength + 2));
-	const estimatedAdj = (diffLength <= 20 ? `` : Math.round((g_stateObj.adjustment - bayesExVal) * 100) / 100);
+	const estimatedAdj = (diffLength <= 20 ? `` : Math.round((g_stateObj.adjustment - bayesExVal) * 10) / 10);
 
 	// 背景スプライトを作成
 	createMultipleSprite(`backResultSprite`, g_headerObj.backResultMaxDepth);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 推定Adjの計算方法を単純平均から誤差が正規分布になると仮定した場合の推定値になるよう変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Tarwilさんからの指摘より。
単純平均の場合、難譜面になるほど外れ値に影響されやすくなっていました。
https://twitter.com/Tarwil1503/status/1489681464681963521

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
