### PR TITLE
fix: [0642] ScrollがDefault以外のときに別キーモード用のデータが取得されない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7154,19 +7154,23 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 */
 	const getPriorityHeader = _ => {
 		const list = [];
+		const anotherKeyFlg = hasVal(g_keyObj[`transKey${_keyCtrlPtn}`]);
+		const addPriorityList = (_type = ``) => {
+			if (anotherKeyFlg) {
+				list.push(`${_type}A`);
+			}
+			list.push(_type);
+		};
 		let type = ``;
 		if (g_stateObj.scroll !== `---`) {
 			type = `Alt`;
 		} else if (g_stateObj.reverse === C_FLG_ON) {
 			type = `Rev`;
 		}
-		if (hasVal(g_keyObj[`transKey${_keyCtrlPtn}`])) {
-			list.push(`${type}A`);
-		}
 		if (type !== ``) {
-			list.push(type);
+			addPriorityList(type);
 		}
-		list.push(``);
+		addPriorityList();
 
 		return list;
 	};


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. ScrollがDefault以外のときに別キーモード用のword/back/maskデータが
適用されない場合がある問題を修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. データの取得優先順 ( PR #1393 )に関する不具合です。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
