### PR TITLE
fix: [0574] 重複するid名の解消

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4296,7 +4296,7 @@ const createOptionWindow = _sprite => {
 			scoreDetail.appendChild(
 				makeDifLblCssButton(`lnk${sd}G`, getStgDetailName(sd), j, _ => changeScoreDetail(j), { w: C_LEN_DIFCOVER_WIDTH, btnStyle: (g_stateObj.scoreDetail === sd ? `Setting` : `Default`) })
 			);
-			createScText(document.getElementById(`lnk${sd}G`), sd, { targetLabel: `lnk${sd}G`, x: -10 });
+			createScText(document.getElementById(`lnk${sd}G`), `${sd}G`, { targetLabel: `lnk${sd}G`, x: -10 });
 		});
 	}
 
@@ -4391,7 +4391,7 @@ const createOptionWindow = _sprite => {
 			context.font = `${C_SIZ_DIFSELECTOR}px ${getBasicFont()}`;
 			context.fillText(speedType, lineX + 35, 218);
 
-			updateScoreDetailLabel(`Speed`, g_lblNameObj[`s_${speedType}`], speedObj[speedType].cnt, j);
+			updateScoreDetailLabel(`Speed`, `${speedType}S`, speedObj[speedType].cnt, j, g_lblNameObj[`s_${speedType}`]);
 		});
 	};
 
@@ -4431,10 +4431,10 @@ const createOptionWindow = _sprite => {
 		});
 
 		const obj = getScoreBaseData(_scoreId);
-		updateScoreDetailLabel(`Density`, g_lblNameObj.s_apm, obj.apm, 0);
-		updateScoreDetailLabel(`Density`, g_lblNameObj.s_time, obj.playingTime, 1);
-		updateScoreDetailLabel(`Density`, g_lblNameObj.s_arrow, obj.arrowCnts, 3);
-		updateScoreDetailLabel(`Density`, g_lblNameObj.s_frz, obj.frzCnts, 4);
+		updateScoreDetailLabel(`Density`, `APM`, obj.apm, 0, g_lblNameObj.s_apm);
+		updateScoreDetailLabel(`Density`, `Time`, obj.playingTime, 1, g_lblNameObj.s_time);
+		updateScoreDetailLabel(`Density`, `Arrow`, obj.arrowCnts, 3, g_lblNameObj.s_arrow);
+		updateScoreDetailLabel(`Density`, `Frz`, obj.frzCnts, 4, g_lblNameObj.s_frz);
 	};
 
 	/**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 譜面明細画面周りでID名が重複していた問題を修正しました。
（共通処理のため、関連するID名も一部変更があります）
2. g_lblNameObjの設定により、譜面明細ラベル名に英数字以外が入りうる問題も合わせて修正しました。

|No|該当箇所|元ID名|変更後ID名|
|----|----|----|----|
|1|譜面明細 - Speedボタンのショートカット|scSpeed|scSpeedG|
|2|譜面明細 - Densityボタンのショートカット|scDensity|scDensityG|
|3|譜面明細 - ToolDifボタンのショートカット|scToolDif|scToolDifG|
|4|譜面明細 - Speed > 全体速度変化回数(Speed)|lblSpeed / dataSpeed|lblSpeedS / dataSpeedS|
|5|譜面明細 - Speed > 個別速度変化回数(Boost)|lblBoost / dataBoost|lblBoostS / dataBoostS|

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. デザイン全般を変える際に支障となるため。
2. updateScoreDetailLabel関数において、2番目の引数はラベル名の元情報となっているが、
`g_lblNameObj`を指定していたため、英数字以外のラベル名となる可能性があった。
（ラベル名の項目は5番目の引数があるため、本来はそれを使うべき）

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 1～3はver27.8.0起因、4～5は従来から発生していました。