### PR TITLE
improve: [0567] currentScriptが取得できないときの処理を見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -43,8 +43,8 @@ const current = _ => {
 	if (document.currentScript) {
 		return document.currentScript.src;
 	}
-	const scripts = document.getElementsByTagName(`script`);
-	const targetScript = scripts[scripts.length - 1];
+	const scripts = Array.from(document.getElementsByTagName(`script`));
+	const targetScript = scripts.find(file => file.src.endsWith(`danoni_main.js`));
 	return targetScript.src;
 };
 const g_rootPath = current().match(/(^.*\/)/)[0];


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. カレントパスの取得処理で、[document.currentScript](https://developer.mozilla.org/ja/docs/Web/API/Document/currentScript) が取得できないとき、
scriptタグ中から`danoni_main.js`をファイルの末尾に持つファイルを取得するよう変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 最近のブラウザで document.currentScript が取得できないことはありませんが、
取得できない場合の処理について、状況によって必ずしも`danoni_main.js`が
マッチしないことがあるため修正しました。
（chrome拡張で追加でjsファイルを読み込んでいる場合など）

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments