### PR TITLE
feat: [0614] 曲名、アーティスト名の多言語対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2485,8 +2485,9 @@ const headerConvert = _dosObj => {
 	obj.artistNames = [];
 	obj.musicNos = [];
 
-	if (hasVal(_dosObj.musicTitle)) {
-		const musicData = splitLF2(_dosObj.musicTitle);
+	const dosMusicTitle = _dosObj[`musicTitle${g_localeObj.val}`] ?? _dosObj.musicTitle;
+	if (hasVal(dosMusicTitle)) {
+		const musicData = splitLF2(dosMusicTitle);
 
 		if (hasVal(_dosObj.musicNo)) {
 			obj.musicNos = _dosObj.musicNo.split(`$`);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 曲名、アーティスト名について言語別に表記を変えられるようにしました。
現状、譜面ヘッダー「musicTitle」が対象で、英語用が「musicTitleEn」、日本語用が「musicTitleJa」です。
指定が無い場合は、「musicTitle」が優先されます。

```
|musicTitleJa=クレマ,木下たまき,https://...|
|musicTitleEn=Cllema,Kinoshita Tamaki,https://...|
```
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. クレジット表記で、言語別に表記を分けている場合があるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 言語別の設定を追加した場合、アーティストURLはそれぞれに指定が必要です。
- 多言語対応は現状日本語（Ja）と英語（En）のみとなっていますが、他の言語を追加することも可能です。
その場合、g_localeObj.list に対象の言語を追加し、
g_lang_lblNameObj, g_lang_msgObj, g_lang_msgInfoObj に追加した言語の訳名を追加する必要があります。 