### PR TITLE
[ver29.3.3] フリーズアロー始点判定有で遅ショボーンを出したときに二重判定することがある問題を修正

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ v27の対応終了時期はv30リリース開始時を予定しています。�
 
 | Version | Supported          | Latest Version | Logs | First Release | End of Support |
 | ------- | ------------------ |----------------|------|---------------|----------------|
-| v29     | :heavy_check_mark: |[v29.3.2](https://github.com/cwtickle/danoniplus/releases/tag/v29.3.2)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-latest)|2022-11-05|-|
+| v29     | :heavy_check_mark: |[v29.3.3](https://github.com/cwtickle/danoniplus/releases/tag/v29.3.3)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-latest)|2022-11-05|-|
 | v28     | :heavy_check_mark: |[v28.6.3](https://github.com/cwtickle/danoniplus/releases/tag/v28.6.3)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v28)|2022-08-21|(At Release v31)|
 | v27     | :warning:          |[v27.8.5](https://github.com/cwtickle/danoniplus/releases/tag/v27.8.5)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v27)|2022-03-18|(At Release v30)|
 | v26     | :x:                |[v26.7.6 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v26.7.6)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v26)|2022-01-30|2022-11-05|

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2022/12/21
+ * Revised : 2022/12/30
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 29.3.2`;
-const g_revisedDate = `2022/12/21`;
+const g_version = `Ver 29.3.3`;
+const g_revisedDate = `2022/12/30`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danoniplus",
-  "version": "29.3.2",
+  "version": "29.3.3",
   "description": "Dancing☆Onigiri (CW Edition) - Web-based Rhythm Game",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- #1376 
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
