### PR TITLE
feat: [0548] danoni_main.cssの記述を任意化

### DIFF
--- a/danoni/dTemplate.html
+++ b/danoni/dTemplate.html
@@ -2,11 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="utf-8">
-<meta http-equiv="Content-Script-Type" content="text/javascript">
-<meta http-equiv="Content-Style-Type" content="text/css">
 <script src="../js/danoni_main.js"></script>
-<link rel="stylesheet" type="text/css" href="../css/danoni_main.css">
-
 
 <title>Dancing★Onigiri</title>
 

--- a/danoni/danoni0.html
+++ b/danoni/danoni0.html
@@ -2,11 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="utf-8">
-<meta http-equiv="Content-Script-Type" content="text/javascript">
-<meta http-equiv="Content-Style-Type" content="text/css">
 <script src="../js/danoni_main.js"></script>
-<link rel="stylesheet" type="text/css" href="../css/danoni_main.css">
-
 
 <title>Dancing★Onigiri Preview</title>
 

--- a/danoni/danoni0_remote.html
+++ b/danoni/danoni0_remote.html
@@ -2,11 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="utf-8">
-<meta http-equiv="Content-Script-Type" content="text/javascript">
-<meta http-equiv="Content-Style-Type" content="text/css">
 <script src="https://cwtickle.github.io/danoniplus/js/danoni_main.js" charset="UTF-8"></script>
-<link rel="stylesheet" type="text/css" href="https://cwtickle.github.io/danoniplus/css/danoni_main.css">
-
 
 <title>Dancing★Onigiri Preview</title>
 

--- a/danoni/danoni1.html
+++ b/danoni/danoni1.html
@@ -2,11 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="utf-8">
-<meta http-equiv="Content-Script-Type" content="text/javascript">
-<meta http-equiv="Content-Style-Type" content="text/css">
 <script src="../js/danoni_main.js"></script>
-<link rel="stylesheet" type="text/css" href="../css/danoni_main.css">
-
 
 <title>Dancing★Onigiri Test</title>
 

--- a/danoni/danoni2.html
+++ b/danoni/danoni2.html
@@ -2,10 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="utf-8">
-<meta http-equiv="Content-Script-Type" content="text/javascript">
-<meta http-equiv="Content-Style-Type" content="text/css">
 <script src="../js/danoni_main.js"></script>
-<link rel="stylesheet" type="text/css" href="../css/danoni_main.css">
 <title>Dancing★Onigiri Test2</title>
 <style type="text/css">
 <!--//

--- a/danoni/danoni3.html
+++ b/danoni/danoni3.html
@@ -2,10 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="utf-8">
-<meta http-equiv="Content-Script-Type" content="text/javascript">
-<meta http-equiv="Content-Style-Type" content="text/css">
 <script src="../js/danoni_main.js"></script>
-<link rel="stylesheet" type="text/css" href="../css/danoni_main.css">
 <title>Dancing★Onigiri Test3</title>
 <style type="text/css">
 <!--//

--- a/danoni/danoni4_skin.html
+++ b/danoni/danoni4_skin.html
@@ -2,10 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="utf-8">
-<meta http-equiv="Content-Script-Type" content="text/javascript">
-<meta http-equiv="Content-Style-Type" content="text/css">
 <script src="../js/danoni_main.js"></script>
-<link rel="stylesheet" type="text/css" href="../css/danoni_main.css">
 <title>Dancing★Onigiri Preview</title>
 <style type="text/css">
 <!--//
@@ -57,7 +54,7 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 
 |tuning=7chat,http://cw7.sakura.ne.jp/7chat/|
 		'>
-<div id="canvas-frame" style="width:600px;">
+<div id="canvas-frame" style="width:600px;margin:auto;">
 	<p>ゲームを準備しています...</p>
 	<p>このメッセージがいつまでも消えない場合、<br>
 		Google ChromeやFirefox等、HTML5に対応したブラウザをご利用ください。</p>

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -54,6 +54,10 @@ const g_randTime = Date.now();
 window.onload = async () => {
 	g_loadObj.main = true;
 	g_currentPage = `initial`;
+	const links = document.querySelectorAll(`link`);
+	if (Array.from(links).filter(elem => elem.getAttribute(`href`).indexOf(`danoni_main.css`) !== -1).length === 0) {
+		await importCssFile2(`${g_rootPath}../css/danoni_main.css?${g_randTime}`);
+	}
 
 	// ロード直後に定数・初期化ファイル、旧バージョン定義関数を読込
 	await loadScript2(`${g_rootPath}../js/lib/danoni_localbinary.js?${g_randTime}`, false);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. danoni_main.cssの記述を任意化しました。
今後は`danoni_main.js`と文字コード指定があればcssファイルも合わせて読み込みます。
従来通りcssファイルを指定した場合でも動作します。
※記述を任意にしただけで、`danoni_main.css`そのものは**今後も必要**です。
```html
<meta charset="utf-8">
<script src="../js/danoni_main.js"></script>
```
2. サンプルHTMLから以下の記述を削除しました。
```html
<meta http-equiv="Content-Script-Type" content="text/javascript">
<meta http-equiv="Content-Style-Type" content="text/css">
<link rel="stylesheet" type="text/css" href="../css/danoni_main.css">
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 記載する量を減らすことで手軽に導入しやすくするため。
2. Content-Script-Type, Content-Style-Type の記述はHTML5以後ではデフォルト不要のため。
cssファイル部分については、1.の理由で不要となったため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- danoni_main.cssの自動読込は、スキンcssを読み込む方法と同じ方法で実装しています（遅延読み込み）。
- htmlに記載している`<link>`要素を見て、`danoni_main.css`という記述がhref属性にいればすでに`danoni_main.css`が読込済みであると見做します。