### PR TITLE
feat: [0552] ColorType:1～4に対してColorPickerに対応

### DIFF
--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -52,6 +52,7 @@ input[type=range]:focus {
 input[type=color] {
 	width:25px;
 	height:25px;
+	border:none;
 }
 
 /* 左から右へ */

--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -49,6 +49,11 @@ input[type=range]:focus {
 	outline: 0;
 }
 
+input[type=color] {
+	width:25px;
+	height:25px;
+}
+
 /* 左から右へ */
 @keyframes leftToRight {
 	0% {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5977,7 +5977,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 					document.getElementById(`pickfrzBar${j}`).value = g_headerObj[`frzColor${g_colorType}`][j][1];
 				}
 			}
-		}, { x: 35, y: 0, w: 30, h: 15, siz: 11 }, g_cssObj.button_Start),
+		}, { x: 35, y: -5, w: 30, h: 20, siz: 14 }, g_cssObj.button_Start),
 	);
 
 	/**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5921,7 +5921,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	const changeColorPicker = (_j, _type, _color) => {
 		if (_color !== ``) {
 			document.getElementById(`pick${_type}${_j}`).value = _color.slice(0, 7);
-			document.getElementById(`pick${_type}${_j}`).style.display = ([`Default`, `Type0`].includes(g_colorType) ? C_DIS_NONE : C_DIS_INHERIT);
+			document.getElementById(`pick${_type}${_j}`).style.display = C_DIS_INHERIT;
 		} else {
 			document.getElementById(`pick${_type}${_j}`).style.display = C_DIS_NONE;
 		}
@@ -5941,6 +5941,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		viewGroupObj.color(`_${g_keycons.colorGroupNum}`);
 		lnkColorType.textContent = `${getStgDetailName(g_colorType)}${g_localStorage.colorType === g_colorType ? ' *' : ''}`;
 		if (_reloadFlg) {
+			colorPickSprite.style.display = ([`Default`, `Type0`].includes(g_colorType) ? C_DIS_NONE : C_DIS_INHERIT);
 			for (let j = 0; j < g_headerObj.setColor.length; j++) {
 				changeColorPicker(j, `arrow`, g_headerObj.setColor[j]);
 				changeColorPicker(j, `arrowShadow`, g_headerObj.setShadowColor[j]);
@@ -5961,7 +5962,21 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	};
 
 
-	const colorPickSprite = createEmptySprite(divRoot, `colorPickSprite`, { x: 0, y: 90, w: 50, h: 300 });
+	const colorPickSprite = createEmptySprite(divRoot, `colorPickSprite`, { x: 0, y: 90, w: 50, h: 280, background: `#00000080` });
+	if ([`Default`, `Type0`].includes(g_colorType)) {
+		colorPickSprite.style.display = C_DIS_NONE;
+	}
+	multiAppend(colorPickSprite,
+		createDivCss2Label(`lblPickArrow`, g_lblNameObj.s_arrow, { x: 0, y: 0, siz: 11, align: C_ALIGN_LEFT }),
+		createDivCss2Label(`lblPickArrow`, g_lblNameObj.s_frz, { x: 0, y: 140, siz: 11, align: C_ALIGN_LEFT }),
+		createCss2Button(`lnkColorCopy`, `[↓]`, _ => {
+			for (let j = 0; j < g_headerObj.setColor.length; j++) {
+				g_headerObj[`frzColor${g_colorType}`][j] = [...Array(g_headerObj[`frzColor${g_colorType}`][j].length)].fill(g_headerObj[`setColor${g_colorType}`][j]);
+				document.getElementById(`pickfrz${j}`).value = g_headerObj[`frzColor${g_colorType}`][j][0];
+				document.getElementById(`pickfrzBar${j}`).value = g_headerObj[`frzColor${g_colorType}`][j][1];
+			}
+		}, { x: 35, y: 0, w: 30, h: 15, siz: 11 }, g_cssObj.button_Start),
+	);
 
 	/**
 	 * ColorPicker部分の作成
@@ -5970,11 +5985,8 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	 * @param {function} _func 
 	 * @param {object} _obj 
 	 */
