### PR TITLE
fix: [0595] シャッフル無効時にシャッフルグループの色付け処理が動く問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6168,7 +6168,9 @@ const keyConfigInit = (_kcType = g_kcType) => {
 
 		// シャッフルグループのデフォルト値からの差異表示（色付け）
 		// 再描画後で無いと色付けできないため、keyConfigInit() 実行後に処理
-		changeShuffleConfigColor(`${g_keyObj.currentKey}_${g_keyObj.currentPtn}`, g_keyObj[`shuffle${g_keyObj.currentKey}_${g_keyObj.currentPtn}_${g_keycons.shuffleGroupNum}`]);
+		if (g_headerObj.shuffleUse) {
+			changeShuffleConfigColor(`${g_keyObj.currentKey}_${g_keyObj.currentPtn}`, g_keyObj[`shuffle${g_keyObj.currentKey}_${g_keyObj.currentPtn}_${g_keycons.shuffleGroupNum}`]);
+		}
 	};
 
 	// ユーザカスタムイベント(初期)


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. シャッフル無効時にシャッフルグループの色付け処理が動く問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #1328 関連。
この処理はシャッフルが有効であることが前提になっているため。
他の部分は問題ないですが、この箇所のみキーパターン変更時に
必ず通る処理になっていたためエラーになっていました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments