### PR TITLE
feat: [0579] 汎用例外処理をカスタム関数（enterFrame）に対して追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -574,12 +574,13 @@ const setShortcutEvent = (_displayName, _func = _ => true, { displayFlg = true, 
  * @param {function} _func 
  * @param {object} _obj
  */
-const checkFunc = (_func, { pos = ``, ended = false, errTxt = `error` } = {}) => {
+const checkFunc = (_func, { pos = ``, ended = true, errTxt = `error` } = {}) => {
 	try {
 		_func;
 	} catch (err) {
 		console.error(`${pos}:\n${err}`);
 		if (ended) {
+			makeWarningWindow(`${errTxt} ${pos}:<br>${err}`);
 			throw errTxt;
 		}
 	}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -576,11 +576,11 @@ const setShortcutEvent = (_displayName, _func = _ => true, { displayFlg = true, 
  */
 const checkFunc = (_func, { pos = ``, ended = true, errTxt = `error` } = {}) => {
 	try {
-		_func;
+		_func();
 	} catch (err) {
 		console.error(`${pos}:\n${err}`);
 		if (ended) {
-			makeWarningWindow(`${errTxt} ${pos}:<br>${err}`);
+			makeWarningWindow(`[${errTxt}] ${pos}:<br>${err}`);
 			throw errTxt;
 		}
 	}
@@ -3836,7 +3836,7 @@ const titleInit = _ => {
 	const flowTitleTimeline = _ => {
 
 		// ユーザカスタムイベント(フレーム毎)
-		checkFunc(g_customJsObj.titleEnterFrame.forEach(func => func()), { pos: g_scoreObj.titleFrameNum, errTxt: `g_customJsObj.titleEnterFrame` });
+		g_customJsObj.titleEnterFrame.forEach(func => checkFunc(func, { pos: g_scoreObj.titleFrameNum, errTxt: `custom/titleEnterFrame` }));
 
 		// 背景・マスクモーション
 		drawTitleResultMotion(g_currentPage);
@@ -8935,7 +8935,7 @@ const mainInit = _ => {
 		}
 
 		// ユーザカスタムイベント(フレーム毎)
-		checkFunc(g_customJsObj.mainEnterFrame.forEach(func => func()), { pos: g_scoreObj.frameNum, errTxt: `g_customJsObj.mainEnterFrame` });
+		g_customJsObj.mainEnterFrame.forEach(func => checkFunc(func, { pos: g_scoreObj.frameNum, errTxt: `custom/mainEnterFrame` }));
 		if (g_customJsObj.mainEnterFrame.length > 0) {
 			g_scoreObj.baseFrame++;
 		}
@@ -10054,7 +10054,7 @@ const resultInit = _ => {
 	const flowResultTimeline = _ => {
 
 		// ユーザカスタムイベント(フレーム毎)
-		checkFunc(g_customJsObj.resultEnterFrame.forEach(func => func()), { pos: g_scoreObj.resultFrameNum, errTxt: `g_customJsObj.resultEnterFrame` });
+		g_customJsObj.resultEnterFrame.forEach(func => checkFunc(func, { pos: g_scoreObj.resultFrameNum, errTxt: `custom/resultEnterFrame` }));
 
 		// 背景・マスクモーション
 		drawTitleResultMotion(g_currentPage);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -565,6 +565,25 @@ const setShortcutEvent = (_displayName, _func = _ => true, { displayFlg = true, 
 	}
 };
 
+/*-----------------------------------------------------------*/
+/* 例外処理                                                   */
+/*-----------------------------------------------------------*/
+
+/**
+ * 関数の例外処理を制御
+ * @param {function} _func 
+ * @param {object} _obj
+ */
+const checkFunc = (_func, { pos = ``, ended = false, errTxt = `error` } = {}) => {
+	try {
+		_func;
+	} catch (err) {
+		console.error(`${pos}:\n${err}`);
+		if (ended) {
+			throw errTxt;
+		}
+	}
+};
 
 /*-----------------------------------------------------------*/
 /* ファイル・リンク制御                                        */
@@ -3816,7 +3835,7 @@ const titleInit = _ => {
 	const flowTitleTimeline = _ => {
 
 		// ユーザカスタムイベント(フレーム毎)
-		g_customJsObj.titleEnterFrame.forEach(func => func());
+		checkFunc(g_customJsObj.titleEnterFrame.forEach(func => func()), { pos: g_scoreObj.titleFrameNum, errTxt: `g_customJsObj.titleEnterFrame` });
 
 		// 背景・マスクモーション
 		drawTitleResultMotion(g_currentPage);
@@ -8915,7 +8934,7 @@ const mainInit = _ => {
 		}
 
 		// ユーザカスタムイベント(フレーム毎)
-		g_customJsObj.mainEnterFrame.forEach(func => func());
+		checkFunc(g_customJsObj.mainEnterFrame.forEach(func => func()), { pos: g_scoreObj.frameNum, errTxt: `g_customJsObj.mainEnterFrame` });
 		if (g_customJsObj.mainEnterFrame.length > 0) {
 			g_scoreObj.baseFrame++;
 		}
@@ -10034,7 +10053,7 @@ const resultInit = _ => {
 	const flowResultTimeline = _ => {
 
 		// ユーザカスタムイベント(フレーム毎)
-		g_customJsObj.resultEnterFrame.forEach(func => func());
+		checkFunc(g_customJsObj.resultEnterFrame.forEach(func => func()), { pos: g_scoreObj.resultFrameNum, errTxt: `g_customJsObj.resultEnterFrame` });
 
 		// 背景・マスクモーション
 		drawTitleResultMotion(g_currentPage);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 汎用例外処理をカスタム関数（enterFrame）に対して追加しました。
エラー発生時、エラーを画面上に表示するようになります。

```javascript
const checkFunc = (_func, { pos = ``, ended = true, errTxt = `error` } = {}) => {
	try {
		_func();
	} catch (err) {
		console.error(`${pos}:\n${err}`);
		if (ended) {
			makeWarningWindow(`[${errTxt}] ${pos}:<br>${err}`);
			throw errTxt;
		}
	}
};
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. これまではエラーがあるとブラウザ側のエラー任せにしており、強制的に止まるようになっていました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/188164963-680e979e-bf17-463b-81b0-e9f1409056d9.png" width="90%">

## :pencil: その他コメント / Other Comments
- カスタム関数を継続して良いかは状況によるため、Draftとして上げます。
