### PR TITLE
feat: [0662] ユーザ定義とは別のカスタムキー定義ができるよう対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1879,10 +1879,10 @@ const initialControl = async () => {
 		keysConvert(dosConvert(_data));
 		g_headerObj.undefinedKeyLists = g_headerObj.undefinedKeyLists.filter(key => g_keyObj[`chara${key}_0`] === undefined);
 	};
+	g_presetObj.keysDataLib.forEach(list => importKeysData(list));
 	if (g_presetObj.keysData !== undefined) {
 		importKeysData(g_presetObj.keysData);
 	}
-	g_presetObj.keysDataLib.forEach(list => importKeysData(list));
 	g_headerObj.keyExtraList = keysConvert(g_rootObj, {
 		keyExtraList: (g_rootObj.keyExtraList !== undefined ?
 			makeDedupliArray(g_rootObj.keyExtraList.split(`,`), g_headerObj.undefinedKeyLists) : g_headerObj.undefinedKeyLists),

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -115,7 +115,9 @@ let g_finishFlg = true;
 /** 共通オブジェクト */
 const g_loadObj = {};
 const g_rootObj = {};
-const g_presetObj = {};
+const g_presetObj = {
+	keysDataLib: [],
+};
 let g_headerObj = {};
 let g_scoreObj = {};
 let g_attrObj = {};
@@ -1873,10 +1875,14 @@ const initialControl = async () => {
 
 	// 譜面ヘッダー、特殊キー情報の読込
 	Object.assign(g_headerObj, headerConvert(g_rootObj));
-	if (g_presetObj.keysData !== undefined) {
-		keysConvert(dosConvert(g_presetObj.keysData));
+	const importKeysData = _data => {
+		keysConvert(dosConvert(_data));
 		g_headerObj.undefinedKeyLists = g_headerObj.undefinedKeyLists.filter(key => g_keyObj[`chara${key}_0`] === undefined);
+	};
+	if (g_presetObj.keysData !== undefined) {
+		importKeysData(g_presetObj.keysData);
 	}
+	g_presetObj.keysDataLib.forEach(list => importKeysData(list));
 	g_headerObj.keyExtraList = keysConvert(g_rootObj, {
 		keyExtraList: (g_rootObj.keyExtraList !== undefined ?
 			makeDedupliArray(g_rootObj.keyExtraList.split(`,`), g_headerObj.undefinedKeyLists) : g_headerObj.undefinedKeyLists),


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. ユーザ定義とは別のカスタムキー定義ができるよう対応しました。
下記のように、`g_presetObj.keysDataLib`にデータを`push`することで
カスタム定義を追加できるようになります。
```javascript
const customLibData = `

|keyExtraList=27k|
|chara27k=...|
|color27k=...|

`;
g_presetObj.keysDataLib.push(customLibData);
```
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. キリズマやパンパネのように、標準搭載とは別の共通定義が必要になってきたため。
これにより、キリズマやパンパネのカスタム定義をユーザ定義から切り離すことが可能になり、
キーパターンの略記も利用できるようになります。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- `g_presetObj.keysDataLib`は配列で定義しています。
- `g_presetObj.keysData`が定義された場合、`g_presetObj.keysDataLib`よりも優先されます。