### PR TITLE
feat: [0676] 譜面エフェクトデータに別の変数が入っていた場合、その変数を参照するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7289,7 +7289,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 
 	/**
 	 * 譜面データに別の関連名が含まれていた場合、関連名の変数を返す
-	 * 例) |back2A_data=back_data| -> back_dataで定義された値を使用
+	 * 例) |backA2_data=back_data| -> back_dataで定義された値を使用
 	 * @param {string} _header 
 	 * @param {string} _dataName 
 	 * @returns 
@@ -7535,8 +7535,8 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	// キー変化定義
 	obj.keychFrames = [0];
 	obj.keychTarget = [`0`];
-	if (hasVal(_dosObj[`keych${setScoreIdHeader(g_stateObj.scoreId, g_stateObj.scoreLockFlg)}_data`])) {
-		const keychdata = splitLF2(_dosObj[`keych${setScoreIdHeader(g_stateObj.scoreId, g_stateObj.scoreLockFlg)}_data`], `,`);
+	if (hasVal(getRefList(`keych`, `${scoreIdHeader}_data`))) {
+		const keychdata = splitLF2(getRefList(`keych`, `${scoreIdHeader}_data`), `,`);
 		obj.keychFrames.push(...keychdata.filter((val, j) => j % 2 === 0));
 		obj.keychTarget.push(...keychdata.filter((val, j) => j % 2 === 1));
 	}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7164,10 +7164,11 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 * @param {string} _footer 
 	 */
 	const setSpeedData = (_header, _scoreNo, _footer = `_data`) => {
+		const dosSpeedData = getRefList(_header, `${_scoreNo}${_footer}`);
 		const speedData = [];
 
-		if (hasVal(_dosObj[`${_header}${_scoreNo}${_footer}`]) && g_stateObj.d_speed === C_FLG_ON) {
-			const tmpArrayData = splitLF(_dosObj[`${_header}${_scoreNo}${_footer}`]);
+		if (hasVal(dosSpeedData) && g_stateObj.d_speed === C_FLG_ON) {
+			const tmpArrayData = splitLF(dosSpeedData);
 
 			tmpArrayData.filter(data => hasVal(data)).forEach(tmpData => {
 				const tmpSpeedData = tmpData.split(`,`);
@@ -7206,11 +7207,12 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 * @param {number} _scoreNo 
 	 */
 	const setColorData = (_header, _scoreNo) => {
+		const dosColorData = getRefList(_header, `${_scoreNo}_data`);
 		const colorData = [];
 		const allFlg = (_header.charAt(0) === `a`);
 
-		if (hasVal(_dosObj[`${_header}${_scoreNo}_data`]) && g_stateObj.d_color === C_FLG_ON) {
-			const tmpArrayData = splitLF(_dosObj[`${_header}${_scoreNo}_data`]);
+		if (hasVal(dosColorData) && g_stateObj.d_color === C_FLG_ON) {
+			const tmpArrayData = splitLF(dosColorData);
 
 			tmpArrayData.filter(data => hasVal(data)).forEach(tmpData => {
 				const tmpColorData = tmpData.split(`,`);
@@ -7239,7 +7241,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 * @param {number} _scoreNo 
 	 */
 	const setCssMotionData = (_header, _scoreNo) => {
-		const dosCssMotionData = _dosObj[`${_header}Motion${_scoreNo}_data`] || _dosObj[`${_header}Motion_data`];
+		const dosCssMotionData = getRefList(`${_header}Motion`, `${_scoreNo}_data`) || getRefList(`${_header}Motion`, `_data`);
 		const cssMotionData = [];
 
 		if (hasVal(dosCssMotionData) && g_stateObj.d_arroweffect === C_FLG_ON) {
@@ -7265,7 +7267,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 * @param {number} _scoreNo 
 	 */
 	const setScrollchData = (_scoreNo) => {
-		const dosScrollchData = _dosObj[`scrollch${_scoreNo}_data`] || _dosObj.scrollch_data;
+		const dosScrollchData = getRefList(`scrollch`, `${_scoreNo}_data`) || getRefList(`scrollch`, `_data`);
 		const scrollchData = [];
 
 		if (hasVal(dosScrollchData)) {
@@ -7286,6 +7288,18 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	};
 
 	/**
+	 * 譜面データに別の関連名が含まれていた場合、関連名の変数を返す
+	 * 例) |back2A_data=back_data| -> back_dataで定義された値を使用
+	 * @param {string} _header 
+	 * @param {string} _dataName 
+	 * @returns 
+	 */
+	const getRefList = (_header, _dataName) => {
+		const data = _dosObj[`${_header}${_dataName}`];
+		return data?.startsWith(_header) ? _dosObj[data] : data;
+	}
+
+	/**
 	 * 譜面データの優先順配列の取得
 	 * @param {string} _header 
 	 * @param {string} _type 
@@ -7293,10 +7307,10 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 * @returns 
 	 */
 	const getPriorityList = (_header, _type, _scoreNo) => [
-		_dosObj[`${_header}${_type}${g_localeObj.val}${_scoreNo}_data`],
-		_dosObj[`${_header}${_type}${g_localeObj.val}_data`],
-		_dosObj[`${_header}${_type}${_scoreNo}_data`],
-		_dosObj[`${_header}${_type}_data`]
+		getRefList(`${_header}${_type}`, `${g_localeObj.val}${_scoreNo}_data`),
+		getRefList(`${_header}${_type}`, `${g_localeObj.val}_data`),
+		getRefList(`${_header}${_type}`, `${_scoreNo}_data`),
+		getRefList(`${_header}${_type}`, `_data`)
 	];
 
 	/**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7164,7 +7164,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 * @param {string} _footer 
 	 */
 	const setSpeedData = (_header, _scoreNo, _footer = `_data`) => {
-		const dosSpeedData = getRefList(_header, `${_scoreNo}${_footer}`);
+		const dosSpeedData = getRefData(_header, `${_scoreNo}${_footer}`);
 		const speedData = [];
 
 		if (hasVal(dosSpeedData) && g_stateObj.d_speed === C_FLG_ON) {
@@ -7207,7 +7207,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 * @param {number} _scoreNo 
 	 */
 	const setColorData = (_header, _scoreNo) => {
-		const dosColorData = getRefList(_header, `${_scoreNo}_data`);
+		const dosColorData = getRefData(_header, `${_scoreNo}_data`);
 		const colorData = [];
 		const allFlg = (_header.charAt(0) === `a`);
 
@@ -7241,7 +7241,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 * @param {number} _scoreNo 
 	 */
 	const setCssMotionData = (_header, _scoreNo) => {
-		const dosCssMotionData = getRefList(`${_header}Motion`, `${_scoreNo}_data`) || getRefList(`${_header}Motion`, `_data`);
+		const dosCssMotionData = getRefData(`${_header}Motion`, `${_scoreNo}_data`) || getRefData(`${_header}Motion`, `_data`);
 		const cssMotionData = [];
 
 		if (hasVal(dosCssMotionData) && g_stateObj.d_arroweffect === C_FLG_ON) {
@@ -7267,7 +7267,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 * @param {number} _scoreNo 
 	 */
 	const setScrollchData = (_scoreNo) => {
-		const dosScrollchData = getRefList(`scrollch`, `${_scoreNo}_data`) || getRefList(`scrollch`, `_data`);
+		const dosScrollchData = getRefData(`scrollch`, `${_scoreNo}_data`) || getRefData(`scrollch`, `_data`);
 		const scrollchData = [];
 
 		if (hasVal(dosScrollchData)) {
@@ -7294,7 +7294,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 * @param {string} _dataName 
 	 * @returns 
 	 */
-	const getRefList = (_header, _dataName) => {
+	const getRefData = (_header, _dataName) => {
 		const data = _dosObj[`${_header}${_dataName}`];
 		return data?.startsWith(_header) ? _dosObj[data] : data;
 	}
@@ -7307,10 +7307,10 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 * @returns 
 	 */
 	const getPriorityList = (_header, _type, _scoreNo) => [
-		getRefList(_header, `${_type}${g_localeObj.val}${_scoreNo}_data`),
-		getRefList(_header, `${_type}${g_localeObj.val}_data`),
-		getRefList(_header, `${_type}${_scoreNo}_data`),
-		getRefList(_header, `${_type}_data`)
+		getRefData(_header, `${_type}${g_localeObj.val}${_scoreNo}_data`),
+		getRefData(_header, `${_type}${g_localeObj.val}_data`),
+		getRefData(_header, `${_type}${_scoreNo}_data`),
+		getRefData(_header, `${_type}_data`)
 	];
 
 	/**
@@ -7536,8 +7536,8 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	// キー変化定義
 	obj.keychFrames = [0];
 	obj.keychTarget = [`0`];
-	if (hasVal(getRefList(`keych`, `${scoreIdHeader}_data`))) {
-		const keychdata = splitLF2(getRefList(`keych`, `${scoreIdHeader}_data`), `,`);
+	if (hasVal(getRefData(`keych`, `${scoreIdHeader}_data`))) {
+		const keychdata = splitLF2(getRefData(`keych`, `${scoreIdHeader}_data`), `,`);
 		obj.keychFrames.push(...keychdata.filter((val, j) => j % 2 === 0));
 		obj.keychTarget.push(...keychdata.filter((val, j) => j % 2 === 1));
 	}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7446,10 +7446,10 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 */
 	const makeBackgroundResultData = (_header, _resultType, _scoreNo, _defaultType = ``) => {
 		const dataList = [];
-		const addResultDataList = (_type = ``) => dataList.push(...getPriorityList(_header, _type, _scoreNo));
-		addResultDataList(_resultType);
+		const addDataList = (_type = ``) => dataList.push(...getPriorityList(_header, _type, _scoreNo));
+		addDataList(_resultType);
 		if (_defaultType !== ``) {
-			addResultDataList(_defaultType);
+			addDataList(_defaultType);
 		}
 
 		const data = dataList.find((v) => v !== undefined);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7307,10 +7307,10 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 * @returns 
 	 */
 	const getPriorityList = (_header, _type, _scoreNo) => [
-		getRefList(`${_header}${_type}`, `${g_localeObj.val}${_scoreNo}_data`),
-		getRefList(`${_header}${_type}`, `${g_localeObj.val}_data`),
-		getRefList(`${_header}${_type}`, `${_scoreNo}_data`),
-		getRefList(`${_header}${_type}`, `_data`)
+		getRefList(_header, `${_type}${g_localeObj.val}${_scoreNo}_data`),
+		getRefList(_header, `${_type}${g_localeObj.val}_data`),
+		getRefList(_header, `${_type}${_scoreNo}_data`),
+		getRefList(_header, `${_type}_data`)
 	];
 
 	/**
@@ -7440,15 +7440,16 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	/**
 	 * リザルトモーションデータ(結果画面用背景・マスクデータ)の分解
 	 * @param {string} _header 
+	 * @param {string} _type
 	 * @param {string} _scoreNo 
-	 * @param {string} _defaultHeader 
+	 * @param {string} _defaultType 
 	 */
-	const makeBackgroundResultData = (_header, _scoreNo, _defaultHeader = ``) => {
+	const makeBackgroundResultData = (_header, _type, _scoreNo, _defaultType = ``) => {
 		const dataList = [];
-		const addResultDataList = _headerType => dataList.push(...getPriorityList(``, _headerType, _scoreNo));
-		addResultDataList(_header);
-		if (_defaultHeader !== ``) {
-			addResultDataList(_defaultHeader);
+		const addResultDataList = (_type = ``) => dataList.push(...getPriorityList(_header, _type, _scoreNo));
+		addResultDataList(_type);
+		if (_defaultType !== ``) {
+			addResultDataList(_defaultType);
 		}
 
 		const data = dataList.find((v) => v !== undefined);
@@ -7526,9 +7527,9 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	} else {
 		g_animationData.forEach(sprite => {
 			[g_headerObj[`${sprite}ResultData`], g_headerObj[`${sprite}ResultMaxDepth`]] =
-				makeBackgroundResultData(`${sprite}result`, scoreIdHeader);
+				makeBackgroundResultData(sprite, `result`, scoreIdHeader);
 			[g_headerObj[`${sprite}FailedData`], g_headerObj[`${sprite}FailedMaxDepth`]] =
-				makeBackgroundResultData(`${sprite}failed${g_stateObj.lifeMode.slice(0, 1)}`, scoreIdHeader, `${sprite}result`);
+				makeBackgroundResultData(sprite, `failed${g_stateObj.lifeMode.slice(0, 1)}`, scoreIdHeader, `result`);
 		});
 	}
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7439,15 +7439,15 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 
 	/**
 	 * リザルトモーションデータ(結果画面用背景・マスクデータ)の分解
-	 * @param {string} _header 
-	 * @param {string} _type
-	 * @param {string} _scoreNo 
-	 * @param {string} _defaultType 
+	 * @param {string} _header 背景、マスク (back, mask)
+	 * @param {string} _resultType リザルトモーションの種類 (result, failedB, failedS)
+	 * @param {string} _scoreNo 譜面番号
+	 * @param {string} _defaultType _resultTypeが無いときの代替名
 	 */
-	const makeBackgroundResultData = (_header, _type, _scoreNo, _defaultType = ``) => {
+	const makeBackgroundResultData = (_header, _resultType, _scoreNo, _defaultType = ``) => {
 		const dataList = [];
 		const addResultDataList = (_type = ``) => dataList.push(...getPriorityList(_header, _type, _scoreNo));
-		addResultDataList(_type);
+		addResultDataList(_resultType);
 		if (_defaultType !== ``) {
 			addResultDataList(_defaultType);
 		}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3217,15 +3217,22 @@ const resetBaseColorList = (_baseObj, _dosObj, { scoreId = `` } = {}) => {
 
 	const obj = {};
 	const scoreIdHeader = setScoreIdHeader(scoreId);
+	const getRefData = (_header, _dataName) => {
+		const data = _dosObj[`${_header}${_dataName}`];
+		return data?.startsWith(_header) ? _dosObj[data] : data;
+	}
 
 	[``, `Shadow`].forEach(pattern => {
-		const _name = `set${pattern}Color${scoreIdHeader}`;
-		const _frzName = `frz${pattern}Color${scoreIdHeader}`;
-		const _arrowInit = `set${pattern}ColorInit`;
-		const _frzInit = `frz${pattern}ColorInit`;
+		const _arrowCommon = `set${pattern}Color`;
+		const _frzCommon = `frz${pattern}Color`;
 
-		const arrowColorTxt = _dosObj[_name] || _dosObj[`set${pattern}Color`];
-		const frzColorTxt = _dosObj[_frzName] || _dosObj[`frz${pattern}Color`];
+		const _name = `${_arrowCommon}${scoreIdHeader}`;
+		const _frzName = `${_frzCommon}${scoreIdHeader}`;
+		const _arrowInit = `${_arrowCommon}Init`;
+		const _frzInit = `${_frzCommon}Init`;
+
+		const arrowColorTxt = getRefData(_arrowCommon, scoreIdHeader) || _dosObj[_arrowCommon];
+		const frzColorTxt = getRefData(_frzCommon, scoreIdHeader) || _dosObj[_frzCommon];
 
 		// 矢印色
 		Object.keys(_baseObj.dfColorgrdSet).forEach(type => {
@@ -7241,7 +7248,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 * @param {number} _scoreNo 
 	 */
 	const setCssMotionData = (_header, _scoreNo) => {
-		const dosCssMotionData = getRefData(`${_header}Motion`, `${_scoreNo}_data`) || getRefData(`${_header}Motion`, `_data`);
+		const dosCssMotionData = getRefData(`${_header}Motion`, `${_scoreNo}_data`) || _dosObj[`${_header}Motion_data`];
 		const cssMotionData = [];
 
 		if (hasVal(dosCssMotionData) && g_stateObj.d_arroweffect === C_FLG_ON) {
@@ -7267,7 +7274,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 * @param {number} _scoreNo 
 	 */
 	const setScrollchData = (_scoreNo) => {
-		const dosScrollchData = getRefData(`scrollch`, `${_scoreNo}_data`) || getRefData(`scrollch`, `_data`);
+		const dosScrollchData = getRefData(`scrollch`, `${_scoreNo}_data`) || _dosObj.scrollch_data;
 		const scrollchData = [];
 
 		if (hasVal(dosScrollchData)) {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 譜面エフェクトデータに別の変数が入っていた場合、その変数を参照する仕様を追加しました。
現状対応している対象は以下の通りです。
    - 速度変化(speed_data, boost_data)
    - 色変化(color_data, acolor_data)
    - 歌詞表示(word_data)
    - 背景・マスクモーション(back_data, mask_data)
    - リザルトモーション (backresult_data, maskresult_data, backfailedB_data)
    - 矢印モーション(arrMotion_data, frzMotion_data)
    - キー数変化 (keych_data)
    - スクロール変化 (scrollch_data)
```
|color_data=200,20,#66ffff,300,20,#ff9999|
|color2_data=color_data|   // 2譜面目の色変化データは1譜面目のものを利用

|word2_data=...|
|word3_data=word2_data|  // 3譜面目の歌詞データは2譜面目のものを利用
```

2. `makeBackgroundResultData`関数の引数を変更しました。
```javascript
makeBackgroundResultData (_header, _scoreNo, _defaultHeader);  // 変更前
makeBackgroundResultData (_header, _resultType, _scoreNo, _defaultType);  // 変更後
```

3. 初期矢印色・初期フリーズアロー色に別の変数が入っていた場合、その変数を参照する仕様を追加しました。
```
|setColor2=....|
|setColor3=setColor2|  // 2譜面目のsetColorデータを参照
```

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 同じ内容を2回書く手間を避けるため。
また、これまで1譜面目をコピーする形式が多かったが、それだけとは限らないため。
2. 1.の変更に伴い、接頭辞判断のための文字列を分離する必要が出てきたため。
また、この部分だけ他の箇所と実装の仕方に差があったため。
3. 1.と同じ理由です。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 別の変数が入っているかどうかは、先頭の接頭辞を見て判断します。
速度変化の場合は`speed`もしくは`boost`、色変化の場合は`color`, `acolor`といった具合です。
通常の指定方法では先頭に改行もしくはフレーム数が入るため、これで区別可能と考えています。
- 関数の引数に変更が出ていますが、外からアクセスできない関数のため影響は無いと考えています。