### PR TITLE
improve: [0650] カスタムキー定義におけるdivX, posX部分のコード整理

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3575,7 +3575,6 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 
 	// 対象キー毎に処理
 	keyExtraList.forEach(newKey => {
-		let tmpDivPtn = [];
 		let tmpMinPatterns = 1;
 		g_keyObj.dfPtnNum = 0;
 
@@ -3623,15 +3622,15 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 		if (_dosObj[`div${newKey}`] !== undefined) {
 			const tmpDivs = _dosObj[`div${newKey}`].split(`$`);
 			for (let k = 0; k < tmpDivs.length; k++) {
-				tmpDivPtn = tmpDivs[k].split(`,`);
+				const tmpDivPtn = tmpDivs[k].split(`,`);
 				const ptnName = `${newKey}_${k + dfPtnNum}`;
 
 				if (g_keyObj[`div${tmpDivPtn[0]}`] !== undefined) {
 					// 既定キーパターンが指定された場合、存在すればその値を適用
 					g_keyObj[`div${ptnName}`] = g_keyObj[`div${tmpDivPtn[0]}`];
 					g_keyObj[`divMax${ptnName}`] = setVal(g_keyObj[`divMax${tmpDivPtn[0]}`], Math.max(...g_keyObj[`pos${ptnName}`]) + 1, C_TYP_FLOAT);
-				} else if (setIntVal(g_keyObj[`div${ptnName}`], -1) !== -1) {
-					// すでに定義済みの場合はスキップ
+				} else if (!hasVal(tmpDivPtn[0]) && setIntVal(g_keyObj[`div${ptnName}`], -1) !== -1) {
+					// カスタムキー側のdivXが未定義だが、すでに初期設定で定義済みの場合はスキップ
 					continue;
 				} else {
 					// それ以外の場合は指定された値を適用（未指定時はその後で指定）

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3608,6 +3608,17 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 		// キーコンフィグ (keyCtrlX_Y)
 		tmpMinPatterns = newKeyMultiParam(newKey, `keyCtrl`, toSplitArray, { errCd: `E_0104`, baseCopyFlg: true });
 
+		// ステップゾーン位置 (posX_Y)
+		newKeyMultiParam(newKey, `pos`, toFloat);
+		if (_dosObj[`pos${newKey}`] === undefined) {
+			for (let k = 0; k < tmpMinPatterns; k++) {
+				const ptnName = `${newKey}_${k + dfPtnNum}`;
+				if (g_keyObj[`color${ptnName}`] !== undefined) {
+					g_keyObj[`pos${ptnName}`] = [...Array(g_keyObj[`color${ptnName}`].length).keys()].map(i => i);
+				}
+			}
+		}
+
 		// 各キーの区切り位置 (divX_Y)
 		if (_dosObj[`div${newKey}`] !== undefined) {
 			const tmpDivs = _dosObj[`div${newKey}`].split(`$`);
@@ -3615,48 +3626,26 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 				tmpDivPtn = tmpDivs[k].split(`,`);
 				const ptnName = `${newKey}_${k + dfPtnNum}`;
 
-				if (setIntVal(tmpDivPtn[0], -1) !== -1) {
-					g_keyObj[`div${ptnName}`] = setIntVal(tmpDivPtn[0], g_keyObj[`chara${newKey}_0`].length);
-				} else if (g_keyObj[`div${tmpDivPtn[0]}`] !== undefined) {
+				if (g_keyObj[`div${tmpDivPtn[0]}`] !== undefined) {
 					// 既定キーパターンが指定された場合、存在すればその値を適用
 					g_keyObj[`div${ptnName}`] = g_keyObj[`div${tmpDivPtn[0]}`];
-					g_keyObj[`divMax${ptnName}`] = setIntVal(g_keyObj[`divMax${tmpDivPtn[0]}`], undefined);
+					g_keyObj[`divMax${ptnName}`] = setVal(g_keyObj[`divMax${tmpDivPtn[0]}`], Math.max(...g_keyObj[`pos${ptnName}`]) + 1, C_TYP_FLOAT);
 				} else if (setIntVal(g_keyObj[`div${ptnName}`], -1) !== -1) {
 					// すでに定義済みの場合はスキップ
 					continue;
-				} else if (g_keyObj[`chara${newKey}_0`] !== undefined) {
-					// 特に指定が無い場合はcharaX_Yの配列長で決定
-					g_keyObj[`div${ptnName}`] = g_keyObj[`chara${newKey}_0`].length;
+				} else {
+					// それ以外の場合は指定された値を適用（未指定時はその後で指定）
+					g_keyObj[`div${ptnName}`] = setVal(tmpDivPtn[0], undefined, C_TYP_NUMBER);
+					g_keyObj[`divMax${ptnName}`] = setVal(tmpDivPtn[1], undefined, C_TYP_FLOAT);
 				}
-
-				// ステップゾーン位置の最終番号
-				if (tmpDivPtn.length > 1) {
-					g_keyObj[`divMax${ptnName}`] = setVal(tmpDivPtn[1], -1, C_TYP_FLOAT);
-				}
-			}
-		} else if (g_keyObj[`chara${newKey}_0`] !== undefined) {
-			// 特に指定が無い場合はcharaX_Yの配列長で決定
-			for (let k = 0; k < tmpMinPatterns; k++) {
-				const ptnName = `${newKey}_${k + dfPtnNum}`;
-				g_keyObj[`div${ptnName}`] = g_keyObj[`chara${newKey}_0`].length;
 			}
 		}
-
-		// ステップゾーン位置 (posX_Y)
-		newKeyMultiParam(newKey, `pos`, toFloat, {
-			loopFunc: (k, keyheader) => {
-				const ptnName = `${newKey}_${k + dfPtnNum}`;
-				if (g_keyObj[`divMax${ptnName}`] === undefined || g_keyObj[`divMax${ptnName}`] === -1) {
-					g_keyObj[`divMax${ptnName}`] = Math.max(...g_keyObj[`${keyheader}_${k + dfPtnNum}`]) + 1;
-				}
-			}
-		});
-		if (_dosObj[`pos${newKey}`] === undefined) {
-			for (let k = 0; k < tmpMinPatterns; k++) {
-				const ptnName = `${newKey}_${k + dfPtnNum}`;
-				if (g_keyObj[`color${ptnName}`] !== undefined) {
-					g_keyObj[`pos${ptnName}`] = [...Array(g_keyObj[`color${ptnName}`].length).keys()].map(i => i);
-				}
+		// divX_Yが未指定の場合はposX_Yを元に適用
+		for (let k = 0; k < tmpMinPatterns; k++) {
+			const ptnName = `${newKey}_${k + dfPtnNum}`;
+			if (g_keyObj[`div${ptnName}`] === undefined) {
+				g_keyObj[`div${ptnName}`] = Math.max(...g_keyObj[`pos${ptnName}`]) + 1;
+				g_keyObj[`divMax${ptnName}`] = g_keyObj[`div${ptnName}`];
 			}
 		}
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. カスタムキー定義におけるdivX, posX部分のコードを整理しました。
キーパターン別のposXの最大値+1をdivXの初期値となるように処理を見直しています。
（これまではposXの最初のキーパターンで決まっていたため、
　別キーモード時にdivXを指定しない場合に意図しない値が設定されるようになっていました）
2. divXが部分的に未定義でも、posXの値を元に補完するようにしました。
以下のように、値の一部省略が可能になります。
```
|div11f=$$6$|  // 1, 2, 4番目はposXの最大値+1を適用、3番目のみ6とする
```
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 重複した処理を無くすことでコードの見通しを良くするため。
2. divXの省略条件があいまいでわかりにくかったため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 一部、`setIntVal`ではなく`setVal`でNUMBER型を指定していますが、
これは`setIntVal`関数ではデフォルト値に`undefined`を充てることができないためです。
（`setIntVal`関数のデフォルト値に`0`が設定されており、`undefined`より優先されてしまう）