### PR TITLE
[0533/keypos-decimal] カスタムキー定義のpos項目について小数点に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3808,6 +3808,7 @@ function keysConvert(_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 	const existParam = (_data, _paramName) => !hasVal(_data) && g_keyObj[_paramName] !== undefined;
 	const toString = _str => _str;
 	const toNumber = _num => parseInt(_num, 10);
+	const toFloat = _num => parseFloat(_num);
 	const toStringOrNumber = _str => isNaN(Number(_str)) ? _str : toNumber(_str);
 	const toSplitArray = _str => _str.split(`/`).map(n => toNumber(n));
 
@@ -3946,13 +3947,13 @@ function keysConvert(_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 
 				// ステップゾーン位置の最終番号
 				if (tmpDivPtn.length > 1) {
-					g_keyObj[`divMax${newKey}_${k}`] = setVal(tmpDivPtn[1], -1, C_TYP_NUMBER);
+					g_keyObj[`divMax${newKey}_${k}`] = setVal(tmpDivPtn[1], -1, C_TYP_FLOAT);
 				}
 			}
 		}
 
 		// ステップゾーン位置 (posX_Y)
-		newKeyMultiParam(newKey, `pos`, toNumber, {
+		newKeyMultiParam(newKey, `pos`, toFloat, {
 			loopFunc: (k, keyheader) => {
 				if (g_keyObj[`divMax${newKey}_${k}`] === undefined || g_keyObj[`divMax${newKey}_${k}`] === -1) {
 					const posLength = g_keyObj[`${keyheader}_${k}`].length;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. カスタムキー定義のpos項目について小数点に対応しました。
下記のような指定が可能になります。
```
|pos8i=0.7,1.4,2,3,4,5,6,7|
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. ステップ間を等間隔にしないケースに柔軟に対応するため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments