### PR TITLE
[ver28.1.2] パターン変更時、カラー・シャッフルグループが前の設定を引きずってしまう問題を修正　他

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ v26の対応終了時期はv29リリース開始時を予定しています。�
 
 | Version | Supported          | Latest Version | Logs | First Release | End of Support |
 | ------- | ------------------ |----------------|------|---------------|----------------|
-| v28     | :heavy_check_mark: |[v28.1.0](https://github.com/cwtickle/danoniplus/releases/tag/v28.1.1)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v28)|2022-08-21|-|
+| v28     | :heavy_check_mark: |[v28.1.2](https://github.com/cwtickle/danoniplus/releases/tag/v28.1.2)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v28)|2022-08-21|-|
 | v27     | :heavy_check_mark: |[v27.8.1](https://github.com/cwtickle/danoniplus/releases/tag/v27.8.1)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v27)|2022-03-18|(At Release v30)|
 | v26     | :warning:          |[v26.7.4](https://github.com/cwtickle/danoniplus/releases/tag/v26.7.4)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v26)|2022-01-30|(At Release v29)|
 | v25     | :x:                |[v25.5.10 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v25.5.10)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v25)|2022-01-04|2022-08-21|

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,7 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 28.1.1`;
+const g_version = `Ver 28.1.2`;
 const g_revisedDate = `2022/10/02`;
 const g_alphaVersion = ``;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danoniplus",
-  "version": "28.1.1",
+  "version": "28.1.2",
   "description": "Dancing☆Onigiri (CW Edition) - Web-based Rhythm Game",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- #1313 
- #1314
- #1315 

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments