### PR TITLE
fix: [0597] 警告ウィンドウ、コメントエリアについて自然折り返しを有効化

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3965,6 +3965,7 @@ const setWindowStyle = (_text, _bkColor, _textColor, _align = C_ALIGN_LEFT) => {
 	// ウィンドウ枠の行を取得するために一時的な枠を作成
 	const tmplbl = createDivCss2Label(`lblTmpWarning`, _text, {
 		x: 0, y: 70, w: g_sWidth, h: 20, siz: C_SIZ_MAIN, lineHeight: `15px`, fontFamily: getBasicFont(),
+		whiteSpace: `normal`,
 	})
 	divRoot.appendChild(tmplbl);
 	const range = new Range();
@@ -3976,6 +3977,7 @@ const setWindowStyle = (_text, _bkColor, _textColor, _align = C_ALIGN_LEFT) => {
 	const lbl = createDivCss2Label(`lblWarning`, _text, {
 		x: 0, y: 70, w: g_sWidth, h: warnHeight, siz: C_SIZ_MAIN, backgroundColor: _bkColor,
 		opacity: 0.9, lineHeight: `15px`, color: _textColor, align: _align, fontFamily: getBasicFont(),
+		whiteSpace: `normal`,
 	});
 	if (warnHeight === 150) {
 		lbl.style.overflow = `auto`;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -135,6 +135,7 @@ const updateWindowSiz = _ => {
         lblComment: {
             x: 0, y: 70, w: g_sWidth, h: g_sHeight - 180, siz: C_SIZ_DIFSELECTOR, align: C_ALIGN_LEFT,
             overflow: `auto`, background: `#222222`, color: `#cccccc`, display: C_DIS_NONE,
+            whiteSpace: `normal`,
         },
         btnComment: {
             x: g_sWidth - 160, y: (g_sHeight / 2) + 150, w: 140, h: 50, siz: 20, border: `solid 1px #999999`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 警告ウィンドウ、コメントエリアについて自然折り返しを有効化しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #1322 にて自然折り返しを無効にしましたが、警告ウィンドウ（英語）にて自然折り返しを使用している箇所があったため仕様を見直しました。コメントエリアも同様のため、念のため自然折り返しを有効に戻しています。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments