### PR TITLE
fix: [0609] クレジットリンク表示の折り返しが利かない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3774,7 +3774,7 @@ const titleInit = _ => {
 	 */
 	const createCreditBtn = (_id, _text, _url) =>
 		createCss2Button(_id, _text, _ => true,
-			Object.assign(g_lblPosObj[_id], { siz: getLinkSiz(_text), resetFunc: _ => openLink(_url) }), g_cssObj.button_Default);
+			Object.assign(g_lblPosObj[_id], { siz: getLinkSiz(_text), whiteSpace: `normal`, resetFunc: _ => openLink(_url) }), g_cssObj.button_Default);
 
 	// ボタン描画
 	multiAppend(divRoot,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. クレジットリンク表示が長い場合、折り返しが利いていない問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
1. PR #1322 の変更に対する自然折り返し箇所の洗い出し漏れです。

## :pencil: その他コメント / Other Comments
- v28.2.1以降で発生している問題のため、過去バージョンは修正不要です。