### PR TITLE
refactor: [0563] 意図していない関数名を見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6372,7 +6372,7 @@ const loadingScoreInit = async () => {
 	let arrivalFrame = getFirstArrivalFrame(firstFrame, speedOnFrame, motionOnFrame);
 
 	// キーパターン(デフォルト)に対応する矢印番号を格納
-	convertreplaceNums();
+	convertReplaceNums();
 
 	const setData = (_data, _minLength = 1) => {
 		return (hasArrayList(_data, _minLength) ? _data.concat() : []);
@@ -6474,7 +6474,7 @@ const loadingScoreInit = async () => {
 	const tempId = setInterval(() => {
 		const executeMain = _ => {
 			clearInterval(tempId);
-			MainInit();
+			mainInit();
 		}
 		if (g_audio.duration !== undefined) {
 			if (g_userAgent.indexOf(`firefox`) !== -1) {
@@ -7529,7 +7529,7 @@ const getFrzLength = (_speedOnFrame, _startFrame, _endFrame) => {
 /**
  * キーパターン(デフォルト)に対応する矢印番号を格納
  */
-const convertreplaceNums = _ => {
+const convertReplaceNums = _ => {
 	const tkObj = getKeyInfo();
 	const baseCharas = g_keyObj[`chara${g_keyObj.currentKey}_0`];
 	const convCharas = g_keyObj[`chara${tkObj.keyCtrlPtn}`];
@@ -7545,6 +7545,7 @@ const convertreplaceNums = _ => {
 		}
 	}
 };
+const convertreplaceNums = _ => convertReplaceNums();
 
 /**
  * 色情報の格納
@@ -7857,7 +7858,7 @@ const setKeyCtrl = (_localStorage, _keyNum, _keyCtrlPtn) => {
 /**
  * メイン画面初期化
  */
-const MainInit = _ => {
+const mainInit = _ => {
 	clearWindow(true, `Main`);
 	const divRoot = document.querySelector(`#divRoot`);
 	document.oncontextmenu = _ => false;
@@ -8437,7 +8438,7 @@ const MainInit = _ => {
 
 	/**
 	 * 自動判定
-	 * ※MainInit内部で指定必須（arrowSprite指定）
+	 * ※mainInit内部で指定必須（arrowSprite指定）
 	 * 
 	 * @param _j 矢印位置
 	 * @param _arrow 矢印(オブジェクト)
@@ -9075,6 +9076,7 @@ const MainInit = _ => {
 
 	g_timeoutEvtId = setTimeout(_ => flowTimeline(), 1000 / g_fps);
 };
+const MainInit = _ => mainInit();
 
 /**
  * アルファマスクの再描画 (Appearance: Hidden+, Sudden+ 用)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7545,7 +7545,6 @@ const convertReplaceNums = _ => {
 		}
 	}
 };
-const convertreplaceNums = _ => convertReplaceNums();
 
 /**
  * 色情報の格納
@@ -9076,7 +9075,6 @@ const mainInit = _ => {
 
 	g_timeoutEvtId = setTimeout(_ => flowTimeline(), 1000 / g_fps);
 };
-const MainInit = _ => mainInit();
 
 /**
  * アルファマスクの再描画 (Appearance: Hidden+, Sudden+ 用)

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3280,6 +3280,10 @@ const g_skinJsObj = {
     result: [],
 };
 
+/** 過去関数の互換 */
+const convertreplaceNums = _ => convertReplaceNums();
+const MainInit = _ => mainInit();
+
 /**
  * 従来のカスタム関数をg_customJsObj, g_skinJsObjへ追加
  * - customjsファイルを読み込んだ直後にこの関数を呼び出している


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. キャメル表記に反している関数名を見直しました。
互換のため、従来の名前も転送するように変更しています。

|変更前|変更後|
|----|----|
|convertreplaceNums|convertReplaceNums|
|MainInit|mainInit|

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 過去のコード見直しの過程で、小文字・大文字で置換してしまった影響です。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments