### PR TITLE
hotfix: [0606] フリーズアローを強制削除した場合の引数誤りを修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8794,9 +8794,9 @@ const mainInit = _ => {
 
 					// 枠外判定前の場合、このタイミングで枠外判定を行う
 					if (g_attrObj[prevFrzName].cnt >= (-1) * g_judgObj.frzJ[g_judgPosObj.iknai]) {
-						judgeIknai(_cnt);
+						judgeIknai(g_attrObj[prevFrzName].cnt);
 						if (g_headerObj.frzStartjdgUse) {
-							judgeUwan(_cnt);
+							judgeUwan(g_attrObj[prevFrzName].cnt);
 						}
 					}
 					judgeObjDelete.frz(_j, prevFrzName);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. フリーズアローを強制削除した場合の引数誤りを修正しました。
削除する対象のフリーズアローの残余フレームではなく、
チェック対象のフリーズアローの残余フレームになっていました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 処理には影響しませんが、カスタムjsで引数を使用していた場合に影響するため。
PR #341 関連です。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- この場合の引数は本来ウワァン/イクナイではない残余フレームのため、
強制的にイクナイの領域にかかる残余フレームに修正が必要かという話がありますが、
強制的に変えてしまうと本来のフレーム数がわからなくなるため、一旦そのままの値を入れています。