### PR TITLE
feat: [0668] キャラクタの回転パターン実装、ConfigTypeの廃止

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2459,6 +2459,7 @@ const preheaderConvert = _dosObj => {
 	}
 
 	obj.jsData = [];
+	obj.stepRtnUse = true;
 
 	const setJsFiles = (_files, _defaultDir, _type = `custom`) => {
 		_files.forEach(file => {
@@ -3549,7 +3550,7 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 						}
 					} else {
 						// 通常の指定方法 (例: |shuffle8i=1,1,1,2,0,0,0,0/1,1,1,1,0,0,0,0| )の場合の取り込み
-						g_keyObj[`${keyheader}_${k + dfPtn}_${ptnCnt}`] = list.split(`,`).map(n => parseInt(n, 10));
+						g_keyObj[`${keyheader}_${k + dfPtn}_${ptnCnt}`] = list.split(`,`).map(n => isNaN(Number(n)) ? n : parseInt(n, 10));
 						ptnCnt++;
 					}
 				});
@@ -3653,7 +3654,7 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 		newKeyTripleParam(newKey, `color`);
 
 		// 矢印の回転量指定、キャラクタパターン (stepRtnX_Y)
-		newKeyMultiParam(newKey, `stepRtn`, toStringOrNumber, { errCd: `E_0103` });
+		newKeyTripleParam(newKey, `stepRtn`);
 
 		// キーコンフィグ (keyCtrlX_Y)
 		newKeyMultiParam(newKey, `keyCtrl`, toKeyCtrlArray, { errCd: `E_0104`, baseCopyFlg: true });
@@ -5885,11 +5886,11 @@ const keyConfigInit = (_kcType = g_kcType) => {
 			// 矢印の塗り部分
 			createColorObject2(`arrowShadow${j}`, {
 				x: keyconX, y: keyconY, background: hasVal(g_headerObj[`setShadowColor${g_colorType}`][colorPos]) ? getShadowColor(colorPos, arrowColor) : ``,
-				rotate: g_keyObj[`stepRtn${keyCtrlPtn}`][j], styleName: `Shadow`, pointerEvents: `none`,
+				rotate: g_keyObj[`stepRtn${keyCtrlPtn}_${g_keycons.stepRtnGroupNum}`][j], styleName: `Shadow`, pointerEvents: `none`,
 			}),
 			// 矢印本体
 			createColorObject2(`arrow${j}`, {
-				x: keyconX, y: keyconY, background: arrowColor, rotate: g_keyObj[`stepRtn${keyCtrlPtn}`][j], pointerEvents: `none`,
+				x: keyconX, y: keyconY, background: arrowColor, rotate: g_keyObj[`stepRtn${keyCtrlPtn}_${g_keycons.stepRtnGroupNum}`][j], pointerEvents: `none`,
 			}),
 		);
 		if (g_headerObj.shuffleUse && g_keyObj[`shuffle${keyCtrlPtn}`] !== undefined) {
@@ -5955,6 +5956,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 				}
 			}
 		},
+		stepRtn: (_type = ``) => { },
 	};
 
 	/**
@@ -5979,6 +5981,9 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		g_keycons[`${_type}GroupNum`] = g_keycons[`${_type}Groups`][getNextNum(_scrollNum, `${_type}Groups`, g_keycons[`${_type}GroupNum`])];
 		g_keyObj[`${_type}${keyCtrlPtn}`] = structuredClone(g_keyObj[`${_type}${keyCtrlPtn}_${g_keycons[`${_type}GroupNum`]}`]);
 		viewGroup(_type);
+		if (_type === `stepRtn`) {
+			keyConfigInit(g_kcType);
+		}
 	};
 
 	/**
@@ -6028,16 +6033,16 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	 * @param {string} _type 
 	 * @param {object} obj (baseX) 
 	 */
