### PR TITLE
feat: [0575] 譜面明細画面の従来のショートカットを実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4284,7 +4284,8 @@ const createOptionWindow = _sprite => {
 			// 選択先を表示、ボタン色を選択中に変更
 			// Qキーを押したときのリンク先を次の明細へ変更
 			g_stateObj.scoreDetail = g_settings.scoreDetails[_val];
-			g_shortcutObj.option.KeyQ.id = g_settings.scoreDetailCursors[(_val + 1) % g_settings.scoreDetailCursors.length];
+			[`option`, `difSelector`].forEach(page => g_shortcutObj[page].KeyQ.id = g_settings.scoreDetailCursors[(_val + 1) % g_settings.scoreDetailCursors.length]);
+
 			$id(`detail${g_stateObj.scoreDetail}`).visibility = `visible`;
 			document.getElementById(`lnk${g_stateObj.scoreDetail}G`).classList.replace(g_cssObj.button_Default, g_cssObj.button_Setting);
 		};
@@ -4309,6 +4310,7 @@ const createOptionWindow = _sprite => {
 		if (g_currentPage === `difSelector`) {
 			resetDifWindow();
 			g_stateObj.scoreDetailViewFlg = false;
+			g_shortcutObj.difSelector.KeyQ.id = g_settings.scoreDetailCursors[0];
 		}
 		const scoreDetail = document.querySelector(`#scoreDetail`);
 		const detailObj = document.querySelector(`#detail${g_stateObj.scoreDetail}`);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4282,8 +4282,9 @@ const createOptionWindow = _sprite => {
 			document.getElementById(`lnk${g_stateObj.scoreDetail}G`).classList.replace(g_cssObj.button_Setting, g_cssObj.button_Default);
 
 			// 選択先を表示、ボタン色を選択中に変更
+			// Qキーを押したときのリンク先を次の明細へ変更
 			g_stateObj.scoreDetail = g_settings.scoreDetails[_val];
-			g_shortcutObj.option.KeyQ.id = `lnk${g_settings.scoreDetails[(_val + 1) % g_settings.scoreDetails.length]}G`;
+			g_shortcutObj.option.KeyQ.id = g_settings.scoreDetailCursors[(_val + 1) % g_settings.scoreDetailCursors.length];
 			$id(`detail${g_stateObj.scoreDetail}`).visibility = `visible`;
 			document.getElementById(`lnk${g_stateObj.scoreDetail}G`).classList.replace(g_cssObj.button_Default, g_cssObj.button_Setting);
 		};
@@ -4316,6 +4317,9 @@ const createOptionWindow = _sprite => {
 		g_stateObj.scoreDetailViewFlg = !g_stateObj.scoreDetailViewFlg;
 		scoreDetail.style.visibility = visibles[Number(g_stateObj.scoreDetailViewFlg)];
 		detailObj.style.visibility = visibles[Number(g_stateObj.scoreDetailViewFlg)];
+
+		// Qキーを押したときのカーソル位置を先頭に初期化
+		g_shortcutObj.option.KeyQ.id = g_settings.scoreDetailCursors[0];
 	};
 
 	/**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4283,6 +4283,7 @@ const createOptionWindow = _sprite => {
 
 			// 選択先を表示、ボタン色を選択中に変更
 			g_stateObj.scoreDetail = g_settings.scoreDetails[_val];
+			g_shortcutObj.option.KeyQ.id = `lnk${g_settings.scoreDetails[(_val + 1) % g_settings.scoreDetails.length]}G`;
 			$id(`detail${g_stateObj.scoreDetail}`).visibility = `visible`;
 			document.getElementById(`lnk${g_stateObj.scoreDetail}G`).classList.replace(g_cssObj.button_Default, g_cssObj.button_Setting);
 		};

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -171,13 +171,6 @@ const updateWindowSiz = _ => {
         },
 
         /** 設定: 譜面明細子画面 */
-        lnkScoreDetailB: {
-            x: 10, w: 100, visibility: `hidden`,
-        },
-        lnkScoreDetail: {
-            x: 10, w: 100, borderStyle: `solid`,
-        },
-
         lblTooldif: {
             y: 5, w: 250, siz: C_SIZ_JDGCNTS,
         },
@@ -783,11 +776,13 @@ const g_settings = {
     opacitys: [10, 25, 50, 75, 100],
 
     scoreDetails: [`Speed`, `Density`, `ToolDif`],
-    scoreDetailNum: 0,
+    scoreDetailCursors: [],
 };
 
 g_settings.volumeNum = g_settings.volumes.length - 1;
 g_settings.opacityNum = g_settings.opacitys.length - 1;
+g_settings.scoreDetailCursors = g_settings.scoreDetails.map(val => `lnk${val}G`);
+g_settings.scoreDetailCursors.push(`btnGraph`);
 
 /**
  * 設定画面間移動

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1198,6 +1198,7 @@ const g_shortcutObj = {
         Numpad1: { id: `lnkSpeedG` },
         Numpad2: { id: `lnkDensityG` },
         Numpad3: { id: `lnkToolDifG` },
+        KeyQ: { id: `lnkSpeedG` },
         KeyP: { id: `lnkDifInfo` },
         KeyZ: { id: `btnSave` },
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1219,6 +1219,7 @@ const g_shortcutObj = {
         Numpad1: { id: `lnkSpeedG` },
         Numpad2: { id: `lnkDensityG` },
         Numpad3: { id: `lnkToolDifG` },
+        KeyQ: { id: `lnkSpeedG` },
         KeyP: { id: `lnkDifInfo` },
 
         Escape: { id: `btnBack` },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 設定画面内の譜面明細表示にて、従来のショートカットキー「Q」を復活させました。
「Q」キーを押すことで次の明細表示へ移動します。画面レイアウトは変えていません。
次のように押したときの挙動が変わります。
    - 明細を開く＆Speed -> Density -> Tooldif -> 明細を閉じる -> 明細を開く＆Speed -> ...
    - すでに明細が開いた状態の場合は次のカーソルへ移動します。
2. 未使用のラベル・設定類を削除しました。
    - g_settings.scoreDetailNum
    - g_lblPosObj.lnkScoreDetail
    - g_lblPosObj.lnkScoreDetailB

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 次の明細を表示する際に1ボタンで移動したいことがあるため。
2. ボタン廃止により現在は使用していないため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
- `g_shortcutObj.option.KeyQ.id` で指定している値は、「Q」キーを押すごとに変わるようになっています。
具体的には、`g_settings.scoreDetails = ['Speed', 'Density', 'ToolDif'];`の配列に従って変わります。
<img src="https://user-images.githubusercontent.com/44026291/185753974-26adc8bf-3330-4d47-afc3-b80b18cd8506.png" width="50%">
<img src="https://user-images.githubusercontent.com/44026291/185754027-53d66d74-166e-4c77-95d2-79c6268c2004.png" width="70%">

## :pencil: その他コメント / Other Comments
- 「Q」キーでカーソル移動するという表示は今のところ考えていません。
- 逆回しは明細表示が現状3つしかないため、実装しない予定です。