### PR TITLE
improve: [0602] 左上に表示されるフレーム数を見かけのフレーム数に変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8325,7 +8325,7 @@ const mainInit = _ => {
 
 	// フレーム数
 	divRoot.appendChild(
-		createDivCss2Label(`lblframe`, g_scoreObj.frameNum, { x: 0, y: 0, w: 100, h: 30, siz: 20, display: g_workObj.lifegaugeDisp, })
+		createDivCss2Label(`lblframe`, g_scoreObj.nominalFrameNum, { x: 0, y: 0, w: 100, h: 30, siz: 20, display: g_workObj.lifegaugeDisp, })
 	);
 
 	// ライフ(数字)部作成
@@ -9069,7 +9069,7 @@ const mainInit = _ => {
 	const flowTimeline = _ => {
 
 		const currentFrame = g_scoreObj.frameNum;
-		lblframe.textContent = currentFrame;
+		lblframe.textContent = g_scoreObj.nominalFrameNum;
 
 		// キーの押下状態を取得
 		for (let j = 0; j < keyNum; j++) {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 左上に表示されるフレーム数を見かけのフレーム数に変更しました。
※左下に表示されている時間表記に連動し、AdjustmentやpreblankFrameが加味されるようになります。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 背景・マスクなどの実装時に、AdjustmentやpreblankFrameが異なることで異なるフレーム数が表示されてしまうため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/196726406-f55935f5-ece0-4b74-8507-e1cea9ae5563.png" width="50%">

## :pencil: その他コメント / Other Comments