### PR TITLE
improve: [0630] ファイル読込で404エラー時にフルパスを表示するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -581,6 +581,17 @@ const openLink = _url => {
 };
 
 /**
+ * URLのフルパスを取得
+ * @param {string} _url 
+ * @returns 
+ */
+const getFullPath = _url => {
+	const link = document.createElement(`a`);
+	link.href = _url;
+	return link.href;
+};
+
+/**
  * プリロードするファイルの設定
  * @param {string} _as 
  * @param {string} _href 
@@ -645,7 +656,7 @@ const loadScript2 = (_url, _requiredFlg = true, _charset = `UTF-8`) => {
 		};
 		script.onerror = _err => {
 			if (_requiredFlg) {
-				makeWarningWindow(g_msgInfoObj.E_0041.split(`{0}`).join(_url.split(`?`)[0]));
+				makeWarningWindow(g_msgInfoObj.E_0041.split(`{0}`).join(getFullPath(baseUrl)));
 				reject(_err);
 			} else {
 				resolve(script);
@@ -673,7 +684,7 @@ const importCssFile2 = _href => {
 			resolve(link);
 		};
 		link.onerror = _ => {
-			makeWarningWindow(g_msgInfoObj.E_0041.split(`{0}`).join(baseUrl), { resetFlg: `title` });
+			makeWarningWindow(g_msgInfoObj.E_0041.split(`{0}`).join(getFullPath(baseUrl)), { resetFlg: `title` });
 			resolve(link);
 		};
 		document.head.appendChild(link);
@@ -6433,7 +6444,7 @@ const loadMusic = _ => {
 			lblLoading.textContent = g_lblNameObj.pleaseWait;
 			setAudio(blobUrl);
 		} else {
-			makeWarningWindow(`${g_msgInfoObj.E_0032}<br>(${request.status} ${request.statusText})`, { backBtnUse: true });
+			makeWarningWindow(`${g_msgInfoObj.E_0041.split('{0}').join(getFullPath(musicUrl))}<br>(${request.status} ${request.statusText})`, { backBtnUse: true });
 		}
 	});
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. ファイル読込で404エラー時にフルパスを表示するよう変更しました。
2. サーバー起動時、楽曲ファイル読込時のエラーとして「E-0041」を割り当てるように変更しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 相対パス記述時、どこに対するエラーかがわかりにくいため。
2. 従来のE-0032では対象のファイル名が無くわかりにくいため。
E-0041であればファイル名が特定できるため、採用しています。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
- 左側がローカルファイル、右側がサーバー版での表示です。

<img src="https://user-images.githubusercontent.com/44026291/213872193-b69783ae-6e85-4b02-b53e-d019f245403e.png" width="50%"><img src="https://user-images.githubusercontent.com/44026291/213872219-56c2b610-a908-4a8b-b688-a1d84cbbcceb.png" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- danoni_constants.js については諸々の関数定義前のため、エラーウィンドウは出ません。
ここについてはこれまで通りです。
- 関数追加：getFullPath