### PR TITLE
refactor: [0615] changeJudgeCharacterの引数名を見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9588,10 +9588,10 @@ const judgeArrow = _j => {
 /**
  * タイミングズレを表示
  * @param {number} _difFrame 
- * @param {string} _jdgf
+ * @param {string} _fjdg
  * @param {number} _justFrames
  */
-const displayDiff = (_difFrame, _jdgf = ``, _justFrames = g_headerObj.justFrames) => {
+const displayDiff = (_difFrame, _fjdg = ``, _justFrames = g_headerObj.justFrames) => {
 	let diffJDisp = ``;
 	g_workObj.diffList.push(_difFrame);
 	const difCnt = Math.abs(_difFrame);
@@ -9600,7 +9600,7 @@ const displayDiff = (_difFrame, _jdgf = ``, _justFrames = g_headerObj.justFrames
 	} else if (_difFrame < _justFrames * (-1)) {
 		diffJDisp = `<span class="common_shobon">Slow ${difCnt} Frames</span>`;
 	}
-	document.getElementById(`diff${_jdgf}J`).innerHTML = diffJDisp;
+	document.getElementById(`diff${_fjdg}J`).innerHTML = diffJDisp;
 };
 
 /**
@@ -9663,13 +9663,13 @@ const lifeDamage = _ => {
  * 判定キャラクタの表示、判定済矢印数・判定数のカウンタ
  * @param {string} _name 
  * @param {string} _character 
- * @param {string} _jdgf 
+ * @param {string} _fjdg 
  */
-const changeJudgeCharacter = (_name, _character, _jdgf = ``) => {
+const changeJudgeCharacter = (_name, _character, _fjdg = ``) => {
 	g_resultObj[_name]++;
 	g_currentArrows++;
-	document.querySelector(`#chara${_jdgf}J`).innerHTML = `<span class="common_${_name}">${_character}</span>`;
-	document.querySelector(`#chara${_jdgf}J`).setAttribute(`cnt`, C_FRM_JDGMOTION);
+	document.querySelector(`#chara${_fjdg}J`).innerHTML = `<span class="common_${_name}">${_character}</span>`;
+	document.querySelector(`#chara${_fjdg}J`).setAttribute(`cnt`, C_FRM_JDGMOTION);
 	document.querySelector(`#lbl${toCapitalize(_name)}`).textContent = g_resultObj[_name];
 };
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9588,10 +9588,10 @@ const judgeArrow = _j => {
 /**
  * タイミングズレを表示
  * @param {number} _difFrame 
- * @param {string} _freezeFlg
+ * @param {string} _jdgf
  * @param {number} _justFrames
  */
-const displayDiff = (_difFrame, _freezeFlg = ``, _justFrames = g_headerObj.justFrames) => {
+const displayDiff = (_difFrame, _jdgf = ``, _justFrames = g_headerObj.justFrames) => {
 	let diffJDisp = ``;
 	g_workObj.diffList.push(_difFrame);
 	const difCnt = Math.abs(_difFrame);
@@ -9600,7 +9600,7 @@ const displayDiff = (_difFrame, _freezeFlg = ``, _justFrames = g_headerObj.justF
 	} else if (_difFrame < _justFrames * (-1)) {
 		diffJDisp = `<span class="common_shobon">Slow ${difCnt} Frames</span>`;
 	}
-	document.getElementById(`diff${_freezeFlg}J`).innerHTML = diffJDisp;
+	document.getElementById(`diff${_jdgf}J`).innerHTML = diffJDisp;
 };
 
 /**
@@ -9663,13 +9663,13 @@ const lifeDamage = _ => {
  * 判定キャラクタの表示、判定済矢印数・判定数のカウンタ
  * @param {string} _name 
  * @param {string} _character 
- * @param {string} _freezeFlg 
+ * @param {string} _jdgf 
  */
-const changeJudgeCharacter = (_name, _character, _freezeFlg = ``) => {
+const changeJudgeCharacter = (_name, _character, _jdgf = ``) => {
 	g_resultObj[_name]++;
 	g_currentArrows++;
-	document.querySelector(`#chara${_freezeFlg}J`).innerHTML = `<span class="common_${_name}">${_character}</span>`;
-	document.querySelector(`#chara${_freezeFlg}J`).setAttribute(`cnt`, C_FRM_JDGMOTION);
+	document.querySelector(`#chara${_jdgf}J`).innerHTML = `<span class="common_${_name}">${_character}</span>`;
+	document.querySelector(`#chara${_jdgf}J`).setAttribute(`cnt`, C_FRM_JDGMOTION);
 	document.querySelector(`#lbl${toCapitalize(_name)}`).textContent = g_resultObj[_name];
 };
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9588,10 +9588,10 @@ const judgeArrow = _j => {
 /**
  * タイミングズレを表示
  * @param {number} _difFrame 
- * @param {string} _fjdg
+ * @param {string} _freezeFlg
  * @param {number} _justFrames
  */
-const displayDiff = (_difFrame, _fjdg = ``, _justFrames = g_headerObj.justFrames) => {
+const displayDiff = (_difFrame, _freezeFlg = ``, _justFrames = g_headerObj.justFrames) => {
 	let diffJDisp = ``;
 	g_workObj.diffList.push(_difFrame);
 	const difCnt = Math.abs(_difFrame);
@@ -9600,7 +9600,7 @@ const displayDiff = (_difFrame, _fjdg = ``, _justFrames = g_headerObj.justFrames
 	} else if (_difFrame < _justFrames * (-1)) {
 		diffJDisp = `<span class="common_shobon">Slow ${difCnt} Frames</span>`;
 	}
-	document.getElementById(`diff${_fjdg}J`).innerHTML = diffJDisp;
+	document.getElementById(`diff${_freezeFlg}J`).innerHTML = diffJDisp;
 };
 
 /**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. changeJudgeCharacterのフリーズマークの引数名を `_freezeflg`から`_fjdg` に変更しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. displayDiff関数の引数と同じ意味のため。
また、元の名前`_freezeflg`については、他の関数が別の意味で`_frzFlg`を利用しているため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 引数名を変えても呼び出し方に変化はないので、影響はありません。