### PR TITLE
[0612] フリーズアロー（始点）に対してFast/Slowを常時カウントするよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9536,7 +9536,7 @@ const judgeArrow = _j => {
 		if (_difCnt <= g_judgObj.arrowJ[g_judgPosObj.uwan]) {
 			const [resultFunc, resultJdg] = checkJudgment(_difCnt);
 			resultFunc(_difFrame);
-			countFastSlow(_difFrame, g_headerObj.justFrames);
+			countFastSlow(_difFrame);
 
 			const stepDivHit = document.querySelector(`#stepHit${_j}`);
 			stepDivHit.style.top = `${g_attrObj[arrowName].prevY - parseFloat($id(`stepRoot${_j}`).top) - 15}px`;
@@ -9554,15 +9554,18 @@ const judgeArrow = _j => {
 
 	const judgeTargetFrzArrow = _difFrame => {
 		const _difCnt = Math.abs(_difFrame);
-		if (_difCnt <= g_judgObj.frzJ[g_judgPosObj.sfsf] && !g_attrObj[frzName].judgEndFlg) {
-			if (g_headerObj.frzStartjdgUse &&
-				(g_workObj.judgFrzHitCnt[_j] === undefined || g_workObj.judgFrzHitCnt[_j] <= fcurrentNo)) {
+		if (_difCnt <= g_judgObj.frzJ[g_judgPosObj.sfsf] && !g_attrObj[frzName].judgEndFlg
+			&& g_workObj.judgFrzHitCnt[_j] <= fcurrentNo) {
+
+			if (g_headerObj.frzStartjdgUse) {
 				const [resultFunc] = checkJudgment(_difCnt);
 				resultFunc(_difFrame);
-				countFastSlow(_difFrame, g_headerObj.justFrames);
-				g_workObj.judgFrzHitCnt[_j] = fcurrentNo + 1;
+			} else {
+				displayDiff(_difFrame, `F`);
 			}
+			countFastSlow(_difFrame);
 			changeHitFrz(_j, fcurrentNo, `frz`);
+			g_workObj.judgFrzHitCnt[_j] = fcurrentNo + 1;
 			return true;
 		}
 		return false;
@@ -9584,9 +9587,10 @@ const judgeArrow = _j => {
 /**
  * タイミングズレを表示
  * @param {number} _difFrame 
+ * @param {string} _fjdg
  * @param {number} _justFrames
  */
-const displayDiff = (_difFrame, _justFrames = 0) => {
+const displayDiff = (_difFrame, _fjdg = ``, _justFrames = g_headerObj.justFrames) => {
 	let diffJDisp = ``;
 	g_workObj.diffList.push(_difFrame);
 	const difCnt = Math.abs(_difFrame);
@@ -9595,7 +9599,7 @@ const displayDiff = (_difFrame, _justFrames = 0) => {
 	} else if (_difFrame < _justFrames * (-1)) {
 		diffJDisp = `<span class="common_shobon">Slow ${difCnt} Frames</span>`;
 	}
-	diffJ.innerHTML = diffJDisp;
+	document.getElementById(`diff${_fjdg}J`).innerHTML = diffJDisp;
 };
 
 /**
@@ -9603,7 +9607,7 @@ const displayDiff = (_difFrame, _justFrames = 0) => {
  * @param {number} _difFrame 
  * @param {number} _justFrames 
  */
-const countFastSlow = (_difFrame, _justFrames = 0) => {
+const countFastSlow = (_difFrame, _justFrames = g_headerObj.justFrames) => {
 	if (_difFrame > _justFrames) {
 		g_resultObj.fast++;
 	} else if (_difFrame < _justFrames * (-1)) {
@@ -9688,7 +9692,7 @@ const judgeRecovery = (_name, _difFrame) => {
 	changeJudgeCharacter(_name, g_lblNameObj[`j_${_name}`]);
 
 	updateCombo();
-	displayDiff(_difFrame, g_headerObj.justFrames);
+	displayDiff(_difFrame);
 
 	lifeRecovery();
 	finishViewing();
@@ -9730,7 +9734,7 @@ const judgeMatari = _difFrame => {
 	changeJudgeCharacter(`matari`, g_lblNameObj.j_matari);
 	comboJ.textContent = ``;
 
-	displayDiff(_difFrame, g_headerObj.justFrames);
+	displayDiff(_difFrame);
 	finishViewing();
 
 	g_customJsObj.judg_matari.forEach(func => func(_difFrame));


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. フリーズアロー（始点）に対して始点判定によらず、Fast/Slowを常時カウントするよう変更しました。
表示の際は、フリーズアローの判定キャラクタの下に表示します。
なおフリーズアロー（始点）を押したときにFast/Slowを出すため、
キター/イクナイの表示タイミングとは異なります。
2. countFastSlow, displayDiff関数のデフォルト引数 _justFrames を `g_headerObj.justFrames`に変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. フリーズアロー（始点）の始点判定が無い場合、Fast/Slowが無いため
フリーズアローが多い譜面のときにFast/Slowが適切に作用しない可能性がありました。
2. _justFrames (ジャストと判断するフレーム)は作品中で一意であるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/199973452-155043dc-dbff-4ff6-af6c-c65d77f6c05d.png" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- フリーズアローの始点判定がある場合は、従来通りFast/Slowを矢印判定側に出します。