### PR TITLE
feat: [0635] Reverse設定無効時、R-FlatをFlatと見做す設定を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8243,7 +8243,7 @@ const mainInit = _ => {
 	let speedCnts = 0;
 	let boostCnts = 0;
 	let keychCnts = 0;
-	const stepZoneDisp = (g_stateObj.d_stepzone === C_FLG_OFF || g_stateObj.scroll === `Flat`) ? C_DIS_NONE : C_DIS_INHERIT;
+	const stepZoneDisp = (g_stateObj.d_stepzone === C_FLG_OFF || g_settings.scrollFlat.includes(g_stateObj.scroll)) ? C_DIS_NONE : C_DIS_INHERIT;
 
 	for (let j = 0; j < keyNum; j++) {
 		const colorPos = g_keyObj[`color${keyCtrlPtn}`][j];
@@ -8286,14 +8286,17 @@ const mainInit = _ => {
 
 		);
 	}
-	if (g_stateObj.scroll === `Flat` && g_stateObj.d_stepzone === C_FLG_ON) {
+	if (g_settings.scrollFlat.includes(g_stateObj.scroll) && g_stateObj.d_stepzone === C_FLG_ON) {
+
+		// スクロール名に`R-`が含まれていればリバースと見做す
+		const reverseFlg = g_stateObj.reverse === C_FLG_ON || g_stateObj.scroll.startsWith(`R-`);
 
 		// ステップゾーンの代わり
 		const lineY = [(C_ARW_WIDTH - g_stateObj.flatStepHeight) / 2, (C_ARW_WIDTH + g_stateObj.flatStepHeight) / 2];
 		lineY.forEach((y, j) => {
 			mainSprite.appendChild(
 				createColorObject2(`stepBar${j}`, {
-					x: 0, y: C_STEP_Y + g_posObj.reverseStepY * Number(g_stateObj.reverse === C_FLG_ON) + y,
+					x: 0, y: C_STEP_Y + g_posObj.reverseStepY * Number(reverseFlg) + y,
 					w: g_headerObj.playingWidth - 50, h: 1, styleName: `lifeBar`,
 				}, g_cssObj.life_Failed)
 			);

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -754,6 +754,7 @@ const g_settings = {
 
     scrolls: [],
     scrollNum: 0,
+    scrollFlat: [`Flat`, `R-Flat`],
 
     shuffles: [C_FLG_OFF, `Mirror`, `Asym-Mirror`, `Random`, `Random+`, `S-Random`, `S-Random+`],
     shuffleNum: 0,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. Reverse設定無効時、R-FlatをFlatと見做す設定を追加しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #1388 を有効にした場合、「R-Flat」を入れた場合に現状ではステップゾーンが見えてしまうため、
明示的にリスト化したもののみ、「Flat」扱いとするようにしました。
リバース可否についてはスクロール名の先頭が「R-」が付いているかどうかで判断します。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- なお、「R-Flat」を設定した場合でもスクロール方向は個別に指定する必要があります。