### PR TITLE
feat: [0666] ヒット位置をステップゾーン位置からずらす機能を実装（Display設定版）

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4237,8 +4237,9 @@ const createOptionWindow = _sprite => {
 		[`autoPlay`, 6.5, 0, 0, 0],
 		[`gauge`, 7.5, 0, 0, 0],
 		[`adjustment`, 10, 0, 0, 0],
-		[`fadein`, 11, 0, 0, 0],
-		[`volume`, 12, 0, 0, 0],
+		[`judgAdj`, 11, 0, 0, 0],
+		[`fadein`, 12, 0, 0, 0],
+		[`volume`, 13, 0, 0, 0],
 	];
 
 	// 設定毎に個別のスプライトを作成し、その中にラベル・ボタン類を配置
@@ -5013,16 +5014,24 @@ const createOptionWindow = _sprite => {
 	}
 
 	// ---------------------------------------------------
-	// タイミング調整 (Adjustment)
+	// タイミング調整 (Adjustment - Music)
 	// 縦位置: 10  短縮ショートカットあり
 	createGeneralSetting(spriteList.adjustment, `adjustment`, {
 		skipTerms: g_settings.adjustmentTerms, hiddenBtn: true, scLabel: g_lblNameObj.sc_adjustment, roundNum: 5,
-		unitName: g_lblNameObj.frame,
+		unitName: g_lblNameObj.frame, adjY: -20,
+	});
+
+	// ---------------------------------------------------
+	// タイミング調整 (Adjustment - Judgment)
+	// 縦位置: 11
+	createGeneralSetting(spriteList.judgAdj, `judgAdj`, {
+		skipTerms: g_settings.judgAdjTerms, scLabel: g_lblNameObj.sc_judgAdj, roundNum: 5,
+		unitName: g_lblNameObj.pixel,
 	});
 
 	// ---------------------------------------------------
 	// フェードイン (Fadein)
