### PR TITLE
fix: [0582] ColorType: Type0が既定値にならない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4971,7 +4971,9 @@ const createOptionWindow = _sprite => {
 					resetColorType({ _fromObj: storageObj, _from: addKey, _toObj: g_dfColorObj, _to: g_keycons.colorSelf });
 
 				} else {
-					g_colorType = `Default`;
+					if (g_localStorage.colorType === g_keycons.colorSelf) {
+						g_colorType = `Default`;
+					}
 					g_keycons.colorTypes = g_keycons.colorTypes.filter(val => val !== g_keycons.colorSelf);
 				}
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. ColorType: Type0が既定値にならない問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. ver28.1.0で修正した際の影響です。
Type0のとき、ColorTypeを`Default`に戻す動作になっていました。
ColorType: `TypeS`が保存済みのColorTypeで、`TypeS`が存在しないキーの場合のみ、`Default`に戻します。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments