### PR TITLE
feat: [0633] 曲中でキー変化する機能の実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2799,6 +2799,12 @@ const headerConvert = _dosObj => {
 		obj.preloadImages = _dosObj.preloadImages.split(`,`).filter(image => hasVal(image)).map(preloadImage => preloadImage);
 	}
 
+	// 初期表示する部分キーの設定
+	obj.keyGroupOrder = [];
+	_dosObj.keyGroupOrder?.split(`$`).forEach((val, j) => {
+		obj.keyGroupOrder[j] = val?.split(`,`) ?? [];
+	});
+
 	// 最終演出表示有無（noneで無効化）
 	obj.finishView = _dosObj.finishView ?? ``;
 
@@ -4996,6 +5002,7 @@ const createOptionWindow = _sprite => {
 			if (isNotSameKey && g_keyObj.prevKey !== `Dummy`) {
 				// キーパターン初期化
 				g_keyObj.currentPtn = 0;
+				g_keycons.keySwitchNum = 0;
 			}
 			const hasKeyStorage = localStorage.getItem(`danonicw-${g_keyObj.currentKey}k`);
 			let storageObj, addKey = ``;
@@ -5685,6 +5692,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	const maxLeftX = Math.min(0, (kWidth - C_ARW_WIDTH) / 2 - maxLeftPos * g_keyObj.blank);
 
 	g_keycons.cursorNumList = [...Array(keyNum).keys()].map(i => i);
+	const configKeyGroupList = g_headerObj.keyGroupOrder[g_stateObj.scoreId] ?? tkObj.keyGroupList;
 
 	/**
 	 * keyconSpriteのスクロール位置調整
@@ -6061,7 +6069,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		for (let j = 0; j < keyNum; j++) {
 			appearConfigView(j, C_DIS_NONE);
 
-			if (tkObj.keyGroupMaps[j].includes(tkObj.keyGroupList[_num])) {
+			if (tkObj.keyGroupMaps[j].includes(configKeyGroupList[_num])) {
 				g_keycons.cursorNumList.push(j);
 				appearConfigView(j, C_DIS_INHERIT);
 			}
@@ -6069,8 +6077,8 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		changeConfigCursor(0);
 
 		// keySwitchボタンを一旦非選択にして、選択中のものを再度色付け
-		if (tkObj.keyGroupList.length > 1) {
-			for (let j = 0; j < tkObj.keyGroupList.length; j++) {
+		if (configKeyGroupList.length > 1) {
+			for (let j = 0; j < configKeyGroupList.length; j++) {
 				document.getElementById(`key${j}`).classList.replace(g_cssObj.button_Next, g_cssObj.button_Mini);
 			}
 			document.getElementById(`key${_num}`).classList.replace(g_cssObj.button_Mini, g_cssObj.button_Next);
@@ -6238,10 +6246,10 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	g_customJsObj.keyconfig.forEach(func => func());
 
 	// 部分キー表示用ボタン描画
-	if (tkObj.keyGroupList.length > 1) {
+	if (configKeyGroupList.length > 1) {
 		multiAppend(divRoot,
 			createDivCss2Label(`lblkey`, `KeySwitch`, { x: g_sWidth - 80, y: 90, w: 60, h: 20, siz: 14 }));
-		tkObj.keyGroupList.forEach((val, j) => {
+		configKeyGroupList.forEach((val, j) => {
 			divRoot.appendChild(
 				createCss2Button(`key${j}`, `${j + 1}`, _ => {
 					appearConfigSteps(j);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2802,7 +2802,9 @@ const headerConvert = _dosObj => {
 	// 初期表示する部分キーの設定
 	obj.keyGroupOrder = [];
 	_dosObj.keyGroupOrder?.split(`$`).forEach((val, j) => {
-		obj.keyGroupOrder[j] = val?.split(`,`) ?? [];
+		if (val !== ``) {
+			obj.keyGroupOrder[j] = val.split(`,`);
+		}
 	});
 
 	// 最終演出表示有無（noneで無効化）

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -850,6 +850,7 @@ const g_keycons = {
 
     cursorNumList: [],
     cursorNum: 0,
+    keySwitchNum: 0,
 };
 
 let g_displays = [`stepZone`, `judgment`, `fastSlow`, `lifeGauge`, `score`, `musicInfo`, `filterLine`,
@@ -2580,7 +2581,7 @@ g_keycons.groups.forEach(type => {
 const g_keyCopyLists = {
     simpleDef: [`blank`, `scale`],
     simple: [`div`, `divMax`, `blank`, `scale`, `keyRetry`, `keyTitleBack`, `transKey`, `scrollDir`, `assistPos`],
-    multiple: [`chara`, `color`, `stepRtn`, `pos`, `shuffle`],
+    multiple: [`chara`, `color`, `stepRtn`, `pos`, `shuffle`, `keyGroup`],
 };
 
 // タイトル画面関連のリスト群

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -847,6 +847,9 @@ const g_keycons = {
     groupSelf: `S`,
 
     groups: [`color`, `shuffle`],
+
+    cursorNumList: [],
+    cursorNum: 0,
 };
 
 let g_displays = [`stepZone`, `judgment`, `fastSlow`, `lifeGauge`, `score`, `musicInfo`, `filterLine`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 曲中でキー変化する機能を実装しました。詳細は下記参照。
1. キーコンフィグ周りのカーソル移動処理を見直しました。
    - キー変化作品に配慮し、カーソル移動配列として `g_keycons.cursorNumList` を作成しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

### 前提
- キーを切り替えるのではなく、切り替えるキー全体をカバーするカスタムキー定義を使って
部分的に一部のキーを見せることでキーの切り替えを行います。
参考：https://cw7.sakura.ne.jp/danoni/2016/0273_DefeatIDoll.html

### キー変化記述仕様
- **keych_data** を使用します。2つ1セットで、`フレーム数,キーラベル`のように使います。
※キー数ではありません。`keyGroup`で定義するキーラベルを使用します。
- キーラベルに`X`など`keyGroup`で未定義のものを入れれば、ステップゾーンを一時的に消すことも可能です。
```
|keych_data=0,11L,1951,5,1955,11L,2810,5,2814,11L,3264,5,3275,11L|
|keych2_data=0,11,1951,5,1955,11,2810,5,2814,11,3264,5,3275,11|
```
### キーラベル割り当て仕様
- キー数別の仕様の一つで、部分キーをどう割り振るかを **keyGroupXX** で指定します。（XXはカスタムキー名）
ここで指定したラベル名を、**keych_data**の偶数番目で使用するとキーを変更（部分キーを適用）できます。
- ある矢印/AAを複数の部分キーで共用して使うときは `11/11L/11W`のようにスラッシュ区切りにすると、
複数の部分キーで使用できます。
```
|charaTr=aleft,adown,aup,aright,aspace,bleft,bleftdia,bdown,bspace,bup,brightdia,bright,cleft,cdown,cup,cright,dleft,ddown,dup,dright,eleft,edown,eup,eright,fleft,fdown,fup,fright,gleft,gleftdia,gdown,gspace,gup,grightdia,gright,oni,hleft,hleftdia,hdown,hspace,hup,hrightdia,hright|
|keyGroupTr=5,5,5,5,5,7i,7i,7i,7i,7i,7i,7i,11,11,11,11,11L,11L,11L,11L,11W,11W,11W,11W,12,12,12,12,11/11L/11W,11/11L/11W,11/11L/11W,11/11L/11W,11/11L/11W,11/11L/11W,11/11L/11W,12,12,12,12,12,12,12,12|
```

### キーコンフィグの部分キー設定順制御、設定範囲指定
- 譜面ヘッダー **keyGroupOrder** で指定します。カンマ区切りで切り替えるキーラベルを指定します。
複数譜面に跨るときは、`$`区切りで対応します。
```
|keyGroupOrder=11L$11L,5,12,7i|
// 1譜面目はラベル：11Lのみ表示
// 2譜面目はラベル：11L, 5, 12, 7i の順に表示
```

### キーコンフィグの仕様
- 部分キー表示の場合、右側の「keySwitch」にあるボタンで切り替えます。
1種類しかない場合は表示されません。
「Reset」ボタンを押すと、今表示している矢印・AAのみ割り当てキーをリセットします。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. キー変化作品実装時、customjsの記述量が多く煩雑のため。
1. キーコンフィグのカーソル移動について、キー変化作品など特殊なケースの場合に
現状ではcustomjsでの明示処理が必要となるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/217821439-4dc8a7c1-459e-4fd9-9593-d139c183b994.png" width="50%"><img src="https://user-images.githubusercontent.com/44026291/217821591-9ea4b9ca-9dff-4c02-a52d-b77469fb49b7.png" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- この設定を使ってもShuffle設定は自動で制限されません。
必要に応じて |shuffleUse=group|や|shuffleUse=false| の指定が必要です。

||Functions &amp; Variables|
|----|----|
|Add|changeConfigCursor, appearConfigSteps, appearStepZone, appearKeyTypes|
|Change|ー|
|Delete|searchNextCursor, resetCursor|