### PR TITLE
feat: [0640] 背景・マスクモーションにカラーオブジェクトが使えるよう対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1478,8 +1478,8 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 				const data = tmpObj.path.slice(`[c]`.length).split(`/`);
 				spriteData[tmpFrame][addFrame].colorObjInfo = {
 					x: tmpObj.left, y: tmpObj.top, w: tmpObj.width, h: tmpObj.height,
-					rotate: data[0], background: makeColorGradation(data[1] ?? `#ffffff`),
-					opacity: tmpObj.opacity,
+					rotate: setVal(data[0], `0`), opacity: tmpObj.opacity,
+					background: makeColorGradation(setVal(data[1], `#ffffff`), { _defaultColorgrd: false }),
 					animationName: tmpObj.animationName,
 					animationDuration: `${tmpObj.animationDuration}s`,
 				};

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1479,6 +1479,7 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 				spriteData[tmpFrame][addFrame].colorObjInfo = {
 					x: tmpObj.left, y: tmpObj.top, w: tmpObj.width, h: tmpObj.height,
 					rotate: data[0], background: data[1] ?? `#ffffff`,
+					opacity: tmpObj.opacity,
 					animationName: tmpObj.animationName,
 					animationDuration: `${tmpObj.animationDuration}s`,
 				};

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1489,7 +1489,7 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 				spriteData[tmpFrame][addFrame].colorObjId = `${tmpFrame}_${addFrame}`;
 				spriteData[tmpFrame][addFrame].colorObjClass = setVal(tmpObj.class, undefined);
 				if (tmpObj.animationFillMode !== undefined) {
-					spriteData[tmpFrame][addFrame].animationFillMode = tmpObj.animationFillMode;
+					spriteData[tmpFrame][addFrame].colorObjInfo.animationFillMode = tmpObj.animationFillMode;
 				}
 
 			} else if (emptyPatterns.includes(tmpObj.path)) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1478,7 +1478,7 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 				const data = tmpObj.path.slice(`[c]`.length).split(`/`);
 				spriteData[tmpFrame][addFrame].colorObjInfo = {
 					x: tmpObj.left, y: tmpObj.top, w: tmpObj.width, h: tmpObj.height,
-					rotate: data[0], background: data[1] ?? `#ffffff`,
+					rotate: data[0], background: makeColorGradation(data[1] ?? `#ffffff`),
 					opacity: tmpObj.opacity,
 					animationName: tmpObj.animationName,
 					animationDuration: `${tmpObj.animationDuration}s`,

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1452,6 +1452,7 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 				opacity: setVal(tmpSpriteData[8], 1, C_TYP_FLOAT),
 				animationName: escapeHtml(setVal(tmpSpriteData[9], C_DIS_NONE)),
 				animationDuration: setIntVal(tmpSpriteData[10]) / g_fps,
+				animationFillMode: setVal(tmpSpriteData[11], g_presetObj.animationFillMode ?? `forwards`),
 			};
 			if (g_headerObj.autoPreload) {
 				if (checkImage(tmpObj.path)) {
@@ -1482,7 +1483,7 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 					background: makeColorGradation(setVal(data[1], `#ffffff`), { _defaultColorgrd: false }),
 					animationName: tmpObj.animationName,
 					animationDuration: `${tmpObj.animationDuration}s`,
-					animationFillMode: setVal(data[2], `forwards`),
+					animationFillMode: tmpObj.animationFillMode,
 				};
 				spriteData[tmpFrame][addFrame].colorObjId = `${tmpFrame}_${addFrame}`;
 				spriteData[tmpFrame][addFrame].colorObjClass = setVal(tmpObj.class, undefined);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1452,8 +1452,10 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 				opacity: setVal(tmpSpriteData[8], 1, C_TYP_FLOAT),
 				animationName: escapeHtml(setVal(tmpSpriteData[9], C_DIS_NONE)),
 				animationDuration: setIntVal(tmpSpriteData[10]) / g_fps,
-				animationFillMode: setVal(tmpSpriteData[11], g_presetObj.animationFillMode ?? `forwards`),
 			};
