### PR TITLE
hotfix: [0578] ローカルファイル時にAdjustmentの小数設定ボタンの非表示化を取り止め

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -5,7 +5,7 @@
  *
  * Source by tickle
  * Created : 2019/11/19
- * Revised : 2022/08/21 (v28.0.1)
+ * Revised : 2022/08/21 (v28.0.0)
  *
  * https://github.com/cwtickle/danoniplus
  */

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -5,7 +5,7 @@
  *
  * Source by tickle
  * Created : 2019/11/19
- * Revised : 2022/08/21 (v28.0.0)
+ * Revised : 2022/08/21 (v28.0.1)
  *
  * https://github.com/cwtickle/danoniplus
  */
@@ -765,7 +765,7 @@ const g_settings = {
 
     adjustments: [...Array(C_MAX_ADJUSTMENT * 20 + 1).keys()].map(i => (i - C_MAX_ADJUSTMENT * 10) / 10),
     adjustmentNum: C_MAX_ADJUSTMENT * 10,
-    adjustmentTerms: (g_isFile ? [50, 10, 1] : [50, 10, 5]),
+    adjustmentTerms: [50, 10, 5],
 
     volumes: [0, 0.5, 1, 2, 5, 10, 25, 50, 75, 100],
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. ローカルファイル時にAdjustmentの小数設定ボタンの非表示化を取り止めました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. ローカルファイルでも、エンコード済み音源ファイルのときは小数Adjustmentが使用できるため。
エンコード済み音源ファイルかどうかはプレイ開始後で判断しているため、この仕様は見送りました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- danoni_constants.js のみの変更です。