### PR TITLE
feat: [0661] キーパターンのスキップボタンを追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6380,19 +6380,19 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		// パターン変更ボタン描画(右回り)
 		createCss2Button(`btnPtnChangeR`, `>`, _ => true, Object.assign(g_lblPosObj.btnPtnChangeR, {
 			resetFunc: _ => changePattern(),
-		}), g_cssObj.button_Start),
+		}), g_cssObj.button_Mini),
 
 		// パターン変更ボタン描画(左回り)
 		createCss2Button(`btnPtnChangeL`, `<`, _ => true, Object.assign(g_lblPosObj.btnPtnChangeL, {
 			resetFunc: _ => changePattern(-1),
-		}), g_cssObj.button_Start),
+		}), g_cssObj.button_Mini),
 
-		// パターン変更ボタン描画(右回り)
+		// パターン変更ボタン描画(右回り/別キーモード間スキップ)
 		createCss2Button(`btnPtnChangeRR`, `|>`, _ => true, Object.assign(g_lblPosObj.btnPtnChangeRR, {
 			resetFunc: _ => changePattern(1, true),
 		}), g_cssObj.button_Setting),
 
-		// パターン変更ボタン描画(左回り)
+		// パターン変更ボタン描画(左回り/別キーモード間スキップ)
 		createCss2Button(`btnPtnChangeLL`, `<|`, _ => true, Object.assign(g_lblPosObj.btnPtnChangeLL, {
 			resetFunc: _ => changePattern(-1, true),
 		}), g_cssObj.button_Setting),

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6284,28 +6284,38 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	 * @param {boolean} _transKeyUse 
 	 * @returns 
 	 */