-	const createColorPickWindow = (_j, _type, _func, { x = 0, y = 0 } = {}) => {
+	const createColorPickWindow = (_j, _type, _func, { x = 0, y = 15 } = {}) => {
 		const picker = createColorPicker(colorPickSprite, `pick${_type}${_j}`, { x, y: y + 25 * _j });
-		if ([`Default`, `Type0`].includes(g_colorType)) {
-			picker.style.display = C_DIS_NONE;
-		}
 		picker.addEventListener(`change`, _func);
 	};
 
@@ -5990,10 +6002,10 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		}, { x: 25 });
 
 		createColorPickWindow(j, `frz`, _ =>
-			g_headerObj[`frzColor${g_colorType}`][j][0] = document.getElementById(`pickfrz${j}`).value, { y: 140 });
+			g_headerObj[`frzColor${g_colorType}`][j][0] = document.getElementById(`pickfrz${j}`).value, { y: 155 });
 
 		createColorPickWindow(j, `frzBar`, _ =>
-			g_headerObj[`frzColor${g_colorType}`][j][1] = document.getElementById(`pickfrzBar${j}`).value, { x: 25, y: 140 });
+			g_headerObj[`frzColor${g_colorType}`][j][1] = document.getElementById(`pickfrzBar${j}`).value, { x: 25, y: 155 });
 	}
 
 	// ConfigType, ColorTypeの初期設定

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5961,11 +5961,11 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		keyConfigInit(g_kcType);
 	};
 
-	const colorPickSprite = createEmptySprite(divRoot, `colorPickSprite`, { x: 0, y: 90, w: 50, h: 280 });
+	const colorPickSprite = createEmptySprite(divRoot, `colorPickSprite`, g_windowObj.colorPickSprite);
 	if ([`Default`, `Type0`].includes(g_colorType)) {
 		colorPickSprite.style.display = C_DIS_NONE;
 	}
-	const pickPos = { x: 0, w: 50, h: 15, siz: 11, align: C_ALIGN_LEFT, background: `#00000020` };
+	const pickPos = { x: 0, w: 50, h: 15, siz: 11, align: C_ALIGN_LEFT, background: `#${g_headerObj.baseBrightFlg ? `eeeeee` : `111111`}80` };
 	multiAppend(colorPickSprite,
 		createDivCss2Label(`lblPickArrow`, g_lblNameObj.s_arrow, Object.assign({ y: 0 }, pickPos)),
 		createDivCss2Label(`lblPickFrz`, g_lblNameObj.s_frz, Object.assign({ y: 140 }, pickPos)),

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5961,14 +5961,14 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		keyConfigInit(g_kcType);
 	};
 
-
-	const colorPickSprite = createEmptySprite(divRoot, `colorPickSprite`, { x: 0, y: 90, w: 50, h: 280, background: `#00000080` });
+	const colorPickSprite = createEmptySprite(divRoot, `colorPickSprite`, { x: 0, y: 90, w: 50, h: 280 });
 	if ([`Default`, `Type0`].includes(g_colorType)) {
 		colorPickSprite.style.display = C_DIS_NONE;
 	}
