### PR TITLE
fix: [0647] キーグループ未指定のときにkeych_dataが使えない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6424,7 +6424,7 @@ const getKeyInfo = _ => {
 	const posMax = (g_keyObj[`divMax${keyCtrlPtn}`] !== undefined ?
 		g_keyObj[`divMax${keyCtrlPtn}`] : Math.max(...g_keyObj[`pos${keyCtrlPtn}`]) + 1);
 	const divideCnt = g_keyObj[`div${keyCtrlPtn}`] - 1;
-	const keyGroupMaps = setVal(g_keyObj[`keyGroup${keyCtrlPtn}`], [...Array(keyNum)].fill([0]), C_TYP_STRING);
+	const keyGroupMaps = setVal(g_keyObj[`keyGroup${keyCtrlPtn}`], [...Array(keyNum)].fill([`0`]), C_TYP_STRING);
 	const keyGroupList = makeDedupliArray(keyGroupMaps.flat()).sort((a, b) => parseInt(a) - parseInt(b));
 
 	return {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7393,14 +7393,12 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	}
 
 	// キー変化定義
-	obj.keychFrames = [];
+	obj.keychFrames = [0];
+	obj.keychTarget = [`0`];
 	if (hasVal(_dosObj[`keych${setScoreIdHeader(g_stateObj.scoreId, g_stateObj.scoreLockFlg)}_data`])) {
 		const keychdata = splitLF2(_dosObj[`keych${setScoreIdHeader(g_stateObj.scoreId, g_stateObj.scoreLockFlg)}_data`], `,`);
-		obj.keychFrames = keychdata.filter((val, j) => j % 2 === 0);
-		obj.keychTarget = keychdata.filter((val, j) => j % 2 === 1);
-	} else {
-		obj.keychFrames = [0];
-		obj.keychTarget = [0];
+		obj.keychFrames.push(...keychdata.filter((val, j) => j % 2 === 0));
+		obj.keychTarget.push(...keychdata.filter((val, j) => j % 2 === 1));
 	}
 
 	return obj;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. キーグループが未指定のとき、keych_dataが使えない問題を修正しました。
    - デフォルトのキーグループ名が「0 (数字)」となっていました。「0 (文字列)」が正しいです。
2. keych_dataの指定がある場合でも、自動で「0フレーム、キーグループ0」が
挿入されるように修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. ステップゾーンを一時的に消す演出などで利用用途があると考えていましたが、
それが使えない状態になっていました。
2. 挿入されても支障がないのと、キー変化作品以外で`keych_data=0,0`を前挿入するのが手間のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
