### PR TITLE
improve: [0603] フェードイン中の個別加速の保持範囲を見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7541,18 +7541,13 @@ const pushArrows = (_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 	if (hasArrayList(_dataObj.boostData, 2)) {
 		let delBoostIdx = 0;
 		for (let k = _dataObj.boostData.length - 2; k >= 0; k -= 2) {
-			if (_dataObj.boostData[k] < g_scoreObj.frameNum) {
-				delBoostIdx = k + 2;
+			tmpObj = getArrowStartFrame(_dataObj.boostData[k], _speedOnFrame, _motionOnFrame);
+			if (tmpObj.frm < g_scoreObj.frameNum) {
+				_dataObj.boostData[k] = g_scoreObj.frameNum;
+				delBoostIdx = k;
 				break;
 			} else {
-				tmpObj = getArrowStartFrame(_dataObj.boostData[k], _speedOnFrame, _motionOnFrame);
-				if (tmpObj.frm < g_scoreObj.frameNum) {
-					_dataObj.boostData[k] = g_scoreObj.frameNum;
-					delBoostIdx = k;
-					break;
-				} else {
-					_dataObj.boostData[k] = tmpObj.frm;
-				}
+				_dataObj.boostData[k] = tmpObj.frm;
 			}
 		}
 		for (let k = 0; k < delBoostIdx; k++) {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. フェードイン中の個別加速の保持範囲を見直しました。
これまでは boost_data がフェードイン位置より前の場合はデータを除外していましたが、
一度矢印位置を考慮して個別加速位置を検索し、それがフェードイン位置より前であれば
そのデータを個別加速として含めるように変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 初回だけ個別加速が掛かっているパターン（|boost_data=0,1.5|）ではフェードインを掛けると従来の方法では外れるようになっていました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments