### PR TITLE
リタイア時にもクリア判定を行うように変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8548,8 +8548,10 @@ const mainInit = _ => {
 			g_audio.pause();
 			clearTimeout(g_timeoutEvtId);
 			if (keyIsDown(g_kCdNameObj.shiftKey)) {
-				g_gameOverFlg = true;
-				g_finishFlg = false;
+				if (g_currentArrows !== g_fullArrows || g_stateObj.lifeMode === C_LFE_BORDER && g_workObj.lifeVal < g_workObj.lifeBorder) {
+					g_gameOverFlg = true;
+					g_finishFlg = false;
+				}
 				resultInit();
 			} else {
 				titleInit();


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- リタイア時は強制的にクリア失敗判定となっていましたが、全ノーツ判定済みであればクリア判定を行うようにしました
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
- endFrameが設定されていない作品などで、譜面終了からリザルト遷移まで時間がかかる場合の利便性向上のため

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