-	const searchPattern = (_tempPtn, _sign, _transKeyUse = false) => {
+	const searchPattern = (_tempPtn, _sign, _transKeyUse = false, _skipFlg = false) => {
 		let nextPtn = _tempPtn + _sign;
+		const initialPtn = hasVal(g_keyObj[`keyCtrl${g_keyObj.currentKey}_-1`]) ? -1 : 0;
 
 		const searchStart = _ => {
-			nextPtn = 0;
-			while (hasVal(g_keyObj[`keyCtrl${g_keyObj.currentKey}_${nextPtn}`])) {
-				nextPtn -= _sign;
+			if (!hasVal(g_keyObj[`keyCtrl${g_keyObj.currentKey}_${nextPtn}`])) {
+				nextPtn = 0;
+				while (hasVal(g_keyObj[`keyCtrl${g_keyObj.currentKey}_${nextPtn}`])) {
+					nextPtn -= _sign;
+				}
+				nextPtn += _sign;
 			}
-			nextPtn += _sign;
 		};
 
-		if (hasVal(g_keyObj[`keyCtrl${g_keyObj.currentKey}_${nextPtn}`])) {
-		} else {
+		const searchNextGroup = _ => {
+			while (nextPtn !== initialPtn &&
+				g_keyObj[`transKey${g_keyObj.currentKey}_${_tempPtn}`] === g_keyObj[`transKey${g_keyObj.currentKey}_${nextPtn}`] &&
+				hasVal(g_keyObj[`keyCtrl${g_keyObj.currentKey}_${nextPtn}`])) {
+				nextPtn += _sign;
+			}
+		};
+
+		searchStart();
+		if (_skipFlg) {
+			searchNextGroup();
 			searchStart();
 		}
 		if (!_transKeyUse) {
 			while (hasVal(g_keyObj[`transKey${g_keyObj.currentKey}_${nextPtn}`])) {
 				nextPtn += _sign;
 			}
-			if (!hasVal(g_keyObj[`keyCtrl${g_keyObj.currentKey}_${nextPtn}`])) {
-				searchStart();
-			}
+			searchStart();
 		}
 		return nextPtn;
 	};
@@ -6313,11 +6323,12 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	/**
 	 * キーパターン変更時処理
 	 * @param {number} _sign 
+	 * @param {boolean} _skipFlg
 	 */
-	const changePattern = (_sign = 1) => {
+	const changePattern = (_sign = 1, _skipFlg = false) => {
 
 		// キーパターンの変更
-		g_keyObj.currentPtn = searchPattern(g_keyObj.currentPtn, _sign, g_headerObj.transKeyUse);
+		g_keyObj.currentPtn = searchPattern(g_keyObj.currentPtn, _sign, g_headerObj.transKeyUse, _skipFlg);
 
 		// カラーグループ、シャッフルグループの再設定
 		g_keycons.groups.forEach(type => resetGroupList(type, `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`));
@@ -6367,13 +6378,23 @@ const keyConfigInit = (_kcType = g_kcType) => {
 			'Self' : g_keyObj.currentPtn + 1}${lblTransKey}`, g_lblPosObj.lblPattern),
 
 		// パターン変更ボタン描画(右回り)
-		createCss2Button(`btnPtnChangeR`, `>>`, _ => true, Object.assign(g_lblPosObj.btnPtnChangeR, {
+		createCss2Button(`btnPtnChangeR`, `>`, _ => true, Object.assign(g_lblPosObj.btnPtnChangeR, {
 			resetFunc: _ => changePattern(),
+		}), g_cssObj.button_Start),
+
+		// パターン変更ボタン描画(左回り)
+		createCss2Button(`btnPtnChangeL`, `<`, _ => true, Object.assign(g_lblPosObj.btnPtnChangeL, {
+			resetFunc: _ => changePattern(-1),
+		}), g_cssObj.button_Start),
+
+		// パターン変更ボタン描画(右回り)
+		createCss2Button(`btnPtnChangeRR`, `|>`, _ => true, Object.assign(g_lblPosObj.btnPtnChangeRR, {
+			resetFunc: _ => changePattern(1, true),
 		}), g_cssObj.button_Setting),
 
 		// パターン変更ボタン描画(左回り)
-		createCss2Button(`btnPtnChangeL`, `<<`, _ => true, Object.assign(g_lblPosObj.btnPtnChangeL, {
-			resetFunc: _ => changePattern(-1),
+		createCss2Button(`btnPtnChangeLL`, `<|`, _ => true, Object.assign(g_lblPosObj.btnPtnChangeLL, {
+			resetFunc: _ => changePattern(-1, true),
 		}), g_cssObj.button_Setting),
 
 		// キーコンフィグリセットボタン描画

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -251,11 +251,19 @@ const updateWindowSiz = _ => {
         },
         btnPtnChangeR: {
             x: g_sWidth / 2, y: g_sHeight - 100,
-            w: g_sWidth / 6, h: C_BTN_HEIGHT / 2, siz: C_LBL_BTNSIZE * 2 / 3,
+            w: g_sWidth / 9, h: C_BTN_HEIGHT / 2, siz: C_LBL_BTNSIZE * 2 / 3,
         },
         btnPtnChangeL: {
+            x: g_sWidth / 18, y: g_sHeight - 100,
+            w: g_sWidth / 9, h: C_BTN_HEIGHT / 2, siz: C_LBL_BTNSIZE * 2 / 3,
+        },
+        btnPtnChangeRR: {
+            x: g_sWidth * 11 / 18, y: g_sHeight - 100,
+            w: g_sWidth / 18, h: C_BTN_HEIGHT / 2, siz: C_LBL_BTNSIZE * 2 / 3,
+        },
+        btnPtnChangeLL: {
             x: 0, y: g_sHeight - 100,
-            w: g_sWidth / 6, h: C_BTN_HEIGHT / 2, siz: C_LBL_BTNSIZE * 2 / 3,
+            w: g_sWidth / 18, h: C_BTN_HEIGHT / 2, siz: C_LBL_BTNSIZE * 2 / 3,
         },
         btnKcReset: {
             x: 0, y: g_sHeight - 75,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. キーコンフィグ画面においてキーパターンのスキップボタンを追加しました。
次の別キーモードに該当するまで、キーパターンをスキップします。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. キーパターンが増えてきたときに、毎回ボタンを押すのが手間のため。
なお、利用頻度は低いと思われるためボタンサイズは小さめに調整しています。
右側のボタンが「Play」ボタンに近いですが、
利用頻度的に問題にはなりにくいと思われるため、このままにします。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/224546250-c8ca772c-5a75-4769-a296-86c95d65b7cc.png" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- スキップボタンは「btnPtnChangeRR」「btnPtnChangeLL」を追加しています。
- 従来のキーパターン変更ボタンの色を `g_cssObj.button_Mini`に変更しています。