### PR TITLE
improve: [0572] 譜面明細ボタンの位置変更、譜面リストから譜面詳細への移動対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4259,7 +4259,7 @@ const createOptionWindow = _sprite => {
 	if (g_headerObj.scoreDetailUse) {
 		spriteList.speed.appendChild(
 			createCss2Button(`btnGraph`, `i`, _ => true, {
-				x: -18, y: -57, w: 23, h: 23, siz: C_SIZ_JDGCNTS, title: g_msgObj.graph,
+				x: -25, y: -60, w: 30, h: 30, siz: C_SIZ_JDGCHARA, title: g_msgObj.graph,
 				resetFunc: _ => setScoreDetail(), cxtFunc: _ => setScoreDetail(),
 			}, g_cssObj.button_Mini)
 		);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4259,7 +4259,7 @@ const createOptionWindow = _sprite => {
 	if (g_headerObj.scoreDetailUse) {
 		spriteList.speed.appendChild(
 			createCss2Button(`btnGraph`, `i`, _ => true, {
-				x: 415, y: 0, w: 23, h: 23, siz: C_SIZ_JDGCNTS, title: g_msgObj.graph,
+				x: -18, y: -57, w: 23, h: 23, siz: C_SIZ_JDGCNTS, title: g_msgObj.graph,
 				resetFunc: _ => setScoreDetail(), cxtFunc: _ => setScoreDetail(),
 			}, g_cssObj.button_Mini)
 		);
@@ -4298,6 +4298,10 @@ const createOptionWindow = _sprite => {
 	 * 譜面明細表示／非表示ボタンの処理
 	 */
 	const setScoreDetail = _ => {
+		if (g_currentPage === `difSelector`) {
+			resetDifWindow();
+			g_stateObj.scoreDetailViewFlg = false;
+		}
 		const scoreDetail = document.querySelector(`#scoreDetail`);
 		const detailObj = document.querySelector(`#detail${g_stateObj.scoreDetail}`);
 		const visibles = [`hidden`, `visible`];

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1212,6 +1212,7 @@ const g_shortcutObj = {
         ArrowDown: { id: `btnDifD` },
         ArrowUp: { id: `btnDifU` },
 
+        KeyI: { id: `btnGraph` },
         Escape: { id: `btnBack` },
         Space: { id: `btnKeyConfig` },
         Enter: { id: `lnkDifficulty` },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 譜面明細ボタン「i」の位置をDifficultyラベル左に移動しました。
2. 譜面リスト（DifSelector）有効時、譜面リストを開いた状態から
譜面明細へ直接移動できるようにしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 譜面明細系のボタン（Speed, Density, ToolDif）が画面左側にあるにもかかわらず、
ON/OFFは右側にあり、動線が手間に感じることがあるため。
2. 譜面リスト（DifSelector）が表示中のとき、譜面明細が裏側にあるためON/OFFを押しても
何も起きないような動きになっていました。この動きを見直しています。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/182005892-221d3116-1686-4c67-b42a-487f7db800cb.png" width="50%"><img src="https://user-images.githubusercontent.com/44026291/182005915-7cd5c208-0cec-4fac-8af0-d4b67f87ef02.png" width="50%">


## :pencil: その他コメント / Other Comments