### PR TITLE
chore: [0627] 同時押し関連の英訳を見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4491,7 +4491,7 @@ const createOptionWindow = _sprite => {
 			context.stroke();
 		}
 
-		const lineNames = [`1Push`, `2Push`, `3Push+`];
+		const lineNames = [`Single`, `Chord`, `Triad+`];
 		Object.keys(g_graphColorObj).filter(val => val.indexOf(`max`) !== -1).forEach((val, j) => {
 			const lineX = 70 + j * 70;
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3125,13 +3125,13 @@ const g_lang_lblNameObj = {
         sdShortcutDesc: `When "Hidden+" or "Sudden+" select, "pageUp" cover up / "pageDown" cover down`,
 
         s_level: `Level`,
-        s_douji: `N-push`,
+        s_douji: `Chords`,
         s_tate: `Jack Corr.`,
         s_cnts: `All Arrows`,
-        s_linecnts: `- Arrow:<br><br>- Freeze Arrow:<br><br>- 3 push positions ({0}):`,
+        s_linecnts: `- Arrow:<br><br>- Freeze Arrow:<br><br>- Polychord positions ({0}):`,
         s_print: `CopyData`,
         s_printTitle: `Dancing☆Onigiri Level Calculator+++`,
-        s_printHeader: `Level\tN-Push\tJack\tAll\tArrow\tFrz\tAPM\tTime`,
+        s_printHeader: `Level\tChords\tJack\tAll\tArrow\tFrz\tAPM\tTime`,
 
         j_ii: ":D Perfect!!",
         j_shakin: ":) Great!",


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 同時押し関連の英訳を見直しました。
    - 単押し：1push -> Single
    - 同時押し：2push -> Chord
    - 3つ押し以上：3push+ -> Triad+
    - 多重押し位置：3-Push positions -> Polychord positions
    - 同時補正：N-Push -> Chords
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 直訳のままになっていたため、見直しました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/210507598-481ed9c9-5e50-4f76-adc5-c47497cf9f98.png" width="50%"><img src="https://user-images.githubusercontent.com/44026291/210507784-b1fd1269-d9bb-43c2-8268-8f15c027189d.png" width="50%">


## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
