### PR TITLE
fix: [0534] 譜面密度グラフで同時押しのカウント誤りを修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1687,10 +1687,12 @@ function storeBaseData(_scoreId, _scoreObj, _keyCtrlPtn) {
 		} else {
 			const point = Math.floor((note - firstArrowFrame) / playingFrame * C_LEN_DENSITY_DIVISION);
 			if (point >= 0) {
-				if (pushCnt > 2) {
-					density3PushData[point] += pushCnt;
+				if (pushCnt >= 2) {
+					density2PushData[point] += pushCnt;
+					if (pushCnt >= 3) {
+						density3PushData[point] += pushCnt;
+					}
 				}
-				density2PushData[point] += pushCnt;
 			}
 			pushCnt = 0;
 		}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 譜面密度グラフで、同時押しのカウント誤りがある部分を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Discordでの指摘より。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments