### PR TITLE
improve: [0607] 左上のフレーム数表記をbaseFrameに変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8325,7 +8325,7 @@ const mainInit = _ => {
 
 	// フレーム数
 	divRoot.appendChild(
-		createDivCss2Label(`lblframe`, g_scoreObj.nominalFrameNum, { x: 0, y: 0, w: 100, h: 30, siz: 20, display: g_workObj.lifegaugeDisp, })
+		createDivCss2Label(`lblframe`, g_scoreObj.baseFrame, { x: 0, y: 0, w: 100, h: 30, siz: 20, display: g_workObj.lifegaugeDisp, })
 	);
 
 	// ライフ(数字)部作成


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 左上のフレーム数表記をg_scroeObj.baseFrameに変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. ver28.4.0よりこの左上のフレーム数はnominalFrameNumを採用していますが、本来は制作者が使うもののため、frameNumやnominalFrameNumよりbaseFrameを採用する方が自然と考えます。

- 各フレームの意味については下記が参考になります。
https://github.com/cwtickle/danoniplus/wiki/AboutFrameProcessing

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
- 参考：PR #1338 