### PR TITLE
fix: [0566] カレントパス取得部分のURIエンコード処理を元に戻す

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -41,11 +41,11 @@ let g_localVersion2 = ``;
  */
 const current = _ => {
 	if (document.currentScript) {
-		return encodeURI(document.currentScript.src);
+		return document.currentScript.src;
 	}
 	const scripts = document.getElementsByTagName(`script`);
 	const targetScript = scripts[scripts.length - 1];
-	return encodeURI(targetScript.src);
+	return targetScript.src;
 };
 const g_rootPath = current().match(/(^.*\/)/)[0];
 const g_remoteFlg = g_rootPath.match(`^https://cwtickle.github.io/danoniplus/`) !== null;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. カレントパス取得部分のURIエンコード処理を元に戻しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Gitterでの指摘より。
https://gitter.im/danonicw/community?at=628912bcdb6f627d25931313

PR #1277 にてカレントパス取得部分のURIエンコード処理を追加しましたが、
`document.currentScript.src`及び`document.getElementsByTagName(`script`)[i].src`では
すでにURIエンコードが行われているため、この処理自体不要でした。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments