### PR TITLE
fix: [0626] フリーズアロー始点判定有で遅ショボーンを出したときに二重判定することがある問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8815,7 +8815,7 @@ const mainInit = _ => {
 				const prevFrzName = `frz${_j}_${g_workObj.judgFrzCnt[_j]}`;
 				const prevFrz = g_attrObj[prevFrzName];
 
-				if (prevFrz.isMoving && prevFrz.cnt < (-1) * g_judgObj.frzJ[g_judgPosObj.kita]) {
+				if (prevFrz.isMoving && !prevFrz.judgEndFlg && prevFrz.cnt < (-1) * g_judgObj.frzJ[g_judgPosObj.kita]) {
 
 					// 自身より前のフリーズアローが未判定の場合、強制的に枠外判定を行いフリーズアローを削除
 					if (prevFrz.cnt >= (-1) * g_judgObj.frzJ[g_judgPosObj.iknai]) {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. フリーズアロー始点判定が有効で、以下の条件のときに判定が二重判定になる問題を修正しました。
    - 該当のフリーズアローの始点判定が遅ショボーン( :( Bad )
    - 該当のフリーズアローが残っている状態で、同一レーンの次のフリーズアローを判定させる
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. この箇所のみ、判定終了フラグ (judgEndFlg) を条件に含めていなかったため、
判定終了後に追加の判定を出してしまう可能性がありました。

(Discordリンク)
https://discord.com/channels/698460971231870977/944491021918683196/1058056741142671441

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- ver29.0.1以降で上記の条件を満たした場合のみ発生します。