+	const pickPos = { x: 0, w: 50, h: 15, siz: 11, align: C_ALIGN_LEFT, background: `#00000020` };
 	multiAppend(colorPickSprite,
-		createDivCss2Label(`lblPickArrow`, g_lblNameObj.s_arrow, { x: 0, y: 0, siz: 11, align: C_ALIGN_LEFT }),
-		createDivCss2Label(`lblPickArrow`, g_lblNameObj.s_frz, { x: 0, y: 140, siz: 11, align: C_ALIGN_LEFT }),
+		createDivCss2Label(`lblPickArrow`, g_lblNameObj.s_arrow, Object.assign({ y: 0 }, pickPos)),
+		createDivCss2Label(`lblPickFrz`, g_lblNameObj.s_frz, Object.assign({ y: 140 }, pickPos)),
 		createCss2Button(`lnkColorCopy`, `[↓]`, _ => {
 			if (window.confirm(g_msgObj.colorCopyConfirm)) {
 				for (let j = 0; j < g_headerObj.setColor.length; j++) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -966,6 +966,25 @@ const createImg = (_id, _imgPath, _x, _y, _width, _height) => {
 };
 
 /**
+ * ColorPickerの作成
+ * @param {string} _id 
+ * @param {string} _color 
+ * @param {object} _obj 
+ * @returns 
+ */
+const createColorPicker = (_parentObj, _id, _color, { x = 0, y = 0 } = {}) => {
+	const picker = document.createElement(`input`);
+	picker.setAttribute(`type`, `color`);
+	picker.id = _id;
+	picker.value = _color;
+	picker.style.left = `${x}px`;
+	picker.style.top = `${y}px`;
+	picker.style.position = `absolute`;
+	_parentObj.appendChild(picker);
+	return picker;
+};
+
+/**
  * 色付きオブジェクトの作成 (拡張属性対応)
  * @param {string} _id 
  * @param {object} _obj (x, y, w, h, color, rotate, styleName, ...rest) 
@@ -5908,6 +5927,11 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		changeSetColor();
 		viewGroupObj.color(`_${g_keycons.colorGroupNum}`);
 		lnkColorType.textContent = `${getStgDetailName(g_colorType)}${g_localStorage.colorType === g_colorType ? ' *' : ''}`;
+		if (_scrollNum !== 0) {
+			for (let j = 0; j < 5; j++) {
+				document.getElementById(`pick${j}`).value = g_headerObj.setColor[j];
+			}
+		}
 	};
 
 	const setImgType = (_scrollNum = 1) => {
@@ -5940,6 +5964,15 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		}
 		return _tempPtn;
 	};
+
+	for (let j = 0; j < 5; j++) {
+		const picker = createColorPicker(divRoot, `pick${j}`,
+			g_headerObj[`setColor${setScoreIdHeader(g_stateObj.scoreId)}${g_colorType}`][j], { y: 70 + 30 * j });
+		picker.addEventListener(`input`, _ => {
+			g_headerObj[`setColor${setScoreIdHeader(g_stateObj.scoreId)}${g_colorType}`][j] = picker.value;
+			g_headerObj.setColor[j] = picker.value;
+		});
+	}
 
 	// ユーザカスタムイベント(初期)
 	g_customJsObj.keyconfig.forEach(func => func());

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5970,10 +5970,12 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		createDivCss2Label(`lblPickArrow`, g_lblNameObj.s_arrow, { x: 0, y: 0, siz: 11, align: C_ALIGN_LEFT }),
 		createDivCss2Label(`lblPickArrow`, g_lblNameObj.s_frz, { x: 0, y: 140, siz: 11, align: C_ALIGN_LEFT }),
 		createCss2Button(`lnkColorCopy`, `[↓]`, _ => {
-			for (let j = 0; j < g_headerObj.setColor.length; j++) {
-				g_headerObj[`frzColor${g_colorType}`][j] = [...Array(g_headerObj[`frzColor${g_colorType}`][j].length)].fill(g_headerObj[`setColor${g_colorType}`][j]);
-				document.getElementById(`pickfrz${j}`).value = g_headerObj[`frzColor${g_colorType}`][j][0];
-				document.getElementById(`pickfrzBar${j}`).value = g_headerObj[`frzColor${g_colorType}`][j][1];
+			if (window.confirm(g_msgObj.colorCopyConfirm)) {
+				for (let j = 0; j < g_headerObj.setColor.length; j++) {
+					g_headerObj[`frzColor${g_colorType}`][j] = [...Array(g_headerObj[`frzColor${g_colorType}`][j].length)].fill(g_headerObj[`setColor${g_colorType}`][j]);
+					document.getElementById(`pickfrz${j}`).value = g_headerObj[`frzColor${g_colorType}`][j][0];
+					document.getElementById(`pickfrzBar${j}`).value = g_headerObj[`frzColor${g_colorType}`][j][1];
+				}
 			}
 		}, { x: 35, y: 0, w: 30, h: 15, siz: 11 }, g_cssObj.button_Start),
 	);

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2369,88 +2369,94 @@ const g_dfColorObj = {
     setColorInit: [`#6666ff`, `#99ffff`, `#ffffff`, `#ffff99`, `#ff9966`],
     setShadowColorInit: [``, ``, ``, ``, ``],
 
-    setColorType1: [`#6666ff`, `#99ffff`, `#ffffff`, `#ffff99`, `#ff9966`],
-    setColorType2: [`#ffffff`, `#9999ff`, `#99ccff`, `#ffccff`, `#ff9999`],
-    setColorType3: [`#ccccff`, `#ccffff`, `#ffffff`, `#ffffcc`, `#ffcc99`],
-    setColorType4: [`#ffffff`, `#ccccff`, `#99ccff`, `#ffccff`, `#ffcccc`],
-
-    setShadowColorType1: [`#00000080`, `#00000080`, `#00000080`, `#00000080`, `#00000080`],
-    setShadowColorType2: [`#00000080`, `#00000080`, `#00000080`, `#00000080`, `#00000080`],
-    setShadowColorType3: [`#6666ff60`, `#33999960`, `#66666660`, `#99993360`, `#cc663360`],
-    setShadowColorType4: [`#66666660`, `#6666ff60`, `#3366cc60`, `#99339960`, `#99333360`],
-
     // フリーズアロー初期色情報
     frzColorInit: [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
     frzShadowColorInit: [``, ``, ``, ``],
-    frzColorType1: [
-        [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-        [`#00ffcc`, `#339999`, `#cccc33`, `#999933`],
-        [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-        [`#cc99ff`, `#9966ff`, `#cccc33`, `#999933`],
-        [`#ff99cc`, `#ff6699`, `#cccc33`, `#999933`]
-    ],
-    frzColorType2: [
-        [`#cccccc`, `#999999`, `#cccc33`, `#999933`],
-        [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-        [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-        [`#cc99cc`, `#ff99ff`, `#cccc33`, `#999933`],
-        [`#ff6666`, `#ff9999`, `#cccc33`, `#999933`]
-    ],
-    frzColorType3: [
-        [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-        [`#00ffcc`, `#339999`, `#cccc33`, `#999933`],
-        [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-        [`#cc99ff`, `#9966ff`, `#cccc33`, `#999933`],
-        [`#ff99cc`, `#ff6699`, `#cccc33`, `#999933`]
-    ],
-    frzColorType4: [
-        [`#cccccc`, `#999999`, `#cccc33`, `#999933`],
-        [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-        [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
-        [`#cc99cc`, `#ff99ff`, `#cccc33`, `#999933`],
-        [`#ff6666`, `#ff9999`, `#cccc33`, `#999933`]
-    ],
+
 };
 
-const g_dfColorLightObj = {
-    setColorType1: [`#6666ff`, `#66cccc`, `#000000`, `#999966`, `#cc6600`],
-    setColorType2: [`#000000`, `#6666ff`, `#cc0000`, `#cc99cc`, `#cc3366`],
-    setColorType3: [`#000000`, `#000000`, `#000000`, `#000000`, `#000000`],
-    setColorType4: [`#000000`, `#000000`, `#000000`, `#000000`, `#000000`],
+const g_dfColorBaseObj = {
 
-    setShadowColorType1: [`#ffffff80`, `#ffffff80`, `#ffffff80`, `#ffffff80`, `#ffffff80`],
-    setShadowColorType2: [`#ffffff80`, `#ffffff80`, `#ffffff80`, `#ffffff80`, `#ffffff80`],
-    setShadowColorType3: [`#6666ff80`, `#66cccc80`, `#ffffff80`, `#99996680`, `#cc660080`],
-    setShadowColorType4: [`#00000080`, `#6666ff80`, `#cc000080`, `#cc99cc80`, `#cc336680`],
+    dark: {
+        setColorType1: [`#6666ff`, `#99ffff`, `#ffffff`, `#ffff99`, `#ff9966`],
+        setColorType2: [`#ffffff`, `#9999ff`, `#99ccff`, `#ffccff`, `#ff9999`],
+        setColorType3: [`#ccccff`, `#ccffff`, `#ffffff`, `#ffffcc`, `#ffcc99`],
+        setColorType4: [`#ffffff`, `#ccccff`, `#99ccff`, `#ffccff`, `#ffcccc`],
 
-    frzColorType1: [
-        [`#66ffff`, `#6600ff`, `#ffff00`, `#999900`],
-        [`#00ffcc`, `#339999`, `#ffff00`, `#999900`],
-        [`#66ffff`, `#6600ff`, `#ffff00`, `#999900`],
-        [`#cc99ff`, `#9966ff`, `#ffff00`, `#999900`],
-        [`#ff99cc`, `#ff6699`, `#ffff00`, `#999900`]
-    ],
-    frzColorType2: [
-        [`#cccccc`, `#999999`, `#ffff00`, `#999900`],
-        [`#66ffff`, `#6600ff`, `#ffff00`, `#999900`],
-        [`#66ffff`, `#6600ff`, `#ffff00`, `#999900`],
-        [`#cc99cc`, `#ff99ff`, `#ffff00`, `#999900`],
-        [`#ff6666`, `#ff9999`, `#ffff00`, `#999900`]
-    ],
-    frzColorType3: [
-        [`#66ffff`, `#6600ff`, `#ffff00`, `#999900`],
-        [`#00ffcc`, `#339999`, `#ffff00`, `#999900`],
-        [`#66ffff`, `#6600ff`, `#ffff00`, `#999900`],
-        [`#cc99ff`, `#9966ff`, `#ffff00`, `#999900`],
-        [`#ff99cc`, `#ff6699`, `#ffff00`, `#999900`]
-    ],
-    frzColorType4: [
-        [`#cccccc`, `#999999`, `#ffff00`, `#999900`],
-        [`#66ffff`, `#6600ff`, `#ffff00`, `#999900`],
-        [`#66ffff`, `#6600ff`, `#ffff00`, `#999900`],
-        [`#cc99cc`, `#ff99ff`, `#ffff00`, `#999900`],
-        [`#ff6666`, `#ff9999`, `#ffff00`, `#999900`]
-    ],
+        setShadowColorType1: [`#00000080`, `#00000080`, `#00000080`, `#00000080`, `#00000080`],
+        setShadowColorType2: [`#00000080`, `#00000080`, `#00000080`, `#00000080`, `#00000080`],
+        setShadowColorType3: [`#6666ff60`, `#33999960`, `#66666660`, `#99993360`, `#cc663360`],
+        setShadowColorType4: [`#66666660`, `#6666ff60`, `#3366cc60`, `#99339960`, `#99333360`],
+
+        frzColorType1: [
+            [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
+            [`#00ffcc`, `#339999`, `#cccc33`, `#999933`],
+            [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
+            [`#cc99ff`, `#9966ff`, `#cccc33`, `#999933`],
+            [`#ff99cc`, `#ff6699`, `#cccc33`, `#999933`]
+        ],
+        frzColorType2: [
+            [`#cccccc`, `#999999`, `#cccc33`, `#999933`],
+            [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
+            [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
+            [`#cc99cc`, `#ff99ff`, `#cccc33`, `#999933`],
+            [`#ff6666`, `#ff9999`, `#cccc33`, `#999933`]
+        ],
+        frzColorType3: [
+            [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
+            [`#00ffcc`, `#339999`, `#cccc33`, `#999933`],
+            [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
+            [`#cc99ff`, `#9966ff`, `#cccc33`, `#999933`],
+            [`#ff99cc`, `#ff6699`, `#cccc33`, `#999933`]
+        ],
+        frzColorType4: [
+            [`#cccccc`, `#999999`, `#cccc33`, `#999933`],
+            [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
+            [`#66ffff`, `#6600ff`, `#cccc33`, `#999933`],
+            [`#cc99cc`, `#ff99ff`, `#cccc33`, `#999933`],
+            [`#ff6666`, `#ff9999`, `#cccc33`, `#999933`]
+        ],
+    },
+    light: {
+        setColorType1: [`#6666ff`, `#66cccc`, `#000000`, `#999966`, `#cc6600`],
+        setColorType2: [`#000000`, `#6666ff`, `#cc0000`, `#cc99cc`, `#cc3366`],
+        setColorType3: [`#000000`, `#000000`, `#000000`, `#000000`, `#000000`],
+        setColorType4: [`#000000`, `#000000`, `#000000`, `#000000`, `#000000`],
+
+        setShadowColorType1: [`#ffffff80`, `#ffffff80`, `#ffffff80`, `#ffffff80`, `#ffffff80`],
+        setShadowColorType2: [`#ffffff80`, `#ffffff80`, `#ffffff80`, `#ffffff80`, `#ffffff80`],
+        setShadowColorType3: [`#6666ff80`, `#66cccc80`, `#ffffff80`, `#99996680`, `#cc660080`],
+        setShadowColorType4: [`#00000080`, `#6666ff80`, `#cc000080`, `#cc99cc80`, `#cc336680`],
+
+        frzColorType1: [
+            [`#66ffff`, `#6600ff`, `#ffff00`, `#999900`],
+            [`#00ffcc`, `#339999`, `#ffff00`, `#999900`],
+            [`#66ffff`, `#6600ff`, `#ffff00`, `#999900`],
+            [`#cc99ff`, `#9966ff`, `#ffff00`, `#999900`],
+            [`#ff99cc`, `#ff6699`, `#ffff00`, `#999900`]
+        ],
+        frzColorType2: [
+            [`#cccccc`, `#999999`, `#ffff00`, `#999900`],
+            [`#66ffff`, `#6600ff`, `#ffff00`, `#999900`],
+            [`#66ffff`, `#6600ff`, `#ffff00`, `#999900`],
+            [`#cc99cc`, `#ff99ff`, `#ffff00`, `#999900`],
+            [`#ff6666`, `#ff9999`, `#ffff00`, `#999900`]
+        ],
+        frzColorType3: [
+            [`#66ffff`, `#6600ff`, `#ffff00`, `#999900`],
+            [`#00ffcc`, `#339999`, `#ffff00`, `#999900`],
+            [`#66ffff`, `#6600ff`, `#ffff00`, `#999900`],
+            [`#cc99ff`, `#9966ff`, `#ffff00`, `#999900`],
+            [`#ff99cc`, `#ff6699`, `#ffff00`, `#999900`]
+        ],
+        frzColorType4: [
+            [`#cccccc`, `#999999`, `#ffff00`, `#999900`],
+            [`#66ffff`, `#6600ff`, `#ffff00`, `#999900`],
+            [`#66ffff`, `#6600ff`, `#ffff00`, `#999900`],
+            [`#cc99cc`, `#ff99ff`, `#ffff00`, `#999900`],
+            [`#ff6666`, `#ff9999`, `#ffff00`, `#999900`]
+        ],
+    },
 };
 
 /**

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -92,6 +92,7 @@ const g_windowObj = {
 
     displaySprite: { x: 25, y: 30, h: C_LEN_SETLBL_HEIGHT * 5 },
     keyconSprite: { overflow: `auto` },
+    colorPickSprite: { x: 0, y: 90, w: 50, h: 280 },
 
     loader: { h: 10, backgroundColor: `#333333` },
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2890,6 +2890,7 @@ const g_lang_msgObj = {
 
         dataResetConfirm: `この作品のローカル設定をクリアします。よろしいですか？\n(ハイスコアやAdjustment等のデータがクリアされます)`,
         keyResetConfirm: `キーを初期配置に戻します。よろしいですか？`,
+        colorCopyConfirm: `フリーズアローの配色を矢印色に置き換えます\n(通常・ヒット時双方を置き換えます)。よろしいですか？`,
 
         difficulty: `譜面を選択します。`,
         speed: `矢印の流れる速度を設定します。\n外側のボタンは1x単位、内側は0.25x単位で変更できます。`,
@@ -2940,6 +2941,7 @@ const g_lang_msgObj = {
 
         dataResetConfirm: `Delete the local settings in this game. Is it OK?\n(High score, adjustment, volume and some settings will be initialized)`,
         keyResetConfirm: `Resets the assigned key to the initial state. Is it OK?`,
+        colorCopyConfirm: `Replace freeze arrow color scheme with arrow color\n(replace both normal and hit). Is this OK?`,
 
         difficulty: `Select a chart.`,
         speed: `Set the speed of the sequences.\nThe outer button can be changed in 1x increments and the inner button in 0.25x increments.`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. ColorType:1～4に対してColorPickerに対応しました。
左端にColorPickerが表示され、それを選択・変更することで
対応する矢印・フリーズアロー色が変わります。
2. 矢印のカラーセットをフリーズアローにコピーする機能を追加しました。
（ColorPickerに対応しているColorTypeのみ）

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 現状、既定色以外の色変更が難しいため。
2. フリーズアローについて1つ1つ設定するのは手間のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/160267271-98ae010c-25a1-42c4-a939-8f93343f389c.png" width="40%"><img src="https://user-images.githubusercontent.com/44026291/160271553-6503b57f-4b77-4a53-9f63-209523541ca7.png" width="40%">

<img src="https://user-images.githubusercontent.com/44026291/160271672-cb697a62-5dee-43ea-a131-04b656ed8a2e.png" width="45%"><img src="https://user-images.githubusercontent.com/44026291/160271706-b2e1479e-ec24-4349-8764-14cb2219668a.png" width="40%">


## :pencil: その他コメント / Other Comments
- ColorType: Default, Type0は譜面別の色保持方法やグラデーションの問題があり煩雑なため、見送ります。
- 今回のcolorPickerは`colorPickSprite`にまとめているので、
カスタムで移動させたい場合はこのオブジェクトを移動すれば問題ありません。
- 現状、以下の問題があります。ただ殆どの場合問題にならないので、このまま進める予定です。
    - 色配列をリセットする方法がない。
    - キリズマ、パンパネのように横スクロールが発生する場合、左端の表示が隠れる。
