### PR TITLE
improve: [0577] 二次元配列のコピー関数の実体をstructuredCloneに変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -365,7 +365,7 @@ const makeDedupliArray = (_array1, ..._arrays) =>
  * @param {array2} _array2d 
  * @returns 
  */
-const copyArray2d = _array2d => JSON.parse(JSON.stringify(_array2d));
+const copyArray2d = _array2d => structuredClone(_array2d);
 
 /**
  * 配列データを合計


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 二次元配列のコピー関数(copyArray2d)の処理を
`JSON.parse(JSON.stringify(data))`から`structuredClone(data)`に変更しました。
https://developer.mozilla.org/en-US/docs/Web/API/structuredClone

現状、ほとんどのブラウザはstructuredCloneを使える状況にあるため、差し替えても影響は無いと思います。
https://caniuse.com/?search=structuredClone

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 今後、ディープコピーしている箇所の処理統一のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 今回の変更はディープコピーが本当に必要な箇所に絞っており、それ以外の箇所はそのままです。
今後、structuredCloneを使うべきかどうかは個別に検討予定です。
