### PR TITLE
improve: [0618] シャッフル設定が無効もしくは一部無効のとき、表示メッセージを変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5626,7 +5626,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		createDescDiv(`kcDesc`, g_lblNameObj.kcDesc.split(`{0}`).join(g_kCd[C_KEY_RETRY])
 			.split(`{1}:`).join(g_isMac ? `` : `Delete:`)),
 
-		createDescDiv(`kcShuffleDesc`, g_lblNameObj.kcShuffleDesc),
+		createDescDiv(`kcShuffleDesc`, g_headerObj.shuffleUse ? g_lblNameObj.kcShuffleDesc : g_lblNameObj.kcNoShuffleDesc),
 	);
 
 	// キーの一覧を表示

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3086,6 +3086,7 @@ const g_lang_lblNameObj = {
     Ja: {
         kcDesc: `[{0}:スキップ / {1}:(代替キーのみ)キー無効化]`,
         kcShuffleDesc: `番号をクリックでシャッフルグループ、矢印をクリックでカラーグループを変更`,
+        kcNoShuffleDesc: `矢印をクリックでカラーグループを変更`,
         sdDesc: `[クリックでON/OFFを切替、灰色でOFF]`,
         kcShortcutDesc: `プレイ中ショートカット：「{0}」タイトルバック / 「{1}」リトライ`,
         transKeyDesc: `別キーモードではハイスコア、キーコンフィグ等は保存されません`,
@@ -3114,6 +3115,7 @@ const g_lang_lblNameObj = {
     En: {
         kcDesc: `[{0}:Skip / {1}:Key invalidation (Alternate keys only)]`,
         kcShuffleDesc: `Click the number to change the shuffle group, and click the arrow to change the color.`,
+        kcNoShuffleDesc: `Click the arrow to change the color group.`,
         sdDesc: `[Click to switch, gray to OFF]`,
         kcShortcutDesc: `Shortcut during play: "{0}" Return to title / "{1}" Retry the game`,
         transKeyDesc: `High score, key config, etc. are not saved in another key mode`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. シャッフル設定が無効もしくは一部無効のとき、表示メッセージを変更しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 画面内に存在しない説明文への対応のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/200992006-3e853c7e-68a3-4929-af88-db9ad54e10d8.png" width="50%"><img src="https://user-images.githubusercontent.com/44026291/200991945-39fc6eb9-52d8-479e-b740-cf57daf41156.png" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
