### PR TITLE
fix: [0638] shuffleUse=false時にキーコンフィグ画面が動作しない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6059,8 +6059,10 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		const appearConfigView = (_j, _display) => {
 			document.getElementById(`arrow${_j}`).style.display = _display;
 			document.getElementById(`arrowShadow${_j}`).style.display = _display;
-			document.getElementById(`sArrow${_j}`).style.display = _display;
 			document.getElementById(`color${_j}`).style.display = _display;
+			if (document.getElementById(`sArrow${_j}`) !== null) {
+				document.getElementById(`sArrow${_j}`).style.display = _display;
+			}
 			const ctrlPtn = g_keyObj[`keyCtrl${g_headerObj.keyLabels[g_stateObj.scoreId]}_${g_keyObj.currentPtn}`][_j];
 			for (let k = 0; k < ctrlPtn.length; k++) {
 				document.getElementById(`keycon${_j}_${k}`).style.display = _display;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. shuffleUse=false時にキーコンフィグ画面が動作しない問題を修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. shuffleUse=false時はシャッフルグループ番号用のボタンをそもそも生成していませんでした。
PR #1390 にて、シャッフルグループ番号用のボタンの表示・非表示を行うようになった結果、問題が表面化しました。この問題を修正しています。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
