### PR TITLE
[0526/keys-extension] 作品別のkeyExtraList指定時に余計なキーを検出する問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1514,7 +1514,7 @@ function initAfterDosLoaded() {
 		}
 		g_headerObj.keyExtraList = keysConvert(g_rootObj, {
 			keyExtraList: (g_rootObj.keyExtraList !== undefined ?
-				makeDedupliArray(g_rootObj.keyExtraList, g_headerObj.undefinedKeyLists) : g_headerObj.undefinedKeyLists),
+				makeDedupliArray(g_rootObj.keyExtraList.split(`,`), g_headerObj.undefinedKeyLists) : g_headerObj.undefinedKeyLists),
 		});
 
 		// キー数情報を初期化


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 作品別のkeyExtraList指定時に余計なキーを検出する問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #1231 でkeysConvert関数の引数に配列を入れるべきところ、一部文字列が混在する箇所がありました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
