### PR TITLE
improve: [0664] キーコンフィグ画面で割り当てキーを直接クリックしたときのキー連続チェックを取り止め

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5905,6 +5905,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 				createCss2Button(`keycon${j}_${k}`, g_kCd[g_keyObj[`keyCtrl${keyCtrlPtn}`][j][k]], _ => {
 					g_currentj = j;
 					g_currentk = k;
+					g_prevKey = -1;
 					g_keycons.cursorNum = g_keycons.cursorNumList.findIndex(val => val === g_currentj);
 					setKeyConfigCursor();
 				}, {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. キーコンフィグ画面で割り当てキーを直接クリックしたときのキー連続チェックを取り止めました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 元々、割り当てキーを直接クリックされていないときの名残（誤爆対策）であり、
意図的に割り当てキーを直接クリックする場合は誤爆とは言えないため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
