### PR TITLE
improve: [0663] キーコンフィグ画面でキー割り当て先をクリックしたときの挙動を変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6094,8 +6094,8 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		cursor.style.left = `${nextLeft}px`;
 		const baseY = C_KYC_HEIGHT * Number(posj > divideCnt) + 57;
 		cursor.style.top = `${baseY + C_KYC_REPHEIGHT * g_currentk}px`;
-		if (g_currentk === 0 && g_kcType === `Replaced`) {
-			g_kcType = C_FLG_ALL;
+		if (g_kcType !== C_FLG_ALL) {
+			g_kcType = (g_currentk === 0 ? `Main` : `Replaced`);
 			lnkKcType.textContent = getStgDetailName(g_kcType);
 		}
 
@@ -6112,9 +6112,23 @@ const keyConfigInit = (_kcType = g_kcType) => {
 
 		g_currentj = g_keycons.cursorNumList[_nextj];
 		g_currentk = 0;
-		if (g_kcType === `Replaced` && (g_keyObj[`keyCtrl${keyCtrlPtn}`][g_currentj][1] !== undefined)) {
+		if (g_kcType === `Replaced`) {
 			g_currentk = 1;
+
+			// 代替キー設定の場合は次の代替キーが見つかるまで移動
+			while (g_keyObj[`keyCtrl${keyCtrlPtn}`][g_currentj][1] === undefined) {
+				g_keycons.cursorNum = (g_keycons.cursorNum + 1) % g_keycons.cursorNumList.length;
+				g_currentj = g_keycons.cursorNumList[g_keycons.cursorNum];
+
+				// 一周して対象が無い場合は代替キーが無いため処理を抜ける（無限ループ対策）
+				if (g_keycons.cursorNum === _nextj) {
+					g_kcType = `Main`;
+					g_currentk = 0;
+					break;
+				}
+			}
 		}
+
 		setKeyConfigCursor();
 		keyconSprite.scrollLeft = - maxLeftX;
 	};


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. キーコンフィグ画面でキー割り当て先をクリックしたときの挙動を変更しました。
    - ConfigTypeが「Main」のとき、代替キーをクリックした場合は「Replaced」に切り替えます。
    - ConfigTypeが「Replaced」のとき、通常キーをクリックした場合は「Main」に切り替えます。
    - ConfigTypeが「ALL」のときはいずれのキーをクリックしても変わりません。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 現状はConfigTypeが「Replaced」のとき、通常キーをクリックした場合は
ConfigTypeが「ALL」になっていました。
これは割り当てキーをクリックする機能が無いとき、代替キーが無いときの機能の名残で、
代替キーが常時存在する現状の仕様にはそぐわないと思われるため、見直しました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
- 代替キー部分を押すと、ConfigTypeが切り替わる例です。
<img src="https://user-images.githubusercontent.com/44026291/225036033-7835c9bf-9fa7-4fba-af30-eb5cf1ad3f84.png" width="70%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 現状は代替キーを最低1つのみ残す設定のため起こりませんが、
仮に代替キーが無い場合を含むキーの場合の挙動は次のように変わります。
    - ConfigTypeが「Replaced」のとき：次の代替キーが存在するまでスキップ
    - 代替キーが1つも無い場合：ConfigTypeで「Replaced」「ALL」が選択できなくなる