### PR TITLE
chore: [0655] GitterをGitLab Issuesに変更

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,9 +3,9 @@
 要望・不具合報告がある場合、以下のいずれかの方法で行うことができます。
 
 - リポジトリをForkして編集した後、Pull Requestを「cwtickle/danoniplus」の「develop」ブランチへ送る。
-- 当リポジトリのIssueもしくは[Gitter](https://gitter.im/danonicw/community)に要望・不具合内容を報告する。  
-※Gitterは「Twitterアカウント」を持っている方でも参加可能です。  
-　Gitter内では、Github同様のmarkdownが使えます。お気軽にどうぞ！
+- 当リポジトリのIssueもしくは[GitLab Issues](https://gitlab.com/cwtickle/danonicw/-/issues)に要望・不具合内容を報告する。  
+※GitLabは「Twitterアカウント」を持っている方でも参加可能です。  
+　GitLab内では、Github同様のmarkdownが使えます。お気軽にどうぞ！
 - 要望・不具合内容をティックル宛([@cw_tickle](https://twitter.com/cw_tickle))へ直接連絡する。
 
 ## [English]
@@ -17,9 +17,9 @@ If you have a request or defect report, you can do it in one of the following wa
 1. Commit your changes (git commit -am 'Added some feature')
 1. Push to the branch (git push origin my-new-feature)
 1. Create new Pull Request to develop branch
-- Report the request / problem contents to [Gitter](https://gitter.im/danonicw/community).  
-※ Gitter can participate even if you have "Twitter account".  
-　 In Gitter, you can use markdown similar to Github. Feel free to help yourself!
+- Report the request / problem contents to [GitLab Issues](https://gitlab.com/cwtickle/danonicw/-/issues).  
+※ GitLab can participate even if you have "Twitter account".  
+　 In GitLab, you can use markdown similar to Github. Feel free to help yourself!
 - Contact the tickle directly ([@cw_tickle](https://twitter.com/cw_tickle)) with the request / problem content.
 
 # コーディングルール 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 -->
 
 ## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
-<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
+<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
 <!-- いずれにも該当しない場合は、変更理由を書いてください -->
 
 ## :camera: スクリーンショット / Screenshot

--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ If you would like to cooperate with the development, please see below. Even if y
 
 開発にご協力いただける方は、下記をご覧ください。GitHubアカウントの無い方でも協力できます！  
 - [How to Contribute / 貢献の仕方](https://github.com/cwtickle/danoniplus/blob/develop/.github/CONTRIBUTING.md)   
-- [Gitter for requests and bug reports / 要望・不具合報告(Gitter)](https://gitter.im/danonicw/community)
+- [GitLab community for requests and bug reports / 要望・不具合報告(GitLab Issues)](https://gitlab.com/cwtickle/danonicw/-/issues)
 - [Contributors / コントリビューター](https://github.com/cwtickle/danoniplus/blob/develop/CONTRIBUTORS.md)
 
 ## Community / コミュニティ
 - [Dancing☆Onigiri Discord server](https://discord.gg/TegbHFY7zg)
-- [Gitter for score reporting / 得点報告(Gitter)](https://gitter.im/danonicw/freeboard)
+- [Gitter for score reporting / 得点報告(Gitter)](https://app.gitter.im/#/room/#danonicw_freeboard:gitter.im)
 - [Twitter #danoni](https://twitter.com/search?q=%23danoni&src=typed_query&f=live)
 
 ## Related Tools Repository / 関連リポジトリ・ツール

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Maintainability](https://api.codeclimate.com/v1/badges/9558f21e17a47a4dc987/maintainability)](https://codeclimate.com/github/cwtickle/danoniplus/maintainability)
 [![CodeQL](https://github.com/cwtickle/danoniplus/workflows/CodeQL/badge.svg)](https://github.com/cwtickle/danoniplus/actions?query=workflow%3ACodeQL)
-[![GitLab Issues](https://img.shields.io/gitlab/issues/open/cwtickle/danonicw?gitlab_url=https%3A%2F%2Fgitlab.com%2F&label=Issues&logo=gitlab)](https://gitlab.com/cwtickle/danonicw/-/issues)  
+[![GitLab Community](https://img.shields.io/gitlab/issues/open/cwtickle/danonicw?gitlab_url=https%3A%2F%2Fgitlab.com%2F&label=Community&logo=gitlab)](https://gitlab.com/cwtickle/danonicw/-/issues)  
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/cwtickle/danoniplus?sort=semver)](https://github.com/cwtickle/danoniplus/security/policy)
 [![GitHub All Releases](https://img.shields.io/github/downloads/cwtickle/danoniplus/total?color=%23ff3399&label=downloads%20%28recently%29)](https://github.com/cwtickle/danoniplus/releases)
 [![GitHub](https://img.shields.io/github/license/cwtickle/danoniplus)](https://github.com/cwtickle/danoniplus/blob/develop/LICENSE)  

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Maintainability](https://api.codeclimate.com/v1/badges/9558f21e17a47a4dc987/maintainability)](https://codeclimate.com/github/cwtickle/danoniplus/maintainability)
 [![CodeQL](https://github.com/cwtickle/danoniplus/workflows/CodeQL/badge.svg)](https://github.com/cwtickle/danoniplus/actions?query=workflow%3ACodeQL)
-[![Join the chat at https://gitter.im/danonicw/community](https://badges.gitter.im/danonicw/community.svg)](https://gitter.im/danonicw/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)  
+[![GitLab Issues](https://img.shields.io/gitlab/issues/open/cwtickle/danonicw?gitlab_url=https%3A%2F%2Fgitlab.com%2F&label=GitLab%20Issues)](https://gitlab.com/cwtickle/danonicw/-/issues)  
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/cwtickle/danoniplus?sort=semver)](https://github.com/cwtickle/danoniplus/security/policy)
 [![GitHub All Releases](https://img.shields.io/github/downloads/cwtickle/danoniplus/total?color=%23ff3399&label=downloads%20%28recently%29)](https://github.com/cwtickle/danoniplus/releases)
 [![GitHub](https://img.shields.io/github/license/cwtickle/danoniplus)](https://github.com/cwtickle/danoniplus/blob/develop/LICENSE)  

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Maintainability](https://api.codeclimate.com/v1/badges/9558f21e17a47a4dc987/maintainability)](https://codeclimate.com/github/cwtickle/danoniplus/maintainability)
 [![CodeQL](https://github.com/cwtickle/danoniplus/workflows/CodeQL/badge.svg)](https://github.com/cwtickle/danoniplus/actions?query=workflow%3ACodeQL)
-[![GitLab Issues](https://img.shields.io/gitlab/issues/open/cwtickle/danonicw?gitlab_url=https%3A%2F%2Fgitlab.com%2F&label=GitLab%20Issues)](https://gitlab.com/cwtickle/danonicw/-/issues)  
+[![GitLab Issues](https://img.shields.io/gitlab/issues/open/cwtickle/danonicw?gitlab_url=https%3A%2F%2Fgitlab.com%2F&label=Issues&logo=gitlab)](https://gitlab.com/cwtickle/danonicw/-/issues)  
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/cwtickle/danoniplus?sort=semver)](https://github.com/cwtickle/danoniplus/security/policy)
 [![GitHub All Releases](https://img.shields.io/github/downloads/cwtickle/danoniplus/total?color=%23ff3399&label=downloads%20%28recently%29)](https://github.com/cwtickle/danoniplus/releases)
 [![GitHub](https://img.shields.io/github/license/cwtickle/danoniplus)](https://github.com/cwtickle/danoniplus/blob/develop/LICENSE)  


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. GitterのリンクをGitLab Issuesに変更しました。
バッジ名はGitterを継承し「Community」としています。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. GitterからElementへの移行に伴い、モバイルアクセスは良化したが、GitHubとの紐づけが弱くなったため。
GitLabはGitHubと似ており、Twitter, Googleアカウントも使えるため従来のGitterに近い使い方ができる。
また、リスト化されることで何が完了して何が議論中かの確認が可能。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/223314015-ab3096bf-037e-4747-9025-21948c1df3de.png" width="90%">
<img src="https://user-images.githubusercontent.com/44026291/223313124-3bc41ca9-fceb-4b2b-a057-9b204c20f7d0.png" width="100%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 本来はGitHubに統合するのが良いが、GitHubアカウントを保持していないメンバーもいるため
他アカウントとの親和性が高く、機能が類似しているGitLabを選択。
- 得点報告用のGitter（Element）はそのままのため、結果画面のリンクには手を入れません。