### PR TITLE
feat: [0616] fast/slowのカウンターと表示関数を統一

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9532,7 +9532,7 @@ const judgeArrow = _j => {
 		if (_difCnt <= g_judgObj.arrowJ[g_judgPosObj.uwan]) {
 			const [resultFunc, resultJdg] = checkJudgment(_difCnt);
 			resultFunc(_difFrame);
-			countFastSlow(_difFrame);
+			displayDiff(_difFrame);
 
 			const stepDivHit = document.querySelector(`#stepHit${_j}`);
 			stepDivHit.style.top = `${g_attrObj[arrowName].prevY - parseFloat($id(`stepRoot${_j}`).top) - 15}px`;
@@ -9556,10 +9556,10 @@ const judgeArrow = _j => {
 			if (g_headerObj.frzStartjdgUse) {
 				const [resultFunc] = checkJudgment(_difCnt);
 				resultFunc(_difFrame);
+				displayDiff(_difFrame);
 			} else {
 				displayDiff(_difFrame, `F`);
 			}
-			countFastSlow(_difFrame);
 
 			if (_difCnt <= g_judgObj.frzJ[g_judgPosObj.sfsf]) {
 				changeHitFrz(_j, fcurrentNo, `frz`);
@@ -9597,23 +9597,12 @@ const displayDiff = (_difFrame, _fjdg = ``, _justFrames = g_headerObj.justFrames
 	const difCnt = Math.abs(_difFrame);
 	if (_difFrame > _justFrames) {
 		diffJDisp = `<span class="common_matari">Fast ${difCnt} Frames</span>`;
-	} else if (_difFrame < _justFrames * (-1)) {
-		diffJDisp = `<span class="common_shobon">Slow ${difCnt} Frames</span>`;
-	}
-	document.getElementById(`diff${_fjdg}J`).innerHTML = diffJDisp;
-};
-
-/**
- * Fast/Slowカウンタ
- * @param {number} _difFrame 
- * @param {number} _justFrames 
- */
-const countFastSlow = (_difFrame, _justFrames = g_headerObj.justFrames) => {
-	if (_difFrame > _justFrames) {
 		g_resultObj.fast++;
 	} else if (_difFrame < _justFrames * (-1)) {
+		diffJDisp = `<span class="common_shobon">Slow ${difCnt} Frames</span>`;
 		g_resultObj.slow++;
 	}
+	document.getElementById(`diff${_fjdg}J`).innerHTML = diffJDisp;
 };
 
 /**
@@ -9691,10 +9680,7 @@ const updateCombo = _ => {
  */
 const judgeRecovery = (_name, _difFrame) => {
 	changeJudgeCharacter(_name, g_lblNameObj[`j_${_name}`]);
-
 	updateCombo();
-	displayDiff(_difFrame);
-
 	lifeRecovery();
 	finishViewing();
 
@@ -9734,8 +9720,6 @@ const judgeShakin = _difFrame => judgeRecovery(`shakin`, _difFrame);
 const judgeMatari = _difFrame => {
 	changeJudgeCharacter(`matari`, g_lblNameObj.j_matari);
 	comboJ.textContent = ``;
-
-	displayDiff(_difFrame);
 	finishViewing();
 
 	g_customJsObj.judg_matari.forEach(func => func(_difFrame));


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1.  fast/slowのカウンターと表示関数を統一しました。
この変更により、ショボーン（Bad）時にFast/Slowを表示するようになります。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. ショボーン（Bad）時のFast/Slowのカウント自体は行っていたが、表示していませんでした。
現在はフリーズアローで7, 8Framesズレを表示するようになっており、表示しない意味がなくなってきたため、
今回の変更で表示するように変更します。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
