### PR TITLE
feat: [0657] カスタムキーのカラー、シャッフルグループについて組み合わせ参照に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3498,21 +3498,27 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 				if (existParam(tmpArray[k], `${keyheader}_${k + dfPtn}`)) {
 					continue;
 				}
-				if (g_keyObj[`${_name}${tmpArray[k]}_0`] !== undefined) {
 
-					// 他のキーパターン (例: |shuffle8i=8_0| ) を指定した場合、該当があれば既存パターンからコピー
-					let m = 0;
-					while (g_keyObj[`${_name}${tmpArray[k]}_${m}`] !== undefined) {
-						g_keyObj[`${keyheader}_${k + dfPtn}_${m}`] = structuredClone(g_keyObj[`${_name}${tmpArray[k]}_${m}`]);
-						m++;
+				let ptnCnt = 0;
+				tmpArray[k].split(`/`).forEach(list => {
+
+					if (g_keyObj[`${_name}${list}_0`] !== undefined) {
+
+						// 他のキーパターン (例: |shuffle8i=8_0| ) を指定した場合、該当があれば既存パターンからコピー
+						let m = 0;
+						while (g_keyObj[`${_name}${list}_${m}`] !== undefined) {
+							g_keyObj[`${keyheader}_${k + dfPtn}_${ptnCnt}`] = structuredClone(g_keyObj[`${_name}${list}_${m}`]);
+							m++;
+							ptnCnt++;
+						}
+					} else {
+
+						// 通常の指定方法 (例: |shuffle8i=1,1,1,2,0,0,0,0/1,1,1,1,0,0,0,0| )の場合の取り込み
+						g_keyObj[`${keyheader}_${k + dfPtn}_${ptnCnt}`] = (list === `` ?
+							[...Array(g_keyObj[`chara${_key}_${k + dfPtn}`].length)].fill(0) : list.split(`,`).map(n => parseInt(n, 10)));
+						ptnCnt++;
 					}
-				} else {
-
-					// 通常の指定方法 (例: |shuffle8i=1,1,1,2,0,0,0,0/1,1,1,1,0,0,0,0| )の場合の取り込み
-					tmpArray[k].split(`/`).forEach((list, m) =>
-						g_keyObj[`${keyheader}_${k + dfPtn}_${m}`] = (list === `` ?
-							[...Array(g_keyObj[`chara${_key}_${k + dfPtn}`].length)].fill(0) : list.split(`,`).map(n => parseInt(n, 10))));
-				}
+				});
 				g_keyObj[`${keyheader}_${k + dfPtn}`] = structuredClone(g_keyObj[`${keyheader}_${k + dfPtn}_0`]);
 			}
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3523,6 +3523,13 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 				g_keyObj[`${keyheader}_${k + dfPtn}`] = structuredClone(g_keyObj[`${keyheader}_${k + dfPtn}_0`]);
 			}
 
+		} else if (g_keyObj[`${keyheader}_${dfPtn}_0`] === undefined) {
+			// 特に指定が無い場合はcharaX_Yの配列長で決定
+			for (let k = 0; k < g_keyObj.minPatterns; k++) {
+				const ptnName = `${_key}_${k + dfPtn}`;
+				g_keyObj[`${_name}${ptnName}_0`] = [...Array(g_keyObj[`chara${ptnName}`].length)].fill(0);
+				g_keyObj[`${_name}${ptnName}`] = structuredClone(g_keyObj[`${_name}${ptnName}_0`]);
+			}
 		} else if (errCd !== `` && g_keyObj[`${keyheader}_0`] === undefined) {
 			makeWarningWindow(g_msgInfoObj[errCd].split(`{0}`).join(_key));
 		}
@@ -3583,7 +3590,7 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 
 	// 対象キー毎に処理
 	keyExtraList.forEach(newKey => {
-		let tmpMinPatterns = 1;
+		g_keyObj.minPatterns = 1;
 		g_keyObj.dfPtnNum = 0;
 
 		// キーパターンの追記 (appendX)
@@ -3604,16 +3611,16 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 		g_keyObj[`minWidth${newKey}`] = _dosObj[`minWidth${newKey}`] ?? g_keyObj[`minWidth${newKey}`] ?? g_keyObj.minWidthDefault;
 
 		// 読込変数の接頭辞 (charaX_Y)
-		tmpMinPatterns = newKeyMultiParam(newKey, `chara`, toString, { errCd: `E_0102` });
+		g_keyObj.minPatterns = newKeyMultiParam(newKey, `chara`, toString, { errCd: `E_0102` });
 
 		// 矢印色パターン (colorX_Y)
-		tmpMinPatterns = newKeyTripleParam(newKey, `color`, { errCd: `E_0101` });
+		newKeyTripleParam(newKey, `color`, { errCd: `E_0101` });
 
 		// 矢印の回転量指定、キャラクタパターン (stepRtnX_Y)
-		tmpMinPatterns = newKeyMultiParam(newKey, `stepRtn`, toStringOrNumber, { errCd: `E_0103` });
+		newKeyMultiParam(newKey, `stepRtn`, toStringOrNumber, { errCd: `E_0103` });
 
 		// キーコンフィグ (keyCtrlX_Y)
-		tmpMinPatterns = newKeyMultiParam(newKey, `keyCtrl`, toSplitArray, { errCd: `E_0104`, baseCopyFlg: true });
+		newKeyMultiParam(newKey, `keyCtrl`, toSplitArray, { errCd: `E_0104`, baseCopyFlg: true });
 
 		// ステップゾーン位置 (posX_Y)
 		newKeyMultiParam(newKey, `pos`, toFloat);
@@ -3640,7 +3647,7 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 			}
 		}
 		// posX_Y, divX_Y, divMaxX_Yが未指定の場合はcharaX_Yを元に適用
