### PR TITLE
feat: [0600] MotionオプションにHi-Boostを追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7345,34 +7345,39 @@ const setSpeedOnFrame = (_speedData, _lastFrame) => {
 
 /**
  * Motionオプション適用時の矢印別の速度設定
- * - 配列の数字は小さいほどステップゾーンに近いことを示す。
- * - 15がステップゾーン上、0～14は矢印の枠外管理用
+ * - 矢印が表示される最大フレーム数を 縦ピクセル数×20 と定義。
  */
-const setMotionOnFrame = _ => {
+const setMotionOnFrame = _ => g_motionFunc[g_stateObj.motion]([...Array(g_sHeight * 20 + 1)].fill(0));
 
-	// 矢印が表示される最大フレーム数
-	const motionLastFrame = g_sHeight * 20;
-	const brakeLastFrame = g_sHeight / 2;
-
-	const motionOnFrame = [...Array(motionLastFrame + 1)].fill(0);
-
-	if (g_stateObj.motion === C_FLG_OFF) {
-	} else if (g_stateObj.motion === `Boost`) {
-		// ステップゾーンに近づくにつれて加速量を大きくする (16 → 85)
-		for (let j = C_MOTION_STD_POS + 1; j < C_MOTION_STD_POS + 70; j++) {
-			motionOnFrame[j] = (C_MOTION_STD_POS + 70 - j) * 3 / 50;
-		}
-	} else if (g_stateObj.motion === `Brake`) {
-		// 初期は+2x、ステップゾーンに近づくにつれて加速量を下げる (20 → 34)
-		for (let j = C_MOTION_STD_POS + 5; j < C_MOTION_STD_POS + 19; j++) {
-			motionOnFrame[j] = (j - 15) * 4 / 14;
-		}
-		for (let j = C_MOTION_STD_POS + 19; j <= brakeLastFrame; j++) {
-			motionOnFrame[j] = 4;
-		}
+/**
+ * Boost用の適用関数
+ * - ステップゾーンに近づくにつれて加速量を大きく/小さくする (16 → 85)
+ * @param {array} _frms 
+ * @param {number} _spd 
+ * @param {number} _pnFlg 正負(1 もしくは -1) 
+ * @returns 
+ */
+const getBoostTrace = (_frms, _spd, _pnFlg = 1) => {
+	for (let j = C_MOTION_STD_POS + 1; j < C_MOTION_STD_POS + 70; j++) {
+		_frms[j] = (C_MOTION_STD_POS + 70 - j) * _pnFlg * _spd / 50;
 	}
+	return _frms;
+};
 
-	return motionOnFrame;
+/**
+ * Brake用の適用関数
+ * - 初期は+2x、ステップゾーンに近づくにつれて加速量を下げる (20 → 34)
+ * @param {array} _frms 
+ * @returns 
+ */
+const getBrakeTrace = _frms => {
+	for (let j = C_MOTION_STD_POS + 5; j < C_MOTION_STD_POS + 19; j++) {
+		_frms[j] = (j - 15) * 4 / 14;
+	}
+	for (let j = C_MOTION_STD_POS + 19; j <= g_sHeight / 2; j++) {
+		_frms[j] = 4;
+	}
+	return _frms;
 };
 
 /**

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -746,7 +746,7 @@ const g_settings = {
     speedNum: 0,
     speedTerms: [20, 5, 1],
 
-    motions: [C_FLG_OFF, `Boost`, `Brake`, `Hi-Boost`, `Compress`],
+    motions: [C_FLG_OFF, `Boost`, `Hi-Boost`, `Brake`],
     motionNum: 0,
 
     reverses: [C_FLG_OFF, C_FLG_ON],
@@ -823,9 +823,8 @@ const g_shuffleFunc = {
 const g_motionFunc = {
     'OFF': _frms => _frms,
     'Boost': _frms => getBoostTrace(_frms, 3),
-    'Brake': _frms => getBrakeTrace(_frms),
     'Hi-Boost': _frms => getBoostTrace(_frms, g_stateObj.speed * 2),
-    'Compress': _frms => getBoostTrace(_frms, g_stateObj.speed, -1),
+    'Brake': _frms => getBrakeTrace(_frms),
 };
 
 const g_keycons = {
@@ -2981,9 +2980,8 @@ const g_lblNameObj = {
     'u_OFF': `OFF`,
     'u_ON': `ON`,
     'u_Boost': `Boost`,
-    'u_Brake': `Brake`,
     'u_Hi-Boost': `Hi-Boost`,
-    'u_Compress': `Compress`,
+    'u_Brake': `Brake`,
 
     'u_Cross': `Cross`,
     'u_Split': `Split`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -746,7 +746,7 @@ const g_settings = {
     speedNum: 0,
     speedTerms: [20, 5, 1],
 
-    motions: [C_FLG_OFF, `Boost`, `Brake`],
+    motions: [C_FLG_OFF, `Boost`, `Brake`, `Hi-Boost`, `Compress`],
     motionNum: 0,
 
     reverses: [C_FLG_OFF, C_FLG_ON],
@@ -813,6 +813,19 @@ const g_shuffleFunc = {
         applySRandom(keyNum, [[...Array(keyNum).keys()]], `arrow`, `frz`);
         applySRandom(keyNum, [[...Array(keyNum).keys()]], `dummyArrow`, `dummyFrz`);
     },
+};
+
+/**
+ * モーション適用関数
+ * - frmsはフレーム別の速度設定用配列。
+ * - 配列の15がステップゾーン上、0～14は矢印の枠外管理用
+ */
+const g_motionFunc = {
+    'OFF': _frms => _frms,
+    'Boost': _frms => getBoostTrace(_frms, 3),
+    'Brake': _frms => getBrakeTrace(_frms),
+    'Hi-Boost': _frms => getBoostTrace(_frms, g_stateObj.speed * 2),
+    'Compress': _frms => getBoostTrace(_frms, g_stateObj.speed, -1),
 };
 
 const g_keycons = {
@@ -2969,6 +2982,8 @@ const g_lblNameObj = {
     'u_ON': `ON`,
     'u_Boost': `Boost`,
     'u_Brake': `Brake`,
+    'u_Hi-Boost': `Hi-Boost`,
+    'u_Compress': `Compress`,
 
     'u_Cross': `Cross`,
     'u_Split': `Split`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. MotionオプションにHi-Boostを追加しました。以前のBoostと同じ軌道です。
2. Motion軌道周りのソースコードを見直しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 以前のBoostに一定の需要があるため。
2. Motionオプションが増えたときの冗長性回避のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments