### PR TITLE
improve: [0593] 17key(KeyPattern: 1)のサイズ見直し

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2544,7 +2544,7 @@ const g_keyObj = {
     minWidth11i: 650,
     minWidth13: 650,
     minWidth16i: 650,
-    minWidth17: 850,
+    minWidth17: 825,
     minWidth23: 900,
 
 };

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2054,7 +2054,7 @@ const g_keyObj = {
     // 矢印群の倍率指定
     scale: 1,
     scale_def: 1,
-    scale17_0: 0.85,
+    scale17_0: 0.95,
 
     // ショートカットキーコード
     keyRetry: 8,
@@ -2544,7 +2544,7 @@ const g_keyObj = {
     minWidth11i: 650,
     minWidth13: 650,
     minWidth16i: 650,
-    minWidth17: 800,
+    minWidth17: 850,
     minWidth23: 900,
 
 };


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 17key(KeyPattern: 1)の矢印拡大率を0.85から0.95に見直しました。
合わせて、最小横幅を800pxから825pxへ見直ししています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 当時は17key以外横に長いキーが存在しなかったため横幅を狭める対応を行いましたが、
23keyが存在する現在では狭めるメリットが薄いと思われるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

### 変更前
<img src="https://user-images.githubusercontent.com/44026291/194813703-63af7bf7-ea56-43a9-a361-212a2a61878e.png" width="70%">

### 変更後
<img src="https://user-images.githubusercontent.com/44026291/194814606-17b96b16-e8fa-4de6-a4fc-325aa0480bdc.png" width="70%">


## :pencil: その他コメント / Other Comments
- danoni_constants.js のみの変更です。