### PR TITLE
feat: [0643] スクロール固有のword/back/maskデータを作成できるよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7155,24 +7155,23 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	const getPriorityHeader = _ => {
 		const list = [];
 		const anotherKeyFlg = hasVal(g_keyObj[`transKey${_keyCtrlPtn}`]);
-		const addPriorityList = (_type = ``) => {
-			if (anotherKeyFlg) {
-				list.push(`${_type}A`);
-			}
-			list.push(_type);
-		};
 		let type = ``;
 		if (g_stateObj.scroll !== `---`) {
 			type = `Alt`;
 		} else if (g_stateObj.reverse === C_FLG_ON) {
 			type = `Rev`;
 		}
-		if (type !== ``) {
-			addPriorityList(type);
-		}
-		addPriorityList();
 
-		return list;
+		if (anotherKeyFlg) {
+			list.push(`${g_stateObj.scroll}A`);
+			list.push(`${type}A`);
+			list.push(`A`);
+		}
+		list.push(g_stateObj.scroll);
+		list.push(type);
+		list.push(``);
+
+		return makeDedupliArray(list);
 	};
 
 	/**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. スクロール固有のword/back/maskデータを作成できるよう変更しました。
    - `backCross_data`, `maskFlat_data`のようにScroll設定に登録済みの名前を指定できます。
    - 別キーモード用の設定は `backCrossA_data`や`maskFlatA_data` のように使います。
2. 別キーモードのword/back/maskデータの優先順を変更しました。
    - `maskRevA_data` > `maskA_data` > `maskRev_data` > `mask_data` で先に見つかったものが適用されます。

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 色付きオブジェクトがback/maskデータで使えるようになったことで、
スクロール固有の設定が必要になってきたため。
2. これまでは `maskA_data` と `maskRev_data` が逆になっていました。別キーモードは別譜面の意味合いが強いため、通常のリバース専用より前に来るのが適切と考え、見直しています。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
