### PR TITLE
[0525/keys-extension] 共通のカスタムキー定義実装、作品別のkeyExtraList指定を任意化

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -241,11 +241,11 @@ const hasArrayList = (_data, _length = 1) => _data !== undefined && _data.length
 /**
  * 重複を排除した配列の生成
  * @param {array} _array1 
- * @param {array} _array2 
+ * @param {...any} _arrays 
  * @returns 
  */
-const makeDedupliArray = (_array1, _array2 = []) =>
-	Array.from((new Set([..._array1, ..._array2])).values());
+const makeDedupliArray = (_array1, ..._arrays) =>
+	Array.from((new Set([..._array1, ..._arrays.flat()])).values());
 
 /**
  * 部分一致検索（リストのいずれかに合致、大小文字問わず）

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4990,8 +4990,6 @@ function createOptionWindow(_sprite) {
 		// ---------------------------------------------------
 		// 1. キーコンフィグ設定 (KeyConfig)
 
-		// 特殊キーフラグ
-		g_stateObj.extraKeyFlg = false;
 
 		g_keyObj.currentKey = g_headerObj.keyLabels[g_stateObj.scoreId];
 		const isNotSameKey = (g_keyObj.prevKey !== g_keyObj.currentKey);
@@ -4999,15 +4997,8 @@ function createOptionWindow(_sprite) {
 		if (g_headerObj.dummyScoreNos !== undefined) {
 			g_stateObj.dummyId = setVal(g_headerObj.dummyScoreNos[g_stateObj.scoreId], ``, C_TYP_NUMBER);
 		}
-
-		if (g_rootObj.keyExtraList !== undefined) {
-			g_rootObj.keyExtraList.split(`,`).some(extraKey => {
-				if (g_keyObj.currentKey === extraKey) {
-					g_stateObj.extraKeyFlg = true;
-					return true;
-				}
-			});
-		}
+		// 特殊キーフラグ
+		g_stateObj.extraKeyFlg = g_headerObj.keyExtraList.includes(g_keyObj.currentKey);
 
 		// ---------------------------------------------------
 		// 2. 初期化設定

--- a/js/template/danoni_setting.js
+++ b/js/template/danoni_setting.js
@@ -261,3 +261,35 @@ const g_presetStockForceDelList = {
 	back: [],
 	mask: [],
 };
+
+/**
+ * 特殊キー定義（共通）
+ * 指定方法は作品別に特殊キーを定義する方法と同じ（ただし、keyExtraList必須）
+ * 
+ * 定義方法は下記を参照のこと
+ * https://github.com/cwtickle/danoniplus/wiki/keys
+ * https://github.com/cwtickle/danoniplus/wiki/tips-0004-extrakeys
+ */
+/*
+const g_presetKeysData = `
+
+|keyExtraList=6,9v|
+|color6=0,1,0,1,0,2$2,0,1,0,1,0|
+|chara6=left,leftdia,down,rightdia,right,space$space,left,leftdia,down,rightdia,right|
+|div6=6$6|
+|stepRtn6=0,45,-90,135,180,onigiri$onigiri,0,45,-90,135,180|
+|keyCtrl6=75/0,79/0,76/0,80/0,187/0,32/0$32/0,75/0,79/0,76/0,80/0,187/0|
+|shuffle6=1,1,1,1,1,0$0,1,1,1,1,1|
+
+|chara9v=9B_0$9B_0|
+|color9v=1,0,1,0,2,0,1,0,1$9B_0|
+|div9v=9$9|
+|keyCtrl9v=52/0,82/0,70/0,86/0,32/0,78/0,74/0,73/0,57/0$9B_0|
+|pos9v=0,1,2,3,4,5,6,7,8$0,1,2,3,4,5,6,7,8|
+|scroll9v=---::1,1,-1,-1,-1,-1,-1,1,1/flat::1,1,1,1,1,1,1,1,1$9B_0|
+|shuffle9v=9B_0$9B_0|
+|stepRtn9v=90,120,150,180,onigiri,0,30,60,90$9B_0|
+|transKey9v=$9B|
+
+`;
+*/


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. danoni_setting.js 上で共通のカスタムキー定義ができるようにしました。
    - 作品別と同じ指定方法で定義します。**keyExtraList指定は必須**です。
```javascript
const g_presetKeysData = `

|keyExtraList=6,9v|
|color6=0,1,0,1,0,2$2,0,1,0,1,0|
|chara6=left,leftdia,down,rightdia,right,space$space,left,leftdia,down,rightdia,right|
|div6=6$6|
|stepRtn6=0,45,-90,135,180,onigiri$onigiri,0,45,-90,135,180|
|keyCtrl6=75/0,79/0,76/0,80/0,187/0,32/0$32/0,75/0,79/0,76/0,80/0,187/0|
|shuffle6=1,1,1,1,1,0$0,1,1,1,1,1|

|chara9v=9B_0$9B_0|
|color9v=1,0,1,0,2,0,1,0,1$9B_0|
|div9v=9$9|
|keyCtrl9v=52/0,82/0,70/0,86/0,32/0,78/0,74/0,73/0,57/0$9B_0|
|pos9v=0,1,2,3,4,5,6,7,8$0,1,2,3,4,5,6,7,8|
|scroll9v=---::1,1,-1,-1,-1,-1,-1,1,1/flat::1,1,1,1,1,1,1,1,1$9B_0|
|shuffle9v=9B_0$9B_0|
|stepRtn9v=90,120,150,180,onigiri,0,30,60,90$9B_0|
|transKey9v=$9B|

`;
```

2. 作品別のカスタムキー定義について、keyExtraList指定を任意にしました。
    - difData内に標準キー及び共通のカスタムキーが無いキーが出てきた場合、
譜面データ内に該当のキー定義が無いかを自動で検索します。
※ただし、既存キーを上書き定義したい場合は従来通り**keyExtraList指定は必須**です。

3. makeDedupliArray関数を汎用化し、配列単独、複数配列の複合でも処理できるようにしました。
```javascript
console.log(makeDedupliArray([1, 2, 3, 3])); // [1, 2, 3]
console.log(makeDedupliArray([1, 2, 3, 3], [3, 4, 5, 5])); // [1, 2, 3, 4, 5]
console.log(makeDedupliArray([1, 2, 3, 3], [3, 4, 5, 5], 6, 7, 8)); // [1, 2, 3, 4, 5, 6, 7, 8]
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. カスタムキーを共通設定側で定義することで、譜面側で定義する数を減らせるため。
また、共通化することでReverseやキーコンなどの設定を作品間で共用できるメリットがある。
2. 作品別のカスタムキーについて、difDataを見れば特定できるため。
3. 関数の利便性向上のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 実装に当たりkeysConvert関数を拡張していますが、既存の使い方であれば問題ないような作りにしています。
