### PR TITLE
feat: [0628] フリーズアロー始点に対するモーションを実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9169,10 +9169,10 @@ const mainInit = _ => {
 			// 矢印モーション
 			changeCssMotions(header, `arrow`, currentFrame);
 
-			// フリーズアローモーション
+			// フリーズアローモーション（全体）
 			changeCssMotions(header, `frz`, currentFrame);
 
-			// フリーズアローモーション
+			// フリーズアローモーション（始点）
 			changeCssMotions(header, `frzTop`, currentFrame);
 
 		});

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7183,9 +7183,11 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	// 矢印モーション（個別）データの分解（3～4つで1セット, セット毎の改行区切り）
 	obj.arrowCssMotionData = setCssMotionData(`arrow`, scoreIdHeader);
 	obj.frzCssMotionData = setCssMotionData(`frz`, scoreIdHeader);
+	obj.frzTopCssMotionData = setCssMotionData(`frzTop`, scoreIdHeader);
 	if (g_stateObj.dummyId !== ``) {
 		obj.dummyArrowCssMotionData = setCssMotionData(`arrow`, _dummyNo);
 		obj.dummyFrzCssMotionData = setCssMotionData(`frz`, _dummyNo);
+		obj.dummyFrzTopCssMotionData = setCssMotionData(`frzTop`, _dummyNo);
 	}
 
 	// 歌詞データの分解 (3つで1セット, セット毎の改行区切り可)
@@ -7670,7 +7672,7 @@ const pushArrows = (_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 	[``, `dummy`].forEach(type =>
 		calcDataTiming(`color`, type, pushColors, { _colorFlg: true }));
 
-	g_typeLists.arrow.forEach(header =>
+	g_typeLists.cssMotion.forEach(header =>
 		calcDataTiming(`cssMotion`, header, pushCssMotions, { _calcFrameFlg: true }));
 
 	g_fadeinStockList.forEach(type =>
@@ -7959,7 +7961,7 @@ const getArrowSettings = _ => {
 	});
 
 	// モーション管理
-	g_typeLists.arrow.forEach(type => g_workObj[`${type}CssMotions`] = [...Array(keyNum)].fill(``));
+	g_typeLists.cssMotion.forEach(type => g_workObj[`${type}CssMotions`] = [...Array(keyNum)].fill(``));
 
 	const scrollDirOptions = (g_keyObj[`scrollDir${keyCtrlPtn}`] !== undefined ?
 		g_keyObj[`scrollDir${keyCtrlPtn}`][g_stateObj.scroll] : [...Array(keyNum)].fill(1));
@@ -9016,6 +9018,12 @@ const mainInit = _ => {
 			}),
 
 		);
+
+		if (g_workObj[`${_name}TopCssMotions`][_j] !== ``) {
+			const frzTop = document.getElementById(`${_name}Top${frzNo}`);
+			frzTop.classList.add(g_workObj[`${_name}TopCssMotions`][_j]);
+			frzTop.style.animationDuration = `${g_workObj.arrivalFrame[g_scoreObj.frameNum] / g_fps}s`;
+		}
 	};
 
 	/**
@@ -9163,6 +9171,9 @@ const mainInit = _ => {
 
 			// フリーズアローモーション
 			changeCssMotions(header, `frz`, currentFrame);
+
+			// フリーズアローモーション
+			changeCssMotions(header, `frzTop`, currentFrame);
 
 		});
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -484,6 +484,7 @@ const g_typeLists = {
     arrow: [`arrow`, `dummyArrow`, `frz`, `dummyFrz`],
     color: [`color`, `acolor`],
     frzColor: [`Normal`, `NormalBar`, `Hit`, `HitBar`],
+    cssMotion: [`arrow`, `dummyArrow`, `frz`, `dummyFrz`, `frzTop`, `dummyFrzTop`],
     dataList: [
         `Arrow`, `FrzArrow`, `FrzLength`,
         `Color`, `ColorCd`,
@@ -491,6 +492,7 @@ const g_typeLists = {
         `FColorHit`, `FColorHitCd`, `FColorHitBar`, `FColorHitBarCd`,
         `ArrowCssMotion`, `ArrowCssMotionName`,
         `FrzCssMotion`, `FrzCssMotionName`,
+        `FrzTopCssMotion`, `FrzTopCssMotionName`,
         `ArrowColorChangeAll`, `FrzColorChangeAll`,
     ],
 };


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. フリーズアロー始点に対するモーション「frzTopMotion_data」を実装しました。
使い方は arrowMotion_data, frzMotion_data と同じです。

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. キリズマでフリーズアローを使用する際に必要となるため。
他の部位についても同様のモーションが要りそうですが、一旦必要なもののみ実装します。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
