### PR TITLE
fix: [0629] divXの第2要素がposX末尾要素の最大値で無い場合の問題を修正

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2576,7 +2576,7 @@ g_keycons.groups.forEach(type => {
 // 特殊キーのコピー種 (simple: 代入、multiple: 配列ごと代入)
 const g_keyCopyLists = {
     simpleDef: [`blank`, `scale`],
-    simple: [`div`, `blank`, `scale`, `keyRetry`, `keyTitleBack`, `transKey`, `scrollDir`, `assistPos`],
+    simple: [`div`, `divMax`, `blank`, `scale`, `keyRetry`, `keyTitleBack`, `transKey`, `scrollDir`, `assistPos`],
     multiple: [`chara`, `color`, `stepRtn`, `pos`, `shuffle`],
 };
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. divXの第2要素がposX末尾要素の最大値で無い場合、
キーコンフィグ保存後にステップゾーン（下段）がずれる問題を修正しました。
下記のキー定義で再現できます。
```
|minWidth10X=650|
|color10X=0,0,0,0,2,1,1,1,1,2|
|chara10X=left,down,up,right,space,sleft,sdown,sup,sright,sspace|
|div10X=9,19|
|stepRtn10X=0,-90,90,180,onigiri,0,-90,90,180,onigiri|
|keyCtrl10X=83/0,68/0,69/82,70/0,32/0,74/0,75/0,73/79,76/0,13/0|
|blank10X=52.5|
|shuffle10X=0,0,0,0,1,2,2,2,2,3|
```
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 上記問題の解消のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/213674056-4b62f9de-a6d5-43fe-9a35-53b03b956623.png" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- おそらく初期時からの問題だと思います。