### PR TITLE
feat: [0613] フリーズアローの始点判定範囲を拡大

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9547,7 +9547,7 @@ const judgeArrow = _j => {
 
 	const judgeTargetFrzArrow = _difFrame => {
 		const _difCnt = Math.abs(_difFrame);
-		if (_difCnt <= g_judgObj.frzJ[g_judgPosObj.sfsf] && !g_attrObj[frzName].judgEndFlg
+		if (_difCnt <= g_judgObj.frzJ[g_judgPosObj.iknai] && !g_attrObj[frzName].judgEndFlg
 			&& g_workObj.judgFrzHitCnt[_j] <= fcurrentNo) {
 
 			if (g_headerObj.frzStartjdgUse) {
@@ -9557,7 +9557,12 @@ const judgeArrow = _j => {
 				displayDiff(_difFrame, `F`);
 			}
 			countFastSlow(_difFrame);
-			changeHitFrz(_j, fcurrentNo, `frz`);
+
+			if (_difCnt <= g_judgObj.frzJ[g_judgPosObj.sfsf]) {
+				changeHitFrz(_j, fcurrentNo, `frz`);
+			} else {
+				changeFailedFrz(_j, fcurrentNo);
+			}
 			g_workObj.judgFrzHitCnt[_j] = fcurrentNo + 1;
 			return true;
 		}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1.  フリーズアローの始点判定範囲についてマターリ/ショボーンも対象に加えるようにしました。
※厳密にはイクナイの枠外判定フレーム（＋8フレーム）より手前が対象です。
この変更により、フリーズアローの始点で早押しがあった場合にイクナイになる可能性があります。
また、フリーズアローの始点判定でマターリ/ショボーンが出現するようになります。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #1354 の変更にてFast/Slowをカウントするようにしましたが、
従来、コード簡略のため始点判定に失敗した場合はすべて枠外判定になるようになっていました。
この方法ではFast/Slowが拾えないため、今回の変更で始点判定範囲を広げる変更を行っています。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->