### PR TITLE
improve: [0592] カラーピッカー関連の説明文を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -889,7 +889,7 @@ const getStrWidth = (_str, _fontsize, _font) => {
  * @param {number} _maxFontsize
  * @param {number} _minFontsize
  */
-const getFontSize = (_str, _maxWidth, _font = getBasicreateDivCss2LabelcFont(), _maxFontsize = 64, _minFontsize = 5) => {
+const getFontSize = (_str, _maxWidth, _font = getBasicFont(), _maxFontsize = 64, _minFontsize = 5) => {
 	for (let siz = _maxFontsize; siz >= _minFontsize; siz--) {
 		if (_maxWidth >= getStrWidth(_str, siz, _font)) {
 			return siz;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6072,7 +6072,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		keyConfigInit(g_kcType);
 	};
 
-	const colorPickSprite = createEmptySprite(divRoot, `colorPickSprite`, g_windowObj.colorPickSprite);
+	const colorPickSprite = createEmptySprite(divRoot, `colorPickSprite`, Object.assign({ title: g_msgObj.pickArrow }, g_windowObj.colorPickSprite));
 	if ([`Default`, `Type0`].includes(g_colorType)) {
 		colorPickSprite.style.display = C_DIS_NONE;
 	}
@@ -6089,8 +6089,6 @@ const keyConfigInit = (_kcType = g_kcType) => {
 			}
 		}, g_lblPosObj.lnkColorCopy, g_cssObj.button_Start),
 	);
-	document.getElementById(`lblPickArrow`).title = g_msgObj.pickArrow;
-	document.getElementById(`lblPickFrz`).title = g_msgObj.pickFrz;
 
 	/**
 	 * ColorPicker部分の作成

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -889,7 +889,7 @@ const getStrWidth = (_str, _fontsize, _font) => {
  * @param {number} _maxFontsize
  * @param {number} _minFontsize
  */
-const getFontSize = (_str, _maxWidth, _font = getBasicFont(), _maxFontsize = 64, _minFontsize = 5) => {
+const getFontSize = (_str, _maxWidth, _font = getBasicreateDivCss2LabelcFont(), _maxFontsize = 64, _minFontsize = 5) => {
 	for (let siz = _maxFontsize; siz >= _minFontsize; siz--) {
 		if (_maxWidth >= getStrWidth(_str, siz, _font)) {
 			return siz;
@@ -6089,6 +6089,8 @@ const keyConfigInit = (_kcType = g_kcType) => {
 			}
 		}, g_lblPosObj.lnkColorCopy, g_cssObj.button_Start),
 	);
+	document.getElementById(`lblPickArrow`).title = g_msgObj.pickArrow;
+	document.getElementById(`lblPickFrz`).title = g_msgObj.pickFrz;
 
 	/**
 	 * ColorPicker部分の作成

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -238,7 +238,7 @@ const updateWindowSiz = _ => {
             x: 0, w: 50, h: 15, siz: 11, align: C_ALIGN_LEFT, background: `#${g_headerObj.baseBrightFlg ? `eeeeee` : `111111`}80`,
         },
         lnkColorCopy: {
-            x: 35, y: -5, w: 30, h: 20, siz: 14,
+            x: 35, y: -5, w: 30, h: 20, siz: 14, title: g_msgObj.pickColorCopy,
         },
 
         btnKcBack: {
@@ -3186,6 +3186,10 @@ const g_lang_msgObj = {
         imgType: `矢印・フリーズアローなどのオブジェクトの見た目を変更します。`,
         colorGroup: `矢印・フリーズアロー色グループの割り当てパターンを変更します。`,
         shuffleGroup: `Mirror/Asym-Mirror/Random/S-Random選択時、シャッフルするグループを変更します。\n矢印の上にある同じ数字同士でシャッフルします。`,
+
+        pickArrow: `色番号ごとの矢印色（枠、塗りつぶし）をカラーピッカーから選んで変更できます。`,
+        pickFrz: `色番号ごとの通常時のフリーズアロー色（枠、帯）をカラーピッカーから選んで変更できます。`,
+        pickColorCopy: `このボタンを押すと、フリーズアローの配色を矢印（枠）の色で上書きします。\nヒット時のフリーズアローの色も上書きします。`,
     },
 
     En: {
@@ -3237,6 +3241,10 @@ const g_lang_msgObj = {
         imgType: `Change the appearance of sequences.`,
         colorGroup: `Change the sequences color group assignment pattern.`,
         shuffleGroup: `Change the shuffle group when Mirror, Asym-Mirror, Random or S-Random are selected.\nShuffle with the same numbers listed above.`,
+
+        pickArrow: `Change the frame or fill of arrow color for each color number from the color picker.`,
+        pickFrz: `Change the frame or bar of normal freeze-arrow color for each color number from the color picker.`,
+        pickColorCopy: `Pressing this button will override the color scheme of the freeze arrow with the frame color of the arrow. It also overrides the color of the freeze arrow on hit.`,
     },
 
 };

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3187,8 +3187,7 @@ const g_lang_msgObj = {
         colorGroup: `矢印・フリーズアロー色グループの割り当てパターンを変更します。`,
         shuffleGroup: `Mirror/Asym-Mirror/Random/S-Random選択時、シャッフルするグループを変更します。\n矢印の上にある同じ数字同士でシャッフルします。`,
 
-        pickArrow: `色番号ごとの矢印色（枠、塗りつぶし）をカラーピッカーから選んで変更できます。`,
-        pickFrz: `色番号ごとの通常時のフリーズアロー色（枠、帯）をカラーピッカーから選んで変更できます。`,
+        pickArrow: `色番号ごとの矢印色（枠、塗りつぶし）、通常時のフリーズアロー色（枠、帯）を\nカラーピッカーから選んで変更できます。`,
         pickColorCopy: `このボタンを押すと、フリーズアローの配色を矢印（枠）の色で上書きします。\nヒット時のフリーズアローの色も上書きします。`,
     },
 
@@ -3242,9 +3241,8 @@ const g_lang_msgObj = {
         colorGroup: `Change the sequences color group assignment pattern.`,
         shuffleGroup: `Change the shuffle group when Mirror, Asym-Mirror, Random or S-Random are selected.\nShuffle with the same numbers listed above.`,
 
-        pickArrow: `Change the frame or fill of arrow color for each color number from the color picker.`,
-        pickFrz: `Change the frame or bar of normal freeze-arrow color for each color number from the color picker.`,
-        pickColorCopy: `Pressing this button will override the color scheme of the freeze arrow with the frame color of the arrow. It also overrides the color of the freeze arrow on hit.`,
+        pickArrow: `Change the frame or fill of arrow color and the frame or bar of normal freeze-arrow color\nfor each color number from the color picker.`,
+        pickColorCopy: `Pressing this button will override the color scheme of the freeze arrow with the frame color of the arrow. \nIt also overrides the color of the freeze arrow on hit.`,
     },
 
 };


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. キーコンフィグ画面のColorType: Type1～4, TypeSで選択可能な、カラーピッカー及び[↓]ボタンに対して説明文を追加しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. カラーピッカーだけでは何を意味しているかが分かりにくいため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/194709323-b02b5937-2de5-4327-825f-09fbeec47022.png" width="60%">

## :pencil: その他コメント / Other Comments