### PR TITLE
fix: [0585] キーパターン変更時、カラー・シャッフルグループが前の設定を引きずってしまう問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4981,21 +4981,13 @@ const createOptionWindow = _sprite => {
 
 				// カラーグループ、シャッフルグループの設定
 				[`color`, `shuffle`].forEach(type => {
-					let k = 1;
-					g_keycons[`${type}Groups`] = [0];
-					while (g_keyObj[`${type}${keyCtrlPtn}_${k}`] !== undefined) {
-						g_keycons[`${type}Groups`].push(k);
-						k++;
-					}
-
+					resetGroupList(type, keyCtrlPtn);
 					if (g_keyObj.currentPtn === -1) {
 						if (storageObj[`${type}${g_keyObj.currentKey}_-1_-1`] !== undefined) {
-							resetGroupList(type);
 							g_keyObj[`${type}${g_keyObj.currentKey}_-1`] = structuredClone(storageObj[`${type}${g_keyObj.currentKey}_-1_-1`]);
 						}
 						g_keyObj[`${type}${g_keyObj.currentKey}_-1_-1`] = structuredClone(g_keyObj[`${type}${g_keyObj.currentKey}_-1`]);
 					} else {
-						resetGroupList(type);
 						g_keyObj[`${type}${keyCtrlPtn}`] = structuredClone(g_keyObj[`${type}${keyCtrlPtn}_0`]);
 					}
 				});
@@ -5355,13 +5347,19 @@ const makeMiniCssButton = (_id, _directionFlg, _heightPos, _func, { dx = 0, dy =
  * カラーグループ、シャッフルグループの再設定
  * @param {string} _type 
  */
-const resetGroupList = (_type) => {
+const resetGroupList = (_type, _keyCtrlPtn) => {
+	let k = 1;
+	g_keycons[`${_type}Groups`] = [0];
+
 	if (g_keyObj.currentPtn === -1) {
 		g_keycons[`${_type}GroupNum`] = -1;
 		g_keycons[`${_type}Groups`] = addValtoArray(g_keycons[`${_type}Groups`], -1);
 	} else {
 		g_keycons[`${_type}GroupNum`] = 0;
-		g_keycons[`${_type}Groups`] = g_keycons[`${_type}Groups`].filter(val => val !== -1);
+	}
+	while (g_keyObj[`${_type}${_keyCtrlPtn}_${k}`] !== undefined) {
+		g_keycons[`${_type}Groups`].push(k);
+		k++;
 	}
 };
 
@@ -5609,7 +5607,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	const maxLeftX = Math.min(0, (kWidth - C_ARW_WIDTH) / 2 - maxLeftPos * g_keyObj.blank);
 
 	// カラーグループ、シャッフルグループの再設定
-	[`color`, `shuffle`].forEach(type => resetGroupList(type));
+	[`color`, `shuffle`].forEach(type => resetGroupList(type, keyCtrlPtn));
 
 	/**
 	 * keyconSpriteのスクロール位置調整


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. キーパターン変更時、カラー・シャッフルグループが前の設定を引きずってしまう問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. すでにカラー・シャッフルグループが複数存在するキーに影響します。
今回の対応で、キーパターン変更都度、カラー・シャッフルグループ配列を作り直す方式に変更しました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- なおこの変更を行っても、KeyPattern: Self 時にカラー・シャッフルグループが一時的に複数化できない問題が残ります。リロードすれば元に戻るため、一旦これで様子を見ます。
具体的な方法が判明した後に修正予定です。