### PR TITLE
improve: [0590] 画面内の意図しない文字の折り返し設定を無効化

### DIFF
--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -13,6 +13,7 @@
 	height:500px;
 	position: relative;
 	overflow: hidden;
+	white-space: nowrap;
 }
 #canvas-frame canvas {
 	position: absolute;

--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -10,24 +10,26 @@
 ------------------------------------------ */
 
 #canvas-frame {
-	height:500px;
+	height: 500px;
 	position: relative;
 	overflow: hidden;
 	white-space: nowrap;
 }
+
 #canvas-frame canvas {
 	position: absolute;
-	left:0;
+	left: 0;
 	overflow: hidden;
 }
 
-input[type=range] {
+input[type="range"] {
 	-webkit-appearance: none;
 	background: transparent;
 	height: 20px;
 	width: 205px;
 }
-input[type=range]::-webkit-slider-thumb {
+
+input[type="range"]::-webkit-slider-thumb {
 	-webkit-appearance: none;
 	background: #606060;
 	height: 20px;
@@ -35,10 +37,12 @@ input[type=range]::-webkit-slider-thumb {
 	opacity: 0.5;
 	border-radius: 50%;
 }
-input[type=range]::-moz-range-track{
+
+input[type="range"]::-moz-range-track {
 	height: 0;
 }
-input[type=range]::-moz-range-thumb{
+
+input[type="range"]::-moz-range-thumb {
 	background: #606060;
 	height: 20px;
 	width: 20px;
@@ -46,24 +50,27 @@ input[type=range]::-moz-range-thumb{
 	border: none;
 	border-radius: 50%;
 }
-input[type=range]:focus {
+
+input[type="range"]:focus {
 	outline: 0;
 }
 
-input[type=color] {
-	width:25px;
-	height:25px;
-	border:none;
+input[type="color"] {
+	width: 25px;
+	height: 25px;
+	border: none;
+	padding: 1px;
 }
 
 /* 左から右へ */
 @keyframes leftToRight {
 	0% {
-		opacity: 0;/* 透明 */
+		opacity: 0;
 		transform: translateX(-50px);
 	}
+
 	100% {
-		opacity: 1;/* 不透明 */
+		opacity: 1;
 		transform: translateX(0);
 	}
 }
@@ -71,11 +78,12 @@ input[type=color] {
 /* 上から下へ */
 @keyframes upToDown {
 	0% {
-		opacity: 0;/* 透明 */
+		opacity: 0;
 		transform: translateY(-50px);
 	}
+
 	100% {
-		opacity: 1;/* 不透明 */
+		opacity: 1;
 		transform: translateY(0);
 	}
 }
@@ -83,19 +91,22 @@ input[type=color] {
 /* 左から右へ移動し、フェードアウト（結果画面で使用） */
 @keyframes leftToRightFade {
 	0% {
-		opacity: 0;/* 透明 */
+		opacity: 0;
 		transform: translateX(-30px);
 	}
+
 	30% {
-		opacity: 1;/* 不透明 */
+		opacity: 1;
 		transform: translateX(0);
 	}
+
 	60% {
-		opacity: 1;/* 不透明 */
+		opacity: 1;
 		transform: translateX(0);
 	}
+
 	100% {
-		opacity: 0;/* 透明 */
+		opacity: 0;
 		transform: translateX(30px);
 	}
 }
@@ -103,19 +114,22 @@ input[type=color] {
 /* 上から下へ移動し、フェードアウト（結果画面で使用） */
 @keyframes upToDownFade {
 	0% {
-		opacity: 0;/* 透明 */
+		opacity: 0;
 		transform: translateY(-30px);
 	}
+
 	30% {
-		opacity: 1;/* 不透明 */
+		opacity: 1;
 		transform: translateY(0);
 	}
+
 	80% {
-		opacity: 1;/* 不透明 */
+		opacity: 1;
 		transform: translateY(0);
 	}
+
 	100% {
-		opacity: 0;/* 透明 */
+		opacity: 0;
 		transform: translateY(10px);
 	}
 }
@@ -123,25 +137,27 @@ input[type=color] {
 /* 徐々に表示（結果画面で使用） */
 @keyframes slowlyAppearing {
 	0% {
-		opacity: 0.5;/* 透明 */
+		opacity: 0.5;
 	}
+
 	80% {
-		opacity: 0.5;/* 透明 */
+		opacity: 0.5;
 	}
+
 	100% {
-		opacity: 1;/* 不透明 */
+		opacity: 1;
 	}
 }
 
 /* 文字拡大から元のサイズへ戻る */
 @keyframes fromBig {
 	0% {
-		opacity: 0;/* 透明 */
+		opacity: 0;
 		transform: scale(1.5, 1.5);
-		
 	}
+
 	100% {
-		opacity: 1;/* 不透明 */
+		opacity: 1;
 		transform: scale(1, 1);
 	}
 }
@@ -149,11 +165,12 @@ input[type=color] {
 /* 徐々に表示(Y方向) */
 @keyframes smallToNormalY {
 	0% {
-		opacity: 0;/* 透明 */
+		opacity: 0;
 		transform: scale(1, 0);
 	}
+
 	100% {
-		opacity: 1;/* 不透明 */
+		opacity: 1;
 		transform: scale(1, 1);
 	}
 }
@@ -163,6 +180,7 @@ input[type=color] {
 	0% {
 		transform: rotateX(0deg);
 	}
+
 	100% {
 		transform: rotateX(360deg);
 	}
@@ -173,6 +191,7 @@ input[type=color] {
 	0% {
 		transform: rotateY(0deg);
 	}
+
 	100% {
 		transform: rotateY(360deg);
 	}
@@ -183,6 +202,7 @@ input[type=color] {
 	0% {
 		transform: rotateZ(0deg);
 	}
+
 	100% {
 		transform: rotateZ(360deg);
 	}
@@ -193,6 +213,7 @@ input[type=color] {
 	0% {
 		filter: blur(8px);
 	}
+
 	100% {
 		filter: blur(0);
 	}
@@ -203,12 +224,15 @@ input[type=color] {
 	0% {
 		filter: brightness(0.0);
 	}
+
 	30% {
 		filter: brightness(2.0);
 	}
+
 	70% {
 		filter: brightness(0.0);
 	}
+
 	100% {
 		filter: brightness(1.0);
 	}
@@ -219,6 +243,7 @@ input[type=color] {
 	0% {
 		opacity: 0;
 	}
+
 	100% {
 		opacity: 1;
 	}
@@ -228,6 +253,7 @@ input[type=color] {
 	0% {
 		opacity: 0;
 	}
+
 	100% {
 		opacity: 1;
 	}
@@ -238,6 +264,7 @@ input[type=color] {
 	0% {
 		opacity: 1;
 	}
+
 	100% {
 		opacity: 0;
 	}
@@ -247,6 +274,7 @@ input[type=color] {
 	0% {
 		opacity: 1;
 	}
+
 	100% {
 		opacity: 0;
 	}
@@ -255,29 +283,35 @@ input[type=color] {
 .toRight {
 	animation-name: leftToRight;
 }
+
 .toSpin {
 	animation-name: spinY;
 }
 
 /* 設定画面：ゲージ設定詳細 */
 .settings_gaugeVal {
-	font-size:12px;
+	font-size: 12px;
 }
+
 .settings_gaugeDivCover {
 	border: 1px #666666 solid;
 	width: 280px;
 }
+
 .settings_gaugeDivTable {
 	display: table;
 	width: 279px;
 }
+
 .settings_gaugeDivTableCol {
 	display: table-cell;
 	border-collapse: collapse;
 }
+
 .settings_gaugeStart {
 	width: 85px;
 }
+
 .settings_gaugeEtc {
 	width: 65px;
 }
@@ -297,6 +331,7 @@ input[type=color] {
 	justify-content: center;
 	cursor: default;
 }
+
 .button_common:hover {
 	cursor: pointer;
 }
@@ -307,6 +342,6 @@ input[type=color] {
 }
 
 /* 警告ウィンドウ */
-#lblWarning > p {
+#lblWarning>p {
 	margin: 15px 5px;
 }

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1824,6 +1824,7 @@ const initialControl = async () => {
 
 		g_sWidth = Math.max(...widthList);
 		$id(`canvas-frame`).width = `${g_sWidth}px`;
+		$id(`divRoot`).width = `${g_sWidth}px`;
 	}
 	if (g_headerObj.playingWidth === `default`) {
 		g_headerObj.playingWidth = g_sWidth;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2924,7 +2924,7 @@ const g_lblNameObj = {
     filterLock: `Lock`,
 
     sc_speed: `←→`,
-    sc_scroll: `R/↑↓`,
+    sc_scroll: `R/<br>↑↓`,
     sc_adjustment: `- +`,
     sc_keyConfigPlay: g_isMac ? `Del+Enter` : `BS+Enter`,
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 画面内の意図しない文字の折り返し設定を無効化しました。
具体的には、画面枠のid: canvas-frame に対して`white-space: nowrap;`を指定しています。
2. ColorPickerのCSSにPadding: 1px指定を追加しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 通常、自然折り返しで改行するケースは少ないと思われるため。
頻度は少ないかもしれませんが、WordPressで表示する場合に
自動折り返しが利いてしまうことがあり、
画面要素に指定することで、その影響を抑えることができます。
2. 環境により、Paddingのデフォルト値指定でColorPickerの色が見えないことがあるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 強制改行`<br>`を入れている箇所は従来通り折り返しされます。
- この設定はダンおに画面内にのみ適用しているため、画面外への影響はないと思われます。