### PR TITLE
[ver26.3.0] 共通設定ファイルの変数統合、ファイル読込部分のコード見直し

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ v19, v25の対応終了時期はv28リリース開始時を予定しています
 
 | Version | Supported          | Latest Version | Logs | First Release | End of Support |
 | ------- | ------------------ |----------------|------|---------------|----------------|
-| v26     | :heavy_check_mark: |[v26.2.0](https://github.com/cwtickle/danoniplus/releases/tag/v26.2.0)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v26)|2022-01-30|-|
+| v26     | :heavy_check_mark: |[v26.3.0](https://github.com/cwtickle/danoniplus/releases/tag/v26.3.0)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v26)|2022-01-30|-|
 | v25     | :heavy_check_mark: |[v25.5.6](https://github.com/cwtickle/danoniplus/releases/tag/v25.5.6)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v25)|2022-01-04|(At Release v28)|
 | v24     | :heavy_check_mark: |[v24.6.5](https://github.com/cwtickle/danoniplus/releases/tag/v24.6.5)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v24)|2021-10-24|(At Release v33)|
 | v23     | :x:                |[v23.5.6 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v23.5.6)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v23)|2021-09-04|2022-01-30|

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2022/02/20
+ * Revised : 2022/02/23
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 26.2.0`;
-const g_revisedDate = `2022/02/20`;
+const g_version = `Ver 26.3.0`;
+const g_revisedDate = `2022/02/23`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -5,7 +5,7 @@
  *
  * Source by tickle
  * Created : 2019/11/19
- * Revised : 2022/02/05 (v26.1.0)
+ * Revised : 2022/02/23 (v26.3.0)
  *
  * https://github.com/cwtickle/danoniplus
  */

--- a/js/template/danoni_setting.js
+++ b/js/template/danoni_setting.js
@@ -1,11 +1,11 @@
 ﻿'use strict';
 /**
  * Dancing☆Onigiri 設定用jsファイル
- * Template Update: 2022/02/20 (v26.2.0)
+ * Template Update: 2022/02/23 (v26.3.0)
  * 
  * このファイルでは、作品全体に対しての初期設定を行うことができます。
  * 譜面データ側で個別に同様の項目が設定されている場合は、譜面データ側の設定が優先されます。
- * 例えばこのファイルで g_presetTuning = `onigiri` とすると全ての作品に製作者名として「onigiri」が設定されますが、
+ * 例えばこのファイルで g_presetObj.tuning = `onigiri` とすると全ての作品に製作者名として「onigiri」が設定されますが、
  * 譜面データ側で |tuning=washoi| とするとその作品には製作者名として「washoi」が設定されます。
  */
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danoniplus",
-  "version": "26.2.0",
+  "version": "26.3.0",
   "description": "Dancing☆Onigiri (CW Edition) - Web-based Rhythm Game",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- #1235 
    - danoni_setting.js で定義されている変数群を、g_presetObjへ移行
    - 共通設定ファイルの変数を使った部分のコード見直し 
- #1236 
    - ファイル読込部分をasync/await形式に書き換え
    - customjsファイルの読み込み順をスキンcssファイルの後、headerConvert関数の前に移動 

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments