### PR TITLE
fix: [0645] フェードインでスクロール反転の初期位置が正しく反映されない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7152,7 +7152,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 				const arrowNum = parseFloat(tmpScrollchData[1]);
 				const scrollDir = parseFloat(tmpScrollchData[2] ?? `1`);
 
-				scrollchData.push([frame, frame, arrowNum, scrollDir]);
+				scrollchData.push([frame, arrowNum, frame, scrollDir]);
 			});
 			return scrollchData.sort((_a, _b) => _a[0] - _b[0]).flat();
 		}
@@ -7738,7 +7738,8 @@ const pushArrows = (_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 	g_workObj.boostData = getTimingData(_dataObj.boostData);
 
 	/**
-	 * 色変化・モーションデータのタイミング更新
+	 * 色変化・モーションデータ・スクロール反転データのタイミング更新
+	 * - この関数を使用する場合、配列グループの先頭2つが「フレーム数、矢印番号」となっていないと動作しない
 	 * @param {string} _type 
 	 * @param {string} _header 
 	 * @param {function} _setFunc 
@@ -7759,6 +7760,7 @@ const pushArrows = (_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 			const calcFrameFlg = (_colorFlg && !isFrzHitColor(baseData[k + 1]) && !baseData[k + 3]) || _calcFrameFlg;
 
 			if (baseData[k] < g_scoreObj.frameNum) {
+				// フェードイン直前にある色変化・モーションデータ・スクロール反転データを取得して格納
 				if (!hasValInArray(baseData[k + 1], frontData)) {
 					frontData.unshift(baseData.slice(k + 1, k + _term));
 				}
@@ -7844,7 +7846,7 @@ const pushArrows = (_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 		return _data;
 	};
 
-	// 個別・全体色変化、モーションデータのタイミング更新
+	// 個別・全体色変化、モーションデータ・スクロール反転データのタイミング更新
 	[``, `dummy`].forEach(type =>
 		calcDataTiming(`color`, type, pushColors, { _colorFlg: true }));
 
@@ -8094,7 +8096,7 @@ const pushCssMotions = (_header, _frame, _val, _styleName, _styleNameRev) => {
  * @param {number} _val 
  * @param {number} _scrollDir 
  */
-const pushScrollchs = (_header, _frameArrow, _frameStep, _val, _scrollDir) => {
+const pushScrollchs = (_header, _frameArrow, _val, _frameStep, _scrollDir) => {
 	const tkObj = getKeyInfo();
 
 	const frameArrow = Math.max(_frameArrow, g_scoreObj.frameNum);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. フェードイン、スクロール反転機能を同時に利用した場合に
スクロール初期位置が正しく反映されない問題を修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. スクロール反転処理について`calcDataTiming`という色変化・モーションデータと同じ関数を使用していましたが、この関数を使用するためには配列グループの2番目に色番号（矢印番号）を指定する必要がありました。
※コメントに但し書きを追記しています。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- スクロール反転固有の問題のため、ver30.2.0のみで発生する問題です。