### PR TITLE
feat: [0665] ヒット位置をステップゾーン位置からずらす機能を実装（Settings版）

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4237,8 +4237,9 @@ const createOptionWindow = _sprite => {
 		[`autoPlay`, 6.5, 0, 0, 0],
 		[`gauge`, 7.5, 0, 0, 0],
 		[`adjustment`, 10, 0, 0, 0],
-		[`fadein`, 11, 0, 0, 0],
-		[`volume`, 12, 0, 0, 0],
+		[`judgAdj`, 11, 0, 0, 0],
+		[`fadein`, 12, 0, 0, 0],
+		[`volume`, 13, 0, 0, 0],
 	];
 
 	// 設定毎に個別のスプライトを作成し、その中にラベル・ボタン類を配置
@@ -5013,16 +5014,24 @@ const createOptionWindow = _sprite => {
 	}
 
 	// ---------------------------------------------------
-	// タイミング調整 (Adjustment)
+	// タイミング調整 (Adjustment - Music)
 	// 縦位置: 10  短縮ショートカットあり
 	createGeneralSetting(spriteList.adjustment, `adjustment`, {
 		skipTerms: g_settings.adjustmentTerms, hiddenBtn: true, scLabel: g_lblNameObj.sc_adjustment, roundNum: 5,
-		unitName: g_lblNameObj.frame,
+		unitName: g_lblNameObj.frame, adjY: -20,
+	});
+
+	// ---------------------------------------------------
+	// タイミング調整 (Adjustment - Judgment)
+	// 縦位置: 11
+	createGeneralSetting(spriteList.judgAdj, `judgAdj`, {
+		skipTerms: g_settings.judgAdjTerms, scLabel: g_lblNameObj.sc_judgAdj, roundNum: 5,
+		unitName: g_lblNameObj.pixel,
 	});
 
 	// ---------------------------------------------------
 	// フェードイン (Fadein)
