### PR TITLE
fix: [0648] カスタムキーのdivMax値がposXの最大値を取得していない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3641,8 +3641,7 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 			loopFunc: (k, keyheader) => {
 				const ptnName = `${newKey}_${k + dfPtnNum}`;
 				if (g_keyObj[`divMax${ptnName}`] === undefined || g_keyObj[`divMax${ptnName}`] === -1) {
-					const posLength = g_keyObj[`${keyheader}_${k + dfPtnNum}`].length;
-					g_keyObj[`divMax${ptnName}`] = g_keyObj[`${keyheader}_${k + dfPtnNum}`][posLength - 1] + 1;
+					g_keyObj[`divMax${ptnName}`] = Math.max(...g_keyObj[`${keyheader}_${k + dfPtnNum}`]) + 1;
 				}
 			}
 		});


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. カスタムキーのdivMax値がposXの最大値を取得していない問題を修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. ver30.2.2で PR #1410 を行いましたが、カスタムキーで適用されていませんでした。
## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
