### PR TITLE
feat: [0621] ヘルプのリンクを言語別に切替できるよう変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Dancing☆Onigiri (CW Edition)は、ブラウザで動作するキーボード�
 公開しているソース一式と、音楽ファイル・譜面データ(テキスト)を組み合わせることで  
 オリジナルのゲームデータを作ることができます。詳細は[Wiki](https://github.com/cwtickle/danoniplus/wiki)をご覧ください。  
 *Dancing Onigiri "CW Edition"* is a rhythm game. 
-You can create original game data by combining a set of published sources with music files and sequences (text file). See the [wiki](https://github.com/cwtickle/danoniplus/wiki/Sidebar-En) for details.
+You can create original game data by combining a set of published sources with music files and sequences (text file). See the [wiki](https://github.com/cwtickle/danoniplus-docs/wiki) for details.
 
 ここで公開しているソースは、以前Flashとして公開していたリズムゲーム  
 「Dancing☆Onigiri」の **HTML5 (HTML Living Standard)** 版です。  
@@ -21,9 +21,9 @@ The source released here is the **HTML5 (HTML Living Standard) version** of the 
 Compared to the previous ParaFla version, we have made various enhancements.
 
 ## Demo
-- [Demo1](http://cw7.sakura.ne.jp/danoni/2013/0237_Cllema.html) クレマ / 木下たまき  
-- [Demo2](http://cw7.sakura.ne.jp/danoni/2017/0305_ShiningStar.html) シャイニングスター / 魔王魂  
-- [Demo3](http://cw7.sakura.ne.jp/danoni/2018/0315_PetitMagie.html) プチ・マギエ / Napi  
+- [Demo1](https://cw7.sakura.ne.jp/danoni/2013/0237_Cllema.html) クレマ / 木下たまき  
+- [Demo2](https://cw7.sakura.ne.jp/danoni/2017/0305_ShiningStar.html) シャイニングスター / 魔王魂  
+- [Demo3](https://cw7.sakura.ne.jp/danoni/2018/0315_PetitMagie.html) プチ・マギエ / Napi  
 
 ## How to Play / 遊び方
 リズムに合わせてやってくる矢印・フリーズアローを、ステップゾーン上で押すリズムゲームです。  

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3821,7 +3821,7 @@ const titleInit = _ => {
 		// ヘルプ
 		createCss2Button(`btnHelp`, `?`, _ => true,
 			Object.assign(g_lblPosObj.btnHelp, {
-				resetFunc: _ => openLink(`https://github.com/cwtickle/danoniplus/wiki/AboutGameSystem`),
+				resetFunc: _ => openLink(g_lblNameObj.helpUrl),
 			}), g_cssObj.button_Setting),
 
 		// 製作者表示

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3840,7 +3840,7 @@ const titleInit = _ => {
 		// セキュリティリンク
 		createCss2Button(`lnkComparison`, `&#x1f6e1;`, _ => true,
 			Object.assign(g_lblPosObj.lnkComparison, {
-				resetFunc: _ => openLink(`https://github.com/cwtickle/danoniplus/security/policy`),
+				resetFunc: _ => openLink(g_lblNameObj.securityUrl),
 			}), g_cssObj.button_Tweet),
 	);
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3113,6 +3113,7 @@ const g_lang_lblNameObj = {
         j_adj: `推定Adj`,
 
         helpUrl: `https://github.com/cwtickle/danoniplus/wiki/AboutGameSystem`,
+        securityUrl: `https://github.com/cwtickle/danoniplus/security/policy`,
     },
     En: {
         kcDesc: `[{0}:Skip / {1}:Key invalidation (Alternate keys only)]`,
@@ -3144,6 +3145,7 @@ const g_lang_lblNameObj = {
         j_adj: `Est-Adj.`,
 
         helpUrl: `https://github.com/cwtickle/danoniplus-docs/wiki/AboutGameSystem`,
+        securityUrl: `https://github.com/cwtickle/danoniplus-docs/wiki/SecurityPolicy`,
     },
 };
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3111,6 +3111,8 @@ const g_lang_lblNameObj = {
         j_iknai: "(・A・)ｲｸﾅｲ",
 
         j_adj: `推定Adj`,
+
+        helpUrl: `https://github.com/cwtickle/danoniplus/wiki/AboutGameSystem`,
     },
     En: {
         kcDesc: `[{0}:Skip / {1}:Key invalidation (Alternate keys only)]`,
@@ -3140,6 +3142,8 @@ const g_lang_lblNameObj = {
         j_iknai: ":( N.G.",
 
         j_adj: `Est-Adj.`,
+
+        helpUrl: `https://github.com/cwtickle/danoniplus-docs/wiki/AboutGameSystem`,
     },
 };
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. ヘルプのリンクを言語別に切替できるよう変更しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 英訳版のリポジトリを別に作成したため。
https://github.com/cwtickle/danoniplus-docs

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
