### PR TITLE
[0532/cr-loading] loadScript2関数未使用の箇所を修正　他コード見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -48,16 +48,16 @@ const current = _ => {
 };
 const g_rootPath = current().match(/(^.*\/)/)[0];
 const g_remoteFlg = g_rootPath.match(`^https://cwtickle.github.io/danoniplus/`) !== null;
+const g_randTime = Date.now();
 
 window.onload = async () => {
 	g_loadObj.main = true;
 	g_currentPage = `initial`;
 
 	// ロード直後に定数・初期化ファイル、旧バージョン定義関数を読込
-	const randTime = new Date().getTime();
-	await loadScript2(`${g_rootPath}../js/lib/danoni_localbinary.js?${randTime}`, false);
-	await loadScript2(`${g_rootPath}../js/lib/danoni_constants.js?${randTime}`);
-	await loadScript2(`${g_rootPath}../js/lib/danoni_legacy_function.js?${randTime}`, false);
+	await loadScript2(`${g_rootPath}../js/lib/danoni_localbinary.js?${g_randTime}`, false);
+	await loadScript2(`${g_rootPath}../js/lib/danoni_constants.js?${g_randTime}`);
+	await loadScript2(`${g_rootPath}../js/lib/danoni_legacy_function.js?${g_randTime}`, false);
 	initialControl();
 };
 
@@ -1355,8 +1355,7 @@ async function initialControl() {
 	}
 
 	// 共通設定ファイルの読込
-	const randTime = new Date().getTime();
-	await loadScript2(`${settingRoot}danoni_setting${settingType}.js?${randTime}`, false);
+	await loadScript2(`${settingRoot}danoni_setting${settingType}.js?${g_randTime}`, false);
 	loadLegacySettingFunc();
 	if (document.querySelector(`#lblLoading`) !== null) {
 		divRoot.removeChild(document.querySelector(`#lblLoading`));
@@ -1564,8 +1563,7 @@ async function loadChartFile(_scoreId = g_stateObj.scoreId) {
 		const fileCommon = fileBase.split(`.${fileExtension}`)[0];
 		const filename = `${fileCommon}${g_stateObj.dosDivideFlg ? setScoreIdHeader(_scoreId) : ''}.${fileExtension}`;
 
-		const randTime = new Date().getTime();
-		await loadScript2(`${filename}?${randTime}`, false, charset);
+		await loadScript2(`${filename}?${g_randTime}`, false, charset);
 		if (typeof externalDosInit === C_TYP_FUNCTION) {
 			if (document.querySelector(`#lblLoading`) !== null) {
 				divRoot.removeChild(document.querySelector(`#lblLoading`));
@@ -1932,7 +1930,7 @@ function loadMultipleFiles(_j, _fileData, _loadType, _afterFunc = _ => true) {
  */
 async function loadMultipleFiles2(_fileData, _loadType) {
 	await Promise.all(_fileData.map(async filePart => {
-		const filePath = `${filePart[1]}${filePart[0]}?${new Date().getTime()}`;
+		const filePath = `${filePart[1]}${filePart[0]}?${g_randTime}`;
 		if (filePart[0].endsWith(`.css`)) {
 			_loadType = `css`;
 		}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1563,7 +1563,7 @@ async function loadChartFile(_scoreId = g_stateObj.scoreId) {
 		const fileCommon = fileBase.split(`.${fileExtension}`)[0];
 		const filename = `${fileCommon}${g_stateObj.dosDivideFlg ? setScoreIdHeader(_scoreId) : ''}.${fileExtension}`;
 
-		await loadScript2(`${filename}?${g_randTime}`, false, charset);
+		await loadScript2(`${filename}?${Date.now()}`, false, charset);
 		if (typeof externalDosInit === C_TYP_FUNCTION) {
 			if (document.querySelector(`#lblLoading`) !== null) {
 				divRoot.removeChild(document.querySelector(`#lblLoading`));


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. loadScript2関数未使用の箇所を修正しました。（エンコード済み音楽データの読込）
2. コードの見直しを行いました。
3. 外部ファイル名末尾のランダム値を一部固定化しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1, 2. コード統一性のため。
3. 譜面ファイル以外は一度しか読み込まないため。
譜面ファイルはリトライ反映に対応するため、そのままとしました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments