### PR TITLE
refactor: [0672] copyArray2dを使わないコードに変更、コメント部分修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3505,9 +3505,9 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) }
 				}
 				const keyPtn = getKeyPtnName(tmpArray[k]);
 				g_keyObj[`${keyheader}_${k + dfPtn}`] = g_keyObj[`${_name}${keyPtn}`] !== undefined ?
-					copyArray2d(g_keyObj[`${_name}${keyPtn}`]) : tmpArray[k].split(`,`).map(n => _convFunc(n));
+					structuredClone(g_keyObj[`${_name}${keyPtn}`]) : tmpArray[k].split(`,`).map(n => _convFunc(n));
 				if (baseCopyFlg) {
-					g_keyObj[`${keyheader}_${k + dfPtn}d`] = copyArray2d(g_keyObj[`${keyheader}_${k + dfPtn}`]);
+					g_keyObj[`${keyheader}_${k + dfPtn}d`] = structuredClone(g_keyObj[`${keyheader}_${k + dfPtn}`]);
 				}
 				loopFunc(k, keyheader);
 			}
@@ -4921,7 +4921,7 @@ const createOptionWindow = _sprite => {
 				g_gaugeType = (g_gaugeOptionObj.custom.length > 0 ? C_LFE_CUSTOM : g_stateObj.lifeMode);
 
 				g_stateObj.lifeVariable = g_gaugeOptionObj[`var${g_gaugeType}`][_gaugeNum];
-				g_settings.gauges = copyArray2d(g_gaugeOptionObj[g_gaugeType.toLowerCase()]);
+				g_settings.gauges = structuredClone(g_gaugeOptionObj[g_gaugeType.toLowerCase()]);
 				g_stateObj.gauge = g_settings.gauges[g_settings.gaugeNum];
 			}
 			setLifeCategory(g_headerObj);
@@ -5172,7 +5172,7 @@ const createOptionWindow = _sprite => {
 		}
 
 		// スクロール設定用の配列を入れ替え
-		g_settings.scrolls = copyArray2d(
+		g_settings.scrolls = structuredClone(
 			typeof g_keyObj[`scrollDir${g_keyObj.currentKey}_${g_keyObj.currentPtn}`] === C_TYP_OBJECT ?
 				Object.keys(g_keyObj[`scrollDir${g_keyObj.currentKey}_${g_keyObj.currentPtn}`]) : g_keyObj.scrollName_def
 		);
@@ -5231,7 +5231,7 @@ const createOptionWindow = _sprite => {
 				setReverseView(document.querySelector(`#btnReverse`));
 			}
 		} else {
-			g_settings.scrolls = copyArray2d(g_keyObj.scrollName_def);
+			g_settings.scrolls = structuredClone(g_keyObj.scrollName_def);
 			setSetting(0, `reverse`);
 		}
 
@@ -5448,7 +5448,7 @@ const getKeyCtrl = (_localStorage, _extraKeyName = ``) => {
 		const isUpdate = prevPtn !== -1 && g_keyObj.prevKey !== g_keyObj.currentKey;
 		g_keyCopyLists.multiple.forEach(header => {
 			if (g_keyObj[`${header}${basePtn}`] !== undefined && isUpdate) {
-				g_keyObj[`${header}${copyPtn}`] = copyArray2d(g_keyObj[`${header}${basePtn}`]);
+				g_keyObj[`${header}${copyPtn}`] = structuredClone(g_keyObj[`${header}${basePtn}`]);
 			}
 		});
 		g_keyCopyLists.simple.forEach(header => {
@@ -5461,7 +5461,7 @@ const getKeyCtrl = (_localStorage, _extraKeyName = ``) => {
 				maxPtn++;
 			}
 			for (let j = 0; j < maxPtn; j++) {
-				g_keyObj[`${type}${copyPtn}_${j}`] = copyArray2d(g_keyObj[`${type}${basePtn}_${j}`]);
+				g_keyObj[`${type}${copyPtn}_${j}`] = structuredClone(g_keyObj[`${type}${basePtn}_${j}`]);
 			}
 			g_keyObj[`${type}${copyPtn}_0d`] = structuredClone(g_keyObj[`${type}${copyPtn}_0`]);
 		});
@@ -6545,12 +6545,12 @@ const changeSetColor = _ => {
 		'Shadow': (isDefault ? defaultType : `${scoreIdHeader}Default`),
 	};
 	Object.keys(currentTypes).forEach(pattern => {
-		g_headerObj[`set${pattern}Color`] = copyArray2d(g_headerObj[`set${pattern}Color${currentTypes[pattern]}`]);
+		g_headerObj[`set${pattern}Color`] = structuredClone(g_headerObj[`set${pattern}Color${currentTypes[pattern]}`]);
 		for (let j = 0; j < g_headerObj.setColorInit.length; j++) {
-			g_headerObj[`frz${pattern}Color`][j] = copyArray2d(g_headerObj[`frz${pattern}Color${currentTypes[pattern]}`][j]);
+			g_headerObj[`frz${pattern}Color`][j] = structuredClone(g_headerObj[`frz${pattern}Color${currentTypes[pattern]}`][j]);
 		}
 		if (!isDefault) {
-			g_headerObj[`set${pattern}Color`] = copyArray2d(g_headerObj[`set${pattern}Color${g_colorType}`]);
+			g_headerObj[`set${pattern}Color`] = structuredClone(g_headerObj[`set${pattern}Color${g_colorType}`]);
 		}
 	});
 
@@ -6793,7 +6793,7 @@ const loadingScoreInit = async () => {
 
 	// Motionオプション適用時の矢印別の速度を取得（配列形式）
 	const motionOnFrame = setMotionOnFrame();
-	g_workObj.motionOnFrames = copyArray2d(motionOnFrame);
+	g_workObj.motionOnFrames = structuredClone(motionOnFrame);
 
 	// 最初のフレームで出現する矢印が、ステップゾーンに到達するまでのフレーム数を取得
 	const firstFrame = (g_scoreObj.frameNum === 0 ? 0 : g_scoreObj.frameNum + g_headerObj.blankFrame);
@@ -6823,7 +6823,7 @@ const loadingScoreInit = async () => {
 			for (let j = 0; j < keyNum; j++) {
 				Object.keys(noteExistObj).forEach(name => {
 					if (tmpObj[`${name}Data`][j] !== undefined && noteExistObj[name]) {
-						g_scoreObj[`${name}Data`][j] = copyArray2d(tmpObj[`${name}Data`][j]);
+						g_scoreObj[`${name}Data`][j] = structuredClone(tmpObj[`${name}Data`][j]);
 					}
 				});
 			}
@@ -6942,7 +6942,7 @@ const applyShuffle = (_keyNum, _shuffleGroup, _style) => {
 
 	// indexに従って並べ替え
 	g_typeLists.arrow.forEach(type => {
-		const tmpData = copyArray2d(g_scoreObj[`${type}Data`]);
+		const tmpData = structuredClone(g_scoreObj[`${type}Data`]);
 		for (let i = 0; i < _keyNum; i++) {
 			g_scoreObj[`${type}Data`][i] = tmpData[index[i]] || [];
 		}
@@ -6956,7 +6956,7 @@ const applyShuffle = (_keyNum, _shuffleGroup, _style) => {
  */
 const applyMirror = (_keyNum, _shuffleGroup, _asymFlg = false) => {
 	// シャッフルグループごとにミラー
-	const style = copyArray2d(_shuffleGroup).map(_group => _group.reverse());
+	const style = structuredClone(_shuffleGroup).map(_group => _group.reverse());
 	if (_asymFlg) {
 		// グループが4の倍数のとき、4n+1, 4n+2のみ入れ替える
 		style.forEach((group, i) => {
@@ -6977,7 +6977,7 @@ const applyMirror = (_keyNum, _shuffleGroup, _asymFlg = false) => {
  */
 const applyRandom = (_keyNum, _shuffleGroup) => {
 	// シャッフルグループごとにシャッフル(Fisher-Yates)
-	const style = copyArray2d(_shuffleGroup).map(_group => {
+	const style = structuredClone(_shuffleGroup).map(_group => {
 		for (let i = _group.length - 1; i > 0; i--) {
 			const random = Math.floor(Math.random() * (i + 1));
 			const tmp = _group[i];
@@ -7712,7 +7712,7 @@ const pushArrows = (_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 				g_workObj[`mk${_header}Length`][_j][_k] = getFrzLength(_speedOnFrame, _data[_k], _data[_k + 1]);
 			}
 		} else if (_frzFlg && g_workObj[`mk${_header}Length`][_j] !== undefined) {
-			g_workObj[`mk${_header}Length`][_j] = copyArray2d(g_workObj[`mk${_header}Length`][_j].slice(_k + 2));
+			g_workObj[`mk${_header}Length`][_j] = structuredClone(g_workObj[`mk${_header}Length`][_j].slice(_k + 2));
 		}
 	};
 
@@ -7753,7 +7753,7 @@ const pushArrows = (_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 
 				// 出現位置が開始前の場合は除外
 				if (_frzFlg && g_workObj[`mk${camelHeader}Length`][_j] !== undefined) {
-					g_workObj[`mk${camelHeader}Length`][_j] = copyArray2d(g_workObj[`mk${camelHeader}Length`][_j].slice(k + 2));
+					g_workObj[`mk${camelHeader}Length`][_j] = structuredClone(g_workObj[`mk${camelHeader}Length`][_j].slice(k + 2));
 				}
 				break;
 
@@ -7819,7 +7819,7 @@ const pushArrows = (_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 			for (let k = 0; k < delIdx; k++) {
 				_data.shift();
 			}
-			return copyArray2d(_data);
+			return structuredClone(_data);
 		}
 		return [];
 	};
@@ -8235,10 +8235,10 @@ const getArrowSettings = _ => {
 	g_workObj.scrollDir = [];
 	g_workObj.scrollDirDefault = [];
 	g_workObj.dividePos = [];
-	g_workObj.stepRtn = copyArray2d(g_keyObj[`stepRtn${keyCtrlPtn}`]);
-	g_workObj.stepHitRtn = copyArray2d(g_keyObj[`stepRtn${keyCtrlPtn}`]);
-	g_workObj.arrowRtn = copyArray2d(g_keyObj[`stepRtn${keyCtrlPtn}`]);
-	g_workObj.keyCtrl = copyArray2d(g_keyObj[`keyCtrl${keyCtrlPtn}`]);
+	g_workObj.stepRtn = structuredClone(g_keyObj[`stepRtn${keyCtrlPtn}`]);
+	g_workObj.stepHitRtn = structuredClone(g_keyObj[`stepRtn${keyCtrlPtn}`]);
+	g_workObj.arrowRtn = structuredClone(g_keyObj[`stepRtn${keyCtrlPtn}`]);
+	g_workObj.keyCtrl = structuredClone(g_keyObj[`keyCtrl${keyCtrlPtn}`]);
 	g_workObj.diffList = [];
 	g_workObj.mainEndTime = 0;
 
@@ -8346,7 +8346,7 @@ const getArrowSettings = _ => {
 		storageObj[`keyCtrl${addKey}`] = setKeyCtrl(g_localKeyStorage, keyNum, keyCtrlPtn);
 		if (g_keyObj.currentPtn !== -1) {
 			storageObj[`keyCtrlPtn${addKey}`] = g_keyObj.currentPtn;
-			g_keyObj[`keyCtrl${keyCtrlPtn}`] = copyArray2d(g_keyObj[`keyCtrl${keyCtrlPtn}d`]);
+			g_keyObj[`keyCtrl${keyCtrlPtn}`] = structuredClone(g_keyObj[`keyCtrl${keyCtrlPtn}d`]);
 		}
 
 		// カラーセットの保存（キー別）

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1529,7 +1529,8 @@ const g_keyObj = {
     chara5_2: [`left`, `down`, `space`, `up`, `right`],
     chara8_2: [`sleft`, `left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
 
-    // カラーパターン(パターン1)
+    // ColorGroup - 1
+    //  - 同じ数字が同じグループになります
     color5_0_0: [0, 0, 0, 0, 2],
     color7_0_0: [0, 1, 0, 2, 0, 1, 0],
     color7i_0_0: [2, 2, 2, 0, 0, 0, 0],
@@ -1562,22 +1563,23 @@ const g_keyObj = {
     color9A_2_0: [3, 0, 3, 0, 2, 0, 3, 0, 3],
     color9B_2_0: [0, 0, 0, 0, 2, 1, 1, 1, 1],
 
-    // カラーパターン(パターン2)
+    // ColorGroup - 2
     color9B_0_1: [4, 3, 1, 0, 2, 0, 1, 3, 4],
-    color9A_2_1: [4, 1, 3, 0, 2, 0, 3, 1, 4],
     color17_0_1: [1, 0, 1, 0, 1, 0, 1, 0, 2, 0, 1, 0, 1, 0, 1, 0, 1],
 
     color17_1_1: [1, 1, 1, 1, 2, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
 
-    // カラーパターン(パターン3)
+    color9A_2_1: [4, 1, 3, 0, 2, 0, 3, 1, 4],
+
+    // ColorGroup - 3
     color17_0_2: [1, 4, 0, 3, 1, 4, 0, 3, 2, 3, 0, 4, 1, 3, 0, 4, 1],
     color17_1_2: [1, 0, 1, 0, 2, 0, 1, 0, 1, 3, 4, 3, 4, 4, 3, 4, 3],
 
-    // カラーパターン(パターン4)
+    // ColorGroup - 4
     color17_0_3: [1, 1, 0, 0, 1, 1, 0, 0, 2, 0, 0, 1, 1, 0, 0, 1, 1],
     color17_1_3: [1, 0, 1, 0, 2, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1],
 
-    // シャッフルグループ(パターン1)
+    // ShuffleGroup - 1
     //  - Mirror, Random, S-Random使用時、同じグループ同士で入れ替えます
     //  - 同じ数字が同じグループになります
     shuffle5_0_0: [0, 0, 0, 0, 1],
@@ -1608,7 +1610,7 @@ const g_keyObj = {
     shuffle5_2_0: [0, 0, 1, 0, 0],
     shuffle8_2_0: [1, 0, 0, 0, 0, 0, 0, 0],
 
-    // シャッフルグループ(パターン2)
+    // ShuffleGroup - 2
     shuffle9A_0_1: [0, 0, 0, 0, 1, 0, 0, 0, 0],
     shuffle11_0_1: [0, 0, 0, 0, 1, 1, 1, 2, 3, 3, 3],
     shuffle11L_0_1: [0, 0, 0, 0, 1, 1, 1, 2, 3, 3, 3],
@@ -1618,12 +1620,12 @@ const g_keyObj = {
 
     shuffle17_1_1: [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
 
-    // シャッフルグループ(パターン3)
+    // ShuffleGroup - 3
     shuffle15A_0_2: [0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 3, 2, 2, 2],
     shuffle17_0_2: [0, 2, 0, 2, 0, 2, 0, 2, 1, 2, 0, 2, 0, 2, 0, 2, 0],
     shuffle17_1_2: [0, 0, 0, 0, 1, 0, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2],
 
-    // 基本パターン (矢印回転、AAキャラクタ)
+    // ShapeGroup - 1 (矢印回転、AAキャラクタ)
     // - AAキャラクタの場合、キャラクタ名を指定
     stepRtn5_0_0: [0, -90, 90, 180, `onigiri`],
     stepRtn7_0_0: [0, -45, -90, `onigiri`, 90, 135, 180],
@@ -1642,18 +1644,8 @@ const g_keyObj = {
     stepRtn14i_0_0: [`giko`, `onigiri`, `iyo`, 0, -90, 90, 180, 0, -45, -90, `onigiri`, 90, 135, 180],
     stepRtn15A_0_0: [0, -90, 90, 180, 0, -90, 90, 180, 0, -45, -90, `onigiri`, 90, 135, 180],
     stepRtn16i_0_0: [`giko`, `onigiri`, `iyo`, 0, -90, 90, 180, 45, 0, -45, -90, `onigiri`, 90, 135, 180, 225],
-    stepRtn17_0_0: [0, -22.5, -45, -67.5, -90, -112.5, -135, -157.5, `onigiri`,
-        22.5, 45, 67.5, 90, 112.5, 135, 157.5, 180],
+    stepRtn17_0_0: [0, -22.5, -45, -67.5, -90, -112.5, -135, -157.5, `onigiri`, 22.5, 45, 67.5, 90, 112.5, 135, 157.5, 180],
     stepRtn23_0_0: [0, -90, 90, 180, 0, -90, 90, 180, 0, 30, 60, 90, 120, 150, 180, `onigiri`, 0, 30, 60, 90, 120, 150, 180],
-
-    // 変則パターン (矢印回転、AAキャラクタ)
-    // - 末尾の番号をカウントアップさせることで実現できる。keyCtrlと合わせること
-    // - 配列の数は、通常パターンと同数で無くてはいけない（keyCtrlも同様）
-    stepRtn11i_0_1: [0, -135, `giko`, 45, 180, `onigiri`, 0, -135, `iyo`, 45, 180],
-    stepRtn17_0_1: [-30, 0, 30, 60, 90, 120, 150, 180, `onigiri`,
-        0, 30, 60, 90, 120, 150, 180, 210],
-    stepRtn17_0_2: [45, 45, 0, 0, -45, -45, -90, -90, `onigiri`,
-        90, 90, 135, 135, 180, 180, 225, 225],
 
     stepRtn5_1_0: [`onigiri`, 0, -90, 90, 180],
     stepRtn8_1_0: [`onigiri`, 0, -45, -90, `onigiri`, 90, 135, 180],
@@ -1665,6 +1657,13 @@ const g_keyObj = {
 
     stepRtn5_2_0: [0, -90, `onigiri`, 90, 180],
     stepRtn8_2_0: [`onigiri`, 0, 30, 60, 90, 120, 150, 180],
+
+    // ShapeGroup - 2 (矢印回転、AAキャラクタ)
+    stepRtn11i_0_1: [0, -135, `giko`, 45, 180, `onigiri`, 0, -135, `iyo`, 45, 180],
+    stepRtn17_0_1: [-30, 0, 30, 60, 90, 120, 150, 180, `onigiri`, 0, 30, 60, 90, 120, 150, 180, 210],
+
+    // ShapeGroup - 3 (矢印回転、AAキャラクタ)
+    stepRtn17_0_2: [45, 45, 0, 0, -45, -45, -90, -90, `onigiri`, 90, 90, 135, 135, 180, 180, 225, 225],
 
     // 各キーの区切り位置
     div9i_0: 6,
@@ -2091,10 +2090,10 @@ Object.keys(g_copyKeyPtn).forEach(keyPtnTo => {
 const keyCtrlName = Object.keys(g_keyObj).filter(val => val.startsWith(`keyCtrl`));
 keyCtrlName.forEach(property => {
     g_keyObj[property].forEach((list, j) => g_keyObj[property][j] = makeBaseArray(g_keyObj[property][j], g_keyObj.minKeyCtrlNum, 0));
-    g_keyObj[`${property}d`] = copyArray2d(g_keyObj[property]);
+    g_keyObj[`${property}d`] = structuredClone(g_keyObj[property]);
 });
 
-// shuffleX_Y, colorX_Yについてデフォルト配列を作成
+// shuffleX_Y, colorX_Y, stepRtnX_Yについてデフォルト配列を作成
 g_keycons.groups.forEach(type => {
     const tmpName = Object.keys(g_keyObj).filter(val => val.startsWith(type) && val.endsWith(`_0`));
     tmpName.forEach(property => g_keyObj[`${property.slice(0, -2)}`] = g_keyObj[property].concat());


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. copyArray2d関数を使わないコードに変更しました。
2. キー数関連のコメントを修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. copyArray2d関数の実体は`structuredClone`ですが、すでに`structuredClone`を使っているコードが混在しているため、今回書き方を統一しました。
2. 過去のコメントと入り混じっている箇所があったため、修正しました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