-		for (let k = 0; k < tmpMinPatterns; k++) {
+		for (let k = 0; k < g_keyObj.minPatterns; k++) {
 			setKeyDfVal(`${newKey}_${k + dfPtnNum}`);
 		}
 
@@ -3661,14 +3668,6 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 
 		// シャッフルグループ (shuffleX_Y)
 		newKeyTripleParam(newKey, `shuffle`);
-		if (g_keyObj[`shuffle${newKey}_${dfPtnNum}_0`] === undefined) {
-			// 特に指定が無い場合はcolorX_Yの配列長で決定
-			for (let k = 0; k < tmpMinPatterns; k++) {
-				const ptnName = `${newKey}_${k + dfPtnNum}`;
-				g_keyObj[`shuffle${ptnName}_0`] = [...Array(g_keyObj[`chara${ptnName}`].length)].fill(0);
-				g_keyObj[`shuffle${ptnName}`] = structuredClone(g_keyObj[`shuffle${ptnName}_0`]);
-			}
-		}
 
 		// キーグループ (keyGroupX_Y)
 		newKeyMultiParam(newKey, `keyGroup`, toSplitArrayStr);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3483,17 +3483,14 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 	 * 新キー用複合パラメータ（特殊）
 	 * @param {string} _key キー数
 	 * @param {string} _name 名前
-	 * @returns 最小パターン数
 	 */
 	const newKeyTripleParam = (_key, _name) => {
-		let tmpMinPatterns = 1;
 		const keyheader = _name + _key;
 		const dfPtn = setIntVal(g_keyObj.dfPtnNum);
 
 		if (hasVal(_dosObj[keyheader])) {
 			const tmpArray = splitLF2(_dosObj[keyheader]);
-			tmpMinPatterns = tmpArray.length;
-			for (let k = 0; k < tmpMinPatterns; k++) {
+			for (let k = 0; k < tmpArray.length; k++) {
 				if (existParam(tmpArray[k], `${keyheader}_${k + dfPtn}`)) {
 					continue;
 				}
@@ -3530,7 +3527,6 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 				g_keyObj[`${_name}${ptnName}`] = structuredClone(g_keyObj[`${_name}${ptnName}_0`]);
 			}
 		}
-		return tmpMinPatterns;
 	};
 
 	/**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3483,10 +3483,9 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 	 * 新キー用複合パラメータ（特殊）
 	 * @param {string} _key キー数
 	 * @param {string} _name 名前
-	 * @param {object} _obj errCd エラーコード
 	 * @returns 最小パターン数
 	 */
-	const newKeyTripleParam = (_key, _name, { errCd = `` } = {}) => {
+	const newKeyTripleParam = (_key, _name) => {
 		let tmpMinPatterns = 1;
 		const keyheader = _name + _key;
 		const dfPtn = setIntVal(g_keyObj.dfPtnNum);
@@ -3530,8 +3529,6 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 				g_keyObj[`${_name}${ptnName}_0`] = [...Array(g_keyObj[`chara${ptnName}`].length)].fill(0);
 				g_keyObj[`${_name}${ptnName}`] = structuredClone(g_keyObj[`${_name}${ptnName}_0`]);
 			}
-		} else if (errCd !== `` && g_keyObj[`${keyheader}_0`] === undefined) {
-			makeWarningWindow(g_msgInfoObj[errCd].split(`{0}`).join(_key));
 		}
 		return tmpMinPatterns;
 	};
@@ -3614,7 +3611,7 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 		g_keyObj.minPatterns = newKeyMultiParam(newKey, `chara`, toString, { errCd: `E_0102` });
 
 		// 矢印色パターン (colorX_Y)
-		newKeyTripleParam(newKey, `color`, { errCd: `E_0101` });
+		newKeyTripleParam(newKey, `color`);
 
 		// 矢印の回転量指定、キャラクタパターン (stepRtnX_Y)
 		newKeyMultiParam(newKey, `stepRtn`, toStringOrNumber, { errCd: `E_0103` });

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3502,8 +3502,11 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 				let ptnCnt = 0;
 				tmpArray[k].split(`/`).forEach(list => {
 
-					if (g_keyObj[`${_name}${list}_0`] !== undefined) {
+					if (list === ``) {
+						// 空指定の場合は一律同じグループへ割り当て
+						g_keyObj[`${keyheader}_${k + dfPtn}_${ptnCnt}`] = [...Array(g_keyObj[`chara${_key}_${k + dfPtn}`].length)].fill(0);
 
+					} else if (g_keyObj[`${_name}${list}_0`] !== undefined) {
 						// 他のキーパターン (例: |shuffle8i=8_0| ) を指定した場合、該当があれば既存パターンからコピー
 						let m = 0;
 						while (g_keyObj[`${_name}${list}_${m}`] !== undefined) {
@@ -3512,10 +3515,8 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 							ptnCnt++;
 						}
 					} else {
-
 						// 通常の指定方法 (例: |shuffle8i=1,1,1,2,0,0,0,0/1,1,1,1,0,0,0,0| )の場合の取り込み
-						g_keyObj[`${keyheader}_${k + dfPtn}_${ptnCnt}`] = (list === `` ?
-							[...Array(g_keyObj[`chara${_key}_${k + dfPtn}`].length)].fill(0) : list.split(`,`).map(n => parseInt(n, 10)));
+						g_keyObj[`${keyheader}_${k + dfPtn}_${ptnCnt}`] = list.split(`,`).map(n => parseInt(n, 10));
 						ptnCnt++;
 					}
 				});
@@ -3602,11 +3603,11 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 		// キーの最小横幅 (minWidthX)
 		g_keyObj[`minWidth${newKey}`] = _dosObj[`minWidth${newKey}`] ?? g_keyObj[`minWidth${newKey}`] ?? g_keyObj.minWidthDefault;
 
-		// 矢印色パターン (colorX_Y)
-		tmpMinPatterns = newKeyTripleParam(newKey, `color`, { errCd: `E_0101` });
-
 		// 読込変数の接頭辞 (charaX_Y)
 		tmpMinPatterns = newKeyMultiParam(newKey, `chara`, toString, { errCd: `E_0102` });
+
+		// 矢印色パターン (colorX_Y)
+		tmpMinPatterns = newKeyTripleParam(newKey, `color`, { errCd: `E_0101` });
 
 		// 矢印の回転量指定、キャラクタパターン (stepRtnX_Y)
 		tmpMinPatterns = newKeyMultiParam(newKey, `stepRtn`, toStringOrNumber, { errCd: `E_0103` });


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. カスタムキーのカラー、シャッフルグループについて組み合わせ参照に対応しました。
具体的には以下のような指定が可能になります。
```
|shuffle8i=8_0/0,0,0,2,0,0,0,3|
// シャッフルグループ1:  8keyのグループ1から参照
// シャッフルグループ2:  指定パターン(0,0,0,2,0,0,0,3)を適用

|color11j=2,0,0,0,0,2,3,3,3,3,2/11_0/11W_0$11j_0/11L_0|
// キーパターン1:
//      カラーグループ1: 指定パターン(2,0,0,0,0,2,3,3,3,3,2)を適用
//      カラーグループ2: 11keyのグループ1から参照
//      カラーグループ3: 11Wkeyのグループ1から参照
// キーパターン2:
//      カラーグループ1～3: 先ほど定義した11jkeyのグループ1から参照
//      カラーグループ4: 11Lkeyのグループ1から参照
```

2. カスタムキーのcolorXの省略に対応しました。
指定が無い場合は、一律charaXのキーパターン指定数に合わせて一律同じグループへ割り当てします。

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. カラー・シャッフルグループについてはグループ毎の指定になり、
少しの変化で全てのパターンを記載するのが手間のため。
2. カラー・シャッフルグループで未定義時の扱いに差があったため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 現状、カスタムキーのcharaXの完全省略には対応していないため、影響は無いと思います。