### PR TITLE
feat: [0644] 矢印・フリーズアローのスクロール方向を反転する機能を実装　他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8139,6 +8139,7 @@ const getArrowSettings = _ => {
 
 	g_workObj.stepX = [];
 	g_workObj.scrollDir = [];
+	g_workObj.scrollDirDefault = [];
 	g_workObj.dividePos = [];
 	g_workObj.stepRtn = copyArray2d(g_keyObj[`stepRtn${keyCtrlPtn}`]);
 	g_workObj.stepHitRtn = copyArray2d(g_keyObj[`stepRtn${keyCtrlPtn}`]);
@@ -8210,6 +8211,7 @@ const getArrowSettings = _ => {
 			});
 		});
 	}
+	g_workObj.scrollDirDefault = g_workObj.scrollDir.concat();
 
 	Object.keys(g_resultObj).forEach(judgeCnt => g_resultObj[judgeCnt] = 0);
 	g_resultObj.spState = ``;
@@ -9707,7 +9709,7 @@ const changeScrollArrowDirs = (_frameNum) => {
 	if (frameData !== undefined) {
 		for (let j = 0; j < frameData.length; j++) {
 			const targetj = frameData[j];
-			g_workObj.scrollDir[targetj] = (g_stateObj.reverse === C_FLG_OFF ? 1 : -1) * g_workObj.mkScrollchArrowDir[_frameNum][j];
+			g_workObj.scrollDir[targetj] = g_workObj.scrollDirDefault[targetj] * g_workObj.mkScrollchArrowDir[_frameNum][j];
 			g_workObj.dividePos[targetj] = (g_workObj.scrollDir[targetj] === 1 ? 0 : 1);
 		}
 	}
@@ -9722,7 +9724,7 @@ const changeStepY = (_frameNum) => {
 	if (frameData !== undefined) {
 		for (let j = 0; j < frameData.length; j++) {
 			const targetj = frameData[j];
-			const dividePos = ((g_stateObj.reverse === C_FLG_OFF ? 1 : -1) * g_workObj.mkScrollchStepDir[_frameNum][j] === 1 ? 0 : 1);
+			const dividePos = (g_workObj.scrollDirDefault[targetj] * g_workObj.mkScrollchStepDir[_frameNum][j] === 1 ? 0 : 1);
 			const baseY = C_STEP_Y + g_posObj.reverseStepY * dividePos;
 			$id(`stepRoot${targetj}`).top = `${baseY}px`;
 			$id(`frzHit${targetj}`).top = `${baseY}px`;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7134,23 +7134,23 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 		return [];
 	};
 
-	const setScrchData = (_scoreNo) => {
-		const dosScrchData = _dosObj[`scrch${_scoreNo}_data`] || _dosObj.scrch_data;
-		const scrchData = [];
+	const setScrollchData = (_scoreNo) => {
+		const dosScrollchData = _dosObj[`scrollch${_scoreNo}_data`] || _dosObj.scrollch_data;
+		const scrollchData = [];
 
-		if (hasVal(dosScrchData)) {
-			splitLF(dosScrchData).filter(data => hasVal(data)).forEach(tmpData => {
-				const tmpScrchData = tmpData.split(`,`);
-				if (isNaN(parseInt(tmpScrchData[0]))) {
+		if (hasVal(dosScrollchData)) {
+			splitLF(dosScrollchData).filter(data => hasVal(data)).forEach(tmpData => {
+				const tmpScrollchData = tmpData.split(`,`);
+				if (isNaN(parseInt(tmpScrollchData[0]))) {
 					return;
 				}
-				const frame = calcFrame(tmpScrchData[0]);
-				const arrowNum = parseFloat(tmpScrchData[1]);
-				const scrollDir = parseFloat(tmpScrchData[2] ?? `1`);
+				const frame = calcFrame(tmpScrollchData[0]);
+				const arrowNum = parseFloat(tmpScrollchData[1]);
+				const scrollDir = parseFloat(tmpScrollchData[2] ?? `1`);
 
-				scrchData.push([frame, frame, arrowNum, scrollDir]);
+				scrollchData.push([frame, frame, arrowNum, scrollDir]);
 			});
-			return scrchData.sort((_a, _b) => _a[0] - _b[0]).flat();
+			return scrollchData.sort((_a, _b) => _a[0] - _b[0]).flat();
 		}
 		return [];
 	};
@@ -7348,7 +7348,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	}
 
 	// スクロール変化データの分解
-	obj.scrchData = setScrchData(scoreIdHeader);
+	obj.scrollchData = setScrollchData(scoreIdHeader);
 
 	// 歌詞データの分解 (3つで1セット, セット毎の改行区切り可)
 	obj.wordData = [];
@@ -7847,7 +7847,7 @@ const pushArrows = (_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 	g_typeLists.arrow.forEach(header =>
 		calcDataTiming(`cssMotion`, header, pushCssMotions, { _calcFrameFlg: true }));
 
-	calcDataTiming(`scrch`, ``, pushScrchs, { _calcFrameFlg: true });
+	calcDataTiming(`scrollch`, ``, pushScrollchs, { _calcFrameFlg: true });
 
 	g_fadeinStockList.forEach(type =>
 		_dataObj[`${type}Data`] = calcAnimationData(type, _dataObj[`${type}Data`]));
@@ -8090,35 +8090,35 @@ const pushCssMotions = (_header, _frame, _val, _styleName, _styleNameRev) => {
  * @param {number} _val 
  * @param {number} _scrollDir 
  */
-const pushScrchs = (_header, _frameArrow, _frameStep, _val, _scrollDir) => {
+const pushScrollchs = (_header, _frameArrow, _frameStep, _val, _scrollDir) => {
 	const tkObj = getKeyInfo();
 
 	const frameArrow = Math.max(_frameArrow, g_scoreObj.frameNum);
 	const frameStep = Math.max(_frameStep, g_scoreObj.frameNum);
 
-	if (g_workObj.mkScrchArrow[frameArrow] === undefined) {
-		g_workObj.mkScrchArrow[frameArrow] = [];
-		g_workObj.mkScrchArrowDir[frameArrow] = [];
+	if (g_workObj.mkScrollchArrow[frameArrow] === undefined) {
+		g_workObj.mkScrollchArrow[frameArrow] = [];
+		g_workObj.mkScrollchArrowDir[frameArrow] = [];
 	}
-	if (g_workObj.mkScrchStep[frameStep] === undefined) {
-		g_workObj.mkScrchStep[frameStep] = [];
-		g_workObj.mkScrchStepDir[frameStep] = [];
+	if (g_workObj.mkScrollchStep[frameStep] === undefined) {
+		g_workObj.mkScrollchStep[frameStep] = [];
+		g_workObj.mkScrollchStepDir[frameStep] = [];
 	}
 	if (_val < 20 || _val >= 1000) {
 		const realVal = g_workObj.replaceNums[_val % 1000];
-		g_workObj.mkScrchArrow[frameArrow].push(realVal);
-		g_workObj.mkScrchArrowDir[frameArrow].push(_scrollDir);
-		g_workObj.mkScrchStep[frameStep].push(realVal);
-		g_workObj.mkScrchStepDir[frameStep].push(_scrollDir);
+		g_workObj.mkScrollchArrow[frameArrow].push(realVal);
+		g_workObj.mkScrollchArrowDir[frameArrow].push(_scrollDir);
+		g_workObj.mkScrollchStep[frameStep].push(realVal);
+		g_workObj.mkScrollchStepDir[frameStep].push(_scrollDir);
 
 	} else {
 		const colorNum = _val - 20;
 		for (let j = 0; j < tkObj.keyNum; j++) {
 			if (g_keyObj[`color${tkObj.keyCtrlPtn}`][j] === colorNum) {
-				g_workObj.mkScrchArrow[frameArrow].push(j);
-				g_workObj.mkScrchArrowDir[frameArrow].push(_scrollDir);
-				g_workObj.mkScrchStep[frameStep].push(j);
-				g_workObj.mkScrchStepDir[frameStep].push(_scrollDir);
+				g_workObj.mkScrollchArrow[frameArrow].push(j);
+				g_workObj.mkScrollchArrowDir[frameArrow].push(_scrollDir);
+				g_workObj.mkScrollchStep[frameStep].push(j);
+				g_workObj.mkScrollchStepDir[frameStep].push(_scrollDir);
 			}
 		}
 	}
@@ -9703,11 +9703,11 @@ const changeCssMotions = (_header, _name, _frameNum) => {
  * @param {number} _frameNum 
  */
 const changeScrollArrowDirs = (_frameNum) => {
-	const frameData = g_workObj.mkScrchArrow[_frameNum];
+	const frameData = g_workObj.mkScrollchArrow[_frameNum];
 	if (frameData !== undefined) {
 		for (let j = 0; j < frameData.length; j++) {
 			const targetj = frameData[j];
-			g_workObj.scrollDir[targetj] = (g_stateObj.reverse === C_FLG_OFF ? 1 : -1) * g_workObj.mkScrchArrowDir[_frameNum][j];
+			g_workObj.scrollDir[targetj] = (g_stateObj.reverse === C_FLG_OFF ? 1 : -1) * g_workObj.mkScrollchArrowDir[_frameNum][j];
 			g_workObj.dividePos[targetj] = (g_workObj.scrollDir[targetj] === 1 ? 0 : 1);
 		}
 	}
@@ -9718,11 +9718,11 @@ const changeScrollArrowDirs = (_frameNum) => {
  * @param {number} _frameNum 
  */
 const changeStepY = (_frameNum) => {
-	const frameData = g_workObj.mkScrchStep[_frameNum];
+	const frameData = g_workObj.mkScrollchStep[_frameNum];
 	if (frameData !== undefined) {
 		for (let j = 0; j < frameData.length; j++) {
 			const targetj = frameData[j];
-			const dividePos = ((g_stateObj.reverse === C_FLG_OFF ? 1 : -1) * g_workObj.mkScrchStepDir[_frameNum][j] === 1 ? 0 : 1);
+			const dividePos = ((g_stateObj.reverse === C_FLG_OFF ? 1 : -1) * g_workObj.mkScrollchStepDir[_frameNum][j] === 1 ? 0 : 1);
 			const baseY = C_STEP_Y + g_posObj.reverseStepY * dividePos;
 			$id(`stepRoot${targetj}`).top = `${baseY}px`;
 			$id(`frzHit${targetj}`).top = `${baseY}px`;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7134,6 +7134,10 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 		return [];
 	};
 
+	/**
+	 * スクロール変化データの分解
+	 * @param {number} _scoreNo 
+	 */
 	const setScrollchData = (_scoreNo) => {
 		const dosScrollchData = _dosObj[`scrollch${_scoreNo}_data`] || _dosObj.scrollch_data;
 		const scrollchData = [];

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -486,7 +486,7 @@ const g_typeLists = {
     frzColor: [`Normal`, `NormalBar`, `Hit`, `HitBar`],
     dataList: [
         `Arrow`, `FrzArrow`, `FrzLength`,
-        `Color`, `ColorCd`, `ScrchArrow`, `ScrchStep`, `ScrchArrowDir`, `ScrchStepDir`,
+        `Color`, `ColorCd`, `ScrollchArrow`, `ScrollchStep`, `ScrollchArrowDir`, `ScrollchStepDir`,
         `FColorNormal`, `FColorNormalCd`, `FColorNormalBar`, `FColorNormalBarCd`,
         `FColorHit`, `FColorHitCd`, `FColorHitBar`, `FColorHitBarCd`,
         `ArrowCssMotion`, `ArrowCssMotionName`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -486,7 +486,7 @@ const g_typeLists = {
     frzColor: [`Normal`, `NormalBar`, `Hit`, `HitBar`],
     dataList: [
         `Arrow`, `FrzArrow`, `FrzLength`,
-        `Color`, `ColorCd`,
+        `Color`, `ColorCd`, `ScrchArrow`, `ScrchStep`, `ScrchArrowDir`, `ScrchStepDir`,
         `FColorNormal`, `FColorNormalCd`, `FColorNormalBar`, `FColorNormalBarCd`,
         `FColorHit`, `FColorHitCd`, `FColorHitBar`, `FColorHitBarCd`,
         `ArrowCssMotion`, `ArrowCssMotionName`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 矢印・フリーズアローのスクロール方向を反転する機能を実装しました。
`scrollch_data`で指定します。改行区切りで`フレーム数, 矢印番号, スクロール方向`の3つで1セットです。
矢印番号は色変化や矢印モーションで使っているものと同じです。
スクロール方向は`-1`で反転、`1`で元に戻します。
```
|scrollch_data=
1100,20,-1
1200,21,-1
1300,22,-1
2000,20,1
2000,21,1
2000,22,1
|
```
2. キー変化`keych_data`について改行区切りに対応しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 演出系で一時的にスクロールを反転したい場合にcustomjsが必要となるため。
2. 他機能との機能統一のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
