### PR TITLE
fix: [0588] キーパターンがselfのとき、カラー・シャッフルグループが1種類になってしまう問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5308,14 +5308,12 @@ const getKeyCtrl = (_localStorage, _extraKeyName = ``) => {
 		});
 
 		[`color`, `shuffle`].forEach(type => {
-			if (isUpdate) {
-				let maxPtn = 0;
-				while (g_keyObj[`${type}${basePtn}_${maxPtn}`] !== undefined) {
-					maxPtn++;
-				}
-				for (let j = 0; j < maxPtn; j++) {
-					g_keyObj[`${type}${copyPtn}_${j}`] = copyArray2d(g_keyObj[`${type}${basePtn}_${j}`]);
-				}
+			let maxPtn = 0;
+			while (g_keyObj[`${type}${basePtn}_${maxPtn}`] !== undefined) {
+				maxPtn++;
+			}
+			for (let j = 0; j < maxPtn; j++) {
+				g_keyObj[`${type}${copyPtn}_${j}`] = copyArray2d(g_keyObj[`${type}${basePtn}_${j}`]);
 			}
 		});
 	}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5888,10 +5888,9 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	const makeGroupButton = (_type, { baseX = g_sWidth * 5 / 6 - 20, cssName } = {}) => {
 		if (g_headerObj[`${_type}Use`] && g_keycons[`${_type}Groups`].length > 1) {
 			const typeName = toCapitalize(_type);
-			const num = g_keycons[`${_type}GroupNum`] === -1 ? g_keycons.groupSelf : g_keycons[`${_type}GroupNum`] + 1;
 			multiAppend(divRoot,
 				makeKCButtonHeader(`lbl${_type}Group`, `${typeName}Group`, { x: baseX - 10, y: 37 }, cssName),
-				makeKCButton(`lnk${typeName}Group`, `${num}`, _ => setGroup(_type), {
+				makeKCButton(`lnk${typeName}Group`, ``, _ => setGroup(_type), {
 					x: baseX, y: 50, w: g_sWidth / 18, title: g_msgObj[`${_type}Group`], cxtFunc: _ => setGroup(_type, -1),
 				}),
 				makeMiniKCButton(`lnk${typeName}Group`, `L`, _ => setGroup(_type, -1), { x: baseX - 10, y: 50 }),


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. キーパターンがselfのとき、カラー・シャッフルグループが1種類になってしまう問題を修正しました。
2. グループボタンの不要な初期表示処理を見直しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 当初は意図して入れていたif文が弊害になっていたため。
2. グループボタンを作成後、ボタン名を表示する処理を`viewGroup`にて行っていたため二重処理となっていました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- おそらく変更しても問題は無いと思いますが、念のため発端のPull Requestを調べてからマージする予定です。
