### PR TITLE
feat: [0632] 拡張スクロール設定に「Reverse」を追加するとReverse設定を無効化するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4717,8 +4717,12 @@ const createOptionWindow = _sprite => {
 	const setReverseView = _btn => {
 		_btn.classList.replace(g_cssObj[`button_Rev${g_settings.reverses[(g_settings.reverseNum + 1) % 2]}`],
 			g_cssObj[`button_Rev${g_settings.reverses[g_settings.reverseNum]}`]);
-		_btn.textContent = g_settings.scrolls.includes(`Reverse`) ?
-			`X` : `${g_lblNameObj.Reverse}:${getStgDetailName(g_stateObj.reverse)}`;
+		if (!g_settings.scrolls.includes(`Reverse`)) {
+			_btn.textContent = `${g_lblNameObj.Reverse}:${getStgDetailName(g_stateObj.reverse)}`;
+		} else {
+			_btn.textContent = `X`;
+			setReverseDefault();
+		}
 	};
 
 	// ---------------------------------------------------
@@ -5298,9 +5302,16 @@ const getKeyReverse = (_localStorage, _extraKeyName = ``) => {
 		g_stateObj.reverse = _localStorage[`reverse${_extraKeyName}`] ?? C_FLG_OFF;
 		g_settings.reverseNum = roundZero(g_settings.reverses.findIndex(reverse => reverse === g_stateObj.reverse));
 	} else {
-		g_stateObj.reverse = C_FLG_OFF;
-		g_settings.reverseNum = 0;
+		setReverseDefault();
 	}
+};
+
+/**
+ * リバースのデフォルト化処理
+ */
+const setReverseDefault = _ => {
+	g_stateObj.reverse = C_FLG_OFF;
+	g_settings.reverseNum = 0;
 };
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4707,15 +4707,18 @@ const createOptionWindow = _sprite => {
 	}
 
 	const setReverse = _btn => {
-		g_settings.reverseNum = (g_settings.reverseNum + 1) % 2;
-		g_stateObj.reverse = g_settings.reverses[g_settings.reverseNum];
-		setReverseView(_btn);
+		if (!g_settings.scrolls.includes(`Reverse`)) {
+			g_settings.reverseNum = (g_settings.reverseNum + 1) % 2;
+			g_stateObj.reverse = g_settings.reverses[g_settings.reverseNum];
+			setReverseView(_btn);
+		}
 	};
 
 	const setReverseView = _btn => {
 		_btn.classList.replace(g_cssObj[`button_Rev${g_settings.reverses[(g_settings.reverseNum + 1) % 2]}`],
 			g_cssObj[`button_Rev${g_settings.reverses[g_settings.reverseNum]}`]);
-		_btn.textContent = `${g_lblNameObj.Reverse}:${getStgDetailName(g_stateObj.reverse)}`;
+		_btn.textContent = g_settings.scrolls.includes(`Reverse`) ?
+			`X` : `${g_lblNameObj.Reverse}:${getStgDetailName(g_stateObj.reverse)}`;
 	};
 
 	// ---------------------------------------------------
@@ -5108,6 +5111,10 @@ const createOptionWindow = _sprite => {
 			spriteList[visibleScr].style.display = C_DIS_INHERIT;
 			spriteList[hiddenScr].style.display = C_DIS_NONE;
 			setSetting(0, visibleScr);
+
+			g_shortcutObj.option.KeyR.id = g_settings.scrolls.includes(`Reverse`) ?
+				g_shortcutObj.option.KeyR.exId : g_shortcutObj.option.KeyR.dfId;
+
 			if (g_settings.scrolls.length > 1) {
 				setReverseView(document.querySelector(`#btnReverse`));
 			}

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1182,7 +1182,7 @@ const g_shortcutObj = {
         KeyM: { id: `lnkMotionR` },
         ArrowUp: { id: `lnkScrollL` },
         ArrowDown: { id: `lnkScrollR` },
-        KeyR: { id: `lnkReverseR` },
+        KeyR: { id: `lnkReverseR`, dfId: `lnkReverseR`, exId: `btnReverse` },
 
         ShiftLeft_KeyS: { id: `lnkShuffleL` },
         KeyS: { id: `lnkShuffleR` },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 拡張スクロール設定（Scroll）に「Reverse」を追加するとReverse設定を無効化するよう変更しました。
    - 「Cross」や「Split」を「Reverse」と並列で設定した場合も無効になるため、必要に応じて対応するリバース設定の追加（この場合は「R-Cross」「R-Split」）が必要です。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. カスタムキーの設定によっては、Reverseを単純反転させたくない場合があるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
- 下記の例では、拡張スクロール（Scroll）に「Reverse」を追加しているため、
Reverseの設定が「X」となり、ボタンが押せない状態になります。
```
|scroll10=Reverse::-1,-1,-1,-1,-1,-1,-1,-1,-1,1|
```
<img src="https://user-images.githubusercontent.com/44026291/215254577-e983e3a7-07b6-4b94-9990-be381d4d3afb.png" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- すでに「Reverse:ON」で保存されている場合を想定し、そういった場合には強制的に「Reverse:OFF」にします。
上記に当てはまらない場合は関係ありません。
- Reverseを切り替えるショートカット(`g_shortcutObj.option.KeyR`)について従来の設定では不都合が出るため、
通常時は「lnkReverseR」、今回のケースでは「btnReverse」を見るよう変更しました。
直書きにすると設定の意味が無いため、プロパティとして「dfId」「exId」と定義を分けています。
```javascript
    KeyR: { id: `lnkReverseR`, dfId: `lnkReverseR`, exId: `btnReverse` },
```