### PR TITLE
feat: [0541] プレイ画面からリザルト画面移行時の100ミリ秒を廃止

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9133,7 +9133,7 @@ const MainInit = _ => {
 			}
 			resetKeyControl();
 			clearTimeout(g_timeoutEvtId);
-			setTimeout(_ => resultInit(), 100);
+			resultInit();
 
 		} else if (g_workObj.lifeVal === 0 && g_workObj.lifeBorder === 0) {
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. プレイ画面からリザルト画面移行時の100ミリ秒を廃止しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 以前は`resultInit()`を即時実行すると矢印・フリーズアローの移動処理が後に残っていたことがあったため
エラーが表示されることがありました。
ただ、上記問題が発生しやすい即時Failedやショートカット操作でも猶予秒はすでに廃止されており、
プレイ終了時であえてこの猶予秒を残す意味は無いため、廃止とする予定です。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- プレイ上の支障はないと思いますが、プレイ画面から結果画面に移行する際のモーションが100ミリ秒（60fpsの場合、6フレーム分）短くなる可能性があります。
- リザルトモーションのタイミングが重要となる作品の場合、
6フレーム後ろに設定する必要がある可能性があります。（未検証）
このため、同一バージョンでのマージは見送ることを考えています。