### PR TITLE
improve: [0598] Display画面の特定項目未使用時に非表示化する設定を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5543,7 +5543,7 @@ const createSettingsDisplayWindow = _sprite => {
 		g_hidSudObj.filterPos = inputSlider(appearanceSlider, lblAppearancePos), false);
 
 	const dispAppearanceSlider = _ => {
-		[`lblAppearancePos`, `lblAppearanceBar`, `lnkLockBtn`].forEach(obj =>
+		[`lblAppearancePos`, `lblAppearanceBar`, `lnkLockBtn`, `lnkfilterLine`].forEach(obj =>
 			document.getElementById(obj).style.visibility =
 			g_appearanceRanges.includes(g_stateObj.appearance) ? `Visible` : `Hidden`
 		);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5553,7 +5553,9 @@ const createSettingsDisplayWindow = _sprite => {
 	// ---------------------------------------------------
 	// 判定表示系の不透明度 (Opacity)
 	// 縦位置: 9
-	createGeneralSetting(spriteList.opacity, `opacity`, { unitName: g_lblNameObj.percent, displayName: g_currentPage });
+	if (g_headerObj.judgmentUse || g_headerObj.fastSlowUse || g_headerObj.appearanceUse) {
+		createGeneralSetting(spriteList.opacity, `opacity`, { unitName: g_lblNameObj.percent, displayName: g_currentPage });
+	}
 };
 
 /**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. Display画面のFilterLineについて、Appearanceが「Hidden+/Sudden+/Hid&amp;Sud+」のときのみ表示するように変更しました。
2. Judgment/FastSlow/Appearanceの全てが設定不可かつ無効のとき、
Opacity設定を非表示化するよう変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. FilterLineは、Appearanceが「Hidden+/Sudden+/Hid&amp;Sud+」のときに表示される
フィルターの境界線を表示する線の表示／非表示を行うためのものであるため。
2. Opacityの対象が全て無効のとき、設定を表示する必要が無いため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/196022328-0776ab92-2fc1-46a9-bf86-b1be57171cbf.png" width="50%"><img src="https://user-images.githubusercontent.com/44026291/196022357-1c49cbc1-428e-4845-81a1-ed741926672b.png" width="50%">

## :pencil: その他コメント / Other Comments