### PR TITLE
improve: [0591] キーコンフィグ周りの文言、ローカルストレージキー変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -187,7 +187,6 @@ let g_langStorage = {};
 // ローカルストレージ設定 (作品別)
 let g_localStorage;
 let g_localStorageUrl;
-let g_localStorageOrgUrl;
 
 // ローカルストレージ設定 (ドメイン・キー別)
 let g_localKeyStorage;
@@ -1914,8 +1913,7 @@ const loadLocalStorage = _ => {
 	// URLからscoreIdを削除
 	const url = new URL(location.href);
 	url.searchParams.delete('scoreId');
-	g_localStorageOrgUrl = url.toString();
-	g_localStorageUrl = `${url.pathname}${url.search}`;
+	g_localStorageUrl = url.toString();
 
 	/**
 	 * ローカルストレージの初期値設定
@@ -1943,7 +1941,7 @@ const loadLocalStorage = _ => {
 	Object.assign(g_msgInfoObj, g_lang_msgInfoObj[g_localeObj.val]);
 
 	// 作品別ローカルストレージの読込
-	const checkStorage = localStorage.getItem(g_localStorageUrl) || localStorage.getItem(g_localStorageOrgUrl);
+	const checkStorage = localStorage.getItem(g_localStorageUrl);
 	if (checkStorage) {
 		g_localStorage = JSON.parse(checkStorage);
 
@@ -8006,10 +8004,6 @@ const getArrowSettings = _ => {
 			localStorage.setItem(`danonicw-${g_keyObj.currentKey}k`, JSON.stringify(g_localKeyStorage));
 		}
 
-		// 古いキーデータの削除（互換用、作品別）
-		if (localStorage.getItem(g_localStorageOrgUrl)) {
-			localStorage.removeItem(g_localStorageOrgUrl);
-		}
 		localStorage.setItem(g_localStorageUrl, JSON.stringify(g_localStorage));
 		g_canLoadDifInfoFlg = true;
 
@@ -10089,7 +10083,7 @@ const resultInit = _ => {
 	if (g_stateObj.shuffle !== `OFF`) {
 		tweetDifData += `:${getStgDetailName(g_stateObj.shuffle)}`;
 	}
-	const twiturl = new URL(g_localStorageOrgUrl);
+	const twiturl = new URL(g_localStorageUrl);
 	twiturl.searchParams.append(`scoreId`, g_stateObj.scoreId);
 
 	let tweetFrzJdg = ``;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10089,7 +10089,7 @@ const resultInit = _ => {
 	if (g_stateObj.shuffle !== `OFF`) {
 		tweetDifData += `:${getStgDetailName(g_stateObj.shuffle)}`;
 	}
-	const twiturl = new URL(g_localStorageUrl);
+	const twiturl = new URL(g_localStorageOrgUrl);
 	twiturl.searchParams.append(`scoreId`, g_stateObj.scoreId);
 
 	let tweetFrzJdg = ``;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7993,6 +7993,11 @@ const getArrowSettings = _ => {
 			storageObj[`${type}${addKey}`] = structuredClone(g_keyObj[`${type}${keyCtrlPtn}_${groupNum}`]);
 			g_keyObj[`${type}${g_keyObj.currentKey}_-1_${groupNum}`] = structuredClone(g_keyObj[`${type}${keyCtrlPtn}_${groupNum}d`]);
 			g_keyObj[`${type}${keyCtrlPtn}_${groupNum}`] = structuredClone(g_keyObj[`${type}${keyCtrlPtn}_${groupNum}d`]);
+
+			// 古いキーデータの削除 (互換用)
+			if (storageObj[`${type}${g_keyObj.currentKey}_-1_-1`] !== undefined) {
+				delete storageObj[`${type}${g_keyObj.currentKey}_-1_-1`];
+			}
 		});
 
 		if (!g_stateObj.extraKeyFlg) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -187,6 +187,7 @@ let g_langStorage = {};
 // ローカルストレージ設定 (作品別)
 let g_localStorage;
 let g_localStorageUrl;
+let g_localStorageOrgUrl;
 
 // ローカルストレージ設定 (ドメイン・キー別)
 let g_localKeyStorage;
@@ -1913,7 +1914,8 @@ const loadLocalStorage = _ => {
 	// URLからscoreIdを削除
 	const url = new URL(location.href);
 	url.searchParams.delete('scoreId');
-	g_localStorageUrl = url.toString();
+	g_localStorageOrgUrl = url.toString();
+	g_localStorageUrl = url.pathname;
 
 	/**
 	 * ローカルストレージの初期値設定
@@ -1941,7 +1943,7 @@ const loadLocalStorage = _ => {
 	Object.assign(g_msgInfoObj, g_lang_msgInfoObj[g_localeObj.val]);
 
 	// 作品別ローカルストレージの読込
-	const checkStorage = localStorage.getItem(g_localStorageUrl);
+	const checkStorage = localStorage.getItem(g_localStorageUrl) || localStorage.getItem(g_localStorageOrgUrl);
 	if (checkStorage) {
 		g_localStorage = JSON.parse(checkStorage);
 
@@ -8002,6 +8004,11 @@ const getArrowSettings = _ => {
 
 		if (!g_stateObj.extraKeyFlg) {
 			localStorage.setItem(`danonicw-${g_keyObj.currentKey}k`, JSON.stringify(g_localKeyStorage));
+		}
+
+		// 古いキーデータの削除（互換用、作品別）
+		if (localStorage.getItem(g_localStorageOrgUrl)) {
+			localStorage.removeItem(g_localStorageOrgUrl);
 		}
 		localStorage.setItem(g_localStorageUrl, JSON.stringify(g_localStorage));
 		g_canLoadDifInfoFlg = true;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1915,7 +1915,7 @@ const loadLocalStorage = _ => {
 	const url = new URL(location.href);
 	url.searchParams.delete('scoreId');
 	g_localStorageOrgUrl = url.toString();
-	g_localStorageUrl = url.pathname;
+	g_localStorageUrl = `${url.pathname}${url.search}`;
 
 	/**
 	 * ローカルストレージの初期値設定

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1814,7 +1814,7 @@ const initialControl = async () => {
 	// デフォルトのカラー・シャッフルグループ設定を退避
 	[`color`, `shuffle`].forEach(type => {
 		const tmpName = Object.keys(g_keyObj).filter(val => val.startsWith(type));
-		tmpName.forEach(property => g_dfKeyObj[property] = structuredClone(g_keyObj[property]));
+		tmpName.forEach(property => g_keyObj[`${property}d`] = structuredClone(g_keyObj[property]));
 	});
 
 	// 自動横幅拡張設定
@@ -5014,8 +5014,9 @@ const createOptionWindow = _sprite => {
 				[`color`, `shuffle`].forEach(type => {
 					resetGroupList(type, keyCtrlPtn);
 					if (g_keyObj.currentPtn === -1) {
-						if (storageObj[`${type}${g_keyObj.currentKey}_-1_-1`] !== undefined) {
-							g_keyObj[`${type}${g_keyObj.currentKey}_-1`] = structuredClone(storageObj[`${type}${g_keyObj.currentKey}_-1_-1`]);
+						const storageKeyName = storageObj[`${type}${addKey}`] || storageObj[`${type}${g_keyObj.currentKey}_-1_-1`];
+						if (storageKeyName !== undefined) {
+							g_keyObj[`${type}${g_keyObj.currentKey}_-1`] = structuredClone(storageKeyName);
 						}
 						g_keyObj[`${type}${g_keyObj.currentKey}_-1_-1`] = structuredClone(g_keyObj[`${type}${g_keyObj.currentKey}_-1`]);
 					} else {
@@ -7989,9 +7990,9 @@ const getArrowSettings = _ => {
 
 		[`color`, `shuffle`].forEach(type => {
 			const groupNum = g_keycons[`${type}GroupNum`];
-			storageObj[`${type}${g_keyObj.currentKey}_-1_-1`] = structuredClone(g_keyObj[`${type}${keyCtrlPtn}_${groupNum}`]);
-			g_keyObj[`${type}${g_keyObj.currentKey}_-1_${groupNum}`] = structuredClone(g_dfKeyObj[`${type}${keyCtrlPtn}_${groupNum}`]);
-			g_keyObj[`${type}${keyCtrlPtn}_${groupNum}`] = structuredClone(g_dfKeyObj[`${type}${keyCtrlPtn}_${groupNum}`]);
+			storageObj[`${type}${addKey}`] = structuredClone(g_keyObj[`${type}${keyCtrlPtn}_${groupNum}`]);
+			g_keyObj[`${type}${g_keyObj.currentKey}_-1_${groupNum}`] = structuredClone(g_keyObj[`${type}${keyCtrlPtn}_${groupNum}d`]);
+			g_keyObj[`${type}${keyCtrlPtn}_${groupNum}`] = structuredClone(g_keyObj[`${type}${keyCtrlPtn}_${groupNum}d`]);
 		});
 
 		if (!g_stateObj.extraKeyFlg) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1956,6 +1956,13 @@ const loadLocalStorage = _ => {
 			g_localStorage.highscores = {};
 		}
 
+		// 廃棄済みリストからデータを消去
+		g_storeSettingsEx.forEach(val => {
+			if (g_localStorage[val] !== undefined) {
+				delete g_localStorage[val];
+			}
+		});
+
 	} else {
 		g_localStorage = {
 			adjustment: 0,
@@ -2907,7 +2914,7 @@ const headerConvert = _dosObj => {
 		});
 	}
 
-	// ローカルストレージに保存済みのDisplay設定・ColorType設定を戻す
+	// ローカルストレージに保存済みのAppearance, Opacity設定・ColorType設定を戻す
 	g_storeSettings.filter(tmpSetting => hasVal(g_localStorage[tmpSetting])).forEach(setting =>
 		g_stateObj[setting] = g_localStorage[setting]);
 	if (g_localStorage.colorType !== undefined) {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -837,7 +837,11 @@ const g_keycons = {
 let g_displays = [`stepZone`, `judgment`, `fastSlow`, `lifeGauge`, `score`, `musicInfo`, `filterLine`,
     `speed`, `color`, `lyrics`, `background`, `arrowEffect`, `special`];
 
-let g_storeSettings = [`appearance`, `opacity`, `d_stepzone`, `d_judgment`, `d_fastslow`, `d_lifegauge`,
+// ローカルストレージ保存対象
+let g_storeSettings = [`appearance`, `opacity`];
+
+// 廃棄対象のリスト(過去の登録対象をリスト化。ここに乗せるとローカルストレージから自動消去される)
+let g_storeSettingsEx = [`d_stepzone`, `d_judgment`, `d_fastslow`, `d_lifegauge`,
     `d_score`, `d_musicinfo`, `d_filterline`];
 
 let g_canDisabledSettings = [`motion`, `scroll`, `shuffle`, `autoPlay`, `gauge`, `appearance`];

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1418,8 +1418,6 @@ const g_cssObj = {
     flex_centering: `flex_centering`,
 };
 
-const g_dfKeyObj = {};
-
 // キー別の設定（一旦ここで定義）
 // ステップゾーンの位置関係は自動化を想定
 const g_keyObj = {
@@ -3067,7 +3065,7 @@ const g_lblNameObj = {
 const g_lang_lblNameObj = {
     Ja: {
         kcDesc: `[{0}:スキップ / {1}:(代替キーのみ)キー無効化]`,
-        kcShuffleDesc: `番号をクリックでシャッフルグループ、矢印をクリックでカラーグループを一時的に変更`,
+        kcShuffleDesc: `番号をクリックでシャッフルグループ、矢印をクリックでカラーグループを変更`,
         sdDesc: `[クリックでON/OFFを切替、灰色でOFF]`,
         kcShortcutDesc: `プレイ中ショートカット：「{0}」タイトルバック / 「{1}」リトライ`,
         transKeyDesc: `別キーモードではハイスコア、キーコンフィグ等は保存されません`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. カラー・シャッフル用のローカルストレージキーを変更しました。
互換のため、ver28.1.0以降のものも取り込めるようにしています。

|変更前|変更後|用途|
|----|----|----|
|shuffleX_-1_-1|shuffle(X)|保存するシャッフルのセット配列|
|colorX_-1_-1|color(X)|保存するカラーのセット配列|

2. キーコンフィグ画面のカラー・シャッフルグループの説明文言を見直しました。
3. g_dfKeyObjを使ってデータ退避している部分を、keyCtrlと同様にg_keyObjへ移行しました。
4. ローカルストレージ（作品別）の保存対象からDisplay設定を対象外としました。
    - StepZone, Judgment, FastSlow, Lifegauge, Score, MusicInfo, FilterLine

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. キー名が冗長でわかりにくいため。
なお、この古いキー名はプレイ開始時（かつデータ保存時）にローカルストレージから削除するようにしています。
2. カラー・シャッフルグループの変更が一時的で無く、保存できるようになったため。
3. 処理統一のため。
4. いずれも恒久的な設定というより一時的に設定する意味合いが強く、
作品別に保存する必要性が薄いため。
Appearance/Opacityは作品によりそのままの設定でプレイする可能性があるため、残します。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 1.についてはこの更新が反映された作品を「Data Save」を有効にした状態でプレイすると反映します。
- 4.はこの更新が反映された作品を読み込んだ時点で反映します。