### PR TITLE
refactor: [0547] webkit-text-fill-colorをcolorに変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3570,7 +3570,7 @@ const titleInit = _ => {
 				background: ${titlegrds[0]};
 				background-clip: text;
 				-webkit-background-clip: text;
-				-webkit-text-fill-color: rgba(255,255,255,0.0);
+				color: rgba(255,255,255,0.0);
 				${txtAnimations[0]}
 			" class="${g_headerObj.titleAnimationClass[0]}">
 				${g_headerObj.musicTitleForView[0]}
@@ -3583,7 +3583,7 @@ const titleInit = _ => {
 				background: ${titlegrds[1]};
 				background-clip: text;
 				-webkit-background-clip: text;
-				-webkit-text-fill-color: rgba(255,255,255,0.0);
+				color: rgba(255,255,255,0.0);
 				${txtAnimations[1]}
 			" class="${g_headerObj.titleAnimationClass[1]}">
 				${g_headerObj.musicTitleForView[1] ?? ``}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. タイトル文字で使用している -webkit-text-fill-color を color に変更しました。
https://developer.mozilla.org/ja/docs/Web/CSS/-webkit-text-fill-color

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. -webkit-text-fill-colorが非標準であり、colorに置き換えても違いが無いため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments