### PR TITLE
improve: [0576] ローカルファイル時にAdjustmentの小数設定ボタンを非表示化

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4224,7 +4224,7 @@ const createOptionWindow = _sprite => {
 	// 速度(Speed)
 	// 縦位置: 2  短縮ショートカットあり
 	createGeneralSetting(spriteList.speed, `speed`, {
-		skipTerms: [20, 5, 1], hiddenBtn: true, scLabel: g_lblNameObj.sc_speed, roundNum: 5,
+		skipTerms: g_settings.speedTerms, hiddenBtn: true, scLabel: g_lblNameObj.sc_speed, roundNum: 5,
 		unitName: ` ${g_lblNameObj.multi}`,
 	});
 
@@ -4831,7 +4831,7 @@ const createOptionWindow = _sprite => {
 	// タイミング調整 (Adjustment)
 	// 縦位置: 10  短縮ショートカットあり
 	createGeneralSetting(spriteList.adjustment, `adjustment`, {
-		skipTerms: [50, 10, 5], hiddenBtn: true, scLabel: g_lblNameObj.sc_adjustment, roundNum: 5,
+		skipTerms: g_settings.adjustmentTerms, hiddenBtn: true, scLabel: g_lblNameObj.sc_adjustment, roundNum: 5,
 		unitName: g_lblNameObj.frame,
 	});
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -743,6 +743,7 @@ let g_appearanceRanges = [`Hidden+`, `Sudden+`, `Hid&Sud+`];
 const g_settings = {
     speeds: [...Array((C_MAX_SPEED - C_MIN_SPEED) * 20 + 1).keys()].map(i => C_MIN_SPEED + i / 20),
     speedNum: 0,
+    speedTerms: [20, 5, 1],
 
     motions: [C_FLG_OFF, `Boost`, `Brake`],
     motionNum: 0,
@@ -764,6 +765,7 @@ const g_settings = {
 
     adjustments: [...Array(C_MAX_ADJUSTMENT * 20 + 1).keys()].map(i => (i - C_MAX_ADJUSTMENT * 10) / 10),
     adjustmentNum: C_MAX_ADJUSTMENT * 10,
+    adjustmentTerms: (g_isFile ? [50, 10, 1] : [50, 10, 5]),
 
     volumes: [0, 0.5, 1, 2, 5, 10, 25, 50, 75, 100],
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. ローカルファイル時にAdjustmentの小数設定ボタンを非表示化しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. ローカルファイル時はAdjustmentの小数が使用できないため。
なお、不可視の±0.1Frame刻みはそのままにしています（画面上見えないため）。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
- ローカルファイル時
<img src="https://user-images.githubusercontent.com/44026291/185771874-3a864335-63aa-4599-ab79-f77604f49563.png" width="60%">

- ローカルサーバー、リモートサーバー時
<img src="https://user-images.githubusercontent.com/44026291/185771886-74966bd0-9fc3-4811-b77e-8762fba12cef.png" width="60%">


## :pencil: その他コメント / Other Comments
- 一部コード整理を行っています。