### PR TITLE
improve: [0596] CSSのベンダープレフィックス指定を一部削除

### DIFF
--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -23,14 +23,14 @@
 }
 
 input[type="range"] {
-	-webkit-appearance: none;
+	appearance: none;
 	background: transparent;
 	height: 20px;
 	width: 205px;
 }
 
 input[type="range"]::-webkit-slider-thumb {
-	-webkit-appearance: none;
+	appearance: none;
 	background: #606060;
 	height: 20px;
 	width: 20px;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1571,7 +1571,6 @@ const drawTitleResultMotion = _displayName => {
 // WebAudioAPIでAudio要素風に再生するクラス
 class AudioPlayer {
 	constructor() {
-		const AudioContext = window.AudioContext ?? window.webkitAudioContext;
 		this._context = new AudioContext();
 		this._gain = this._context.createGain();
 		this._gain.connect(this._context.destination);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -949,8 +949,6 @@ const createDiv = (_id, _x, _y, _width, _height, _classes = []) => {
 const setUserSelect = (_style, _value = C_DIS_NONE) => {
 	_style.userSelect = _value;
 	_style.webkitUserSelect = _value;
-	_style.msUserSelect = _value;
-	_style.mozUserSelect = _value;
 	_style.webkitTouchCallout = _value;
 };
 
@@ -9329,9 +9327,7 @@ const changeAppearanceFilter = (_appearance, _num = 10) => {
 	const bottomShape = `inset(${numPlus}% 0% ${_num}% 0%)`;
 
 	$id(`arrowSprite${topNum}`).clipPath = topShape;
-	$id(`arrowSprite${topNum}`).webkitClipPath = topShape;
 	$id(`arrowSprite${bottomNum}`).clipPath = bottomShape;
-	$id(`arrowSprite${bottomNum}`).webkitClipPath = bottomShape;
 
 	$id(`filterBar0`).top = `${g_posObj.arrowHeight * _num / 100}px`;
 	$id(`filterBar1`).top = `${g_posObj.arrowHeight * (100 - _num) / 100}px`;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. CSSのベンダープレフィックス指定を一部削除しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Can I Useの状況より、ベンダープレフィックスが不要でも動くようになってきたため。
https://caniuse.com/?search=clip-path
https://caniuse.com/?search=user-select
https://caniuse.com/?search=appearance
https://caniuse.com/?search=audio-context

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- webkit-touch-calloutも不要になってきましたが、今回は据え置きます。
https://caniuse.com/?search=touch-callout

- CSS Masks 及び background-clip はまだベンダープレフィックスが必要なブラウザが多いため据え置きます。
https://caniuse.com/?search=mask
https://caniuse.com/?search=background-clip