### PR TITLE
fix: [0589] データセーブしない場合にカラー・シャッフルグループの設定が引き継がれない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5014,11 +5014,13 @@ const createOptionWindow = _sprite => {
 				[`color`, `shuffle`].forEach(type => {
 					resetGroupList(type, keyCtrlPtn);
 					if (g_keyObj.currentPtn === -1) {
+						g_keycons[`${type}GroupNum`] = -1;
 						if (storageObj[`${type}${g_keyObj.currentKey}_-1_-1`] !== undefined) {
 							g_keyObj[`${type}${g_keyObj.currentKey}_-1`] = structuredClone(storageObj[`${type}${g_keyObj.currentKey}_-1_-1`]);
 						}
 						g_keyObj[`${type}${g_keyObj.currentKey}_-1_-1`] = structuredClone(g_keyObj[`${type}${g_keyObj.currentKey}_-1`]);
 					} else {
+						g_keycons[`${type}GroupNum`] = 0;
 						g_keyObj[`${type}${keyCtrlPtn}`] = structuredClone(g_keyObj[`${type}${keyCtrlPtn}_0`]);
 					}
 				});
@@ -5381,10 +5383,10 @@ const resetGroupList = (_type, _keyCtrlPtn) => {
 	g_keycons[`${_type}Groups`] = [0];
 
 	if (g_keyObj.currentPtn === -1) {
-		g_keycons[`${_type}GroupNum`] = -1;
 		g_keycons[`${_type}Groups`] = addValtoArray(g_keycons[`${_type}Groups`], -1);
-	} else {
-		g_keycons[`${_type}GroupNum`] = 0;
+	}
+	if (!g_canLoadDifInfoFlg) {
+		g_keycons[`${_type}GroupNum`] = (g_keyObj.currentPtn === -1 ? -1 : 0);
 	}
 	while (g_keyObj[`${_type}${_keyCtrlPtn}_${k}`] !== undefined) {
 		g_keycons[`${_type}Groups`].push(k);
@@ -5605,9 +5607,6 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	g_kcType = _kcType;
 	g_currentPage = `keyConfig`;
 
-	// 譜面初期情報ロード許可フラグ
-	g_canLoadDifInfoFlg = false;
-
 	multiAppend(divRoot,
 
 		// キーコンフィグ画面タイトル
@@ -5637,6 +5636,9 @@ const keyConfigInit = (_kcType = g_kcType) => {
 
 	// カラーグループ、シャッフルグループの再設定
 	[`color`, `shuffle`].forEach(type => resetGroupList(type, keyCtrlPtn));
+
+	// 譜面初期情報ロード許可フラグ
+	g_canLoadDifInfoFlg = false;
 
 	/**
 	 * keyconSpriteのスクロール位置調整


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. データセーブしない場合にカラー・シャッフルグループの設定が引き継がれない問題を修正しました。
2. キーパターン変更ボタン周りの処理を見直しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. ver28.1.0にて`resetColorType`関数を導入しましたが、この関数内でカラー・シャッフルグループを初期化する処理を入れていました。タイトルバックで戻ってきた場合やキーパターンを切り替える場合は問題ないのですが、以下の場合に初期化されると問題となるケースがありました。キーパターン変更ボタンを押したときに初期化するよう見直しています。
    - データセーブしない場合にタイトルバックした場合
    - プレイ開始前にカラー・シャッフルグループを変更後、再度設定画面・キーコンフィグ画面を行き来した場合
2. 上記に伴い、同じコードの繰り返しが見られたため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments