### PR TITLE
[0569/append-keyptn] カスタムキーのパターン追記方法を拡張

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3349,17 +3349,18 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 	const newKeyMultiParam = (_key, _name, _convFunc, { errCd = ``, baseCopyFlg = false, loopFunc = _ => true } = {}) => {
 		let tmpMinPatterns = 1;
 		const keyheader = _name + _key;
+		const dfPtn = setIntVal(g_keyObj.dfPtnNum);
 		if (hasVal(_dosObj[keyheader])) {
 			const tmpArray = splitLF2(_dosObj[keyheader]);
 			tmpMinPatterns = tmpArray.length;
 			for (let k = 0; k < tmpMinPatterns; k++) {
-				if (existParam(tmpArray[k], `${keyheader}_${k}`)) {
+				if (existParam(tmpArray[k], `${keyheader}_${k + dfPtn}`)) {
 					continue;
 				}
-				g_keyObj[`${keyheader}_${k}`] = g_keyObj[`${_name}${tmpArray[k]}`] !== undefined ?
+				g_keyObj[`${keyheader}_${k + dfPtn}`] = g_keyObj[`${_name}${tmpArray[k]}`] !== undefined ?
 					copyArray2d(g_keyObj[`${_name}${tmpArray[k]}`]) : tmpArray[k].split(`,`).map(n => _convFunc(n));
 				if (baseCopyFlg) {
-					g_keyObj[`${keyheader}_${k}d`] = copyArray2d(g_keyObj[`${keyheader}_${k}`]);
+					g_keyObj[`${keyheader}_${k + dfPtn}d`] = copyArray2d(g_keyObj[`${keyheader}_${k + dfPtn}`]);
 				}
 				loopFunc(k, keyheader);
 			}
@@ -3377,10 +3378,11 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 	 */
 	const newKeySingleParam = (_key, _name, _type) => {
 		const keyheader = _name + _key;
+		const dfPtn = setIntVal(g_keyObj.dfPtnNum);
 		if (_dosObj[keyheader] !== undefined) {
 			const tmps = _dosObj[keyheader].split(`$`);
 			for (let k = 0; k < tmps.length; k++) {
-				g_keyObj[`${keyheader}_${k}`] = setVal(g_keyObj[`${_name}${tmps[k]}`], setVal(tmps[k], ``, _type));
+				g_keyObj[`${keyheader}_${k + dfPtn}`] = setVal(g_keyObj[`${_name}${tmps[k]}`], setVal(tmps[k], ``, _type));
 			}
 		}
 	};
@@ -3395,11 +3397,12 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 	 */
 	const newKeyPairParam = (_key, _name, _pairName, _defaultName = ``, _defaultVal = 0) => {
 		const keyheader = _name + _key;
+		const dfPtn = setIntVal(g_keyObj.dfPtnNum);
 
 		if (_dosObj[keyheader] !== undefined) {
 			const tmpParams = splitLF2(_dosObj[keyheader]);
 			for (let k = 0; k < tmpParams.length; k++) {
-				const pairName = `${_pairName}${_key}_${k}`;
+				const pairName = `${_pairName}${_key}_${k + dfPtn}`;
 				if (!hasVal(tmpParams[k])) {
 					continue;
 				}
@@ -3408,7 +3411,7 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 					Object.assign(g_keyObj[pairName], g_keyObj[`${_pairName}${tmpParams[k]}`]);
 				} else {
 					if (_defaultName !== ``) {
-						g_keyObj[pairName][_defaultName] = [...Array(g_keyObj[`color${_key}_${k}`].length)].fill(_defaultVal);
+						g_keyObj[pairName][_defaultName] = [...Array(g_keyObj[`color${_key}_${k + dfPtn}`].length)].fill(_defaultVal);
 					}
 					tmpParams[k].split(`/`).forEach(pairs => {
 						const tmpParamPair = pairs.split(`::`);
@@ -3425,18 +3428,31 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 	 * @param {string} _header 
 	 * @returns 
 	 */
-	const copyChildArray = (_k, _header) => g_keyObj[`${_header}_${_k}_0`] = copyArray2d(g_keyObj[`${_header}_${_k}`]);
+	const copyChildArray = (_k, _header) =>
+		g_keyObj[`${_header}_${_k + g_keyObj.dfPtnNum}_0`] = copyArray2d(g_keyObj[`${_header}_${_k + g_keyObj.dfPtnNum}`]);
 
 	// 対象キー毎に処理
 	keyExtraList.forEach(newKey => {
 		let tmpDivPtn = [];
 		let tmpMinPatterns = 1;
+		g_keyObj.dfPtnNum = 0;
+
+		// キーパターンの追記 (appendX)
+		if (setBoolVal(_dosObj[`append${newKey}`])) {
+			for (let j = 0; ; j++) {
+				if (g_keyObj[`color${newKey}_${j}`] === undefined) {
+					break;
+				}
+				g_keyObj.dfPtnNum++;
+			}
+		}
+		const dfPtnNum = g_keyObj.dfPtnNum;
 
 		// キーの名前 (keyNameX)
 		g_keyObj[`keyName${newKey}`] = _dosObj[`keyName${newKey}`] ?? newKey;
 
 		// キーの最小横幅 (minWidthX)
-		g_keyObj[`minWidth${newKey}`] = _dosObj[`minWidth${newKey}`] ?? g_keyObj.minWidthDefault;
+		g_keyObj[`minWidth${newKey}`] = _dosObj[`minWidth${newKey}`] ?? g_keyObj[`minWidth${newKey}`] ?? g_keyObj.minWidthDefault;
 
 		// 矢印色パターン (colorX_Y)
 		tmpMinPatterns = newKeyMultiParam(newKey, `color`, toNumber, {
@@ -3458,24 +3474,25 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 			const tmpDivs = _dosObj[`div${newKey}`].split(`$`);
 			for (let k = 0; k < tmpDivs.length; k++) {
 				tmpDivPtn = tmpDivs[k].split(`,`);
+				const ptnName = `${newKey}_${k + dfPtnNum}`;
 
 				if (setIntVal(tmpDivPtn[0], -1) !== -1) {
-					g_keyObj[`div${newKey}_${k}`] = setIntVal(tmpDivPtn[0], g_keyObj[`chara${newKey}_0`].length);
+					g_keyObj[`div${ptnName}`] = setIntVal(tmpDivPtn[0], g_keyObj[`chara${newKey}_0`].length);
 				} else if (g_keyObj[`div${tmpDivPtn[0]}`] !== undefined) {
 					// 既定キーパターンが指定された場合、存在すればその値を適用
-					g_keyObj[`div${newKey}_${k}`] = g_keyObj[`div${tmpDivPtn[0]}`];
-					g_keyObj[`divMax${newKey}_${k}`] = setIntVal(g_keyObj[`divMax${tmpDivPtn[0]}`], undefined);
-				} else if (setIntVal(g_keyObj[`div${newKey}_${k}`], -1) !== -1) {
+					g_keyObj[`div${ptnName}`] = g_keyObj[`div${tmpDivPtn[0]}`];
+					g_keyObj[`divMax${ptnName}`] = setIntVal(g_keyObj[`divMax${tmpDivPtn[0]}`], undefined);
+				} else if (setIntVal(g_keyObj[`div${ptnName}`], -1) !== -1) {
 					// すでに定義済みの場合はスキップ
 					continue;
 				} else if (g_keyObj[`chara${newKey}_0`] !== undefined) {
 					// 特に指定が無い場合はcharaX_Yの配列長で決定
-					g_keyObj[`div${newKey}_${k}`] = g_keyObj[`chara${newKey}_0`].length;
+					g_keyObj[`div${ptnName}`] = g_keyObj[`chara${newKey}_0`].length;
 				}
 
 				// ステップゾーン位置の最終番号
 				if (tmpDivPtn.length > 1) {
-					g_keyObj[`divMax${newKey}_${k}`] = setVal(tmpDivPtn[1], -1, C_TYP_FLOAT);
+					g_keyObj[`divMax${ptnName}`] = setVal(tmpDivPtn[1], -1, C_TYP_FLOAT);
 				}
 			}
 		}
@@ -3483,16 +3500,18 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 		// ステップゾーン位置 (posX_Y)
 		newKeyMultiParam(newKey, `pos`, toFloat, {
 			loopFunc: (k, keyheader) => {
-				if (g_keyObj[`divMax${newKey}_${k}`] === undefined || g_keyObj[`divMax${newKey}_${k}`] === -1) {
-					const posLength = g_keyObj[`${keyheader}_${k}`].length;
-					g_keyObj[`divMax${newKey}_${k}`] = g_keyObj[`${keyheader}_${k}`][posLength - 1] + 1;
+				const ptnName = `${newKey}_${k + dfPtnNum}`;
+				if (g_keyObj[`divMax${ptnName}`] === undefined || g_keyObj[`divMax${ptnName}`] === -1) {
+					const posLength = g_keyObj[`${keyheader}_${k + dfPtnNum}`].length;
+					g_keyObj[`divMax${ptnName}`] = g_keyObj[`${keyheader}_${k + dfPtnNum}`][posLength - 1] + 1;
 				}
 			}
 		});
 		if (_dosObj[`pos${newKey}`] === undefined) {
 			for (let k = 0; k < tmpMinPatterns; k++) {
-				if (g_keyObj[`color${newKey}_${k}`] !== undefined) {
-					g_keyObj[`pos${newKey}_${k}`] = [...Array(g_keyObj[`color${newKey}_${k}`].length).keys()].map(i => i);
+				const ptnName = `${newKey}_${k + dfPtnNum}`;
+				if (g_keyObj[`color${ptnName}`] !== undefined) {
+					g_keyObj[`pos${ptnName}`] = [...Array(g_keyObj[`color${ptnName}`].length).keys()].map(i => i);
 				}
 			}
 		}

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1412,6 +1412,7 @@ const g_keyObj = {
     currentPtn: 0,
 
     prevKey: `Dummy`,
+    dfPtnNum: 0,
 
     // キー別ヘッダー
     // - 譜面データ中に出てくる矢印(ノーツ)の種類と順番(ステップゾーン表示順)を管理する。


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. カスタムキーのパターン追記方法を拡張しました。
`|appendX=true|`(X: 既存キー数)を指定すると、既存パターンに追加する設定を指定できます。
従来のように、既存パターンを繰り返す必要はありません。
```
|keyExtraList=12|
|minWidth12=675|
|append12=true|
|chara12=oni,left,leftdia,down,sleft,sdown,sup,sright,space,up,rightdia,right$12_4|
|color12=1,0,1,0,3,3,3,3,0,1,0,1$12_4|
|pos12=0,1,2,3,4,5,6,7,8,9,10,11$12_4|
|div12=12$12|
|stepRtn12=45,0,-45,-90,giko,onigiri,iyo,c,90,135,180,225$12_4|
|keyCtrl12=112/0,113/0,114/0,115/0,116/0,117/0,118/0,119/0,120/0,121/0,122/0,123/0$81/0,87/0,69/0,82/0,84/0,89/0,85/0,73/0,79/0,80/0,192/0,219/0|
|shuffle12=0,0,0,0,1,1,1,1,2,2,2,2$12_4|
|blank12=50$50|
|scroll12=Cross::1,1,1,1,-1,-1,-1,-1,1,1,1,1/Split::1,1,1,1,1,1,-1,-1,-1,-1,-1,-1$12_4|
|transKey12=12i$12i|
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 既存キーの設定を上書きするリスクがあるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- パターンの略記指定は、既存パターンを追加した後の状態のものを指定します。
- 12keyは12_0～12_3までの4パターンが既存定義されているため、
追記設定を行う場合、下記のケースでは12_4, 12_5の2パターンが追加されます。
```
|append12=true|
|color12=1,0,1,0,3,3,3,3,0,1,0,1$12_4| <- この場合、12_4は`1,0,1,0,3,3,3,3,0,1,0,1`を指します。
```

