### PR TITLE
feat: [0675] 譜面密度グラフについて、上位3番目まで色付けするよう変更

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -561,6 +561,9 @@ const g_settingBtnObj = {
 const g_limitObj = {
     adjustment: 30,
     hitPosition: 50,
+
+    densityDivision: 16,
+    densityMaxVals: 3,
 };
 const C_MAX_ADJUSTMENT = 30;
 const C_MAX_SPEED = 10;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 譜面密度グラフについて、上位3番目まで色付けするよう変更しました。
上位3番目で同率の場合は同率すべてに対して色付けします。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. これまで同率の場合は1か所しか色付けされていなかったため。
また最大だけを色付けするより、複数の上位を色付けした方が譜面傾向がつかみやすいため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/227708252-a34a148a-77cd-4005-a92d-022f89008ee0.png" width="45%"><img src="https://user-images.githubusercontent.com/44026291/227708377-44d1606f-bab5-48c8-8b08-11dc0483096b.png" width="45%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 今回の変更で、`g_detailObj.densityData[_scoreId]`を単独の数字から配列に変更しています。