+			if (setVal(tmpSpriteData[11], g_presetObj.animationFillMode) !== undefined) {
+				tmpObj.animationFillMode = setVal(tmpSpriteData[11], g_presetObj.animationFillMode);
+			}
 			if (g_headerObj.autoPreload) {
 				if (checkImage(tmpObj.path)) {
 					if (g_headerObj.syncBackPath) {
@@ -1483,10 +1485,12 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 					background: makeColorGradation(setVal(data[1], `#ffffff`), { _defaultColorgrd: false }),
 					animationName: tmpObj.animationName,
 					animationDuration: `${tmpObj.animationDuration}s`,
-					animationFillMode: tmpObj.animationFillMode,
 				};
 				spriteData[tmpFrame][addFrame].colorObjId = `${tmpFrame}_${addFrame}`;
 				spriteData[tmpFrame][addFrame].colorObjClass = setVal(tmpObj.class, undefined);
+				if (tmpObj.animationFillMode !== undefined) {
+					spriteData[tmpFrame][addFrame].animationFillMode = tmpObj.animationFillMode;
+				}
 
 			} else if (emptyPatterns.includes(tmpObj.path)) {
 				// ループ、フレームジャンプ、空の場合の処理

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1482,6 +1482,7 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 					background: makeColorGradation(setVal(data[1], `#ffffff`), { _defaultColorgrd: false }),
 					animationName: tmpObj.animationName,
 					animationDuration: `${tmpObj.animationDuration}s`,
+					animationFillMode: setVal(data[2], `forwards`),
 				};
 				spriteData[tmpFrame][addFrame].colorObjId = `${tmpFrame}_${addFrame}`;
 				spriteData[tmpFrame][addFrame].colorObjClass = setVal(tmpObj.class, undefined);

--- a/js/template/danoni_setting.js
+++ b/js/template/danoni_setting.js
@@ -187,6 +187,14 @@ g_presetObj.customDesignUse = {
 */
 //g_presetObj.customImageList = [`ball`, `square`];
 
+/**
+ * 背景・マスクモーションで利用する「animationFillMode」のデフォルト値
+ * - none      : 初期画像へ戻す
+ * - forwards  : アニメーション100%の状態を維持（デフォルト）
+ * - backwards : アニメーション  0%の状態に戻す
+ */
+//g_presetObj.animationFillMode = `none`;
+
 
 /*
 ------------------------------------------------------------------------


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 背景・マスクモーションにカラーオブジェクト（色付きオブジェクト）が使えるよう対応しました。
https://github.com/cwtickle/danoniplus/wiki/AboutColorObject
```
|backtitle_data=
330,3,[c]giko/#ff9999,,5,200,200,200,0,spinY,120,forwards
480,3
|
```

### 記述方法
- 3番目の記法以外は画像の場合と同じです。
なお、回転量についてはアニメーションを含ませる場合、
CSSアニメーション側にも回転量を指定する必要があります。
- 3番目の記法にある**color**には色名やグラデーション記法が指定可能です。
譜面ヘッダーの`defaultColorgrd`とは連動しません。
```
|backtitle_data=
330,3,[c]giko/#ff9999:yellow,,5,200,200,200,0,spinY,120,forwards
480,3
|
```

|番号|論理名|設定例|内容|
|----|----|----|----|
|1|Frame|200|変更するタイミングのフレーム数を指定します。|
|2|Depth|0|背景の深度を数字で指定します。0以上の値を指定。<br>深度は大きくすることもできますが、その分背景スプライトの数が増えるので重くなる可能性があります。|
|3|**ColorObject/Color**|[c]giko/#ff9999|`[c]カラーオブジェクト名:回転量/カラーコード` の形式で指定します。<br>矢印の場合のみ、カラーオブジェクト名の省略が可能です。|
|4|**ColorObject Class**|imgMotion|カラーオブジェクトに付加するClassを設定します。以下で設定が足りない場合などに使用します。|
|5|Left(X)|25|カラーオブジェクトを表示するX座標を指定します。|
|6|Top(Y)|30|カラーオブジェクトを表示するY座標を指定します。|
|7|**Width(X)**|200|カラーオブジェクトの横サイズをpxで指定します。|
|8|**Height(Y)**|200|カラーオブジェクトの縦サイズをpxで指定します。|
|9|Opacity|0.5|カラーオブジェクトの透明度を0～1の間で指定します。デフォルトは1(透明度なし)。<br>CSSアニメーションでopacity設定がある場合は無効。|
|10|Animation-Name|leftToRightFade|CSSアニメーション名を指定します。内容はCSSで定義します。<br>デフォルトはnone(なし)です。|
|11|Animation-Duration|120|CSSアニメーションを動かす間隔をフレーム数で指定します。|
|12|Animation-Fill-Mode|backwards|CSSアニメーション終了時のスタイル設定。デフォルトは未指定。|

2. 背景・マスクデータに`animationFillMode`を指定できるようにしました。（最後に追加）
https://developer.mozilla.org/ja/docs/Web/CSS/animation-fill-mode

3. 背景・マスクデータの`animationFillMode`のデフォルト値を共通設定ファイルで設定できるようにしました。
```javascript
    g_presetObj.animationFillMode = `forwards`;
```

### 留意点
- カラーオブジェクト名は`g_imgObj`で定義されているプロパティ名の中から指定します。
ただし、ImgTypeが変わってしまうと画像もImgTypeに合わせて変わってしまうため注意が必要です。
    - arrow, arrowShadow, onigiri, iyo, giko, c, morara, monar, onigiriShadow, など
- このような場合は、`g_imgObj`にカスタムの変数を定義することで回避可能です。
（ローカルファイルでは使用できないため、サーバー上で確認が必要です）

#### customjsでのカスタム画像指定例
```javascript
function addImages(){
	g_imgObj.arrowSpecial = `../img/classic/arrow.png`;  // 対象の画像を直接指定
}
g_customJsObj.preTitle.push(addImages); // 挿入する場所はcustomJsのpreTitle（読込前）
```
#### 譜面側の定義（上で定義したarrowSpecialを指定）
```
|backtitle_data=
330,3,[c]arrowSpecial/#ff9999:yellow,,5,200,200,200,0,spinY,120
480,3
|
```

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Resolved #900 
2. アニメーション終了後の状態を保持したいケースがあるが、毎回cssで対応するのは手間のため。
ただし、別途cssで定義している可能性があるため、デフォルトは指定なしとしています。
3. 利用頻度の高い設定と思われるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
- 画面左下の赤矢印がカラーオブジェクトです。

<img src="https://user-images.githubusercontent.com/44026291/218490262-4df34ed3-5968-40b5-9c29-bb2bf20e1e34.png" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- danoni_localBinary.js に未定義のカラーオブジェクトについては、
ローカルファイル起動では表示できないため、注意が必要です。