### PR TITLE
improve: [0651] カスタムキー定義のshuffleXについて部分省略指定に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3510,7 +3510,8 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 
 					// 通常の指定方法 (例: |shuffle8i=1,1,1,2,0,0,0,0/1,1,1,1,0,0,0,0| )の場合の取り込み
 					tmpArray[k].split(`/`).forEach((list, m) =>
-						g_keyObj[`${keyheader}_${k + dfPtn}_${m}`] = list.split(`,`).map(n => parseInt(n, 10)));
+						g_keyObj[`${keyheader}_${k + dfPtn}_${m}`] = (list === `` ?
+							[...Array(g_keyObj[`color${_key}_${k + dfPtn}`].length)].fill(0) : list.split(`,`).map(n => parseInt(n, 10))));
 				}
 				g_keyObj[`${keyheader}_${k + dfPtn}`] = structuredClone(g_keyObj[`${keyheader}_${k + dfPtn}_0`]);
 			}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. カスタムキー定義のshuffleXについて部分省略指定に対応しました。
`shuffleX`について、下記のように部分的に空指定ができるようになります。
何も指定しない場合は、全てのシャッフルグループがグループ1に割り当てられます。
```
|shuffle10p=$$11i_0$11i_1|

|minWidth10p=650|
|color10p=0,1,2,1,0,0,1,2,1,0$10p_0$11i_0$11i_1|
|chara10p=left,down,gor,up,right,sleft,sdown,siyo,sup,sright$10p_0$11i_0$11i_1|
|stepRtn10p=-45,45,onigiri,135,-135,-45,45,onigiri,135,-135$10p_0$11i_0$11i_1|
|keyCtrl10p=88/90,69/87,68/70/83,84/82,86/67,66/78,89/85,72/74/75,73/79,77/188$88/90,87/81,68/83/70,82/84,67/86,77/78,85/89,75/74/76,79/80,188/190$11i_0$11i_1|
|blank10p=50$50$50$50|
|scroll10p=Cross::1,1,1,-1,-1,-1,-1,1,1,1/Split::1,1,1,1,1,-1,-1,-1,-1,-1/Alternate::1,-1,1,-1,1,1,-1,1,-1,1$10p_0$11i_0$11i_1|
|transKey10p=$$11i$11i|
```
- キーの上書きなどでシャッフルグループを変えたくないときは、略記指定が使えます。（変化なし）
```
|shuffle7=7_0$7_1|
```

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 別キーモードなどでシャッフルグループを部分流用したい場合で、
カスタムキーそのもののシャッフルグループには手を入れたくない場合の無用な設定を防ぎます。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
