### PR TITLE
fix: [0649] カスタムキーのdivX, shuffleXが未定義のときの問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3634,6 +3634,12 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 					g_keyObj[`divMax${ptnName}`] = setVal(tmpDivPtn[1], -1, C_TYP_FLOAT);
 				}
 			}
+		} else if (g_keyObj[`chara${newKey}_0`] !== undefined) {
+			// 特に指定が無い場合はcharaX_Yの配列長で決定
+			for (let k = 0; k < tmpMinPatterns; k++) {
+				const ptnName = `${newKey}_${k + dfPtnNum}`;
+				g_keyObj[`div${ptnName}`] = g_keyObj[`chara${newKey}_0`].length;
+			}
 		}
 
 		// ステップゾーン位置 (posX_Y)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3678,6 +3678,14 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 
 		// シャッフルグループ (shuffleX_Y)
 		newKeyTripleParam(newKey, `shuffle`);
+		if (g_keyObj[`shuffle${newKey}_${dfPtnNum}_0`] === undefined) {
+			// 特に指定が無い場合はcolorX_Yの配列長で決定
+			for (let k = 0; k < tmpMinPatterns; k++) {
+				const ptnName = `${newKey}_${k + dfPtnNum}`;
+				g_keyObj[`shuffle${ptnName}_0`] = [...Array(g_keyObj[`color${ptnName}`].length)].fill(0);
+				g_keyObj[`shuffle${ptnName}`] = structuredClone(g_keyObj[`shuffle${ptnName}_0`]);
+			}
+		}
 
 		// キーグループ (keyGroupX_Y)
 		newKeyMultiParam(newKey, `keyGroup`, toSplitArrayStr);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. カスタムキーのdivXが未定義のとき、ステップゾーンが並ばない問題を修正しました。
2. カスタムキーのshuffleXが未定義のとき、エラーで止まる問題を修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1, 2. いずれも意図しない挙動のため。
divX, shuffleXがそもそもない場合の考慮がされていませんでした。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 過去バージョンにも影響がある部分のため、合わせて修正予定です。