-	// 縦位置: 11 スライダーあり
+	// 縦位置: 12 スライダーあり
 	spriteList.fadein.appendChild(createLblSetting(`Fadein`));
 
 	const lnkFadein = createDivCss2Label(`lnkFadein`, `${g_stateObj.fadein}${g_lblNameObj.percent}`,
@@ -5053,7 +5062,7 @@ const createOptionWindow = _sprite => {
 
 	// ---------------------------------------------------
 	// ボリューム (Volume) 
-	// 縦位置: 12
+	// 縦位置: 13
 	createGeneralSetting(spriteList.volume, `volume`, { unitName: g_lblNameObj.percent });
 
 	/**
@@ -5259,12 +5268,12 @@ const createOptionWindow = _sprite => {
  */
 const createGeneralSetting = (_obj, _settingName, { unitName = ``,
 	skipTerms = [...Array(3)].fill(1), hiddenBtn = false, addRFunc = _ => { }, addLFunc = _ => { },
-	settingLabel = _settingName, displayName = `option`, scLabel = ``, roundNum = 0 } = {}) => {
+	settingLabel = _settingName, displayName = `option`, scLabel = ``, roundNum = 0, adjY = 0 } = {}) => {
 
 	const settingUpper = toCapitalize(_settingName);
 	const linkId = `lnk${settingUpper}`;
 	const initName = `${getStgDetailName(g_stateObj[_settingName])}${unitName}`;
-	_obj.appendChild(createLblSetting(settingUpper, 0, toCapitalize(settingLabel)));
+	_obj.appendChild(createLblSetting(settingUpper, adjY, toCapitalize(settingLabel)));
 
 	if (g_headerObj[`${_settingName}Use`] === undefined || g_headerObj[`${_settingName}Use`]) {
 
@@ -8522,8 +8531,8 @@ const mainInit = _ => {
 
 	// 矢印・フリーズアロー描画スプライト（ステップゾーンの上に配置）
 	const arrowSprite = [
-		createEmptySprite(mainSprite, `arrowSprite0`, { w: g_headerObj.playingWidth, h: g_posObj.arrowHeight }),
-		createEmptySprite(mainSprite, `arrowSprite1`, { w: g_headerObj.playingWidth, h: g_posObj.arrowHeight }),
+		createEmptySprite(mainSprite, `arrowSprite0`, { y: g_stateObj.judgAdj, w: g_headerObj.playingWidth, h: g_posObj.arrowHeight }),
+		createEmptySprite(mainSprite, `arrowSprite1`, { y: -g_stateObj.judgAdj, w: g_headerObj.playingWidth, h: g_posObj.arrowHeight }),
 	];
 
 	// Appearanceのオプション適用時は一部描画を隠す

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9824,6 +9824,7 @@ const changeHitFrz = (_j, _k, _name) => {
 
 	const styfrzBar = $id(`${_name}Bar${frzNo}`);
 	const styfrzBtm = $id(`${_name}Btm${frzNo}`);
+	const styfrzTopShadow = $id(`${_name}TopShadow${frzNo}`);
 	const styfrzBtmShadow = $id(`${_name}BtmShadow${frzNo}`);
 	const colorPos = g_keyObj[`color${g_keyObj.currentKey}_${g_keyObj.currentPtn}`][_j];
 
@@ -9834,9 +9835,12 @@ const changeHitFrz = (_j, _k, _name) => {
 	// 早押ししたboostCnt分のフリーズアロー終端位置の修正
 	const delFrzMotionLength = sumData(g_workObj.motionOnFrames.slice(0, currentFrz.boostCnt + 1));
 
+	// 判定位置調整分の補正
+	const judgPos = g_stateObj.judgAdj * g_workObj.scrollDir[_j];
+
 	currentFrz.frzBarLength -= (delFrzLength + delFrzMotionLength) * currentFrz.dir;
-	currentFrz.barY -= (delFrzLength + delFrzMotionLength) * currentFrz.dividePos + g_stateObj.judgAdj * g_workObj.scrollDir[_j];
-	currentFrz.btmY -= delFrzLength + delFrzMotionLength + g_stateObj.judgAdj * g_workObj.scrollDir[_j];
+	currentFrz.barY -= (delFrzLength + delFrzMotionLength) * currentFrz.dividePos + judgPos;
+	currentFrz.btmY -= delFrzLength + delFrzMotionLength + judgPos;
 	currentFrz.y += delFrzLength;
 	currentFrz.isMoving = false;
 
@@ -9845,6 +9849,7 @@ const changeHitFrz = (_j, _k, _name) => {
 	styfrzBar.background = g_workObj[`${_name}HitBarColors`][_j];
 	styfrzBtm.top = `${currentFrz.btmY}px`;
 	styfrzBtm.background = g_workObj[`${_name}HitColors`][_j];
+	styfrzTopShadow.opacity = 0;
 	styfrzBtmShadow.top = styfrzBtm.top;
 	if (_name === `frz`) {
 		if (g_headerObj.frzShadowColor[colorPos][1] !== ``) {
@@ -9869,9 +9874,15 @@ const changeFailedFrz = (_j, _k) => {
 	$id(`frzHit${_j}`).opacity = 0;
 	$id(`frzTop${frzNo}`).display = C_DIS_INHERIT;
 	$id(`frzTop${frzNo}`).background = `#cccccc`;
+	$id(`frzTopShadow${frzNo}`).opacity = 1;
 	$id(`frzBar${frzNo}`).background = `#999999`;
 	$id(`frzBar${frzNo}`).opacity = 1;
 	$id(`frzBtm${frzNo}`).background = `#cccccc`;
+
+	// 判定位置調整分の補正
+	const judgPos = g_stateObj.judgAdj * g_workObj.scrollDir[_j];
+	$id(`frzTop${frzNo}`).top = `${- judgPos}px`;
+	$id(`frzTopShadow${frzNo}`).top = `${- judgPos}px`;
 
 	const colorPos = g_keyObj[`color${g_keyObj.currentKey}_${g_keyObj.currentPtn}`][_j];
 	if (g_headerObj.frzShadowColor[colorPos][0] !== ``) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8265,6 +8265,7 @@ const getArrowSettings = _ => {
 		g_keyObj[`scrollDir${keyCtrlPtn}`][g_stateObj.scroll] : [...Array(keyNum)].fill(1));
 
 	g_stateObj.autoAll = (g_stateObj.autoPlay === C_FLG_ALL ? C_FLG_ON : C_FLG_OFF);
+	g_workObj.judgAdj = (g_stateObj.autoAll ? 0 : g_stateObj.judgAdj);
 	changeSetColor();
 
 	for (let j = 0; j < keyNum; j++) {
@@ -8534,8 +8535,8 @@ const mainInit = _ => {
 
 	// 矢印・フリーズアロー描画スプライト（ステップゾーンの上に配置）
 	const arrowSprite = [
-		createEmptySprite(mainSprite, `arrowSprite0`, { y: g_stateObj.judgAdj, w: g_headerObj.playingWidth, h: g_posObj.arrowHeight }),
-		createEmptySprite(mainSprite, `arrowSprite1`, { y: -g_stateObj.judgAdj, w: g_headerObj.playingWidth, h: g_posObj.arrowHeight }),
+		createEmptySprite(mainSprite, `arrowSprite0`, { y: g_workObj.judgAdj, w: g_headerObj.playingWidth, h: g_posObj.arrowHeight }),
+		createEmptySprite(mainSprite, `arrowSprite1`, { y: -g_workObj.judgAdj, w: g_headerObj.playingWidth, h: g_posObj.arrowHeight }),
 	];
 
 	// Appearanceのオプション適用時は一部描画を隠す
@@ -9839,7 +9840,7 @@ const changeHitFrz = (_j, _k, _name) => {
 	const delFrzMotionLength = sumData(g_workObj.motionOnFrames.slice(0, currentFrz.boostCnt + 1));
 
 	// 判定位置調整分の補正
-	const judgPos = g_stateObj.judgAdj * g_workObj.scrollDir[_j];
+	const judgPos = g_workObj.judgAdj * g_workObj.scrollDir[_j];
 
 	currentFrz.frzBarLength -= (delFrzLength + delFrzMotionLength) * currentFrz.dir;
 	currentFrz.barY -= (delFrzLength + delFrzMotionLength) * currentFrz.dividePos + judgPos;
@@ -9883,7 +9884,7 @@ const changeFailedFrz = (_j, _k) => {
 	$id(`frzBtm${frzNo}`).background = `#cccccc`;
 
 	// 判定位置調整分の補正
-	const judgPos = g_stateObj.judgAdj * g_workObj.scrollDir[_j];
+	const judgPos = g_workObj.judgAdj * g_workObj.scrollDir[_j];
 	$id(`frzTop${frzNo}`).top = `${- judgPos}px`;
 	$id(`frzTopShadow${frzNo}`).top = `${- judgPos}px`;
 
@@ -9924,7 +9925,7 @@ const judgeArrow = _j => {
 			displayDiff(_difFrame);
 
 			const stepDivHit = document.querySelector(`#stepHit${_j}`);
-			stepDivHit.style.top = `${currentArrow.prevY - parseFloat($id(`stepRoot${_j}`).top) - 15 + g_stateObj.judgAdj * g_workObj.scrollDir[_j]}px`;
+			stepDivHit.style.top = `${currentArrow.prevY - parseFloat($id(`stepRoot${_j}`).top) - 15 + g_workObj.judgAdj * g_workObj.scrollDir[_j]}px`;
 			stepDivHit.style.opacity = 0.75;
 			stepDivHit.classList.value = ``;
 			stepDivHit.classList.add(g_cssObj[`main_step${resultJdg}`]);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9835,8 +9835,8 @@ const changeHitFrz = (_j, _k, _name) => {
 	const delFrzMotionLength = sumData(g_workObj.motionOnFrames.slice(0, currentFrz.boostCnt + 1));
 
 	currentFrz.frzBarLength -= (delFrzLength + delFrzMotionLength) * currentFrz.dir;
-	currentFrz.barY -= (delFrzLength + delFrzMotionLength) * currentFrz.dividePos;
-	currentFrz.btmY -= delFrzLength + delFrzMotionLength;
+	currentFrz.barY -= (delFrzLength + delFrzMotionLength) * currentFrz.dividePos + g_stateObj.judgAdj * g_workObj.scrollDir[_j];
+	currentFrz.btmY -= delFrzLength + delFrzMotionLength + g_stateObj.judgAdj * g_workObj.scrollDir[_j];
 	currentFrz.y += delFrzLength;
 	currentFrz.isMoving = false;
 
@@ -9910,7 +9910,7 @@ const judgeArrow = _j => {
 			displayDiff(_difFrame);
 
 			const stepDivHit = document.querySelector(`#stepHit${_j}`);
-			stepDivHit.style.top = `${currentArrow.prevY - parseFloat($id(`stepRoot${_j}`).top) - 15}px`;
+			stepDivHit.style.top = `${currentArrow.prevY - parseFloat($id(`stepRoot${_j}`).top) - 15 + g_stateObj.judgAdj * g_workObj.scrollDir[_j]}px`;
 			stepDivHit.style.opacity = 0.75;
 			stepDivHit.classList.value = ``;
 			stepDivHit.classList.add(g_cssObj[`main_step${resultJdg}`]);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2018,8 +2018,8 @@ const loadLocalStorage = _ => {
 		g_localStorage = JSON.parse(checkStorage);
 
 		// Adjustment(Music, Judgment), Volume, Appearance, Opacity初期値設定
-		checkLocalParam(`adjustment`, C_TYP_FLOAT, C_MAX_ADJUSTMENT);
-		checkLocalParam(`judgAdj`, C_TYP_FLOAT, C_MAX_ADJUSTMENT);
+		checkLocalParam(`adjustment`, C_TYP_FLOAT, g_limitObj.musicAdj);
+		checkLocalParam(`judgAdj`, C_TYP_FLOAT, g_limitObj.judgAdj);
 		checkLocalParam(`volume`, C_TYP_NUMBER, g_settings.volumes.length - 1);
 		checkLocalParam(`appearance`);
 		checkLocalParam(`opacity`, C_TYP_NUMBER, g_settings.opacitys.length - 1);
@@ -6793,8 +6793,8 @@ const loadingScoreInit = async () => {
 	// フレーム・曲開始位置調整
 	let preblankFrame = 0;
 	if (g_scoreObj.frameNum === 0) {
-		if (firstArrowFrame - C_MAX_ADJUSTMENT < arrivalFrame) {
-			preblankFrame = arrivalFrame - firstArrowFrame + C_MAX_ADJUSTMENT;
+		if (firstArrowFrame - g_limitObj.musicAdj < arrivalFrame) {
+			preblankFrame = arrivalFrame - firstArrowFrame + g_limitObj.musicAdj;
 
 			// 譜面データの再読み込み
 			const noteExistObj = {
@@ -7549,7 +7549,7 @@ const getFirstArrowFrame = (_dataObj, _keyCtrlPtn = `${g_keyObj.currentKey}_${g_
 
 		data.filter(data => hasVal(data)).forEach(_objData => {
 			if (_objData[0] !== ``) {
-				if (_objData[0] < tmpFirstNum && _objData[0] + C_MAX_ADJUSTMENT > 0) {
+				if (_objData[0] < tmpFirstNum && _objData[0] + g_limitObj.musicAdj > 0) {
 					tmpFirstNum = _objData[0];
 				}
 			}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2017,8 +2017,9 @@ const loadLocalStorage = _ => {
 	if (checkStorage) {
 		g_localStorage = JSON.parse(checkStorage);
 
-		// Adjustment, Volume, Appearance, Opacity初期値設定
+		// Adjustment(Music, Judgment), Volume, Appearance, Opacity初期値設定
 		checkLocalParam(`adjustment`, C_TYP_FLOAT, C_MAX_ADJUSTMENT);
+		checkLocalParam(`judgAdj`, C_TYP_FLOAT, C_MAX_ADJUSTMENT);
 		checkLocalParam(`volume`, C_TYP_NUMBER, g_settings.volumes.length - 1);
 		checkLocalParam(`appearance`);
 		checkLocalParam(`opacity`, C_TYP_NUMBER, g_settings.opacitys.length - 1);
@@ -2038,6 +2039,7 @@ const loadLocalStorage = _ => {
 	} else {
 		g_localStorage = {
 			adjustment: 0,
+			judgAdj: 0,
 			volume: 100,
 			highscores: {},
 		};
@@ -8309,6 +8311,7 @@ const getArrowSettings = _ => {
 
 		// ローカルストレージへAdjustment, Volume, Display関連設定を保存
 		g_localStorage.adjustment = g_stateObj.adjustment;
+		g_localStorage.judgAdj = g_stateObj.judgAdj;
 		g_localStorage.volume = g_stateObj.volume;
 		g_localStorage.colorType = g_colorType;
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2018,7 +2018,7 @@ const loadLocalStorage = _ => {
 		g_localStorage = JSON.parse(checkStorage);
 
 		// Adjustment(Music, Judgment), Volume, Appearance, Opacity初期値設定
-		checkLocalParam(`adjustment`, C_TYP_FLOAT, g_limitObj.musicAdj);
+		checkLocalParam(`adjustment`, C_TYP_FLOAT, g_limitObj.chartAdj);
 		checkLocalParam(`judgAdj`, C_TYP_FLOAT, g_limitObj.judgAdj);
 		checkLocalParam(`volume`, C_TYP_NUMBER, g_settings.volumes.length - 1);
 		checkLocalParam(`appearance`);
@@ -6793,8 +6793,8 @@ const loadingScoreInit = async () => {
 	// フレーム・曲開始位置調整
 	let preblankFrame = 0;
 	if (g_scoreObj.frameNum === 0) {
-		if (firstArrowFrame - g_limitObj.musicAdj < arrivalFrame) {
-			preblankFrame = arrivalFrame - firstArrowFrame + g_limitObj.musicAdj;
+		if (firstArrowFrame - g_limitObj.chartAdj < arrivalFrame) {
+			preblankFrame = arrivalFrame - firstArrowFrame + g_limitObj.chartAdj;
 
 			// 譜面データの再読み込み
 			const noteExistObj = {
@@ -7549,7 +7549,7 @@ const getFirstArrowFrame = (_dataObj, _keyCtrlPtn = `${g_keyObj.currentKey}_${g_
 
 		data.filter(data => hasVal(data)).forEach(_objData => {
 			if (_objData[0] !== ``) {
-				if (_objData[0] < tmpFirstNum && _objData[0] + g_limitObj.musicAdj > 0) {
+				if (_objData[0] < tmpFirstNum && _objData[0] + g_limitObj.chartAdj > 0) {
 					tmpFirstNum = _objData[0];
 				}
 			}

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -86,7 +86,7 @@ const g_windowObj = {
     difList: { x: 165, y: 65, w: 280, h: 255, overflow: `auto` },
     difCover: { x: 25, y: 65, w: 140, h: 255, overflow: `auto`, opacity: 0.95 },
 
-    scoreDetail: { x: 20, y: 90, w: 420, h: 230, visibility: `hidden` },
+    scoreDetail: { x: 20, y: 85, w: 420, h: 236, visibility: `hidden` },
     detailObj: { w: 420, h: 230, visibility: `hidden` },
 
     colorPickSprite: { x: 0, y: 90, w: 50, h: 280 },

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -781,7 +781,7 @@ const g_settings = {
 
     judgAdjs: [...Array(C_MAX_ADJUSTMENT * 20 + 1).keys()].map(i => (i - C_MAX_ADJUSTMENT * 10) / 10),
     judgAdjNum: C_MAX_ADJUSTMENT * 10,
-    judgAdjTerms: [10, 5],
+    judgAdjTerms: [50, 10],
 
     volumes: [0, 0.5, 1, 2, 5, 10, 25, 50, 75, 100],
 
@@ -1227,6 +1227,11 @@ const g_shortcutObj = {
         ShiftLeft_NumpadSubtract: { id: `lnkAdjustmentL` },
         AltLeft_NumpadSubtract: { id: `lnkAdjustmentLLL` },
         NumpadSubtract: { id: `lnkAdjustmentLL` },
+
+        ShiftLeft_KeyB: { id: `lnkJudgAdjR` },
+        KeyB: { id: `lnkJudgAdjRR` },
+        ShiftLeft_KeyT: { id: `lnkJudgAdjL` },
+        KeyT: { id: `lnkJudgAdjLL` },
 
         ShiftLeft_KeyV: { id: `lnkVolumeL` },
         KeyV: { id: `lnkVolumeR` },
@@ -2427,8 +2432,8 @@ const g_lblNameObj = {
     Shuffle: `Shuffle`,
     AutoPlay: `AutoPlay`,
     Gauge: `Gauge`,
-    Adjustment: `Adjustment<br><small>Music)</small>`,
-    JudgAdj: `<small>Judgment)</small>`,
+    Adjustment: `Adjustment<br><small>[ Music ]</small>`,
+    JudgAdj: `<small>[ Judgment ]</small>`,
     Fadein: `Fadein`,
     Volume: `Volume`,
 
@@ -2441,6 +2446,7 @@ const g_lblNameObj = {
     sc_speed: `←→`,
     sc_scroll: `R/<br>↑↓`,
     sc_adjustment: `- +`,
+    sc_judgAdj: `T B`,
     sc_keyConfigPlay: g_isMac ? `Del+Enter` : `BS+Enter`,
 
     g_start: `Start`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -782,9 +782,9 @@ const g_settings = {
     adjustmentNum: g_limitObj.musicAdj * 10,
     adjustmentTerms: [50, 10, 5],
 
-    judgAdjs: [...Array(g_limitObj.judgAdj * 4 + 1).keys()].map(i => (i - g_limitObj.judgAdj * 2) / 2),
-    judgAdjNum: g_limitObj.judgAdj * 2,
-    judgAdjTerms: [10, 2],
+    judgAdjs: [...Array(g_limitObj.judgAdj * 20 + 1).keys()].map(i => (i - g_limitObj.judgAdj * 10) / 10),
+    judgAdjNum: g_limitObj.judgAdj * 10,
+    judgAdjTerms: [50, 10],
 
     volumes: [0, 0.5, 1, 2, 5, 10, 25, 50, 75, 100],
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -32,7 +32,7 @@ const C_LEN_SETLBL_LEFT = 160;
 const C_LEN_SETLBL_WIDTH = 210;
 const C_LEN_DIFSELECTOR_WIDTH = 250;
 const C_LEN_DIFCOVER_WIDTH = 110;
-const C_LEN_SETLBL_HEIGHT = 23;
+const C_LEN_SETLBL_HEIGHT = 21.5;
 const C_SIZ_SETLBL = 17;
 const C_LEN_SETDIFLBL_HEIGHT = 25;
 const C_SIZ_SETDIFLBL = 17;
@@ -559,6 +559,7 @@ const g_settingBtnObj = {
 };
 
 const C_MAX_ADJUSTMENT = 30;
+const C_MAX_STEP_ADJUSTMENT = 30;
 const C_MAX_SPEED = 10;
 const C_MIN_SPEED = 1;
 
@@ -669,6 +670,7 @@ const g_stateObj = {
     autoAll: C_FLG_OFF,
     gauge: `Normal`,
     adjustment: 0,
+    judgAdj: 0,
     fadein: 0,
     volume: 100,
     lifeRcv: 2,
@@ -776,6 +778,10 @@ const g_settings = {
     adjustments: [...Array(C_MAX_ADJUSTMENT * 20 + 1).keys()].map(i => (i - C_MAX_ADJUSTMENT * 10) / 10),
     adjustmentNum: C_MAX_ADJUSTMENT * 10,
     adjustmentTerms: [50, 10, 5],
+
+    judgAdjs: [...Array(C_MAX_ADJUSTMENT * 20 + 1).keys()].map(i => (i - C_MAX_ADJUSTMENT * 10) / 10),
+    judgAdjNum: C_MAX_ADJUSTMENT * 10,
+    judgAdjTerms: [10, 5],
 
     volumes: [0, 0.5, 1, 2, 5, 10, 25, 50, 75, 100],
 
@@ -2421,13 +2427,15 @@ const g_lblNameObj = {
     Shuffle: `Shuffle`,
     AutoPlay: `AutoPlay`,
     Gauge: `Gauge`,
-    Adjustment: `Adjustment`,
+    Adjustment: `Adjustment<br><small>Music)</small>`,
+    JudgAdj: `<small>Judgment)</small>`,
     Fadein: `Fadein`,
     Volume: `Volume`,
 
     multi: `x`,
     frame: `f`,
     percent: `%`,
+    pixel: `px`,
     filterLock: `Lock`,
 
     sc_speed: `←→`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -558,8 +558,11 @@ const g_settingBtnObj = {
     }
 };
 
+const g_limitObj = {
+    musicAdj: 30,
+    judgAdj: 50,
+};
 const C_MAX_ADJUSTMENT = 30;
-const C_MAX_STEP_ADJUSTMENT = 30;
 const C_MAX_SPEED = 10;
 const C_MIN_SPEED = 1;
 
@@ -775,13 +778,13 @@ const g_settings = {
     autoPlays: [C_FLG_OFF, C_FLG_ALL],
     autoPlayNum: 0,
 
-    adjustments: [...Array(C_MAX_ADJUSTMENT * 20 + 1).keys()].map(i => (i - C_MAX_ADJUSTMENT * 10) / 10),
-    adjustmentNum: C_MAX_ADJUSTMENT * 10,
+    adjustments: [...Array(g_limitObj.musicAdj * 20 + 1).keys()].map(i => (i - g_limitObj.musicAdj * 10) / 10),
+    adjustmentNum: g_limitObj.musicAdj * 10,
     adjustmentTerms: [50, 10, 5],
 
-    judgAdjs: [...Array(C_MAX_ADJUSTMENT * 20 + 1).keys()].map(i => (i - C_MAX_ADJUSTMENT * 10) / 10),
-    judgAdjNum: C_MAX_ADJUSTMENT * 10,
-    judgAdjTerms: [50, 10],
+    judgAdjs: [...Array(g_limitObj.judgAdj * 4 + 1).keys()].map(i => (i - g_limitObj.judgAdj * 2) / 2),
+    judgAdjNum: g_limitObj.judgAdj * 2,
+    judgAdjTerms: [10, 2],
 
     volumes: [0, 0.5, 1, 2, 5, 10, 25, 50, 75, 100],
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2683,7 +2683,8 @@ const g_lang_msgObj = {
         shuffle: `譜面を左右反転したり、ランダムにします。\nランダムにした場合は別譜面扱いとなり、ハイスコアは保存されません。`,
         autoPlay: `オートプレイや一部キーを自動で打たせる設定を行います。\nオートプレイ時はハイスコアを保存しません。`,
         gauge: `クリア条件を設定します。\n[Start] ゲージ初期値, [Border] クリア条件(ハイフン時は0),\n[Recovery] 回復量, [Damage] ダメージ量`,
-        adjustment: `タイミングにズレを感じる場合、\n数値を変えることでフレーム単位のズレを直すことができます。\n外側のボタンは5f刻み、真ん中は1f刻み、内側は0.5f刻みで調整できます。`,
+        adjustment: `曲とのタイミングにズレを感じる場合、\n数値を変えることでフレーム単位のズレを直すことができます。\n外側のボタンは5f刻み、真ん中は1f刻み、内側は0.5f刻みで調整できます。`,
+        judgAdj: `判定位置にズレを感じる場合、\n数値を変えることで判定の中央位置を1px単位で調整することができます。\n早押し・遅押し傾向にある場合に使用します。`,
         fadein: `譜面を途中から再生します。\n途中から開始した場合はハイスコアを保存しません。`,
         volume: `ゲーム内の音量を設定します。`,
 
@@ -2737,7 +2738,8 @@ const g_lang_msgObj = {
         shuffle: `Flip the chart left and right or make it random.\nIf you make it random, it will be treated as other charts and the high score will not be saved.`,
         autoPlay: `Set to auto play and to hit some keys automatically.\nHigh score is not saved during auto play.`,
         gauge: `Set the clear condition.\n[Start] initial value, [Border] borderline value (hyphen means zero),\n[Recovery] recovery amount, [Damage] damage amount`,
-        adjustment: `If you feel a shift in timing, \nyou can correct the shift in frame units by changing the value.\nThe outer button can be adjusted in 5 frame increments, the middle in 1 frame increments, \nand the inner button in 0.5 frame increments.`,
+        adjustment: `If you feel that the timing is out of sync with the music, \nyou can correct the shift in frame units by changing the value.\nThe outer button can be adjusted in 5 frame increments, the middle in 1 frame increments, \nand the inner button in 0.5 frame increments.`,
+        judgAdj: `If you feel a discrepancy in the judgment position, \nyou can adjust the center position of the judgment in 1px increments \nby changing the numerical value. \nUse this function when there is a tendency to push too fast or too slow.`,
         fadein: `Plays the chart from the middle.\nIf you start in the middle, the high score will not be saved.`,
         volume: `Set the in-game volume.`,
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -559,7 +559,7 @@ const g_settingBtnObj = {
 };
 
 const g_limitObj = {
-    musicAdj: 30,
+    chartAdj: 30,
     judgAdj: 50,
 };
 const C_MAX_ADJUSTMENT = 30;
@@ -778,8 +778,8 @@ const g_settings = {
     autoPlays: [C_FLG_OFF, C_FLG_ALL],
     autoPlayNum: 0,
 
-    adjustments: [...Array(g_limitObj.musicAdj * 20 + 1).keys()].map(i => (i - g_limitObj.musicAdj * 10) / 10),
-    adjustmentNum: g_limitObj.musicAdj * 10,
+    adjustments: [...Array(g_limitObj.chartAdj * 20 + 1).keys()].map(i => (i - g_limitObj.chartAdj * 10) / 10),
+    adjustmentNum: g_limitObj.chartAdj * 10,
     adjustmentTerms: [50, 10, 5],
 
     judgAdjs: [...Array(g_limitObj.judgAdj * 20 + 1).keys()].map(i => (i - g_limitObj.judgAdj * 10) / 10),
@@ -2435,8 +2435,8 @@ const g_lblNameObj = {
     Shuffle: `Shuffle`,
     AutoPlay: `AutoPlay`,
     Gauge: `Gauge`,
-    Adjustment: `Adjustment<br><small>[ Music ]</small>`,
-    JudgAdj: `<small>[ Judgment ]</small>`,
+    Adjustment: `Adjustment<br><small>[ Chart ]</small>`,
+    JudgAdj: `<small>[ Hit Position ]</small>`,
     Fadein: `Fadein`,
     Volume: `Volume`,
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -83,8 +83,8 @@ const g_windowObj = {
     divRoot: { margin: `auto`, letterSpacing: `normal` },
     divBack: { background: `linear-gradient(#000000, #222222)` },
 
-    difList: { x: 165, y: 65, w: 280, h: 255, overflow: `auto` },
-    difCover: { x: 25, y: 65, w: 140, h: 255, overflow: `auto`, opacity: 0.95 },
+    difList: { x: 165, y: 60, w: 280, h: 261, overflow: `auto` },
+    difCover: { x: 25, y: 60, w: 140, h: 261, overflow: `auto`, opacity: 0.95 },
 
     scoreDetail: { x: 20, y: 85, w: 420, h: 236, visibility: `hidden` },
     detailObj: { w: 420, h: 230, visibility: `hidden` },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 判定基準位置をステップゾーン位置からずらす機能を実装しました。
    - Adjustment (Judgment) として設定します。
    - ステップゾーン位置に対して、判定基準位置を上下にpx単位でずらします。
    - 仕組みとしては矢印・フリーズアローを表示する`arrowSprite0`, `arrowSprite1`の位置を上下させることで実現しています。（ステップゾーン位置は`arrowSprite0`, `arrowSprite1`に依存しないため、そのまま）
    - 設定幅は`1px`, `5px`で設定しています。
    ショートカットは「T」「B」キーに割り当てています。
    - ローカルストレージ保存に対応します。作品別の保存を予定しています。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 目押しによる早押しに対応するため。
なお、この設定を変えてもステップゾーンの位置は変わりません。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/225944126-3314dd77-4d72-42b4-a235-f2be63643698.png" width="60%">
<img src="https://user-images.githubusercontent.com/44026291/226108006-0fe47d5c-8d20-4394-b1f6-7e0801309a05.png" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- どのくらいの幅を持たせるべきか、正負の持たせ方は適切か、
設定名はこれでいいか？など確認する点が多そうなため、GitLab Issueなどにも展開します。
https://gitlab.com/cwtickle/danonicw/-/issues/46
- 設定枠が足りないため、設定用ボタンの縦サイズを`23px`から`21.5px`に変更しています。
合わせて、譜面明細子画面のサイズや位置も少し変えています。