### PR TITLE
feat: [0559] titleInit実行前にカスタム関数を挿入できるよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1880,6 +1880,7 @@ const initialControl = async () => {
 			getScoreDetailData(j);
 		}
 	}
+	g_customJsObj.preTitle.forEach(func => func());
 	titleInit();
 };
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. titleInit実行前にカスタム関数を挿入できるよう変更しました。
```javascript
function preTitleInit() {
    // 処理
}
// g_customJsObj.preTitleに関数を挿入することで有効化（titleInit実行直前に処理）
g_customJsObj.preTitle.push(preTitleInit);
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. #1275 の対応により、画面表示が行われる前に固有の設定を変更するケースが出てくると思われるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments