### PR TITLE
fix: [0586] カラー・シャッフルグループ変更後、各グループが一時的に複数化できない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2402,8 +2402,9 @@ const preheaderConvert = _dosObj => {
 	// 背景・マスクモーションのパス指定方法を他の設定に合わせる設定
 	obj.syncBackPath = setBoolVal(_dosObj.syncBackPath ?? g_presetObj.syncBackPath);
 
+	// デフォルトのカラー・シャッフルグループ設定を退避
 	[`color`, `shuffle`].forEach(type => {
-		const tmpName = Object.keys(g_keyObj).filter(val => val.startsWith(type) && val.endsWith(`_0`));
+		const tmpName = Object.keys(g_keyObj).filter(val => val.startsWith(type));
 		tmpName.forEach(property => g_dfKeyObj[property] = structuredClone(g_keyObj[property]));
 	});
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. カラー・シャッフルグループ変更後、各グループが一時的に複数化できない問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #1313 関連。
退避するはずのカラー・シャッフルグループが一部漏れていました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- これもver28.1.0関連の問題ですが、重要度は低いため次の更新時に取り込む予定です。