### PR TITLE
feat: [0594] シャッフルグループのデフォルトからの差分に対して色付け

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5292,7 +5292,6 @@ const getKeyCtrl = (_localStorage, _extraKeyName = ``) => {
 	const baseKeyCtrlPtn = _localStorage[`keyCtrlPtn${_extraKeyName}`];
 	const basePtn = `${g_keyObj.currentKey}_${baseKeyCtrlPtn}`;
 	const baseKeyNum = g_keyObj[`chara${basePtn}`].length;
-	g_keyObj.basePtn = basePtn;
 
 	if (_localStorage[`keyCtrl${_extraKeyName}`] !== undefined && _localStorage[`keyCtrl${_extraKeyName}`][0].length > 0) {
 		const prevPtn = g_keyObj.currentPtn;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5292,6 +5292,7 @@ const getKeyCtrl = (_localStorage, _extraKeyName = ``) => {
 	const baseKeyCtrlPtn = _localStorage[`keyCtrlPtn${_extraKeyName}`];
 	const basePtn = `${g_keyObj.currentKey}_${baseKeyCtrlPtn}`;
 	const baseKeyNum = g_keyObj[`chara${basePtn}`].length;
+	g_keyObj.basePtn = basePtn;
 
 	if (_localStorage[`keyCtrl${_extraKeyName}`] !== undefined && _localStorage[`keyCtrl${_extraKeyName}`][0].length > 0) {
 		const prevPtn = g_keyObj.currentPtn;
@@ -5324,6 +5325,7 @@ const getKeyCtrl = (_localStorage, _extraKeyName = ``) => {
 			for (let j = 0; j < maxPtn; j++) {
 				g_keyObj[`${type}${copyPtn}_${j}`] = copyArray2d(g_keyObj[`${type}${basePtn}_${j}`]);
 			}
+			g_keyObj[`${type}${copyPtn}_0d`] = structuredClone(g_keyObj[`${type}${copyPtn}_0`]);
 		});
 	}
 };
@@ -5673,22 +5675,8 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	 * @param {number} _k 
 	 * @param {string} _cssName 
 	 */
-	const changeKeyConfigColor = (_j, _k, _cssName) => {
-		const obj = document.querySelector(`#keycon${_j}_${_k}`);
-		const resetClass = _className => {
-			if (obj.classList.contains(_className)) {
-				obj.classList.remove(_className);
-			}
-		};
-
-		// CSSクラスの除去
-		resetClass(g_cssObj.keyconfig_Changekey);
-		resetClass(g_cssObj.keyconfig_Defaultkey);
-		resetClass(g_cssObj.title_base);
-
-		// 指定されたCSSクラスを適用
-		obj.classList.add(_cssName);
-	};
+	const changeKeyConfigColor = (_j, _k, _cssName) =>
+		changeConfigColor(document.querySelector(`#keycon${_j}_${_k}`), _cssName);
 
 	/**
 	 * 一時的に矢印色・シャッフルグループを変更（共通処理）
@@ -5729,6 +5717,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		const tmpShuffle = changeTmpData(`shuffle`, 10, _j, _scrollNum);
 		document.getElementById(`sArrow${_j}`).textContent = tmpShuffle + 1;
 
+		changeShuffleConfigColor(keyCtrlPtn, g_keyObj[`shuffle${keyCtrlPtn}_${g_keycons.shuffleGroupNum}`][_j], _j);
 		adjustScrollPoint(parseFloat($id(`arrow${_j}`).left));
 	};
 
@@ -5834,6 +5823,10 @@ const keyConfigInit = (_kcType = g_kcType) => {
 				document.getElementById(`lnk${toCapitalize(_type)}Group`).textContent = getStgDetailName(num);
 			}
 			viewGroupObj[_type](`_${g_keycons[`${_type}GroupNum`]}`);
+
+			if (_type === `shuffle`) {
+				changeShuffleConfigColor(keyCtrlPtn, g_keyObj[`shuffle${keyCtrlPtn}_${g_keycons.shuffleGroupNum}`]);
+			}
 		}
 	};
 	const setGroup = (_type, _scrollNum = 1) => {
@@ -6172,6 +6165,8 @@ const keyConfigInit = (_kcType = g_kcType) => {
 
 		// キーコンフィグ画面を再呼び出し
 		keyConfigInit();
+
+		changeShuffleConfigColor(`${g_keyObj.currentKey}_${g_keyObj.currentPtn}`, g_keyObj[`shuffle${g_keyObj.currentKey}_${g_keyObj.currentPtn}_${g_keycons.shuffleGroupNum}`]);
 	};
 
 	// ユーザカスタムイベント(初期)
@@ -6339,6 +6334,44 @@ const changeSetColor = _ => {
 	// 影矢印が未指定の場合はType1, Type2の影矢印指定を無くす
 	if (!hasVal(g_headerObj[`setShadowColor${scoreIdHeader}Default`][0]) && [`Type1`, `Type2`].includes(g_colorType)) {
 		g_headerObj.setShadowColor = [...Array(g_headerObj.setColorInit.length)].fill(``);
+	}
+};
+
+/**
+ * コンフィグの色変更
+ * @param {object} _obj 
+ * @param {string} _cssName 
+ */
+const changeConfigColor = (_obj, _cssName) => {
+	const resetClass = _className => {
+		if (_obj.classList.contains(_className)) {
+			_obj.classList.remove(_className);
+		}
+	};
+
+	// CSSクラスの除去
+	resetClass(g_cssObj.keyconfig_Changekey);
+	resetClass(g_cssObj.keyconfig_Defaultkey);
+	resetClass(g_cssObj.title_base);
+
+	// 指定されたCSSクラスを適用
+	_obj.classList.add(_cssName);
+};
+
+/**
+ * シャッフルグループの色変更
+ * @param {array} _vals 
+ */
+const changeShuffleConfigColor = (_keyCtrlPtn, _vals, _j = -1) => {
+	const changeTargetColor = (_val, _k) => {
+		const equalShuffleGr = (_val === g_keyObj[`shuffle${_keyCtrlPtn}_0d`][_k]);
+		changeConfigColor(document.getElementById(`sArrow${_k}`), equalShuffleGr ? g_cssObj.title_base : g_cssObj.keyconfig_Changekey);
+	};
+
+	if (_j === -1) {
+		_vals.forEach((val, j) => changeTargetColor(val, j));
+	} else {
+		changeTargetColor(_vals, _j);
 	}
 };
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5813,6 +5813,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 
 	/**
 	 * カラー・シャッフルグループ設定の表示
+	 * - シャッフルグループではデフォルトからの差異表示もここで行う
 	 * @param {string} _type 
 	 */
 	const viewGroup = _type => {
@@ -6165,6 +6166,8 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		// キーコンフィグ画面を再呼び出し
 		keyConfigInit();
 
+		// シャッフルグループのデフォルト値からの差異表示（色付け）
+		// 再描画後で無いと色付けできないため、keyConfigInit() 実行後に処理
 		changeShuffleConfigColor(`${g_keyObj.currentKey}_${g_keyObj.currentPtn}`, g_keyObj[`shuffle${g_keyObj.currentKey}_${g_keyObj.currentPtn}_${g_keycons.shuffleGroupNum}`]);
 	};
 
@@ -6366,8 +6369,8 @@ const changeConfigColor = (_obj, _cssName) => {
  */
 const changeShuffleConfigColor = (_keyCtrlPtn, _vals, _j = -1) => {
 	const changeTargetColor = (_val, _k) => {
-		const equalShuffleGr = (_val === g_keyObj[`shuffle${_keyCtrlPtn}_0d`][_k]);
-		changeConfigColor(document.getElementById(`sArrow${_k}`), equalShuffleGr ? g_cssObj.title_base : g_cssObj.keyconfig_Changekey);
+		const isEqualShuffleGr = (_val === g_keyObj[`shuffle${_keyCtrlPtn}_0d`][_k]);
+		changeConfigColor(document.getElementById(`sArrow${_k}`), isEqualShuffleGr ? g_cssObj.title_base : g_cssObj.keyconfig_Changekey);
 	};
 
 	if (_j === -1) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6359,7 +6359,10 @@ const changeConfigColor = (_obj, _cssName) => {
 
 /**
  * シャッフルグループの色変更
- * @param {array} _vals 
+ * - デフォルト値と違う番号になった場合、色付けする
+ * @param {string} _keyCtrlPtn キーコンフィグパターン
+ * @param {array} _vals シャッフルグループ番号（群）
+ * @param {number} _j (-1: 全体に対して色付け, それ以外: 指定箇所のみ色付け)
  */
 const changeShuffleConfigColor = (_keyCtrlPtn, _vals, _j = -1) => {
 	const changeTargetColor = (_val, _k) => {
@@ -6368,7 +6371,7 @@ const changeShuffleConfigColor = (_keyCtrlPtn, _vals, _j = -1) => {
 	};
 
 	if (_j === -1) {
-		_vals.forEach((val, j) => changeTargetColor(val, j));
+		_vals.forEach((val, m) => changeTargetColor(val, m));
 	} else {
 		changeTargetColor(_vals, _j);
 	}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. シャッフルグループのデフォルトからの差分に対して色付けするようにしました。
グループ1のパターンを常にデフォルトとして比較します。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Resolves #1327 
割り当てキーや色であれば、何が変わったか判断できますが
シャッフルグループは数字しかないため何が変わったかがわかりにくいため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/195377262-bdb088aa-73fd-434f-8a51-421291c13623.png" width="60%">

## :pencil: その他コメント / Other Comments

||Functions &amp; Variables|
|----|----|
|Add|changeConfigColor, changeShuffleConfigColor|
|Change|ー|
|Delete|ー|
