### PR TITLE
feat: [0659] 既存キー上書き時に相対パターン番号を略記で指定できるよう変更　他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3445,6 +3445,15 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 	const toSplitArray = _str => _str.split(`/`).map(n => toNumber(n));
 	const toSplitArrayStr = _str => _str.split(`/`).map(n => n);
 
+	const getKeyPtnName = _str => {
+		const regex = /\((\d+)\)/;
+		const checkStr = _str.match(regex);
+		if (checkStr !== null) {
+			return _str.replace(regex, (match, p) => `${parseInt(p, 10) + setIntVal(g_keyObj.dfPtnNum)}`);
+		}
+		return _str;
+	};
+
 	/**
 	 * 新キー用複合パラメータ
 	 * @param {string} _key キー数
@@ -3465,8 +3474,9 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 				if (existParam(tmpArray[k], `${keyheader}_${k + dfPtn}`)) {
 					continue;
 				}
-				g_keyObj[`${keyheader}_${k + dfPtn}`] = g_keyObj[`${_name}${tmpArray[k]}`] !== undefined ?
-					copyArray2d(g_keyObj[`${_name}${tmpArray[k]}`]) : tmpArray[k].split(`,`).map(n => _convFunc(n));
+				const keyPtn = getKeyPtnName(tmpArray[k]);
+				g_keyObj[`${keyheader}_${k + dfPtn}`] = g_keyObj[`${_name}${keyPtn}`] !== undefined ?
+					copyArray2d(g_keyObj[`${_name}${keyPtn}`]) : tmpArray[k].split(`,`).map(n => _convFunc(n));
 				if (baseCopyFlg) {
 					g_keyObj[`${keyheader}_${k + dfPtn}d`] = copyArray2d(g_keyObj[`${keyheader}_${k + dfPtn}`]);
 				}
@@ -3498,15 +3508,16 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 				let ptnCnt = 0;
 				tmpArray[k].split(`/`).forEach(list => {
 
+					const keyPtn = getKeyPtnName(list);
 					if (list === ``) {
 						// 空指定の場合は一律同じグループへ割り当て
 						g_keyObj[`${keyheader}_${k + dfPtn}_${ptnCnt}`] = [...Array(g_keyObj[`chara${_key}_${k + dfPtn}`].length)].fill(0);
 
-					} else if (g_keyObj[`${_name}${list}_0`] !== undefined) {
+					} else if (g_keyObj[`${_name}${keyPtn}_0`] !== undefined) {
 						// 他のキーパターン (例: |shuffle8i=8_0| ) を指定した場合、該当があれば既存パターンからコピー
 						let m = 0;
-						while (g_keyObj[`${_name}${list}_${m}`] !== undefined) {
-							g_keyObj[`${keyheader}_${k + dfPtn}_${ptnCnt}`] = structuredClone(g_keyObj[`${_name}${list}_${m}`]);
+						while (g_keyObj[`${_name}${keyPtn}_${m}`] !== undefined) {
+							g_keyObj[`${keyheader}_${k + dfPtn}_${ptnCnt}`] = structuredClone(g_keyObj[`${_name}${keyPtn}_${m}`]);
 							m++;
 							ptnCnt++;
 						}
@@ -3566,8 +3577,9 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 					continue;
 				}
 				g_keyObj[pairName] = {}
-				if (g_keyObj[`${_pairName}${tmpParams[k]}`] !== undefined) {
-					Object.assign(g_keyObj[pairName], g_keyObj[`${_pairName}${tmpParams[k]}`]);
+				const keyPtn = getKeyPtnName(tmpParams[k]);
+				if (g_keyObj[`${_pairName}${keyPtn}`] !== undefined) {
+					Object.assign(g_keyObj[pairName], g_keyObj[`${_pairName}${keyPtn}`]);
 				} else {
 					if (_defaultName !== ``) {
 						g_keyObj[pairName][_defaultName] = [...Array(g_keyObj[`chara${_key}_${k + dfPtn}`].length)].fill(_defaultVal);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3584,18 +3584,22 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 					continue;
 				}
 				g_keyObj[pairName] = {}
-				const keyPtn = getKeyPtnName(tmpParams[k]);
-				if (g_keyObj[`${_pairName}${keyPtn}`] !== undefined) {
-					Object.assign(g_keyObj[pairName], g_keyObj[`${_pairName}${keyPtn}`]);
-				} else {
-					if (_defaultName !== ``) {
-						g_keyObj[pairName][_defaultName] = [...Array(g_keyObj[`chara${_key}_${k + dfPtn}`].length)].fill(_defaultVal);
-					}
-					tmpParams[k].split(`/`).forEach(pairs => {
+
+				// デフォルト項目がある場合は先に定義
+				if (_defaultName !== ``) {
+					g_keyObj[pairName][_defaultName] = [...Array(g_keyObj[`chara${_key}_${k + dfPtn}`].length)].fill(_defaultVal);
+				}
+				tmpParams[k].split(`/`).forEach(pairs => {
+					const keyPtn = getKeyPtnName(pairs);
+					if (g_keyObj[`${_pairName}${keyPtn}`] !== undefined) {
+						// 他のキーパターン指定時、該当があればプロパティを全コピー
+						Object.assign(g_keyObj[pairName], g_keyObj[`${_pairName}${keyPtn}`]);
+					} else {
+						// 通常の指定方法（例：|scroll8i=Cross::1,1,1,-1,-1,-1,1,1/Split::1,1,1,1,-1,-1,-1,-1|）から取り込み
 						const tmpParamPair = pairs.split(`::`);
 						g_keyObj[pairName][tmpParamPair[0]] = tmpParamPair[1].split(`,`).map(n => parseInt(n, 10));
-					});
-				}
+					}
+				});
 			}
 		}
 	};

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3591,7 +3591,8 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 				}
 				tmpParams[k].split(`/`).forEach(pairs => {
 					const keyPtn = getKeyPtnName(pairs);
-					if (g_keyObj[`${_pairName}${keyPtn}`] !== undefined) {
+					if (pairs === ``) {
+					} else if (g_keyObj[`${_pairName}${keyPtn}`] !== undefined) {
 						// 他のキーパターン指定時、該当があればプロパティを全コピー
 						Object.assign(g_keyObj[pairName], g_keyObj[`${_pairName}${keyPtn}`]);
 					} else {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3445,6 +3445,13 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 	const toSplitArray = _str => _str.split(`/`).map(n => toNumber(n));
 	const toSplitArrayStr = _str => _str.split(`/`).map(n => n);
 
+	/**
+	 * キーパターン（相対パターン）をキーパターン（実際のパターン番号）に変換
+	 * 例) 12_(0) -> 12_4
+	 * それ以外の文字列が来た場合は、そのままの値を戻す
+	 * @param {string} _str 
+	 * @returns 
+	 */
 	const getKeyPtnName = _str => {
 		const regex = /\((\d+)\)/;
 		const checkStr = _str.match(regex);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 既存キー上書き時に相対パターン番号を略記で指定できるよう変更しました。
カスタムキー指定で`|appendX=true|`（既存キー上書き）にした場合、
カスタム部分の番号参照で`12_(0)`のように記載すると、カスタムパターンの1番目のデータを流用できます。

下記の例では、`12_(0)`と指定することで追加パターンの1番目（実際には`12_4`）として割り当てられます。
```
|keyExtraList=12|

|minWidth12=675|
|append12=true|
|chara12=oni,left,leftdia,down,sleft,sdown,sup,sright,space,up,rightdia,right$12_(0)|
|color12=1,0,1,0,3,3,3,3,0,1,0,1$12_(0)|
|pos12=0,1,2,3,4,5,6,7,8,9,10,11$12_(0)|
|div12=12$12|
|stepRtn12=45,0,-45,-90,giko,onigiri,iyo,c,90,135,180,225$12_(0)|
|keyCtrl12=112/0,113/0,114/0,115/0,116/0,117/0,118/0,119/0,120/0,121/0,122/0,123/0$81/0,87/0,69/0,82/0,84/0,89/0,85/0,73/0,79/0,80/0,192/0,219/0|
|shuffle12=0,0,0,0,1,1,1,1,2,2,2,2$12_(0)/12_(0)|
|blank12=50$50|
|scroll12=Cross::1,1,1,1,-1,-1,-1,-1,1,1,1,1/Split::1,1,1,1,1,1,-1,-1,-1,-1,-1,-1$12_(0)|
|transKey12=12i$12i|
```
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

2. カスタムキーのスクロール拡張、アシスト設定に対して部分参照に対応しました。
以下の例では、9Akeyのキーパターン1の設定（Cross, Split, Alternate, Twist, Asymmetry）を参照しつつ、
CrossとAA-Splitの設定を追加・上書きする例です。
```
|scroll9j=9A_0/Cross::1,1,1,-1,-1,-1,1,1,1/AA-Split::1,-1,-1,-1,1,-1,-1,-1,1|
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 従来は既存キーのパターン数を考慮し、`12_4`のように記載する必要がありました。
この手法の場合、後で既存キーが増えてしまうときに問題となるため。
2. PR #1425 と同様、後で一部設定を変えたいときなどに有用のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 従来のように、直接指定する方法や直接パターン名参照する方法も可能です。