-	// 縦位置: 11 スライダーあり
+	// 縦位置: 12 スライダーあり
 	spriteList.fadein.appendChild(createLblSetting(`Fadein`));
 
 	const lnkFadein = createDivCss2Label(`lnkFadein`, `${g_stateObj.fadein}${g_lblNameObj.percent}`,
@@ -5053,7 +5062,7 @@ const createOptionWindow = _sprite => {
 
 	// ---------------------------------------------------
 	// ボリューム (Volume) 
-	// 縦位置: 12
+	// 縦位置: 13
 	createGeneralSetting(spriteList.volume, `volume`, { unitName: g_lblNameObj.percent });
 
 	/**
@@ -5259,12 +5268,12 @@ const createOptionWindow = _sprite => {
  */
 const createGeneralSetting = (_obj, _settingName, { unitName = ``,
 	skipTerms = [...Array(3)].fill(1), hiddenBtn = false, addRFunc = _ => { }, addLFunc = _ => { },
-	settingLabel = _settingName, displayName = `option`, scLabel = ``, roundNum = 0 } = {}) => {
+	settingLabel = _settingName, displayName = `option`, scLabel = ``, roundNum = 0, adjY = 0 } = {}) => {
 
 	const settingUpper = toCapitalize(_settingName);
 	const linkId = `lnk${settingUpper}`;
 	const initName = `${getStgDetailName(g_stateObj[_settingName])}${unitName}`;
-	_obj.appendChild(createLblSetting(settingUpper, 0, toCapitalize(settingLabel)));
+	_obj.appendChild(createLblSetting(settingUpper, adjY, toCapitalize(settingLabel)));
 
 	if (g_headerObj[`${_settingName}Use`] === undefined || g_headerObj[`${_settingName}Use`]) {
 
@@ -8522,8 +8531,8 @@ const mainInit = _ => {
 
 	// 矢印・フリーズアロー描画スプライト（ステップゾーンの上に配置）
 	const arrowSprite = [
-		createEmptySprite(mainSprite, `arrowSprite0`, { w: g_headerObj.playingWidth, h: g_posObj.arrowHeight }),
-		createEmptySprite(mainSprite, `arrowSprite1`, { w: g_headerObj.playingWidth, h: g_posObj.arrowHeight }),
+		createEmptySprite(mainSprite, `arrowSprite0`, { y: g_stateObj.judgAdj, w: g_headerObj.playingWidth, h: g_posObj.arrowHeight }),
+		createEmptySprite(mainSprite, `arrowSprite1`, { y: -g_stateObj.judgAdj, w: g_headerObj.playingWidth, h: g_posObj.arrowHeight }),
 	];
 
 	// Appearanceのオプション適用時は一部描画を隠す

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2019,7 +2019,7 @@ const loadLocalStorage = _ => {
 
 		// Adjustment(Music, Judgment), Volume, Appearance, Opacity初期値設定
 		checkLocalParam(`adjustment`, C_TYP_FLOAT, g_limitObj.musicAdj);
-		checkLocalParam(`judgAdj`, C_TYP_FLOAT, g_limitObj.judgAdj);
+		checkLocalParam(`hitPosition`, C_TYP_FLOAT, g_limitObj.hitPosition);
 		checkLocalParam(`volume`, C_TYP_NUMBER, g_settings.volumes.length - 1);
 		checkLocalParam(`appearance`);
 		checkLocalParam(`opacity`, C_TYP_NUMBER, g_settings.opacitys.length - 1);
@@ -2039,7 +2039,7 @@ const loadLocalStorage = _ => {
 	} else {
 		g_localStorage = {
 			adjustment: 0,
-			judgAdj: 0,
+			hitPosition: 0,
 			volume: 100,
 			highscores: {},
 		};
@@ -4238,10 +4238,9 @@ const createOptionWindow = _sprite => {
 		[`shuffle`, 5.5, 0, 0, 0],
 		[`autoPlay`, 6.5, 0, 0, 0],
 		[`gauge`, 7.5, 0, 0, 0],
-		[`adjustment`, 10, 0, 0, 0],
-		[`judgAdj`, 11, 0, 0, 0],
-		[`fadein`, 12, 0, 0, 0],
-		[`volume`, 13, 0, 0, 0],
+		[`adjustment`, 10.5, 0, 0, 0],
+		[`fadein`, 11.5, 0, 0, 0],
+		[`volume`, 12.5, 0, 0, 0],
 	];
 
 	// 設定毎に個別のスプライトを作成し、その中にラベル・ボタン類を配置
@@ -5016,24 +5015,16 @@ const createOptionWindow = _sprite => {
 	}
 
 	// ---------------------------------------------------
-	// タイミング調整 (Adjustment - Music)
-	// 縦位置: 10  短縮ショートカットあり
+	// タイミング調整 (Adjustment)
+	// 縦位置: 10.5  短縮ショートカットあり
 	createGeneralSetting(spriteList.adjustment, `adjustment`, {
 		skipTerms: g_settings.adjustmentTerms, hiddenBtn: true, scLabel: g_lblNameObj.sc_adjustment, roundNum: 5,
-		unitName: g_lblNameObj.frame, adjY: -20,
-	});
-
-	// ---------------------------------------------------
-	// タイミング調整 (Adjustment - Judgment)
-	// 縦位置: 11
-	createGeneralSetting(spriteList.judgAdj, `judgAdj`, {
-		skipTerms: g_settings.judgAdjTerms, scLabel: g_lblNameObj.sc_judgAdj, roundNum: 5,
-		unitName: g_lblNameObj.pixel,
+		unitName: g_lblNameObj.frame,
 	});
 
 	// ---------------------------------------------------
 	// フェードイン (Fadein)
-	// 縦位置: 12 スライダーあり
+	// 縦位置: 11.5 スライダーあり
 	spriteList.fadein.appendChild(createLblSetting(`Fadein`));
 
 	const lnkFadein = createDivCss2Label(`lnkFadein`, `${g_stateObj.fadein}${g_lblNameObj.percent}`,
@@ -5064,7 +5055,7 @@ const createOptionWindow = _sprite => {
 
 	// ---------------------------------------------------
 	// ボリューム (Volume) 
-	// 縦位置: 13
+	// 縦位置: 12.5
 	createGeneralSetting(spriteList.volume, `volume`, { unitName: g_lblNameObj.percent });
 
 	/**
@@ -5343,7 +5334,7 @@ const createGeneralSetting = (_obj, _settingName, { unitName = ``,
  */
 const createLblSetting = (_settingName, _adjY = 0, _settingLabel = _settingName) => {
 	const lbl = createDivCss2Label(`lbl${_settingName}`, g_lblNameObj[_settingLabel], {
-		x: 0, y: _adjY, w: 100,
+		x: -25, y: _adjY, w: 150,
 	}, `settings_${_settingName}`);
 	lbl.title = g_msgObj[`${_settingName.charAt(0).toLowerCase()}${_settingName.slice(1)}`];
 	return lbl;
@@ -5642,6 +5633,7 @@ const createSettingsDisplayWindow = _sprite => {
 	const settingList = [
 		[`appearance`, 7.4, 10, 0, 0],
 		[`opacity`, 9, 10, 0, 0],
+		[`hitPosition`, 10, 10, 0, 0],
 	];
 
 	// 設定毎に個別のスプライトを作成し、その中にラベル・ボタン類を配置
@@ -5701,6 +5693,14 @@ const createSettingsDisplayWindow = _sprite => {
 	if (opacityUse) {
 		createGeneralSetting(spriteList.opacity, `opacity`, { unitName: g_lblNameObj.percent, displayName: g_currentPage });
 	}
+
+	// ---------------------------------------------------
+	// タイミング調整 (HitPosition)
+	// 縦位置: 10
+	createGeneralSetting(spriteList.hitPosition, `hitPosition`, {
+		skipTerms: g_settings.hitPositionTerms, scLabel: g_lblNameObj.sc_hitPosition, roundNum: 5,
+		unitName: g_lblNameObj.pixel,
+	});
 };
 
 /**
@@ -8265,7 +8265,7 @@ const getArrowSettings = _ => {
 		g_keyObj[`scrollDir${keyCtrlPtn}`][g_stateObj.scroll] : [...Array(keyNum)].fill(1));
 
 	g_stateObj.autoAll = (g_stateObj.autoPlay === C_FLG_ALL ? C_FLG_ON : C_FLG_OFF);
-	g_workObj.judgAdj = (g_stateObj.autoAll ? 0 : g_stateObj.judgAdj);
+	g_workObj.hitPosition = (g_stateObj.autoAll ? 0 : g_stateObj.hitPosition);
 	changeSetColor();
 
 	for (let j = 0; j < keyNum; j++) {
@@ -8312,7 +8312,7 @@ const getArrowSettings = _ => {
 
 		// ローカルストレージへAdjustment, Volume, Display関連設定を保存
 		g_localStorage.adjustment = g_stateObj.adjustment;
-		g_localStorage.judgAdj = g_stateObj.judgAdj;
+		g_localStorage.hitPosition = g_stateObj.hitPosition;
 		g_localStorage.volume = g_stateObj.volume;
 		g_localStorage.colorType = g_colorType;
 
@@ -8535,8 +8535,8 @@ const mainInit = _ => {
 
 	// 矢印・フリーズアロー描画スプライト（ステップゾーンの上に配置）
 	const arrowSprite = [
-		createEmptySprite(mainSprite, `arrowSprite0`, { y: g_workObj.judgAdj, w: g_headerObj.playingWidth, h: g_posObj.arrowHeight }),
-		createEmptySprite(mainSprite, `arrowSprite1`, { y: -g_workObj.judgAdj, w: g_headerObj.playingWidth, h: g_posObj.arrowHeight }),
+		createEmptySprite(mainSprite, `arrowSprite0`, { y: g_workObj.hitPosition, w: g_headerObj.playingWidth, h: g_posObj.arrowHeight }),
+		createEmptySprite(mainSprite, `arrowSprite1`, { y: -g_workObj.hitPosition, w: g_headerObj.playingWidth, h: g_posObj.arrowHeight }),
 	];
 
 	// Appearanceのオプション適用時は一部描画を隠す
@@ -9840,11 +9840,11 @@ const changeHitFrz = (_j, _k, _name) => {
 	const delFrzMotionLength = sumData(g_workObj.motionOnFrames.slice(0, currentFrz.boostCnt + 1));
 
 	// 判定位置調整分の補正
-	const judgPos = g_workObj.judgAdj * g_workObj.scrollDir[_j];
+	const hitPos = g_workObj.hitPosition * g_workObj.scrollDir[_j];
 
 	currentFrz.frzBarLength -= (delFrzLength + delFrzMotionLength) * currentFrz.dir;
-	currentFrz.barY -= (delFrzLength + delFrzMotionLength) * currentFrz.dividePos + judgPos;
-	currentFrz.btmY -= delFrzLength + delFrzMotionLength + judgPos;
+	currentFrz.barY -= (delFrzLength + delFrzMotionLength) * currentFrz.dividePos + hitPos;
+	currentFrz.btmY -= delFrzLength + delFrzMotionLength + hitPos;
 	currentFrz.y += delFrzLength;
 	currentFrz.isMoving = false;
 
@@ -9884,9 +9884,9 @@ const changeFailedFrz = (_j, _k) => {
 	$id(`frzBtm${frzNo}`).background = `#cccccc`;
 
 	// 判定位置調整分の補正
-	const judgPos = g_workObj.judgAdj * g_workObj.scrollDir[_j];
-	$id(`frzTop${frzNo}`).top = `${- judgPos}px`;
-	$id(`frzTopShadow${frzNo}`).top = `${- judgPos}px`;
+	const hitPos = g_workObj.hitPosition * g_workObj.scrollDir[_j];
+	$id(`frzTop${frzNo}`).top = `${- hitPos}px`;
+	$id(`frzTopShadow${frzNo}`).top = `${- hitPos}px`;
 
 	const colorPos = g_keyObj[`color${g_keyObj.currentKey}_${g_keyObj.currentPtn}`][_j];
 	if (g_headerObj.frzShadowColor[colorPos][0] !== ``) {
@@ -9925,7 +9925,7 @@ const judgeArrow = _j => {
 			displayDiff(_difFrame);
 
 			const stepDivHit = document.querySelector(`#stepHit${_j}`);
-			stepDivHit.style.top = `${currentArrow.prevY - parseFloat($id(`stepRoot${_j}`).top) - 15 + g_workObj.judgAdj * g_workObj.scrollDir[_j]}px`;
+			stepDivHit.style.top = `${currentArrow.prevY - parseFloat($id(`stepRoot${_j}`).top) - 15 + g_workObj.hitPosition * g_workObj.scrollDir[_j]}px`;
 			stepDivHit.style.opacity = 0.75;
 			stepDivHit.classList.value = ``;
 			stepDivHit.classList.add(g_cssObj[`main_step${resultJdg}`]);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5334,7 +5334,7 @@ const createGeneralSetting = (_obj, _settingName, { unitName = ``,
  */
 const createLblSetting = (_settingName, _adjY = 0, _settingLabel = _settingName) => {
 	const lbl = createDivCss2Label(`lbl${_settingName}`, g_lblNameObj[_settingLabel], {
-		x: -25, y: _adjY, w: 150,
+		x: 0, y: _adjY, w: 100,
 	}, `settings_${_settingName}`);
 	lbl.title = g_msgObj[`${_settingName.charAt(0).toLowerCase()}${_settingName.slice(1)}`];
 	return lbl;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2018,7 +2018,7 @@ const loadLocalStorage = _ => {
 		g_localStorage = JSON.parse(checkStorage);
 
 		// Adjustment(Music, Judgment), Volume, Appearance, Opacity初期値設定
-		checkLocalParam(`adjustment`, C_TYP_FLOAT, g_limitObj.musicAdj);
+		checkLocalParam(`adjustment`, C_TYP_FLOAT, g_limitObj.adjustment);
 		checkLocalParam(`hitPosition`, C_TYP_FLOAT, g_limitObj.hitPosition);
 		checkLocalParam(`volume`, C_TYP_NUMBER, g_settings.volumes.length - 1);
 		checkLocalParam(`appearance`);
@@ -6793,8 +6793,8 @@ const loadingScoreInit = async () => {
 	// フレーム・曲開始位置調整
 	let preblankFrame = 0;
 	if (g_scoreObj.frameNum === 0) {
-		if (firstArrowFrame - g_limitObj.musicAdj < arrivalFrame) {
-			preblankFrame = arrivalFrame - firstArrowFrame + g_limitObj.musicAdj;
+		if (firstArrowFrame - g_limitObj.adjustment < arrivalFrame) {
+			preblankFrame = arrivalFrame - firstArrowFrame + g_limitObj.adjustment;
 
 			// 譜面データの再読み込み
 			const noteExistObj = {
@@ -7549,7 +7549,7 @@ const getFirstArrowFrame = (_dataObj, _keyCtrlPtn = `${g_keyObj.currentKey}_${g_
 
 		data.filter(data => hasVal(data)).forEach(_objData => {
 			if (_objData[0] !== ``) {
-				if (_objData[0] < tmpFirstNum && _objData[0] + g_limitObj.musicAdj > 0) {
+				if (_objData[0] < tmpFirstNum && _objData[0] + g_limitObj.adjustment > 0) {
 					tmpFirstNum = _objData[0];
 				}
 			}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2017,12 +2017,12 @@ const loadLocalStorage = _ => {
 	if (checkStorage) {
 		g_localStorage = JSON.parse(checkStorage);
 
-		// Adjustment(Music, Judgment), Volume, Appearance, Opacity初期値設定
-		checkLocalParam(`adjustment`, C_TYP_FLOAT, g_limitObj.adjustment);
-		checkLocalParam(`hitPosition`, C_TYP_FLOAT, g_limitObj.hitPosition);
+		// Adjustment, Volume, Appearance, Opacity, hitPosition初期値設定
+		checkLocalParam(`adjustment`, C_TYP_FLOAT, g_settings.adjustmentNum);
 		checkLocalParam(`volume`, C_TYP_NUMBER, g_settings.volumes.length - 1);
 		checkLocalParam(`appearance`);
 		checkLocalParam(`opacity`, C_TYP_NUMBER, g_settings.opacitys.length - 1);
+		checkLocalParam(`hitPosition`, C_TYP_FLOAT, g_settings.hitPositionNum);
 
 		// ハイスコア取得準備
 		if (g_localStorage.highscores === undefined) {
@@ -8309,7 +8309,7 @@ const getArrowSettings = _ => {
 		// 次回キーコンフィグ画面へ戻ったとき、保存済みキーコンフィグ設定が表示されるようにする
 		g_keyObj.prevKey = `Dummy`;
 
-		// ローカルストレージへAdjustment, Volume, Display関連設定を保存
+		// ローカルストレージへAdjustment, hitPosition, Volume, colorType設定を保存
 		g_localStorage.adjustment = g_stateObj.adjustment;
 		g_localStorage.hitPosition = g_stateObj.hitPosition;
 		g_localStorage.volume = g_stateObj.volume;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9824,6 +9824,7 @@ const changeHitFrz = (_j, _k, _name) => {
 
 	const styfrzBar = $id(`${_name}Bar${frzNo}`);
 	const styfrzBtm = $id(`${_name}Btm${frzNo}`);
+	const styfrzTopShadow = $id(`${_name}TopShadow${frzNo}`);
 	const styfrzBtmShadow = $id(`${_name}BtmShadow${frzNo}`);
 	const colorPos = g_keyObj[`color${g_keyObj.currentKey}_${g_keyObj.currentPtn}`][_j];
 
@@ -9834,9 +9835,12 @@ const changeHitFrz = (_j, _k, _name) => {
 	// 早押ししたboostCnt分のフリーズアロー終端位置の修正
 	const delFrzMotionLength = sumData(g_workObj.motionOnFrames.slice(0, currentFrz.boostCnt + 1));
 
+	// 判定位置調整分の補正
+	const judgPos = g_stateObj.judgAdj * g_workObj.scrollDir[_j];
+
 	currentFrz.frzBarLength -= (delFrzLength + delFrzMotionLength) * currentFrz.dir;
-	currentFrz.barY -= (delFrzLength + delFrzMotionLength) * currentFrz.dividePos + g_stateObj.judgAdj * g_workObj.scrollDir[_j];
-	currentFrz.btmY -= delFrzLength + delFrzMotionLength + g_stateObj.judgAdj * g_workObj.scrollDir[_j];
+	currentFrz.barY -= (delFrzLength + delFrzMotionLength) * currentFrz.dividePos + judgPos;
+	currentFrz.btmY -= delFrzLength + delFrzMotionLength + judgPos;
 	currentFrz.y += delFrzLength;
 	currentFrz.isMoving = false;
 
@@ -9845,6 +9849,7 @@ const changeHitFrz = (_j, _k, _name) => {
 	styfrzBar.background = g_workObj[`${_name}HitBarColors`][_j];
 	styfrzBtm.top = `${currentFrz.btmY}px`;
 	styfrzBtm.background = g_workObj[`${_name}HitColors`][_j];
+	styfrzTopShadow.opacity = 0;
 	styfrzBtmShadow.top = styfrzBtm.top;
 	if (_name === `frz`) {
 		if (g_headerObj.frzShadowColor[colorPos][1] !== ``) {
@@ -9869,9 +9874,15 @@ const changeFailedFrz = (_j, _k) => {
 	$id(`frzHit${_j}`).opacity = 0;
 	$id(`frzTop${frzNo}`).display = C_DIS_INHERIT;
 	$id(`frzTop${frzNo}`).background = `#cccccc`;
+	$id(`frzTopShadow${frzNo}`).opacity = 1;
 	$id(`frzBar${frzNo}`).background = `#999999`;
 	$id(`frzBar${frzNo}`).opacity = 1;
 	$id(`frzBtm${frzNo}`).background = `#cccccc`;
+
+	// 判定位置調整分の補正
+	const judgPos = g_stateObj.judgAdj * g_workObj.scrollDir[_j];
+	$id(`frzTop${frzNo}`).top = `${- judgPos}px`;
+	$id(`frzTopShadow${frzNo}`).top = `${- judgPos}px`;
 
 	const colorPos = g_keyObj[`color${g_keyObj.currentKey}_${g_keyObj.currentPtn}`][_j];
 	if (g_headerObj.frzShadowColor[colorPos][0] !== ``) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8265,6 +8265,7 @@ const getArrowSettings = _ => {
 		g_keyObj[`scrollDir${keyCtrlPtn}`][g_stateObj.scroll] : [...Array(keyNum)].fill(1));
 
 	g_stateObj.autoAll = (g_stateObj.autoPlay === C_FLG_ALL ? C_FLG_ON : C_FLG_OFF);
+	g_workObj.judgAdj = (g_stateObj.autoAll ? 0 : g_stateObj.judgAdj);
 	changeSetColor();
 
 	for (let j = 0; j < keyNum; j++) {
@@ -8534,8 +8535,8 @@ const mainInit = _ => {
 
 	// 矢印・フリーズアロー描画スプライト（ステップゾーンの上に配置）
 	const arrowSprite = [
-		createEmptySprite(mainSprite, `arrowSprite0`, { y: g_stateObj.judgAdj, w: g_headerObj.playingWidth, h: g_posObj.arrowHeight }),
-		createEmptySprite(mainSprite, `arrowSprite1`, { y: -g_stateObj.judgAdj, w: g_headerObj.playingWidth, h: g_posObj.arrowHeight }),
+		createEmptySprite(mainSprite, `arrowSprite0`, { y: g_workObj.judgAdj, w: g_headerObj.playingWidth, h: g_posObj.arrowHeight }),
+		createEmptySprite(mainSprite, `arrowSprite1`, { y: -g_workObj.judgAdj, w: g_headerObj.playingWidth, h: g_posObj.arrowHeight }),
 	];
 
 	// Appearanceのオプション適用時は一部描画を隠す
@@ -9839,7 +9840,7 @@ const changeHitFrz = (_j, _k, _name) => {
 	const delFrzMotionLength = sumData(g_workObj.motionOnFrames.slice(0, currentFrz.boostCnt + 1));
 
 	// 判定位置調整分の補正
-	const judgPos = g_stateObj.judgAdj * g_workObj.scrollDir[_j];
+	const judgPos = g_workObj.judgAdj * g_workObj.scrollDir[_j];
 
 	currentFrz.frzBarLength -= (delFrzLength + delFrzMotionLength) * currentFrz.dir;
 	currentFrz.barY -= (delFrzLength + delFrzMotionLength) * currentFrz.dividePos + judgPos;
@@ -9883,7 +9884,7 @@ const changeFailedFrz = (_j, _k) => {
 	$id(`frzBtm${frzNo}`).background = `#cccccc`;
 
 	// 判定位置調整分の補正
-	const judgPos = g_stateObj.judgAdj * g_workObj.scrollDir[_j];
+	const judgPos = g_workObj.judgAdj * g_workObj.scrollDir[_j];
 	$id(`frzTop${frzNo}`).top = `${- judgPos}px`;
 	$id(`frzTopShadow${frzNo}`).top = `${- judgPos}px`;
 
@@ -9924,7 +9925,7 @@ const judgeArrow = _j => {
 			displayDiff(_difFrame);
 
 			const stepDivHit = document.querySelector(`#stepHit${_j}`);
-			stepDivHit.style.top = `${currentArrow.prevY - parseFloat($id(`stepRoot${_j}`).top) - 15 + g_stateObj.judgAdj * g_workObj.scrollDir[_j]}px`;
+			stepDivHit.style.top = `${currentArrow.prevY - parseFloat($id(`stepRoot${_j}`).top) - 15 + g_workObj.judgAdj * g_workObj.scrollDir[_j]}px`;
 			stepDivHit.style.opacity = 0.75;
 			stepDivHit.classList.value = ``;
 			stepDivHit.classList.add(g_cssObj[`main_step${resultJdg}`]);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9835,8 +9835,8 @@ const changeHitFrz = (_j, _k, _name) => {
 	const delFrzMotionLength = sumData(g_workObj.motionOnFrames.slice(0, currentFrz.boostCnt + 1));
 
 	currentFrz.frzBarLength -= (delFrzLength + delFrzMotionLength) * currentFrz.dir;
-	currentFrz.barY -= (delFrzLength + delFrzMotionLength) * currentFrz.dividePos;
-	currentFrz.btmY -= delFrzLength + delFrzMotionLength;
+	currentFrz.barY -= (delFrzLength + delFrzMotionLength) * currentFrz.dividePos + g_stateObj.judgAdj * g_workObj.scrollDir[_j];
+	currentFrz.btmY -= delFrzLength + delFrzMotionLength + g_stateObj.judgAdj * g_workObj.scrollDir[_j];
 	currentFrz.y += delFrzLength;
 	currentFrz.isMoving = false;
 
@@ -9910,7 +9910,7 @@ const judgeArrow = _j => {
 			displayDiff(_difFrame);
 
 			const stepDivHit = document.querySelector(`#stepHit${_j}`);
-			stepDivHit.style.top = `${currentArrow.prevY - parseFloat($id(`stepRoot${_j}`).top) - 15}px`;
+			stepDivHit.style.top = `${currentArrow.prevY - parseFloat($id(`stepRoot${_j}`).top) - 15 + g_stateObj.judgAdj * g_workObj.scrollDir[_j]}px`;
 			stepDivHit.style.opacity = 0.75;
 			stepDivHit.classList.value = ``;
 			stepDivHit.classList.add(g_cssObj[`main_step${resultJdg}`]);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5261,7 +5261,7 @@ const createOptionWindow = _sprite => {
  */
 const createGeneralSetting = (_obj, _settingName, { unitName = ``,
 	skipTerms = [...Array(3)].fill(1), hiddenBtn = false, addRFunc = _ => { }, addLFunc = _ => { },
-	settingLabel = _settingName, displayName = `option`, scLabel = ``, roundNum = 0, adjY = 0 } = {}) => {
+	settingLabel = _settingName, displayName = g_currentPage, scLabel = ``, roundNum = 0, adjY = 0 } = {}) => {
 
 	const settingUpper = toCapitalize(_settingName);
 	const linkId = `lnk${settingUpper}`;
@@ -5647,7 +5647,6 @@ const createSettingsDisplayWindow = _sprite => {
 	// 矢印の見え方 (Appearance)
 	// 縦位置: 7.4
 	createGeneralSetting(spriteList.appearance, `appearance`, {
-		displayName: g_currentPage,
 		addRFunc: _ => dispAppearanceSlider(),
 		addLFunc: _ => dispAppearanceSlider(),
 	});
@@ -5691,7 +5690,7 @@ const createSettingsDisplayWindow = _sprite => {
 		opacityUse ||= g_headerObj[`${display}Use`] || g_headerObj[`${display}Set`] === C_FLG_ON);
 
 	if (opacityUse) {
-		createGeneralSetting(spriteList.opacity, `opacity`, { unitName: g_lblNameObj.percent, displayName: g_currentPage });
+		createGeneralSetting(spriteList.opacity, `opacity`, { unitName: g_lblNameObj.percent });
 	}
 
 	// ---------------------------------------------------

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2018,8 +2018,8 @@ const loadLocalStorage = _ => {
 		g_localStorage = JSON.parse(checkStorage);
 
 		// Adjustment(Music, Judgment), Volume, Appearance, Opacity初期値設定
-		checkLocalParam(`adjustment`, C_TYP_FLOAT, C_MAX_ADJUSTMENT);
-		checkLocalParam(`judgAdj`, C_TYP_FLOAT, C_MAX_ADJUSTMENT);
+		checkLocalParam(`adjustment`, C_TYP_FLOAT, g_limitObj.musicAdj);
+		checkLocalParam(`judgAdj`, C_TYP_FLOAT, g_limitObj.judgAdj);
 		checkLocalParam(`volume`, C_TYP_NUMBER, g_settings.volumes.length - 1);
 		checkLocalParam(`appearance`);
 		checkLocalParam(`opacity`, C_TYP_NUMBER, g_settings.opacitys.length - 1);
@@ -6793,8 +6793,8 @@ const loadingScoreInit = async () => {
 	// フレーム・曲開始位置調整
 	let preblankFrame = 0;
 	if (g_scoreObj.frameNum === 0) {
-		if (firstArrowFrame - C_MAX_ADJUSTMENT < arrivalFrame) {
-			preblankFrame = arrivalFrame - firstArrowFrame + C_MAX_ADJUSTMENT;
+		if (firstArrowFrame - g_limitObj.musicAdj < arrivalFrame) {
+			preblankFrame = arrivalFrame - firstArrowFrame + g_limitObj.musicAdj;
 
 			// 譜面データの再読み込み
 			const noteExistObj = {
@@ -7549,7 +7549,7 @@ const getFirstArrowFrame = (_dataObj, _keyCtrlPtn = `${g_keyObj.currentKey}_${g_
 
 		data.filter(data => hasVal(data)).forEach(_objData => {
 			if (_objData[0] !== ``) {
-				if (_objData[0] < tmpFirstNum && _objData[0] + C_MAX_ADJUSTMENT > 0) {
+				if (_objData[0] < tmpFirstNum && _objData[0] + g_limitObj.musicAdj > 0) {
 					tmpFirstNum = _objData[0];
 				}
 			}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2017,8 +2017,9 @@ const loadLocalStorage = _ => {
 	if (checkStorage) {
 		g_localStorage = JSON.parse(checkStorage);
 
-		// Adjustment, Volume, Appearance, Opacity初期値設定
+		// Adjustment(Music, Judgment), Volume, Appearance, Opacity初期値設定
 		checkLocalParam(`adjustment`, C_TYP_FLOAT, C_MAX_ADJUSTMENT);
+		checkLocalParam(`judgAdj`, C_TYP_FLOAT, C_MAX_ADJUSTMENT);
 		checkLocalParam(`volume`, C_TYP_NUMBER, g_settings.volumes.length - 1);
 		checkLocalParam(`appearance`);
 		checkLocalParam(`opacity`, C_TYP_NUMBER, g_settings.opacitys.length - 1);
@@ -2038,6 +2039,7 @@ const loadLocalStorage = _ => {
 	} else {
 		g_localStorage = {
 			adjustment: 0,
+			judgAdj: 0,
 			volume: 100,
 			highscores: {},
 		};
@@ -8309,6 +8311,7 @@ const getArrowSettings = _ => {
 
 		// ローカルストレージへAdjustment, Volume, Display関連設定を保存
 		g_localStorage.adjustment = g_stateObj.adjustment;
+		g_localStorage.judgAdj = g_stateObj.judgAdj;
 		g_localStorage.volume = g_stateObj.volume;
 		g_localStorage.colorType = g_colorType;
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -86,7 +86,7 @@ const g_windowObj = {
     difList: { x: 165, y: 65, w: 280, h: 255, overflow: `auto` },
     difCover: { x: 25, y: 65, w: 140, h: 255, overflow: `auto`, opacity: 0.95 },
 
-    scoreDetail: { x: 20, y: 90, w: 420, h: 230, visibility: `hidden` },
+    scoreDetail: { x: 20, y: 85, w: 420, h: 236, visibility: `hidden` },
     detailObj: { w: 420, h: 230, visibility: `hidden` },
 
     colorPickSprite: { x: 0, y: 90, w: 50, h: 280 },

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -781,7 +781,7 @@ const g_settings = {
 
     judgAdjs: [...Array(C_MAX_ADJUSTMENT * 20 + 1).keys()].map(i => (i - C_MAX_ADJUSTMENT * 10) / 10),
     judgAdjNum: C_MAX_ADJUSTMENT * 10,
-    judgAdjTerms: [10, 5],
+    judgAdjTerms: [50, 10],
 
     volumes: [0, 0.5, 1, 2, 5, 10, 25, 50, 75, 100],
 
@@ -1227,6 +1227,11 @@ const g_shortcutObj = {
         ShiftLeft_NumpadSubtract: { id: `lnkAdjustmentL` },
         AltLeft_NumpadSubtract: { id: `lnkAdjustmentLLL` },
         NumpadSubtract: { id: `lnkAdjustmentLL` },
+
+        ShiftLeft_KeyB: { id: `lnkJudgAdjR` },
+        KeyB: { id: `lnkJudgAdjRR` },
+        ShiftLeft_KeyT: { id: `lnkJudgAdjL` },
+        KeyT: { id: `lnkJudgAdjLL` },
 
         ShiftLeft_KeyV: { id: `lnkVolumeL` },
         KeyV: { id: `lnkVolumeR` },
@@ -2427,8 +2432,8 @@ const g_lblNameObj = {
     Shuffle: `Shuffle`,
     AutoPlay: `AutoPlay`,
     Gauge: `Gauge`,
-    Adjustment: `Adjustment<br><small>Music)</small>`,
-    JudgAdj: `<small>Judgment)</small>`,
+    Adjustment: `Adjustment<br><small>[ Music ]</small>`,
+    JudgAdj: `<small>[ Judgment ]</small>`,
     Fadein: `Fadein`,
     Volume: `Volume`,
 
@@ -2441,6 +2446,7 @@ const g_lblNameObj = {
     sc_speed: `←→`,
     sc_scroll: `R/<br>↑↓`,
     sc_adjustment: `- +`,
+    sc_judgAdj: `T B`,
     sc_keyConfigPlay: g_isMac ? `Del+Enter` : `BS+Enter`,
 
     g_start: `Start`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -782,9 +782,9 @@ const g_settings = {
     adjustmentNum: g_limitObj.musicAdj * 10,
     adjustmentTerms: [50, 10, 5],
 
-    judgAdjs: [...Array(g_limitObj.judgAdj * 4 + 1).keys()].map(i => (i - g_limitObj.judgAdj * 2) / 2),
-    judgAdjNum: g_limitObj.judgAdj * 2,
-    judgAdjTerms: [10, 2],
+    judgAdjs: [...Array(g_limitObj.judgAdj * 20 + 1).keys()].map(i => (i - g_limitObj.judgAdj * 10) / 10),
+    judgAdjNum: g_limitObj.judgAdj * 10,
+    judgAdjTerms: [50, 10],
 
     volumes: [0, 0.5, 1, 2, 5, 10, 25, 50, 75, 100],
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -32,7 +32,7 @@ const C_LEN_SETLBL_LEFT = 160;
 const C_LEN_SETLBL_WIDTH = 210;
 const C_LEN_DIFSELECTOR_WIDTH = 250;
 const C_LEN_DIFCOVER_WIDTH = 110;
-const C_LEN_SETLBL_HEIGHT = 23;
+const C_LEN_SETLBL_HEIGHT = 21.5;
 const C_SIZ_SETLBL = 17;
 const C_LEN_SETDIFLBL_HEIGHT = 25;
 const C_SIZ_SETDIFLBL = 17;
@@ -559,6 +559,7 @@ const g_settingBtnObj = {
 };
 
 const C_MAX_ADJUSTMENT = 30;
+const C_MAX_STEP_ADJUSTMENT = 30;
 const C_MAX_SPEED = 10;
 const C_MIN_SPEED = 1;
 
@@ -669,6 +670,7 @@ const g_stateObj = {
     autoAll: C_FLG_OFF,
     gauge: `Normal`,
     adjustment: 0,
+    judgAdj: 0,
     fadein: 0,
     volume: 100,
     lifeRcv: 2,
@@ -776,6 +778,10 @@ const g_settings = {
     adjustments: [...Array(C_MAX_ADJUSTMENT * 20 + 1).keys()].map(i => (i - C_MAX_ADJUSTMENT * 10) / 10),
     adjustmentNum: C_MAX_ADJUSTMENT * 10,
     adjustmentTerms: [50, 10, 5],
+
+    judgAdjs: [...Array(C_MAX_ADJUSTMENT * 20 + 1).keys()].map(i => (i - C_MAX_ADJUSTMENT * 10) / 10),
+    judgAdjNum: C_MAX_ADJUSTMENT * 10,
+    judgAdjTerms: [10, 5],
 
     volumes: [0, 0.5, 1, 2, 5, 10, 25, 50, 75, 100],
 
@@ -2421,13 +2427,15 @@ const g_lblNameObj = {
     Shuffle: `Shuffle`,
     AutoPlay: `AutoPlay`,
     Gauge: `Gauge`,
-    Adjustment: `Adjustment`,
+    Adjustment: `Adjustment<br><small>Music)</small>`,
+    JudgAdj: `<small>Judgment)</small>`,
     Fadein: `Fadein`,
     Volume: `Volume`,
 
     multi: `x`,
     frame: `f`,
     percent: `%`,
+    pixel: `px`,
     filterLock: `Lock`,
 
     sc_speed: `←→`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2478,7 +2478,7 @@ const g_lblNameObj = {
     d_Special: `Special`,
 
     Appearance: `Appearance`,
-    Opacity: `Judg. opacity`,
+    Opacity: `Opacity`,
     HitPosition: `Hit position`,
 
     'u_x': `x`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -32,7 +32,7 @@ const C_LEN_SETLBL_LEFT = 160;
 const C_LEN_SETLBL_WIDTH = 210;
 const C_LEN_DIFSELECTOR_WIDTH = 250;
 const C_LEN_DIFCOVER_WIDTH = 110;
-const C_LEN_SETLBL_HEIGHT = 21.5;
+const C_LEN_SETLBL_HEIGHT = 22;
 const C_SIZ_SETLBL = 17;
 const C_LEN_SETDIFLBL_HEIGHT = 25;
 const C_SIZ_SETDIFLBL = 17;
@@ -559,8 +559,8 @@ const g_settingBtnObj = {
 };
 
 const g_limitObj = {
-    musicAdj: 30,
-    judgAdj: 50,
+    adjustment: 30,
+    hitPosition: 50,
 };
 const C_MAX_ADJUSTMENT = 30;
 const C_MAX_SPEED = 10;
@@ -673,7 +673,7 @@ const g_stateObj = {
     autoAll: C_FLG_OFF,
     gauge: `Normal`,
     adjustment: 0,
-    judgAdj: 0,
+    hitPosition: 0,
     fadein: 0,
     volume: 100,
     lifeRcv: 2,
@@ -778,13 +778,13 @@ const g_settings = {
     autoPlays: [C_FLG_OFF, C_FLG_ALL],
     autoPlayNum: 0,
 
-    adjustments: [...Array(g_limitObj.musicAdj * 20 + 1).keys()].map(i => (i - g_limitObj.musicAdj * 10) / 10),
-    adjustmentNum: g_limitObj.musicAdj * 10,
+    adjustments: [...Array(g_limitObj.adjustment * 20 + 1).keys()].map(i => (i - g_limitObj.adjustment * 10) / 10),
+    adjustmentNum: g_limitObj.adjustment * 10,
     adjustmentTerms: [50, 10, 5],
 
-    judgAdjs: [...Array(g_limitObj.judgAdj * 20 + 1).keys()].map(i => (i - g_limitObj.judgAdj * 10) / 10),
-    judgAdjNum: g_limitObj.judgAdj * 10,
-    judgAdjTerms: [50, 10],
+    hitPositions: [...Array(g_limitObj.hitPosition * 20 + 1).keys()].map(i => (i - g_limitObj.hitPosition * 10) / 10),
+    hitPositionNum: g_limitObj.hitPosition * 10,
+    hitPositionTerms: [50, 10],
 
     volumes: [0, 0.5, 1, 2, 5, 10, 25, 50, 75, 100],
 
@@ -1231,11 +1231,6 @@ const g_shortcutObj = {
         AltLeft_NumpadSubtract: { id: `lnkAdjustmentLLL` },
         NumpadSubtract: { id: `lnkAdjustmentLL` },
 
-        ShiftLeft_KeyB: { id: `lnkJudgAdjR` },
-        KeyB: { id: `lnkJudgAdjRR` },
-        ShiftLeft_KeyT: { id: `lnkJudgAdjL` },
-        KeyT: { id: `lnkJudgAdjLL` },
-
         ShiftLeft_KeyV: { id: `lnkVolumeL` },
         KeyV: { id: `lnkVolumeR` },
 
@@ -1287,6 +1282,11 @@ const g_shortcutObj = {
         KeyA: { id: `lnkAppearanceR` },
         ShiftLeft_KeyO: { id: `lnkOpacityL` },
         KeyO: { id: `lnkOpacityR` },
+
+        ShiftLeft_KeyB: { id: `lnkHitPositionR` },
+        KeyB: { id: `lnkHitPositionRR` },
+        ShiftLeft_KeyT: { id: `lnkHitPositionL` },
+        KeyT: { id: `lnkHitPositionLL` },
 
         Digit1: { id: `lnkstepZone` },
         Digit2: { id: `lnkjudgment` },
@@ -2435,8 +2435,7 @@ const g_lblNameObj = {
     Shuffle: `Shuffle`,
     AutoPlay: `AutoPlay`,
     Gauge: `Gauge`,
-    Adjustment: `Adjustment<br><small>[ Music ]</small>`,
-    JudgAdj: `<small>[ Judgment ]</small>`,
+    Adjustment: `Adjustment`,
     Fadein: `Fadein`,
     Volume: `Volume`,
 
@@ -2449,7 +2448,7 @@ const g_lblNameObj = {
     sc_speed: `←→`,
     sc_scroll: `R/<br>↑↓`,
     sc_adjustment: `- +`,
-    sc_judgAdj: `T B`,
+    sc_hitPosition: `T B`,
     sc_keyConfigPlay: g_isMac ? `Del+Enter` : `BS+Enter`,
 
     g_start: `Start`,
@@ -2479,7 +2478,8 @@ const g_lblNameObj = {
     d_Special: `Special`,
 
     Appearance: `Appearance`,
-    Opacity: `Opacity`,
+    Opacity: `Judg. opacity`,
+    HitPosition: `Hit position`,
 
     'u_x': `x`,
     'u_%': `%`,
@@ -2687,7 +2687,7 @@ const g_lang_msgObj = {
         autoPlay: `オートプレイや一部キーを自動で打たせる設定を行います。\nオートプレイ時はハイスコアを保存しません。`,
         gauge: `クリア条件を設定します。\n[Start] ゲージ初期値, [Border] クリア条件(ハイフン時は0),\n[Recovery] 回復量, [Damage] ダメージ量`,
         adjustment: `曲とのタイミングにズレを感じる場合、\n数値を変えることでフレーム単位のズレを直すことができます。\n外側のボタンは5f刻み、真ん中は1f刻み、内側は0.5f刻みで調整できます。`,
-        judgAdj: `判定位置にズレを感じる場合、\n数値を変えることで判定の中央位置を1px単位で調整することができます。\n早押し・遅押し傾向にある場合に使用します。`,
+        hitPosition: `判定位置にズレを感じる場合、\n数値を変えることで判定の中央位置を1px単位で調整することができます。\n早押し・遅押し傾向にある場合に使用します。`,
         fadein: `譜面を途中から再生します。\n途中から開始した場合はハイスコアを保存しません。`,
         volume: `ゲーム内の音量を設定します。`,
 
@@ -2742,7 +2742,7 @@ const g_lang_msgObj = {
         autoPlay: `Set to auto play and to hit some keys automatically.\nHigh score is not saved during auto play.`,
         gauge: `Set the clear condition.\n[Start] initial value, [Border] borderline value (hyphen means zero),\n[Recovery] recovery amount, [Damage] damage amount`,
         adjustment: `If you feel that the timing is out of sync with the music, \nyou can correct the shift in frame units by changing the value.\nThe outer button can be adjusted in 5 frame increments, the middle in 1 frame increments, \nand the inner button in 0.5 frame increments.`,
-        judgAdj: `If you feel a discrepancy in the judgment position, \nyou can adjust the center position of the judgment in 1px increments \nby changing the numerical value. \nUse this function when there is a tendency to push too fast or too slow.`,
+        hitPosition: `If you feel a discrepancy in the judgment position, \nyou can adjust the center position of the judgment in 1px increments \nby changing the numerical value. \nUse this function when there is a tendency to push too fast or too slow.`,
         fadein: `Plays the chart from the middle.\nIf you start in the middle, the high score will not be saved.`,
         volume: `Set the in-game volume.`,
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -558,8 +558,11 @@ const g_settingBtnObj = {
     }
 };
 
+const g_limitObj = {
+    musicAdj: 30,
+    judgAdj: 50,
+};
 const C_MAX_ADJUSTMENT = 30;
-const C_MAX_STEP_ADJUSTMENT = 30;
 const C_MAX_SPEED = 10;
 const C_MIN_SPEED = 1;
 
@@ -775,13 +778,13 @@ const g_settings = {
     autoPlays: [C_FLG_OFF, C_FLG_ALL],
     autoPlayNum: 0,
 
-    adjustments: [...Array(C_MAX_ADJUSTMENT * 20 + 1).keys()].map(i => (i - C_MAX_ADJUSTMENT * 10) / 10),
-    adjustmentNum: C_MAX_ADJUSTMENT * 10,
+    adjustments: [...Array(g_limitObj.musicAdj * 20 + 1).keys()].map(i => (i - g_limitObj.musicAdj * 10) / 10),
+    adjustmentNum: g_limitObj.musicAdj * 10,
     adjustmentTerms: [50, 10, 5],
 
-    judgAdjs: [...Array(C_MAX_ADJUSTMENT * 20 + 1).keys()].map(i => (i - C_MAX_ADJUSTMENT * 10) / 10),
-    judgAdjNum: C_MAX_ADJUSTMENT * 10,
-    judgAdjTerms: [50, 10],
+    judgAdjs: [...Array(g_limitObj.judgAdj * 4 + 1).keys()].map(i => (i - g_limitObj.judgAdj * 2) / 2),
+    judgAdjNum: g_limitObj.judgAdj * 2,
+    judgAdjTerms: [10, 2],
 
     volumes: [0, 0.5, 1, 2, 5, 10, 25, 50, 75, 100],
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2683,7 +2683,8 @@ const g_lang_msgObj = {
         shuffle: `譜面を左右反転したり、ランダムにします。\nランダムにした場合は別譜面扱いとなり、ハイスコアは保存されません。`,
         autoPlay: `オートプレイや一部キーを自動で打たせる設定を行います。\nオートプレイ時はハイスコアを保存しません。`,
         gauge: `クリア条件を設定します。\n[Start] ゲージ初期値, [Border] クリア条件(ハイフン時は0),\n[Recovery] 回復量, [Damage] ダメージ量`,
-        adjustment: `タイミングにズレを感じる場合、\n数値を変えることでフレーム単位のズレを直すことができます。\n外側のボタンは5f刻み、真ん中は1f刻み、内側は0.5f刻みで調整できます。`,
+        adjustment: `曲とのタイミングにズレを感じる場合、\n数値を変えることでフレーム単位のズレを直すことができます。\n外側のボタンは5f刻み、真ん中は1f刻み、内側は0.5f刻みで調整できます。`,
+        judgAdj: `判定位置にズレを感じる場合、\n数値を変えることで判定の中央位置を1px単位で調整することができます。\n早押し・遅押し傾向にある場合に使用します。`,
         fadein: `譜面を途中から再生します。\n途中から開始した場合はハイスコアを保存しません。`,
         volume: `ゲーム内の音量を設定します。`,
 
@@ -2737,7 +2738,8 @@ const g_lang_msgObj = {
         shuffle: `Flip the chart left and right or make it random.\nIf you make it random, it will be treated as other charts and the high score will not be saved.`,
         autoPlay: `Set to auto play and to hit some keys automatically.\nHigh score is not saved during auto play.`,
         gauge: `Set the clear condition.\n[Start] initial value, [Border] borderline value (hyphen means zero),\n[Recovery] recovery amount, [Damage] damage amount`,
-        adjustment: `If you feel a shift in timing, \nyou can correct the shift in frame units by changing the value.\nThe outer button can be adjusted in 5 frame increments, the middle in 1 frame increments, \nand the inner button in 0.5 frame increments.`,
+        adjustment: `If you feel that the timing is out of sync with the music, \nyou can correct the shift in frame units by changing the value.\nThe outer button can be adjusted in 5 frame increments, the middle in 1 frame increments, \nand the inner button in 0.5 frame increments.`,
+        judgAdj: `If you feel a discrepancy in the judgment position, \nyou can adjust the center position of the judgment in 1px increments \nby changing the numerical value. \nUse this function when there is a tendency to push too fast or too slow.`,
         fadein: `Plays the chart from the middle.\nIf you start in the middle, the high score will not be saved.`,
         volume: `Set the in-game volume.`,
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2479,7 +2479,7 @@ const g_lblNameObj = {
 
     Appearance: `Appearance`,
     Opacity: `Opacity`,
-    HitPosition: `Hit position`,
+    HitPosition: `HitPosition`,
 
     'u_x': `x`,
     'u_%': `%`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2687,7 +2687,6 @@ const g_lang_msgObj = {
         autoPlay: `オートプレイや一部キーを自動で打たせる設定を行います。\nオートプレイ時はハイスコアを保存しません。`,
         gauge: `クリア条件を設定します。\n[Start] ゲージ初期値, [Border] クリア条件(ハイフン時は0),\n[Recovery] 回復量, [Damage] ダメージ量`,
         adjustment: `曲とのタイミングにズレを感じる場合、\n数値を変えることでフレーム単位のズレを直すことができます。\n外側のボタンは5f刻み、真ん中は1f刻み、内側は0.5f刻みで調整できます。`,
-        hitPosition: `判定位置にズレを感じる場合、\n数値を変えることで判定の中央位置を1px単位で調整することができます。\n早押し・遅押し傾向にある場合に使用します。`,
         fadein: `譜面を途中から再生します。\n途中から開始した場合はハイスコアを保存しません。`,
         volume: `ゲーム内の音量を設定します。`,
 
@@ -2712,6 +2711,7 @@ const g_lang_msgObj = {
 
         appearance: `流れる矢印の見え方を制御します。`,
         opacity: `判定キャラクタ、コンボ数、Fast/Slow、Hidden+/Sudden+の\n境界線表示の透明度を設定します。`,
+        hitPosition: `判定位置にズレを感じる場合、\n数値を変えることで判定の中央位置を1px単位(プラス:手前, マイナス:奥側)で調整することができます。\n早押し・遅押し傾向にある場合に使用します。`,
 
         configType: `キーコンフィグ対象を切り替えます。\n[Main] メインキーのみ, [Replaced] 代替キーのみ, [ALL] 全て`,
         colorType: `矢印色の配色パターンを変更します。\nType1～4選択時は色変化が自動でOFFになります。\n[Type0] グラデーション切替, [Type1～4] デフォルトパターン`,
@@ -2742,7 +2742,6 @@ const g_lang_msgObj = {
         autoPlay: `Set to auto play and to hit some keys automatically.\nHigh score is not saved during auto play.`,
         gauge: `Set the clear condition.\n[Start] initial value, [Border] borderline value (hyphen means zero),\n[Recovery] recovery amount, [Damage] damage amount`,
         adjustment: `If you feel that the timing is out of sync with the music, \nyou can correct the shift in frame units by changing the value.\nThe outer button can be adjusted in 5 frame increments, the middle in 1 frame increments, \nand the inner button in 0.5 frame increments.`,
-        hitPosition: `If you feel a discrepancy in the judgment position, \nyou can adjust the center position of the judgment in 1px increments \nby changing the numerical value. \nUse this function when there is a tendency to push too fast or too slow.`,
         fadein: `Plays the chart from the middle.\nIf you start in the middle, the high score will not be saved.`,
         volume: `Set the in-game volume.`,
 
@@ -2767,6 +2766,7 @@ const g_lang_msgObj = {
 
         appearance: `Controls how the flowing sequences look.`,
         opacity: `Set the transparency of some objects such as judgment, combo counts, fast and slow`,
+        hitPosition: `If you feel a discrepancy in the judgment position, \nyou can adjust the center position of the judgment in 1px increments \n (plus: in front, minus: at the back) by changing the numerical value. \nUse this function when there is a tendency to push too fast or too slow.`,
 
         configType: `Switch the key config target.\n[Main] main keys only, [Replaced] alternate keys only, [ALL] all keys`,
         colorType: `Change the color scheme of the sequences color.\nWhen Type 1 to 4 are selected, the color change is automatically turned off.\n[Type0] Switch the sequences color gradations, [Type1～4] default color scheme`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -83,8 +83,8 @@ const g_windowObj = {
     divRoot: { margin: `auto`, letterSpacing: `normal` },
     divBack: { background: `linear-gradient(#000000, #222222)` },
 
-    difList: { x: 165, y: 65, w: 280, h: 255, overflow: `auto` },
-    difCover: { x: 25, y: 65, w: 140, h: 255, overflow: `auto`, opacity: 0.95 },
+    difList: { x: 165, y: 60, w: 280, h: 261, overflow: `auto` },
+    difCover: { x: 25, y: 60, w: 140, h: 261, overflow: `auto`, opacity: 0.95 },
 
     scoreDetail: { x: 20, y: 85, w: 420, h: 236, visibility: `hidden` },
     detailObj: { w: 420, h: 230, visibility: `hidden` },

--- a/skin/danoni_skin_default.css
+++ b/skin/danoni_skin_default.css
@@ -1,4 +1,5 @@
 ﻿@charset "UTF-8";
+
 /* ----------------------------------------
   Dancing☆Onigiri (CW Edition)
   スキンcssファイル (default)
@@ -10,102 +11,129 @@
 ------------------------------------------ */
 /* 背景 */
 #divBack {
-    background: linear-gradient(#000000, #222222);
+	background: linear-gradient(#000000, #222222);
 }
 
 /* タイトル */
 .title_base {
-	color:#cccccc;
+	color: #cccccc;
 }
 
 /* 設定別カラー */
 .settings_Title::first-letter {
-	color:#6666ff;
-	font-size:40px;
+	color: #6666ff;
+	font-size: 40px;
 }
+
 .settings_Title2::first-letter {
-	color:#ff6666;
-	font-size:40px;
+	color: #ff6666;
+	font-size: 40px;
 }
+
 .settings_TitleStar::first-letter {
-	color:#ffff66;
-	font-size:40px;
+	color: #ffff66;
+	font-size: 40px;
 }
+
 .settings_Display::first-letter {
-	color:#ffff66;
-	font-size:40px;
+	color: #ffff66;
+	font-size: 40px;
 }
+
 .settings_Difficulty::first-letter {
-	color:#ff9999;
+	color: #ff9999;
 }
+
 .settings_Speed::first-letter {
-	color:#ffff99;
+	color: #ffff99;
 }
+
 .settings_Motion::first-letter {
-	color:#eeff99;
+	color: #eeff99;
 }
+
 .settings_Reverse::first-letter {
-	color:#ddff99;
+	color: #ddff99;
 }
+
 .settings_Scroll::first-letter {
-	color:#ddff99;
+	color: #ddff99;
 }
+
 .settings_Shuffle::first-letter {
-	color:#99ff99;
+	color: #99ff99;
 }
+
 .settings_AutoPlay::first-letter {
-	color:#99ffbb;
+	color: #99ffbb;
 }
+
 .settings_Gauge::first-letter {
-	color:#99ffdd;
+	color: #99ffdd;
 }
+
 .settings_Adjustment::first-letter {
-	color:#99ffff;
+	color: #99ffff;
 }
+
 .settings_Fadein::first-letter {
-	color:#99eeff;
+	color: #99eeff;
 }
+
 .settings_Volume::first-letter {
-	color:#99ddff;
+	color: #99ddff;
 }
+
 .settings_Appearance::first-letter {
-	color:#cc99ff;
+	color: #cc99ff;
 }
+
 .settings_Opacity::first-letter {
-	color:#999999;
+	color: #ee99ff;
+}
+
+.settings_HitPosition::first-letter {
+	color: #ff99ff;
 }
 
 .settings_DifSelector {
 	background-color: #111111;
 }
+
 .settings_Disabled {
-	color:#666666;
+	color: #666666;
 }
+
 .settings_FadeinBar {
-	color:#ffffff;
+	color: #ffffff;
 }
 
 /* 設定画面：ゲージ設定詳細 */
 .settings_lifeVal {
 	color: #ff9966;
 }
+
 .settings_gaugeTableBorder {
-	border-color: #666666; 
+	border-color: #666666;
 }
 
 /* キーコンフィグ */
 .keyconfig_warning {
 	color: #ffff99;
 }
+
 .keyconfig_ConfigType::first-letter {
 	color: #99ddff;
 }
+
 .keyconfig_ColorType::first-letter {
 	color: #ffdd99;
 }
+
 .keyconfig_Changekey {
 	color: #ffff00;
 }
+
 .keyconfig_Defaultkey {
 	color: #99ccff;
 }
@@ -114,21 +142,27 @@
 .main_stepKeyDown {
 	background-color: #66ffff;
 }
+
 .main_stepDefault {
 	background-color: #999999;
 }
+
 .main_stepDummy {
 	background-color: #777777;
 }
+
 .main_stepIi {
 	background-color: #66ffff;
 }
+
 .main_stepShakin {
 	background-color: #99ff99;
 }
+
 .main_stepMatari {
 	background-color: #ff9966;
 }
+
 .main_stepShobon {
 	background-color: #ccccff;
 }
@@ -136,9 +170,11 @@
 .main_objStepShadow {
 	background-color: #000000;
 }
+
 .main_objShadow {
 	background-color: #000000;
 }
+
 .main_frzHitTop {
 	background-color: #ffffff;
 }
@@ -147,24 +183,29 @@
 .life_Max {
 	background-color: #444400;
 }
+
 .life_Cleared {
 	background-color: #004444;
 }
+
 .life_Failed {
 	background-color: #444444;
 }
+
 .life_Background {
 	background-color: #222222;
 }
+
 .life_BorderColor {
 	background-color: #555555;
-	color:#cccccc;
+	color: #cccccc;
 }
 
 /* 結果画面：項目、設定値 */
 .result_lbl {
 	color: #999999;
 }
+
 .result_style {
 	color: #cccccc;
 }
@@ -173,27 +214,35 @@
 .common_ii {
 	color: #66ffff;
 }
+
 .common_shakin {
 	color: #99ff99;
 }
+
 .common_matari {
 	color: #ff9966;
 }
+
 .common_shobon {
 	color: #ccccff;
 }
+
 .common_uwan {
 	color: #ff9999;
 }
+
 .common_kita {
 	color: #ffff99;
 }
+
 .common_iknai {
 	color: #99ff66;
 }
+
 .common_combo {
 	color: #ffffff;
 }
+
 .common_score {
 	color: #ffffff;
 }
@@ -202,42 +251,53 @@
 .result_PlayDataWindow {
 	border: solid 0.5px #666666;
 }
+
 /* 結果画面：スコア */
 .result_score {
 	color: #ffffff;
 }
+
 /* 結果画面：ハイスコア差分、ハイスコア時のカラー */
 .result_scoreHiBlanket {
 	color: #999999;
 }
+
 .result_scoreHi {
 	color: #cccccc;
 }
+
 .result_scoreHiPlus {
 	color: #ffff99;
 }
+
 /* 結果画面：ハイスコア更新外の表示色 */
 .result_noRecord {
 	color: #999999;
 }
+
 /* 結果画面：完全PF、PF、FC、Cleared、Failed */
 .result_AllPerfect {
-	color:#ffffff;
+	color: #ffffff;
 }
+
 .result_Perfect {
-	color:#ffffcc;
+	color: #ffffcc;
 }
+
 .result_FullCombo {
-	color:#66ffff;
+	color: #66ffff;
 }
+
 .result_Cleared {
-	color:#ffff66;
+	color: #ffff66;
 }
+
 .result_Failed {
-	color:#ff6666;
+	color: #ff6666;
 }
+
 .result_Window::first-letter {
-	font-size:80px;
+	font-size: 80px;
 }
 
 /* ボタン */
@@ -246,76 +306,93 @@
 	color: #ffffff;
 	background-color: #333333;
 }
+
 .button_Start:hover {
 	color: #ffffff;
 	background-color: #666666;
 }
+
 /* デフォルト */
 .button_Default {
 	color: #ffffff;
 	background-color: #111111;
 }
+
 .button_Default:hover {
 	color: #ffffff;
 	background-color: #666666;
 }
+
 /* デフォルト(色指定なし) */
 .button_Default_NoColor {
 	background-color: #00000000;
 }
+
 .button_Default_NoColor:hover {
 	background-color: #666666;
 }
+
 /* カーソル */
 .button_Mini {
 	color: #ffffff;
 	background-color: #333333;
 }
+
 .button_Mini:hover {
 	color: #ffffff;
 	background-color: #999900;
 }
+
 /* 戻る */
 .button_Back {
 	color: #cccccc;
 	background-color: #111133;
 }
+
 .button_Back:hover {
 	color: #cccccc;
 	background-color: #000099;
 }
+
 /* 設定 */
 .button_Setting {
 	color: #ffffff;
 	background-color: #333311;
 }
+
 .button_Setting:hover {
 	color: #ffffff;
 	background-color: #999900;
 }
+
 /* 進む */
 .button_Next {
 	color: #ffffff;
 	background-color: #331111;
 }
+
 .button_Next:hover {
 	color: #ffffff;
 	background-color: #990000;
 }
+
 /* リセット */
 .button_Reset {
 	color: #ffffff;
 	background-color: #113311;
 }
+
 .button_Reset:hover {
 	color: #ffffff;
 	background-color: #009900;
 }
+
 /* ツイート */
 .button_Tweet {
 	color: #ffffff;
 	background-color: #113333;
 }
+
 .button_Tweet:hover {
 	color: #ffffff;
 	background-color: #009999;
@@ -324,26 +401,31 @@
 /* ボタン：ON/OFF */
 .button_OFF {
 	color: #666666;
-	border-color: #000000 #333333; 
+	border-color: #000000 #333333;
 }
+
 .button_ON {
 	color: #ffffff;
-	border-color: #000000 #cccccc; 
+	border-color: #000000 #cccccc;
 }
+
 /* ボタン：ON/OFF リバース用 */
 .button_RevOFF {
 	color: #cccccc;
-	border-color: #000000 #999999; 
+	border-color: #000000 #999999;
 }
+
 .button_RevON {
 	color: #ffffff;
-	border-color: #000000 #ddff99; 
+	border-color: #000000 #ddff99;
 }
+
 /* ボタン：ON/OFF 無効化ボタン用 */
 .button_DisabledOFF {
 	color: #999999;
 	background-color: #333333;
 }
+
 .button_DisabledON {
 	color: #ffffff;
 	background-color: #009999;

--- a/skin/danoni_skin_light.css
+++ b/skin/danoni_skin_light.css
@@ -1,4 +1,5 @@
 ﻿@charset "UTF-8";
+
 /* ----------------------------------------
   Dancing☆Onigiri (CW Edition)
   スキンcssファイル (light)
@@ -10,102 +11,129 @@
 ------------------------------------------ */
 /* 背景 */
 #divBack {
-    background: linear-gradient(#dddddd, #ffffff);
+	background: linear-gradient(#dddddd, #ffffff);
 }
 
 /* タイトル */
 .title_base {
-	color:#222222;
+	color: #222222;
 }
 
 /* 設定別カラー */
 .settings_Title::first-letter {
-	color:#000099;
-	font-size:40px;
+	color: #000099;
+	font-size: 40px;
 }
+
 .settings_Title2::first-letter {
-	color:#990000;
-	font-size:40px;
+	color: #990000;
+	font-size: 40px;
 }
+
 .settings_TitleStar::first-letter {
-	color:#999900;
-	font-size:40px;
+	color: #999900;
+	font-size: 40px;
 }
+
 .settings_Display::first-letter {
-	color:#777700;
-	font-size:40px;
+	color: #777700;
+	font-size: 40px;
 }
+
 .settings_Difficulty::first-letter {
-	color:#990000;
+	color: #990000;
 }
+
 .settings_Speed::first-letter {
-	color:#777700;
+	color: #777700;
 }
+
 .settings_Motion::first-letter {
-	color:#667700;
+	color: #667700;
 }
+
 .settings_Reverse::first-letter {
-	color:#557733;
+	color: #557733;
 }
+
 .settings_Scroll::first-letter {
-	color:#557733;
+	color: #557733;
 }
+
 .settings_Shuffle::first-letter {
-	color:#337733;
+	color: #337733;
 }
+
 .settings_AutoPlay::first-letter {
-	color:#337744;
+	color: #337744;
 }
+
 .settings_Gauge::first-letter {
-	color:#227755;
+	color: #227755;
 }
+
 .settings_Adjustment::first-letter {
-	color:#007777;
+	color: #007777;
 }
+
 .settings_Fadein::first-letter {
-	color:#005577;
+	color: #005577;
 }
+
 .settings_Volume::first-letter {
-	color:#003377;
+	color: #003377;
 }
+
 .settings_Appearance::first-letter {
-	color:#9900ff;
+	color: #9900ff;
 }
+
 .settings_Opacity::first-letter {
-	color:#666666;
+	color: #cc00ff;
+}
+
+.settings_HitPosition::first-letter {
+	color: #ff00ff;
 }
 
 .settings_DifSelector {
-	background-color:#eeeeee;
+	background-color: #eeeeee;
 }
+
 .settings_Disabled {
-	color:#999999;
+	color: #999999;
 }
+
 .settings_FadeinBar {
-	color:#000000;
+	color: #000000;
 }
 
 /* 設定画面：ゲージ設定詳細 */
 .settings_lifeVal {
 	color: #996600;
 }
+
 .settings_gaugeTableBorder {
-	border-color: #222222; 
+	border-color: #222222;
 }
 
 /* キーコンフィグ */
 .keyconfig_warning {
 	color: #999900;
 }
+
 .keyconfig_ConfigType::first-letter {
 	color: #003377;
 }
+
 .keyconfig_ColorType::first-letter {
 	color: #773300;
 }
+
 .keyconfig_Changekey {
 	color: #999900;
 }
+
 .keyconfig_Defaultkey {
 	color: #000099;
 }
@@ -114,21 +142,27 @@
 .main_stepKeyDown {
 	background-color: #009999;
 }
+
 .main_stepDefault {
 	background-color: #666666;
 }
+
 .main_stepDummy {
 	background-color: #666666;
 }
+
 .main_stepIi {
 	background-color: #009999;
 }
+
 .main_stepShakin {
 	background-color: #009900;
 }
+
 .main_stepMatari {
 	background-color: #cc8800;
 }
+
 .main_stepShobon {
 	background-color: #0000cc;
 }
@@ -136,9 +170,11 @@
 .main_objStepShadow {
 	background-color: #eeeeee;
 }
+
 .main_objShadow {
 	background-color: #666666;
 }
+
 .main_frzHitTop {
 	background-color: #cccccc;
 }
@@ -147,24 +183,29 @@
 .life_Max {
 	background-color: #cccc66;
 }
+
 .life_Cleared {
 	background-color: #66cccc;
 }
+
 .life_Failed {
 	background-color: #999999;
 }
+
 .life_Background {
 	background-color: #cccccc;
 }
+
 .life_BorderColor {
 	background-color: #555555;
-	color:#cccccc;
+	color: #cccccc;
 }
 
 /* 結果画面：項目、設定値 */
 .result_lbl {
 	color: #333333;
 }
+
 .result_style {
 	color: #111111;
 }
@@ -173,27 +214,35 @@
 .common_ii {
 	color: #009999;
 }
+
 .common_shakin {
 	color: #009900;
 }
+
 .common_matari {
 	color: #cc8800;
 }
+
 .common_shobon {
 	color: #0000cc;
 }
+
 .common_uwan {
 	color: #cc0000;
 }
+
 .common_kita {
 	color: #999900;
 }
+
 .common_iknai {
 	color: #669900;
 }
+
 .common_combo {
 	color: #000000;
 }
+
 .common_score {
 	color: #000000;
 }
@@ -202,42 +251,53 @@
 .result_PlayDataWindow {
 	border: solid 0.5px #666666;
 }
+
 /* 結果画面：スコア */
 .result_score {
 	color: #000000;
 }
+
 /* 結果画面：ハイスコア差分、ハイスコア時のカラー */
 .result_scoreHiBlanket {
 	color: #222222;
 }
+
 .result_scoreHi {
 	color: #000000;
 }
+
 .result_scoreHiPlus {
 	color: #777700;
 }
+
 /* 結果画面：ハイスコア更新外の表示色 */
 .result_noRecord {
 	color: #222222;
 }
+
 /* 結果画面：完全PF、PF、FC、Cleared、Failed */
 .result_AllPerfect {
 	color: #999999;
 }
+
 .result_Perfect {
 	color: #999900;
 }
+
 .result_FullCombo {
 	color: #007777;
 }
+
 .result_Cleared {
 	color: #666600;
 }
+
 .result_Failed {
 	color: #990000;
 }
+
 .result_Window::first-letter {
-	font-size:80px;
+	font-size: 80px;
 }
 
 /* ボタン */
@@ -246,76 +306,93 @@
 	color: #000000;
 	background-color: #dddddd;
 }
+
 .button_Start:hover {
 	color: #000000;
 	background-color: #999999;
 }
+
 /* デフォルト */
 .button_Default {
 	color: #000000;
 	background-color: #eeeeee;
 }
+
 .button_Default:hover {
 	color: #000000;
 	background-color: #bbbbbb;
 }
+
 /* デフォルト(色指定なし) */
 .button_Default_NoColor {
 	background-color: #00000000;
 }
+
 .button_Default_NoColor:hover {
 	background-color: #bbbbbb;
 }
+
 /* カーソル */
 .button_Mini {
 	color: #000000;
 	background-color: #cccccc;
 }
+
 .button_Mini:hover {
 	color: #000000;
 	background-color: #999999;
 }
+
 /* 戻る */
 .button_Back {
-    color: #000000;
+	color: #000000;
 	background-color: #ccccff;
 }
+
 .button_Back:hover {
-    color: #000000;
+	color: #000000;
 	background-color: #9999ff;
 }
+
 /* 設定 */
 .button_Setting {
 	color: #000000;
 	background-color: #ffffcc;
 }
+
 .button_Setting:hover {
 	color: #000000;
 	background-color: #ffff66;
 }
+
 /* 進む */
 .button_Next {
 	color: #000000;
 	background-color: #ffcccc;
 }
+
 .button_Next:hover {
 	color: #000000;
 	background-color: #ff9999;
 }
+
 /* リセット */
 .button_Reset {
 	color: #000000;
 	background-color: #ccffcc;
 }
+
 .button_Reset:hover {
 	color: #000000;
 	background-color: #99ff99;
 }
+
 /* ツイート */
 .button_Tweet {
 	color: #000000;
 	background-color: #ccffff;
 }
+
 .button_Tweet:hover {
 	color: #000000;
 	background-color: #66ffff;
@@ -324,26 +401,31 @@
 /* ボタン：ON/OFF */
 .button_OFF {
 	color: #cccccc;
-	border-color: #00000000 #cccccc; 
+	border-color: #00000000 #cccccc;
 }
+
 .button_ON {
 	color: #000000;
-	border-color: #00000000 #333333; 
+	border-color: #00000000 #333333;
 }
+
 /* ボタン：ON/OFF リバース用 */
 .button_RevOFF {
 	color: #666666;
-	border-color: #00000000 #666666; 
+	border-color: #00000000 #666666;
 }
+
 .button_RevON {
 	color: #000000;
-	border-color: #00000000 #557733; 
+	border-color: #00000000 #557733;
 }
+
 /* ボタン：ON/OFF 無効化ボタン用 */
 .button_DisabledOFF {
 	color: #999999;
 	background-color: #333333;
 }
+
 .button_DisabledON {
 	color: #ffffff;
 	background-color: #009999;

--- a/skin/danoni_skin_skyblue.css
+++ b/skin/danoni_skin_skyblue.css
@@ -1,4 +1,5 @@
 ﻿@charset "UTF-8";
+
 /* ----------------------------------------
   Dancing☆Onigiri (CW Edition)
   スキンcssファイル (skyblue)
@@ -10,102 +11,129 @@
 ------------------------------------------ */
 /* 背景 */
 #divBack {
-    background: linear-gradient(#ccffff, #ccccff);
+	background: linear-gradient(#ccffff, #ccccff);
 }
 
 /* タイトル */
 .title_base {
-	color:#222222;
+	color: #222222;
 }
 
 /* 設定別カラー */
 .settings_Title::first-letter {
-	color:#000099;
-	font-size:40px;
+	color: #000099;
+	font-size: 40px;
 }
+
 .settings_Title2::first-letter {
-	color:#990000;
-	font-size:40px;
+	color: #990000;
+	font-size: 40px;
 }
+
 .settings_TitleStar::first-letter {
-	color:#999900;
-	font-size:40px;
+	color: #999900;
+	font-size: 40px;
 }
+
 .settings_Display::first-letter {
-	color:#777700;
-	font-size:40px;
+	color: #777700;
+	font-size: 40px;
 }
+
 .settings_Difficulty::first-letter {
-	color:#000099;
+	color: #000099;
 }
+
 .settings_Speed::first-letter {
-	color:#003399;
+	color: #003399;
 }
+
 .settings_Motion::first-letter {
-	color:#006699;
+	color: #006699;
 }
+
 .settings_Reverse::first-letter {
-	color:#009999;
+	color: #009999;
 }
+
 .settings_Scroll::first-letter {
-	color:#009999;
+	color: #009999;
 }
+
 .settings_Shuffle::first-letter {
-	color:#006699;
+	color: #006699;
 }
+
 .settings_AutoPlay::first-letter {
-	color:#003399;
+	color: #003399;
 }
+
 .settings_Gauge::first-letter {
-	color:#000099;
+	color: #000099;
 }
+
 .settings_Adjustment::first-letter {
-	color:#003399;
+	color: #003399;
 }
+
 .settings_Fadein::first-letter {
-	color:#006699;
+	color: #006699;
 }
+
 .settings_Volume::first-letter {
-	color:#009999;
+	color: #009999;
 }
+
 .settings_Appearance::first-letter {
-	color:#9900ff;
+	color: #9900ff;
 }
+
 .settings_Opacity::first-letter {
-	color:#666666;
+	color: #cc00ff;
+}
+
+.settings_HitPosition::first-letter {
+	color: #ff00ff;
 }
 
 .settings_DifSelector {
-	background-color:#ccddee;
+	background-color: #ccddee;
 }
+
 .settings_Disabled {
-	color:#999999;
+	color: #999999;
 }
+
 .settings_FadeinBar {
-	color:#000000;
+	color: #000000;
 }
 
 /* 設定画面：ゲージ設定詳細 */
 .settings_lifeVal {
 	color: #996600;
 }
+
 .settings_gaugeTableBorder {
-	border-color: #222222; 
+	border-color: #222222;
 }
 
 /* キーコンフィグ */
 .keyconfig_warning {
 	color: #999900;
 }
+
 .keyconfig_ConfigType::first-letter {
 	color: #003377;
 }
+
 .keyconfig_ColorType::first-letter {
 	color: #773300;
 }
+
 .keyconfig_Changekey {
 	color: #999900;
 }
+
 .keyconfig_Defaultkey {
 	color: #000099;
 }
@@ -114,21 +142,27 @@
 .main_stepKeyDown {
 	background-color: #009999;
 }
+
 .main_stepDefault {
 	background-color: #666666;
 }
+
 .main_stepDummy {
 	background-color: #666666;
 }
+
 .main_stepIi {
 	background-color: #009999;
 }
+
 .main_stepShakin {
 	background-color: #009900;
 }
+
 .main_stepMatari {
 	background-color: #cc8800;
 }
+
 .main_stepShobon {
 	background-color: #0000cc;
 }
@@ -136,9 +170,11 @@
 .main_objStepShadow {
 	background-color: #eeeeee;
 }
+
 .main_objShadow {
 	background-color: #666666;
 }
+
 .main_frzHitTop {
 	background-color: #cccccc;
 }
@@ -147,24 +183,29 @@
 .life_Max {
 	background-color: #cccc66;
 }
+
 .life_Cleared {
 	background-color: #66cccc;
 }
+
 .life_Failed {
 	background-color: #999999;
 }
+
 .life_Background {
 	background-color: #cccccc;
 }
+
 .life_BorderColor {
 	background-color: #555555;
-	color:#cccccc;
+	color: #cccccc;
 }
 
 /* 結果画面：項目、設定値 */
 .result_lbl {
 	color: #333333;
 }
+
 .result_style {
 	color: #111111;
 }
@@ -173,27 +214,35 @@
 .common_ii {
 	color: #009999;
 }
+
 .common_shakin {
 	color: #009900;
 }
+
 .common_matari {
 	color: #cc8800;
 }
+
 .common_shobon {
 	color: #0000cc;
 }
+
 .common_uwan {
 	color: #cc0000;
 }
+
 .common_kita {
 	color: #999900;
 }
+
 .common_iknai {
 	color: #669900;
 }
+
 .common_combo {
 	color: #000000;
 }
+
 .common_score {
 	color: #000000;
 }
@@ -202,42 +251,53 @@
 .result_PlayDataWindow {
 	border: solid 0.5px #666666;
 }
+
 /* 結果画面：スコア */
 .result_score {
 	color: #000000;
 }
+
 /* 結果画面：ハイスコア差分、ハイスコア時のカラー */
 .result_scoreHiBlanket {
 	color: #222222;
 }
+
 .result_scoreHi {
 	color: #000000;
 }
+
 .result_scoreHiPlus {
 	color: #777700;
 }
+
 /* 結果画面：ハイスコア更新外の表示色 */
 .result_noRecord {
 	color: #222222;
 }
+
 /* 結果画面：完全PF、PF、FC、Cleared、Failed */
 .result_AllPerfect {
 	color: #999999;
 }
+
 .result_Perfect {
 	color: #999900;
 }
+
 .result_FullCombo {
 	color: #007777;
 }
+
 .result_Cleared {
 	color: #666600;
 }
+
 .result_Failed {
 	color: #990000;
 }
+
 .result_Window::first-letter {
-	font-size:80px;
+	font-size: 80px;
 }
 
 /* ボタン */
@@ -246,76 +306,93 @@
 	color: #000000;
 	background-color: #ddffff;
 }
+
 .button_Start:hover {
 	color: #000000;
 	background-color: #66ccff;
 }
+
 /* デフォルト */
 .button_Default {
 	color: #000000;
 	background-color: #00000000;
 }
+
 .button_Default:hover {
 	color: #000000;
 	background-color: #99ccff;
 }
+
 /* デフォルト(色指定なし) */
 .button_Default_NoColor {
 	background-color: #00000000;
 }
+
 .button_Default_NoColor:hover {
 	background-color: #99ccff;
 }
+
 /* カーソル */
 .button_Mini {
 	color: #000000;
 	background-color: #bbccdd;
 }
+
 .button_Mini:hover {
 	color: #000000;
 	background-color: #99aabb;
 }
+
 /* 戻る */
 .button_Back {
-    color: #000000;
+	color: #000000;
 	background-color: #ccccff;
 }
+
 .button_Back:hover {
-    color: #000000;
+	color: #000000;
 	background-color: #9999ff;
 }
+
 /* 設定 */
 .button_Setting {
 	color: #000000;
 	background-color: #ffffcc;
 }
+
 .button_Setting:hover {
 	color: #000000;
 	background-color: #ffff66;
 }
+
 /* 進む */
 .button_Next {
 	color: #000000;
 	background-color: #ffcccc;
 }
+
 .button_Next:hover {
 	color: #000000;
 	background-color: #ff9999;
 }
+
 /* リセット */
 .button_Reset {
 	color: #000000;
 	background-color: #ccffcc;
 }
+
 .button_Reset:hover {
 	color: #000000;
 	background-color: #99ff99;
 }
+
 /* ツイート */
 .button_Tweet {
 	color: #000000;
 	background-color: #ccffff;
 }
+
 .button_Tweet:hover {
 	color: #000000;
 	background-color: #66ffff;
@@ -324,26 +401,31 @@
 /* ボタン：ON/OFF */
 .button_OFF {
 	color: #cccccc;
-	border-color: #00000000 #999999; 
+	border-color: #00000000 #999999;
 }
+
 .button_ON {
 	color: #000000;
-	border-color: #00000000 #333333; 
+	border-color: #00000000 #333333;
 }
+
 /* ボタン：ON/OFF リバース用 */
 .button_RevOFF {
 	color: #666666;
-	border-color: #00000000 #666666; 
+	border-color: #00000000 #666666;
 }
+
 .button_RevON {
 	color: #000000;
-	border-color: #00000000 #009999; 
+	border-color: #00000000 #009999;
 }
+
 /* ボタン：ON/OFF 無効化ボタン用 */
 .button_DisabledOFF {
 	color: #999999;
 	background-color: #333333;
 }
+
 .button_DisabledON {
 	color: #ffffff;
 	background-color: #009999;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 矢印・フリーズアローのヒット位置をステップゾーン位置からずらす機能を実装しました。
PR #1436 の設定をDisplay設定に移したバージョンです。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 目押しによる早押しに対応するため。
なお、この設定を変えてもステップゾーンの位置は変わりません。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/226147312-265819d7-3ac0-47e0-bcdd-00c8681d58a0.png" width="50%"><img src="https://user-images.githubusercontent.com/44026291/226147332-3409cdd6-fc81-46e1-a447-b148f189105b.png" width="50%">
<img src="https://user-images.githubusercontent.com/44026291/226108006-0fe47d5c-8d20-4394-b1f6-7e0801309a05.png" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 設定用ボタンの縦サイズを`23px`から`22px`に見直しています。
- 対応するショートカットキーがうまく表示されない問題があります。