### PR TITLE
feat: [0581] カラーセットのキー別一括保存対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4930,21 +4930,9 @@ const createOptionWindow = _sprite => {
 				g_keycons.shuffleGroupNum = 0;
 			}
 			const hasKeyStorage = localStorage.getItem(`danonicw-${g_keyObj.currentKey}k`);
+			let storageObj, addKey = ``;
 
-			if (g_stateObj.extraKeyFlg) {
-
-				// 特殊キーの場合は作品毎のローカルストレージから取得
-				if (isNotSameKey) {
-					getKeyReverse(g_localStorage, g_keyObj.currentKey);
-
-					// キーコンフィグ初期値設定
-					if (g_localStorage[`keyCtrlPtn${g_keyObj.currentKey}`] === undefined) {
-						g_localStorage[`keyCtrlPtn${g_keyObj.currentKey}`] = 0;
-					}
-					getKeyCtrl(g_localStorage, g_keyObj.currentKey);
-				}
-
-			} else {
+			if (!g_stateObj.extraKeyFlg) {
 
 				// キー別のローカルストレージの初期設定　※特殊キーは除く
 				g_localKeyStorage = hasKeyStorage ? JSON.parse(hasKeyStorage) : {
@@ -4952,18 +4940,22 @@ const createOptionWindow = _sprite => {
 					keyCtrl: [[]],
 					keyCtrlPtn: 0,
 				};
+				storageObj = g_localKeyStorage;
 
-				if (isNotSameKey) {
-					getKeyReverse(g_localKeyStorage);
-
-					// キーコンフィグ初期値設定
-					if (g_localKeyStorage.keyCtrlPtn === undefined) {
-						g_localKeyStorage.keyCtrlPtn = 0;
-					}
-					getKeyCtrl(g_localKeyStorage);
-				}
-
+			} else {
+				storageObj = g_localStorage;
+				addKey = g_keyObj.currentKey;
 			}
+			if (isNotSameKey) {
+				getKeyReverse(storageObj, addKey);
+
+				// キーコンフィグ初期値設定
+				if (storageObj[`keyCtrlPtn${addKey}`] === undefined) {
+					storageObj[`keyCtrlPtn${addKey}`] = 0;
+				}
+				getKeyCtrl(storageObj, addKey);
+			}
+
 			const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
 			if (g_keyObj[`shuffle${keyCtrlPtn}_1`] !== undefined) {
 				g_keyObj[`shuffle${keyCtrlPtn}`] = g_keyObj[`shuffle${keyCtrlPtn}_${g_keycons.shuffleGroupNum}`].concat();
@@ -7868,6 +7860,7 @@ const getArrowSettings = _ => {
 		g_localStorage.volume = g_stateObj.volume;
 		g_localStorage.colorType = g_colorType;
 
+		// カラーセットの保存（作品別）
 		if (!g_keycons.colorDefTypes.includes(g_colorType)) {
 
 			resetColorType({ _toObj: g_localStorage });
@@ -7889,23 +7882,23 @@ const getArrowSettings = _ => {
 		}
 		g_storeSettings.forEach(setting => g_localStorage[setting] = g_stateObj[setting]);
 
-		// ローカルストレージ(キー別)へデータ保存　※特殊キーは除く
-		if (!g_stateObj.extraKeyFlg) {
-			g_localKeyStorage.reverse = g_stateObj.reverse;
-			g_localKeyStorage.keyCtrl = setKeyCtrl(g_localKeyStorage, keyNum, keyCtrlPtn);
-			if (g_keyObj.currentPtn !== -1) {
-				g_localKeyStorage.keyCtrlPtn = g_keyObj.currentPtn;
-				g_keyObj[`keyCtrl${keyCtrlPtn}`] = copyArray2d(g_keyObj[`keyCtrl${keyCtrlPtn}d`]);
-			}
-			localStorage.setItem(`danonicw-${g_keyObj.currentKey}k`, JSON.stringify(g_localKeyStorage));
+		let storageObj = g_localKeyStorage;
+		let addKey = ``;
 
-		} else {
-			g_localStorage[`reverse${g_keyObj.currentKey}`] = g_stateObj.reverse;
-			g_localStorage[`keyCtrl${g_keyObj.currentKey}`] = setKeyCtrl(g_localKeyStorage, keyNum, keyCtrlPtn);
-			if (g_keyObj.currentPtn !== -1) {
-				g_localStorage[`keyCtrlPtn${g_keyObj.currentKey}`] = g_keyObj.currentPtn;
-				g_keyObj[`keyCtrl${keyCtrlPtn}`] = copyArray2d(g_keyObj[`keyCtrl${keyCtrlPtn}d`]);
-			}
+		// リバース、キーコンフィグの保存（キー別）
+		if (g_stateObj.extraKeyFlg) {
+			storageObj = g_localStorage;
+			addKey = g_keyObj.currentKey;
+		}
+		storageObj[`reverse${addKey}`] = g_stateObj.reverse;
+		storageObj[`keyCtrl${addKey}`] = setKeyCtrl(g_localKeyStorage, keyNum, keyCtrlPtn);
+		if (g_keyObj.currentPtn !== -1) {
+			storageObj[`keyCtrlPtn${addKey}`] = g_keyObj.currentPtn;
+			g_keyObj[`keyCtrl${keyCtrlPtn}`] = copyArray2d(g_keyObj[`keyCtrl${keyCtrlPtn}d`]);
+		}
+
+		if (!g_stateObj.extraKeyFlg) {
+			localStorage.setItem(`danonicw-${g_keyObj.currentKey}k`, JSON.stringify(g_localKeyStorage));
 		}
 		localStorage.setItem(g_localStorageUrl, JSON.stringify(g_localStorage));
 		g_canLoadDifInfoFlg = true;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4977,6 +4977,7 @@ const createOptionWindow = _sprite => {
 
 				const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
 
+				// カラーグループ、シャッフルグループの設定
 				[`color`, `shuffle`].forEach(type => {
 					let k = 1;
 					g_keycons[`${type}Groups`] = [0];
@@ -4987,14 +4988,12 @@ const createOptionWindow = _sprite => {
 
 					if (g_keyObj.currentPtn === -1) {
 						if (storageObj[`${type}${g_keyObj.currentKey}_-1_-1`] !== undefined) {
-							g_keycons[`${type}GroupNum`] = -1;
-							g_keycons[`${type}Groups`] = addValtoArray(g_keycons[`${type}Groups`], -1);
+							resetGroupList(type);
 							g_keyObj[`${type}${g_keyObj.currentKey}_-1`] = structuredClone(storageObj[`${type}${g_keyObj.currentKey}_-1_-1`]);
 						}
 						g_keyObj[`${type}${g_keyObj.currentKey}_-1_-1`] = structuredClone(g_keyObj[`${type}${g_keyObj.currentKey}_-1`]);
 					} else {
-						g_keycons[`${type}GroupNum`] = 0;
-						g_keycons[`${type}Groups`] = g_keycons[`${type}Groups`].filter(val => val !== -1);
+						resetGroupList(type);
 						g_keyObj[`${type}${keyCtrlPtn}`] = structuredClone(g_keyObj[`${type}${keyCtrlPtn}_0`]);
 					}
 				});
@@ -5350,6 +5349,20 @@ const makeMiniCssButton = (_id, _directionFlg, _heightPos, _func, { dx = 0, dy =
 	}, g_cssObj.button_Mini);
 };
 
+/**
+ * カラーグループ、シャッフルグループの再設定
+ * @param {string} _type 
+ */
+const resetGroupList = (_type) => {
+	if (g_keyObj.currentPtn === -1) {
+		g_keycons[`${_type}GroupNum`] = -1;
+		g_keycons[`${_type}Groups`] = addValtoArray(g_keycons[`${_type}Groups`], -1);
+	} else {
+		g_keycons[`${_type}GroupNum`] = 0;
+		g_keycons[`${_type}Groups`] = g_keycons[`${_type}Groups`].filter(val => val !== -1);
+	}
+};
+
 /*-----------------------------------------------------------*/
 /* Scene : SETTINGS-DISPLAY [lemon] */
 /*-----------------------------------------------------------*/
@@ -5593,15 +5606,8 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	const maxLeftPos = Math.max(divideCnt, posMax - divideCnt - 2) / 2;
 	const maxLeftX = Math.min(0, (kWidth - C_ARW_WIDTH) / 2 - maxLeftPos * g_keyObj.blank);
 
-	[`color`, `shuffle`].forEach(type => {
-		if (g_keyObj.currentPtn === -1) {
-			g_keycons[`${type}GroupNum`] = -1;
-			g_keycons[`${type}Groups`] = addValtoArray(g_keycons[`${type}Groups`], -1);
-		} else {
-			g_keycons[`${type}GroupNum`] = 0;
-			g_keycons[`${type}Groups`] = g_keycons[`${type}Groups`].filter(val => val !== -1);
-		}
-	});
+	// カラーグループ、シャッフルグループの再設定
+	[`color`, `shuffle`].forEach(type => resetGroupList(type));
 
 	/**
 	 * keyconSpriteのスクロール位置調整

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1949,16 +1949,12 @@ const loadLocalStorage = _ => {
 		if (g_localStorage.highscores === undefined) {
 			g_localStorage.highscores = {};
 		}
-		if (g_localStorage.setColor === undefined) {
-			g_localStorage.setColor = [];
-		}
 
 	} else {
 		g_localStorage = {
 			adjustment: 0,
 			volume: 100,
 			highscores: {},
-			setColor: [],
 		};
 	}
 };
@@ -2910,12 +2906,6 @@ const headerConvert = _dosObj => {
 		g_stateObj[setting] = g_localStorage[setting]);
 	if (g_localStorage.colorType !== undefined) {
 		g_colorType = g_localStorage.colorType;
-		if (g_localStorage.setColor.length > 0) {
-			g_colorType = `TypeS`;
-			g_keycons.colorTypes.unshift(`TypeS`);
-			resetColorType({ _fromObj: g_localStorage, _toObj: obj, _to: `TypeS` });
-			resetColorType({ _fromObj: g_localStorage, _toObj: g_dfColorObj, _to: `TypeS` });
-		}
 		if (obj.colorUse) {
 			g_stateObj.d_color = g_keycons.colorDefTypes.findIndex(val => val === g_colorType) !== -1 ? C_FLG_ON : C_FLG_OFF;
 		}
@@ -4906,8 +4896,6 @@ const createOptionWindow = _sprite => {
 
 		// ---------------------------------------------------
 		// 1. キーコンフィグ設定 (KeyConfig)
-
-
 		g_keyObj.currentKey = g_headerObj.keyLabels[g_stateObj.scoreId];
 		const isNotSameKey = (g_keyObj.prevKey !== g_keyObj.currentKey);
 
@@ -4939,6 +4927,7 @@ const createOptionWindow = _sprite => {
 					reverse: C_FLG_OFF,
 					keyCtrl: [[]],
 					keyCtrlPtn: 0,
+					setColor: [],
 				};
 				storageObj = g_localKeyStorage;
 
@@ -4954,6 +4943,21 @@ const createOptionWindow = _sprite => {
 					storageObj[`keyCtrlPtn${addKey}`] = 0;
 				}
 				getKeyCtrl(storageObj, addKey);
+
+				// カラーセット初期値設定
+				if (storageObj[`setColor${addKey}`] === undefined) {
+					storageObj[`setColor${addKey}`] = [];
+				}
+				if (storageObj[`setColor${addKey}`].length > 0) {
+					if (!g_keycons.colorTypes.includes(`TypeS`)) {
+						g_keycons.colorTypes.unshift(`TypeS`);
+					}
+					resetColorType({ _fromObj: storageObj, _from: addKey, _to: `TypeS` });
+					resetColorType({ _fromObj: storageObj, _from: addKey, _toObj: g_dfColorObj, _to: `TypeS` });
+				} else {
+					g_colorType = `Default`;
+					g_keycons.colorTypes = g_keycons.colorTypes.filter(val => val !== `TypeS`);
+				}
 			}
 
 			const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
@@ -7860,26 +7864,6 @@ const getArrowSettings = _ => {
 		g_localStorage.volume = g_stateObj.volume;
 		g_localStorage.colorType = g_colorType;
 
-		// カラーセットの保存（作品別）
-		if (!g_keycons.colorDefTypes.includes(g_colorType)) {
-
-			resetColorType({ _toObj: g_localStorage });
-			resetColorType({ _from: g_colorType, _to: g_colorType, _fromObj: g_dfColorObj });
-
-			g_colorType = `TypeS`;
-			g_localStorage.colorType = `TypeS`;
-			if (!g_keycons.colorTypes.includes(`TypeS`)) {
-				g_keycons.colorTypes.unshift(`TypeS`);
-			}
-			resetColorType({ _to: `TypeS` });
-
-		} else {
-			g_keycons.colorTypes = g_keycons.colorTypes.filter(val => val !== `TypeS`);
-			g_localStorage.setColor = [];
-			g_localStorage.setShadowColor = [];
-			g_localStorage.frzColor = [];
-			g_localStorage.frzShadowColor = [];
-		}
 		g_storeSettings.forEach(setting => g_localStorage[setting] = g_stateObj[setting]);
 
 		let storageObj = g_localKeyStorage;
@@ -7895,6 +7879,20 @@ const getArrowSettings = _ => {
 		if (g_keyObj.currentPtn !== -1) {
 			storageObj[`keyCtrlPtn${addKey}`] = g_keyObj.currentPtn;
 			g_keyObj[`keyCtrl${keyCtrlPtn}`] = copyArray2d(g_keyObj[`keyCtrl${keyCtrlPtn}d`]);
+		}
+
+		// カラーセットの保存（キー別）
+		if (!g_keycons.colorDefTypes.includes(g_colorType)) {
+
+			resetColorType({ _toObj: storageObj, _to: addKey });
+			resetColorType({ _from: g_colorType, _to: g_colorType, _fromObj: g_dfColorObj });
+
+			g_colorType = `TypeS`;
+			g_localStorage.colorType = `TypeS`;
+			if (!g_keycons.colorTypes.includes(`TypeS`)) {
+				g_keycons.colorTypes.unshift(`TypeS`);
+			}
+			resetColorType({ _to: `TypeS` });
 		}
 
 		if (!g_stateObj.extraKeyFlg) {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -819,7 +819,7 @@ const g_keycons = {
     configTypeNum: 0,
 
     colorTypes: [`Default`, `Type0`, `Type1`, `Type2`, `Type3`, `Type4`],
-    colorDefs: [C_FLG_ON, C_FLG_ON, C_FLG_OFF, C_FLG_OFF, C_FLG_OFF, C_FLG_OFF],
+    colorDefTypes: [`Default`, `Type0`],
     colorTypeNum: 0,
 
     imgTypes: [],

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -821,12 +821,17 @@ const g_keycons = {
     colorTypes: [`Default`, `Type0`, `Type1`, `Type2`, `Type3`, `Type4`],
     colorDefTypes: [`Default`, `Type0`],
     colorTypeNum: 0,
+    colorSelf: `TypeS`,
 
     imgTypes: [],
     imgTypeNum: 0,
 
+    colorGroups: [0],
     colorGroupNum: 0,
+
+    shuffleGroups: [0],
     shuffleGroupNum: 0,
+    groupSelf: `S`,
 };
 
 let g_displays = [`stepZone`, `judgment`, `fastSlow`, `lifeGauge`, `score`, `musicInfo`, `filterLine`,
@@ -1412,6 +1417,8 @@ const g_cssObj = {
 
     flex_centering: `flex_centering`,
 };
+
+const g_dfKeyObj = {};
 
 // キー別の設定（一旦ここで定義）
 // ステップゾーンの位置関係は自動化を想定


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. これまで画面を開いているときだけ有効になっていた、カラーセットをキー別に丸ごと保存するようにしました。
Type1～4を選択している場合に有効で、保存後は`TypeS`という表記に変わります。
Default/Type0についてはこれまで通りです。
なお、ColorTypeの設定はこれまで通り作品別に保存されます。

<img src="https://user-images.githubusercontent.com/44026291/193415334-80a2e988-9576-4481-9eb0-4c3d2babdbca.png" width="60%">

2. カラーグループ、シャッフルグループの保存に対応しました。
    - カラーグループ、シャッフルグループが保存された場合は「S」と表記されます。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. これまでは必要時に毎回再設定が必要になっていたため。
2. 1.と同じ理由です。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 別キーに切替時、ColorType = `TypeS`が存在しない場合は ColorType = `Default` に切り替わります。
