### PR TITLE
feat: [0551] 作品別のカスタムファイル指定に対して共通設定を参照する機能を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2333,11 +2333,11 @@ const preheaderConvert = _dosObj => {
 
 	// 外部jsファイルの指定
 	const tmpCustomjs = _dosObj.customjs ?? g_presetObj.customJs ?? C_JSF_CUSTOM;
-	setJsFiles(tmpCustomjs.split(`,`), C_DIR_JS);
+	setJsFiles(tmpCustomjs.replaceAll(`*`, g_presetObj.customJs).split(`,`), C_DIR_JS);
 
 	// 外部cssファイルの指定
 	const tmpCustomcss = _dosObj.customcss ?? g_presetObj.customCss ?? ``;
-	setJsFiles(tmpCustomcss.split(`,`), C_DIR_CSS);
+	setJsFiles(tmpCustomcss.replaceAll(`*`, g_presetObj.customCss).split(`,`), C_DIR_CSS);
 
 	// デフォルト曲名表示、背景、Ready表示の利用有無
 	g_titleLists.init.forEach(objName => {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 作品別のカスタムファイル指定（customjs, customcss）に対して、共通設定ファイル上のカスタムファイル指定（g_presetObj.customJs, g_presetObj.customCss）を参照できる機能を実装しました。

- danoni_setting.js で`g_presetObj.customJs`が定義されているとき、
作品側の譜面ヘッダー「customjs」で「*」を指定すると、
`g_presetObj.customJs`で指定しているファイルに置き換えます。
※customcssも同様に設定可能です。
```javascript
g_presetObj.customJs = `danoni_init.js,danoni_init_type2.js`;
```
```
|customjs=*,special.js|
-> |customjs=danoni_init.js,danoni_init_type2.js,special.js| と同じ意味
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. g_presetObj.customJsがすでにあるにもかかわらず、
作品別のcustomJsを指定する場合は同じファイル名を記載する必要があるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments