### PR TITLE
feat: [0636] 別キーモード用の歌詞表示・背景/マスクモーションを実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7104,6 +7104,29 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	];
 
 	/**
+	 * 歌詞表示、背景・マスクデータの優先順取得 
+	 * @returns 
+	 */
+	const getPriorityHeader = _ => {
+		const list = [];
+		let type = ``;
+		if (g_stateObj.scroll !== `---`) {
+			type = `Alt`;
+		} else if (g_stateObj.reverse === C_FLG_ON) {
+			type = `Rev`;
+		}
+		if (hasVal(g_keyObj[`transKey${_keyCtrlPtn}`])) {
+			list.push(`${type}A`);
+		}
+		if (type !== ``) {
+			list.push(type);
+		}
+		list.push(``);
+
+		return list;
+	};
+
+	/**
 	 * 歌詞データの分解
 	 * @param {string} _scoreNo 
 	 */
@@ -7112,11 +7135,9 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 		let wordReverseFlg = false;
 		const divideCnt = getKeyInfo().divideCnt;
 		const addDataList = (_type = ``) => wordDataList.push(...getPriorityList(`word`, _type, _scoreNo));
+		getPriorityHeader().forEach(val => addDataList(val));
 
-		if (g_stateObj.scroll !== `---`) {
-			addDataList(`Alt`);
-		} else if (g_stateObj.reverse === C_FLG_ON) {
-			addDataList(`Rev`);
+		if (g_stateObj.reverse === C_FLG_ON) {
 
 			// wordRev_dataが指定されている場合はそのままの位置を採用
 			// word_dataのみ指定されている場合、下記ルールに従って設定
@@ -7129,7 +7150,6 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 				}
 			}
 		}
-		addDataList();
 
 		const inputWordData = wordDataList.find((v) => v !== undefined);
 		return (inputWordData !== undefined ? makeSpriteWordData(inputWordData, wordReverseFlg) : [[], -1]);
@@ -7198,13 +7218,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	const makeBackgroundData = (_header, _scoreNo) => {
 		const dataList = [];
 		const addDataList = (_type = ``) => dataList.push(...getPriorityList(_header, _type, _scoreNo));
-
-		if (g_stateObj.scroll !== `---`) {
-			addDataList(`Alt`);
-		} else if (g_stateObj.reverse === C_FLG_ON) {
-			addDataList(`Rev`);
-		}
-		addDataList();
+		getPriorityHeader().forEach(val => addDataList(val));
 
 		const data = dataList.find((v) => v !== undefined);
 		return (data !== undefined ? makeSpriteData(data, calcFrame) : [[], -1]);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 別キーモード用の歌詞表示・背景/マスクモーションを実装しました。
    - wordA_data, wordRevA_data, wordAltA_data のように使用します。
    名前が違うだけで、使い方は従来の歌詞表示・背景/マスクモーションと同じです。

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 別キーモードまで考慮する場合、表現が変わる可能性があるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
