### PR TITLE
fix: [0599] Opacity設定の非表示条件誤りを修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5553,7 +5553,11 @@ const createSettingsDisplayWindow = _sprite => {
 	// ---------------------------------------------------
 	// 判定表示系の不透明度 (Opacity)
 	// 縦位置: 9
-	if (g_headerObj.judgmentUse || g_headerObj.fastSlowUse || g_headerObj.appearanceUse) {
+	let opacityUse = false;
+	[`judgment`, `fastSlow`, `filterLine`].forEach(display =>
+		opacityUse ||= g_headerObj[`${display}Use`] || g_headerObj[`${display}Set`] === C_FLG_ON);
+
+	if (opacityUse) {
 		createGeneralSetting(spriteList.opacity, `opacity`, { unitName: g_lblNameObj.percent, displayName: g_currentPage });
 	}
 };


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. Opacity設定の非表示条件誤りを修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #1333 にてOpacity設定の条件付き非表示化を実装しましたが、その条件に誤りがありました。
Judgment, FastSlow, FilterLineの設定がいずれも無効で、その設定値がOFFになっている必要がありました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/196024470-ba44256a-7e5c-4d23-8ac6-4c4ec58f273f.png" width="50%">

## :pencil: その他コメント / Other Comments