### PR TITLE
fix: [0673] 譜面リスト中、上下キーを使って選択した譜面がキー数違いのときの問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4322,6 +4322,9 @@ const createOptionWindow = _sprite => {
 			setDifficulty(true);
 			deleteChildspriteAll(`difList`);
 			makeDifList(difList, g_stateObj.filterKeys);
+			if (g_keyObj.prevKey !== g_keyObj.currentKey) {
+				g_keyObj.prevKey = g_keyObj.currentKey;
+			}
 		}, {
 			x: 430 + _scrollNum * 10, y: 40, w: 20, h: 20, siz: C_SIZ_JDGCNTS,
 		}, g_cssObj.button_Mini);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 譜面リストで、上下キーを使って選択した譜面がキー数違いのときに
キーコンフィグ画面へ移動すると画面が止まる問題を修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 譜面を切り替える際、キー数が変わったことをチェックするために`g_keyObj.prevKey`という変数に
前の譜面のキー数を格納していました。
Difficultyのボタン及び譜面リストのボタンをクリックした場合は`g_keyObj.prevKey`が更新されるようになっていましたが、譜面リストを上下に切り替える際に`g_keyObj.prevKey`が更新されるようになっていませんでした。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/226926883-9bc583ea-9b5e-4949-b983-6f00d9e037f4.png" width="45%"><img src="https://user-images.githubusercontent.com/44026291/226927045-4402beb1-f6ba-4ada-9075-b996c978a739.png" width="45%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- ver24.5.1以降で発生します。