### PR TITLE
feat: [0545] プレイ画面から結果画面への移行フレーム差を埋める対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7662,6 +7662,7 @@ const getArrowSettings = _ => {
 	g_workObj.arrowRtn = copyArray2d(g_keyObj[`stepRtn${keyCtrlPtn}`]);
 	g_workObj.keyCtrl = copyArray2d(g_keyObj[`keyCtrl${keyCtrlPtn}`]);
 	g_workObj.diffList = [];
+	g_workObj.mainEndTime = 0;
 
 	const keyCtrlLen = g_workObj.keyCtrl.length;
 	g_workObj.keyCtrlN = [...Array(keyCtrlLen)].map(_ => []);
@@ -9009,6 +9010,7 @@ const MainInit = _ => {
 			}
 			resetKeyControl();
 			clearTimeout(g_timeoutEvtId);
+			g_workObj.mainEndTime = thisTime;
 			resultInit();
 
 		} else if (g_workObj.lifeVal === 0 && g_workObj.lifeBorder === 0) {
@@ -9561,7 +9563,7 @@ const resultInit = _ => {
 	// 曲時間制御変数
 	let thisTime;
 	let buffTime;
-	let resultStartTime = performance.now();
+	let resultStartTime = g_workObj.mainEndTime > 0 ? g_workObj.mainEndTime : performance.now();
 
 	if (g_stateObj.d_background === C_FLG_OFF && g_headerObj.resultMotionSet) {
 	} else {
@@ -10025,8 +10027,7 @@ const resultInit = _ => {
 		g_scoreObj.maskResultFrameNum++;
 		g_timeoutEvtResultId = setTimeout(_ => flowResultTimeline(), 1000 / g_fps - buffTime);
 	};
-
-	g_timeoutEvtResultId = setTimeout(_ => flowResultTimeline(), 1000 / g_fps);
+	flowResultTimeline();
 
 	// キー操作イベント（デフォルト）
 	setShortcutEvent(g_currentPage);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. プレイ画面から結果画面への移行フレーム差を埋める対応を行いました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Resolves #902 

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- ローカルで試した限りでは平均3フレームほど遅延しますが、殆ど気にならないと思われます。
遅れは時間経過と共にリカバリーされます。
https://github.com/cwtickle/danoniplus/wiki/AboutFrameProcessing