-	const makeGroupButton = (_type, { baseX = g_sWidth * 5 / 6 - 20, cssName } = {}) => {
+	const makeGroupButton = (_type, { baseX = g_sWidth * 5 / 6 - 20, baseY = 0, cssName } = {}) => {
 		if (g_headerObj[`${_type}Use`] && g_keycons[`${_type}Groups`].length > 1) {
 			const typeName = toCapitalize(_type);
 			multiAppend(divRoot,
-				makeKCButtonHeader(`lbl${_type}Group`, `${typeName}Group`, { x: baseX - 10, y: 37 }, cssName),
+				makeKCButtonHeader(`lbl${_type}Group`, `${typeName}Group`, { x: baseX - 10, y: baseY }, cssName),
 				makeKCButton(`lnk${typeName}Group`, ``, _ => setGroup(_type), {
-					x: baseX, y: 50, w: g_sWidth / 18, title: g_msgObj[`${_type}Group`], cxtFunc: _ => setGroup(_type, -1),
+					x: baseX, y: baseY + 13, w: g_sWidth / 18, title: g_msgObj[`${_type}Group`], cxtFunc: _ => setGroup(_type, -1),
 				}),
-				makeMiniKCButton(`lnk${typeName}Group`, `L`, _ => setGroup(_type, -1), { x: baseX - 10, y: 50 }),
-				makeMiniKCButton(`lnk${typeName}Group`, `R`, _ => setGroup(_type), { x: baseX + g_sWidth / 18, y: 50 }),
+				makeMiniKCButton(`lnk${typeName}Group`, `L`, _ => setGroup(_type, -1), { x: baseX - 10, y: baseY + 13 }),
+				makeMiniKCButton(`lnk${typeName}Group`, `R`, _ => setGroup(_type), { x: baseX + g_sWidth / 18, y: baseY + 13 }),
 			);
 		} else {
 			g_keycons[`${_type}GroupNum`] = 0;
@@ -6058,19 +6063,13 @@ const keyConfigInit = (_kcType = g_kcType) => {
 			g_lblPosObj.kcMsg, g_cssObj.keyconfig_warning
 		),
 
-		// キーコンフィグタイプ切替ボタン
-		makeKCButtonHeader(`lblKcType`, `ConfigType`, { x: 10 }, g_cssObj.keyconfig_ConfigType),
-		makeKCButton(`lnkKcType`, g_kcType, _ => setConfigType(), {
-			x: 20, title: g_msgObj.configType, cxtFunc: _ => setConfigType(-1),
-		}),
-
 		// キーカラータイプ切替ボタン
-		makeKCButtonHeader(`lblcolorType`, `ColorType`, {}, g_cssObj.keyconfig_ColorType),
+		makeKCButtonHeader(`lblcolorType`, `ColorType`, { x: 10 }, g_cssObj.keyconfig_ColorType),
 		makeKCButton(`lnkColorType`, g_colorType, _ => setColorType(), {
-			title: g_msgObj.colorType, cxtFunc: _ => setColorType(-1),
+			x: 20, title: g_msgObj.colorType, cxtFunc: _ => setColorType(-1),
 		}),
-		makeMiniKCButton(`lnkColorType`, `L`, _ => setColorType(-1)),
-		makeMiniKCButton(`lnkColorType`, `R`, _ => setColorType(), { x: g_sWidth - 20 }),
+		makeMiniKCButton(`lnkColorType`, `L`, _ => setColorType(-1), { x: 10 }),
+		makeMiniKCButton(`lnkColorType`, `R`, _ => setColorType(), { x: 20 + g_sWidth / 6 }),
 	);
 
 	if (g_headerObj.imgType.length > 1) {
@@ -6089,6 +6088,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	// カラー/シャッフルグループ切替ボタン（カラー/シャッフルパターンが複数ある場合のみ）
 	makeGroupButton(`color`, { cssName: g_cssObj.keyconfig_ColorType });
 	makeGroupButton(`shuffle`, { baseX: g_sWidth * 11 / 12 - 10, cssName: g_cssObj.settings_Shuffle });
+	makeGroupButton(`stepRtn`, { baseY: 37, cssName: g_cssObj.settings_Adjustment });
 
 	/**
 	 * カーソル位置の設定
@@ -6101,10 +6101,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		cursor.style.left = `${nextLeft}px`;
 		const baseY = C_KYC_HEIGHT * Number(posj > divideCnt) + 57;
 		cursor.style.top = `${baseY + C_KYC_REPHEIGHT * g_currentk}px`;
-		if (g_kcType !== C_FLG_ALL) {
-			g_kcType = (g_currentk === 0 ? `Main` : `Replaced`);
-			lnkKcType.textContent = getStgDetailName(g_kcType);
-		}
+		g_kcType = (g_currentk === 0 ? `Main` : `Replaced`);
 
 		// 次の位置が見えなくなったらkeyconSpriteの位置を調整する
 		adjustScrollPoint(nextLeft);
@@ -6152,7 +6149,6 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	const setConfigType = (_scrollNum = 1) => {
 		g_kcType = g_keycons.configTypes[getNextNum(_scrollNum, `configTypes`, g_kcType)];
 		changeConfigCursor(g_keycons.cursorNum);
-		lnkKcType.textContent = getStgDetailName(g_kcType);
 	};
 
 	/**

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -853,9 +853,13 @@ const g_keycons = {
 
     shuffleGroups: [0],
     shuffleGroupNum: 0,
+
+    stepRtnGroups: [0],
+    stepRtnGroupNum: 0,
+
     groupSelf: `S`,
 
-    groups: [`color`, `shuffle`],
+    groups: [`color`, `shuffle`, `stepRtn`],
 
     cursorNumList: [],
     cursorNum: 0,
@@ -1376,6 +1380,7 @@ const g_cssObj = {
     settings_Disabled: `settings_Disabled`,
     settings_FadeinBar: `settings_FadeinBar`,
     settings_Shuffle: `settings_Shuffle`,
+    settings_Adjustment: `settings_Adjustment`,
 
     keyconfig_warning: `keyconfig_warning`,
     keyconfig_ConfigType: `keyconfig_ConfigType`,
@@ -1596,39 +1601,40 @@ const g_keyObj = {
 
     // 基本パターン (矢印回転、AAキャラクタ)
     // - AAキャラクタの場合、キャラクタ名を指定
-    stepRtn5_0: [0, -90, 90, 180, `onigiri`],
-    stepRtn7_0: [0, -45, -90, `onigiri`, 90, 135, 180],
-    stepRtn7i_0: [`giko`, `onigiri`, `iyo`, 0, -90, 90, 180],
-    stepRtn8_0: [0, -45, -90, `onigiri`, 90, 135, 180, `onigiri`],
-    stepRtn9A_0: [0, -90, 90, 180, `onigiri`, 0, -90, 90, 180],
-    stepRtn9B_0: [45, 0, -45, -90, `onigiri`, 90, 135, 180, 225],
-    stepRtn9i_0: [0, -90, 90, 180, `monar`, `giko`, `c`, `morara`, `onigiri`],
-    stepRtn11_0: [0, -90, 90, 180, 0, -45, -90, `onigiri`, 90, 135, 180],
-    stepRtn11L_0: [0, -90, 90, 180, 0, -45, -90, `onigiri`, 90, 135, 180],
-    stepRtn11W_0: [`giko`, 135, 45, `iyo`, 0, -45, -90, `onigiri`, 90, 135, 180],
-    stepRtn11i_0: [0, -90, `giko`, 90, 180, `onigiri`, 0, -90, `iyo`, 90, 180],
-    stepRtn12_0: [0, -90, 90, 180, `onigiri`, 0, 30, 60, 90, 120, 150, 180],
-    stepRtn13_0: [0, -90, 90, 180, 0, -90, 90, 180, `onigiri`, 0, -90, 90, 180],
-    stepRtn14_0: [45, 0, -90, 90, 180, 135, `onigiri`, 0, 30, 60, 90, 120, 150, 180],
-    stepRtn14i_0: [`giko`, `onigiri`, `iyo`, 0, -90, 90, 180, 0, -45, -90, `onigiri`, 90, 135, 180],
-    stepRtn15A_0: [0, -90, 90, 180, 0, -90, 90, 180, 0, -45, -90, `onigiri`, 90, 135, 180],
-    stepRtn16i_0: [`giko`, `onigiri`, `iyo`, 0, -90, 90, 180, 45, 0, -45, -90, `onigiri`, 90, 135, 180, 225],
-    stepRtn17_0: [0, -22.5, -45, -67.5, -90, -112.5, -135, -157.5, `onigiri`,
+    stepRtn5_0_0: [0, -90, 90, 180, `onigiri`],
+    stepRtn7_0_0: [0, -45, -90, `onigiri`, 90, 135, 180],
+    stepRtn7i_0_0: [`giko`, `onigiri`, `iyo`, 0, -90, 90, 180],
+    stepRtn8_0_0: [0, -45, -90, `onigiri`, 90, 135, 180, `onigiri`],
+    stepRtn9A_0_0: [0, -90, 90, 180, `onigiri`, 0, -90, 90, 180],
+    stepRtn9B_0_0: [45, 0, -45, -90, `onigiri`, 90, 135, 180, 225],
+    stepRtn9i_0_0: [0, -90, 90, 180, `monar`, `giko`, `c`, `morara`, `onigiri`],
+    stepRtn11_0_0: [0, -90, 90, 180, 0, -45, -90, `onigiri`, 90, 135, 180],
+    stepRtn11L_0_0: [0, -90, 90, 180, 0, -45, -90, `onigiri`, 90, 135, 180],
+    stepRtn11W_0_0: [`giko`, 135, 45, `iyo`, 0, -45, -90, `onigiri`, 90, 135, 180],
+    stepRtn11i_0_0: [0, -90, `giko`, 90, 180, `onigiri`, 0, -90, `iyo`, 90, 180],
+    stepRtn12_0_0: [0, -90, 90, 180, `onigiri`, 0, 30, 60, 90, 120, 150, 180],
+    stepRtn13_0_0: [0, -90, 90, 180, 0, -90, 90, 180, `onigiri`, 0, -90, 90, 180],
+    stepRtn14_0_0: [45, 0, -90, 90, 180, 135, `onigiri`, 0, 30, 60, 90, 120, 150, 180],
+    stepRtn14i_0_0: [`giko`, `onigiri`, `iyo`, 0, -90, 90, 180, 0, -45, -90, `onigiri`, 90, 135, 180],
+    stepRtn15A_0_0: [0, -90, 90, 180, 0, -90, 90, 180, 0, -45, -90, `onigiri`, 90, 135, 180],
+    stepRtn16i_0_0: [`giko`, `onigiri`, `iyo`, 0, -90, 90, 180, 45, 0, -45, -90, `onigiri`, 90, 135, 180, 225],
+    stepRtn17_0_0: [0, -22.5, -45, -67.5, -90, -112.5, -135, -157.5, `onigiri`,
         22.5, 45, 67.5, 90, 112.5, 135, 157.5, 180],
-    stepRtn23_0: [0, -90, 90, 180, 0, -90, 90, 180, 0, 30, 60, 90, 120, 150, 180, `onigiri`, 0, 30, 60, 90, 120, 150, 180],
+    stepRtn23_0_0: [0, -90, 90, 180, 0, -90, 90, 180, 0, 30, 60, 90, 120, 150, 180, `onigiri`, 0, 30, 60, 90, 120, 150, 180],
 
     // 変則パターン (矢印回転、AAキャラクタ)
     // - 末尾の番号をカウントアップさせることで実現できる。keyCtrlと合わせること
     // - 配列の数は、通常パターンと同数で無くてはいけない（keyCtrlも同様）
-    stepRtn5_1: [`onigiri`, 0, -90, 90, 180],
-    stepRtn8_1: [`onigiri`, 0, -45, -90, `onigiri`, 90, 135, 180],
-    stepRtn9i_1: [`monar`, `giko`, `c`, `morara`, `onigiri`, 0, -90, 90, 180],
-    stepRtn11i_1: [0, -135, `giko`, 45, 180, `onigiri`, 0, -135, `iyo`, 45, 180],
-    stepRtn17_1: [0, -45, -90, -135, `onigiri`, 45, 90, 135, 180,
+    stepRtn11i_0_1: [0, -135, `giko`, 45, 180, `onigiri`, 0, -135, `iyo`, 45, 180],
+
+    stepRtn5_1_0: [`onigiri`, 0, -90, 90, 180],
+    stepRtn8_1_0: [`onigiri`, 0, -45, -90, `onigiri`, 90, 135, 180],
+    stepRtn9i_1_0: [`monar`, `giko`, `c`, `morara`, `onigiri`, 0, -90, 90, 180],
+    stepRtn17_1_0: [0, -45, -90, -135, `onigiri`, 45, 90, 135, 180,
         -22.5, -67.5, -112.5, -157.5, 22.5, 67.5, 112.5, 157.5],
 
-    stepRtn5_2: [0, -90, `onigiri`, 90, 180],
-    stepRtn8_2: [`onigiri`, 0, 30, 60, 90, 120, 150, 180],
+    stepRtn5_2_0: [0, -90, `onigiri`, 90, 180],
+    stepRtn8_2_0: [`onigiri`, 0, 30, 60, 90, 120, 150, 180],
 
     // 各キーの区切り位置
     div9i_0: 6,
@@ -1969,11 +1975,9 @@ const g_copyKeyPtn = {
     '7_5': `8_4`,
     '7_6': `8_5`,
 
-    '11i_1': `11i_0`,
     '9A_1': `9A_0`,
     '9A_2': `9B_0`,
     '9A_3': `11i_0`,
-    '9A_4': `11i_1`,
     '9B_1': `9A_0`,
     '9B_2': `9A_1`,
 
@@ -2007,7 +2011,7 @@ const g_copyKeyPtn = {
 // キーパターンのコピー処理
 // ただし、すでに定義済みの場合は定義済みのものを優先する
 Object.keys(g_copyKeyPtn).forEach(keyPtnTo => {
-    let colorGr = 0, shuffleGr = 0;
+    let colorGr = 0, shuffleGr = 0, stepRtnGr = 0;
     const keyPtnFrom = g_copyKeyPtn[keyPtnTo];
     const copyKeyPtn = (_name, _from = keyPtnFrom, _to = keyPtnTo) => {
         if (g_keyObj[`${_name}${_to}`] === undefined) {
@@ -2028,8 +2032,11 @@ Object.keys(g_copyKeyPtn).forEach(keyPtnTo => {
         copyKeyPtn(`shuffle`, `${keyPtnFrom}_${shuffleGr}`, `${keyPtnTo}_${shuffleGr}`);
         shuffleGr++;
     }
+    while (g_keyObj[`stepRtn${keyPtnFrom}_${stepRtnGr}`] !== undefined) {
+        copyKeyPtn(`stepRtn`, `${keyPtnFrom}_${stepRtnGr}`, `${keyPtnTo}_${stepRtnGr}`);
+        stepRtnGr++;
+    }
     copyKeyPtn(`chara`);
-    copyKeyPtn(`stepRtn`);
     copyKeyPtn(`pos`);
     copyKeyPtn(`keyCtrl`);
     copyKeyPtn(`scrollDir`);
@@ -2534,6 +2541,7 @@ const g_lblNameObj = {
     ImgType: `ImgType`,
     ColorGroup: `ColorGr.`,
     ShuffleGroup: `ShuffleGr.`,
+    StepRtnGroup: `ShapeGr.`,
     KeyPattern: `KeyPattern`,
 
     j_maxCombo: `MaxCombo`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. キャラクタの回転パターン（ShapeGr.）を実装しました。
カラー・シャッフルグループと同様に、**stepRtnX_Y**に対して複数パターンが定義できるようになります。
2. ConfigTypeを廃止しました。内部的に変数は残しています。
合わせてColorTypeを画面左側へ移動し、カラー・シャッフルグループを右上のスペースへ移動しました。
3. 11ikeyに対して、キャラクタの回転パターン追加に合わせキーパターンを見直しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 同じキーのキャラクタの変更や回転だけのためにキーパターンを追加するのは非効率のため。
Resolved #1430 
2. 1の追加に当たり、キーコンフィグ画面にスペースが無いため。
現在はキー割り当て部分のクリックで対象のキー割当ができるため、無くても影響はほぼ無いと考えています。
3. 1の追加で余計と思われるキーパターンをShapeGr.へ移動しました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/226166916-ff173fbc-b1a4-43ad-960a-b11d1fef179f.png" width="70%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 3の変更により、キーパターン番号が変更になるキーがあります。
対象は9Akey（の11ikeyコンバート）、11ikeyです。
特殊キーで該当のキーを使用している場合（略記を使用している場合）は変更が必要です。