### PR TITLE
improve: [0573] 譜面明細系のボタンを役割毎に分割

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4265,33 +4265,36 @@ const createOptionWindow = _sprite => {
 		);
 		g_stateObj.scoreDetailViewFlg = false;
 		const scoreDetail = createEmptySprite(optionsprite, `scoreDetail`, g_windowObj.scoreDetail, g_cssObj.settings_DifSelector);
-		const viewScText = _ => createScText(lnkScoreDetail, `ScoreDetail`, { targetLabel: `lnkScoreDetail`, x: -10 });
 
 		/**
 		 * 譜面明細表示の切替
 		 * @param {number} _val 
 		 */
-		const changeScoreDetail = (_val = 1) => {
+		const changeScoreDetail = (_val = 0) => {
 			g_stateObj.scoreDetailViewFlg = true;
 			scoreDetail.style.visibility = `visible`;
+
+			// 表示内容を非表示化、ボタン色をデフォルトに戻す
 			$id(`detail${g_stateObj.scoreDetail}`).visibility = `hidden`;
-			setSetting(_val, `scoreDetail`);
-			viewScText();
+			document.getElementById(`lnk${g_stateObj.scoreDetail}G`).classList.replace(g_cssObj.button_Setting, g_cssObj.button_Default);
+
+			// 選択先を表示、ボタン色を選択中に変更
+			g_stateObj.scoreDetail = g_settings.scoreDetails[_val];
 			$id(`detail${g_stateObj.scoreDetail}`).visibility = `visible`;
+			document.getElementById(`lnk${g_stateObj.scoreDetail}G`).classList.replace(g_cssObj.button_Default, g_cssObj.button_Setting);
 		};
 
 		multiAppend(scoreDetail,
 			createScoreDetail(`Speed`),
 			createScoreDetail(`Density`),
 			createScoreDetail(`ToolDif`, false),
-			makeSettingLblCssButton(`lnkScoreDetailB`, `- - -`, 0, _ => changeScoreDetail(-1),
-				g_lblPosObj.lnkScoreDetailB, g_cssObj.button_RevON),
-			makeSettingLblCssButton(`lnkScoreDetail`, `${getStgDetailName(g_stateObj.scoreDetail)}`, 0, _ => changeScoreDetail(),
-				Object.assign(g_lblPosObj.lnkScoreDetail, {
-					cxtFunc: _ => changeScoreDetail(-1),
-				}), g_cssObj.button_RevON),
 		);
-		viewScText();
+		g_settings.scoreDetails.forEach((sd, j) => {
+			scoreDetail.appendChild(
+				makeDifLblCssButton(`lnk${sd}G`, getStgDetailName(sd), j, _ => changeScoreDetail(j), { w: C_LEN_DIFCOVER_WIDTH, btnStyle: (g_stateObj.scoreDetail === sd ? `Setting` : `Default`) })
+			);
+			createScText(document.getElementById(`lnk${sd}G`), sd, { targetLabel: `lnk${sd}G`, x: -10 });
+		});
 	}
 
 	/**
@@ -4443,7 +4446,7 @@ const createOptionWindow = _sprite => {
 		const baseLabel = (_bLabel, _bLabelname, _bAlign) =>
 			document.querySelector(`#detail${_name}`).appendChild(
 				createDivCss2Label(`${_bLabel}`, `${_bLabelname}`, {
-					x: 10, y: 65 + _pos * 20, w: 100, h: 20, siz: C_SIZ_DIFSELECTOR, align: _bAlign,
+					x: 10, y: 105 + _pos * 20, w: 100, h: 20, siz: C_SIZ_DIFSELECTOR, align: _bAlign,
 				})
 			);
 		if (document.querySelector(`#data${_label}`) === null) {
@@ -4548,7 +4551,7 @@ const createOptionWindow = _sprite => {
 			makeDifInfoLabel(`dataArrowInfo`, ``, g_lblPosObj.dataArrowInfo),
 			makeDifInfoLabel(`lblArrowInfo2`, ``, g_lblPosObj.lblArrowInfo2),
 			makeDifInfoLabel(`dataArrowInfo2`, ``, g_lblPosObj.dataArrowInfo2),
-			makeSettingLblCssButton(`lnkDifInfo`, g_lblNameObj.s_print, 0, _ => {
+			makeDifLblCssButton(`lnkDifInfo`, g_lblNameObj.s_print, 8, _ => {
 				copyTextToClipboard(
 					`****** ${g_lblNameObj.s_printTitle} [${g_version}] ******\r\n\r\n`
 					+ `\t${g_lblNameObj.s_printHeader}\r\n\r\n${printData}`, g_msgInfoObj.I_0003

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4271,6 +4271,9 @@ const createOptionWindow = _sprite => {
 		 * @param {number} _val 
 		 */
 		const changeScoreDetail = (_val = 0) => {
+			if (g_currentPage === `difSelector`) {
+				resetDifWindow();
+			}
 			g_stateObj.scoreDetailViewFlg = true;
 			scoreDetail.style.visibility = `visible`;
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1223,6 +1223,7 @@ const g_shortcutObj = {
         Numpad1: { id: `lnkSpeedG` },
         Numpad2: { id: `lnkDensityG` },
         Numpad3: { id: `lnkToolDifG` },
+        KeyP: { id: `lnkDifInfo` },
 
         Escape: { id: `btnBack` },
         Space: { id: `btnKeyConfig` },

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -207,7 +207,7 @@ const updateWindowSiz = _ => {
             x: 140, y: 70, w: 275, h: 150, overflow: `auto`,
         },
         lnkDifInfo: {
-            x: 10, y: 30, w: 100, borderStyle: `solid`,
+            w: C_LEN_DIFCOVER_WIDTH, borderStyle: `solid`,
         },
 
         /** ディスプレイ画面 */
@@ -1192,8 +1192,12 @@ const g_shortcutObj = {
         KeyV: { id: `lnkVolumeR` },
 
         KeyI: { id: `btnGraph` },
-        ShiftLeft_KeyQ: { id: `lnkScoreDetailB` },
-        KeyQ: { id: `lnkScoreDetail` },
+        Digit1: { id: `lnkSpeedG` },
+        Digit2: { id: `lnkDensityG` },
+        Digit3: { id: `lnkToolDifG` },
+        Numpad1: { id: `lnkSpeedG` },
+        Numpad2: { id: `lnkDensityG` },
+        Numpad3: { id: `lnkToolDifG` },
         KeyP: { id: `lnkDifInfo` },
         KeyZ: { id: `btnSave` },
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1217,6 +1217,13 @@ const g_shortcutObj = {
         ArrowUp: { id: `btnDifU` },
 
         KeyI: { id: `btnGraph` },
+        Digit1: { id: `lnkSpeedG` },
+        Digit2: { id: `lnkDensityG` },
+        Digit3: { id: `lnkToolDifG` },
+        Numpad1: { id: `lnkSpeedG` },
+        Numpad2: { id: `lnkDensityG` },
+        Numpad3: { id: `lnkToolDifG` },
+
         Escape: { id: `btnBack` },
         Space: { id: `btnKeyConfig` },
         Enter: { id: `lnkDifficulty` },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 譜面明細系のボタンを役割毎に分割し、それぞれにショートカットキーを割り当てました。
それぞれ「1」「2」「3」のボタンに割り当てています。
2. Speed/Density/ToolDif選択時、どれが選択中かがわかるようなレイアウトに変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Speed/Density/ToolDifの移動がページ送りとなっており、わかりにくく感じることがあるため。
https://twitter.com/FUJI_kt/status/1553612119362650115
2. 譜面リストの画面レイアウトと仕様が合っていないため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/182018132-b8734cb3-0aea-470d-9c25-f29b464d8174.png" width="50%"><img src="https://user-images.githubusercontent.com/44026291/182018176-815228a0-7a4e-4564-998d-b79431362426.png" width="50%">
<img src="https://user-images.githubusercontent.com/44026291/182018261-9a00966e-c667-4703-bc71-3714714066d4.png" width="50%">

- 譜面リストとの重ね合わせ
    - この時点で「1」「2」「3」キーを押すと、譜面リストを閉じて譜面明細画面へ切り替わる
<img src="https://user-images.githubusercontent.com/44026291/182018559-e195e472-5b52-4df2-9ed4-bf2fcdc67704.png" width="50%">


## :pencil: その他コメント / Other Comments
- idの改廃状況は次の通りです。
    - 削除: lnkScoreDetail, lnkScoreDetailB (共通ボタン廃止のため)
    - 追加: lnkSpeedG, lnkDensityG, lnkToolDifG (個別ボタン追加のため)
- ラベル名の変更は従来通り `g_lblNameObj`で変更が可能です。
    - u_Speed, u_Density, u_ToolDif