### PR TITLE
improve: [0677] 定数をg_limitObj, g_graphColorObjへ移行

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -979,7 +979,7 @@ const getFontSize = (_str, _maxWidth, _font = getBasicFont(), _maxFontsize = 64,
  */
 const createDescDiv = (_id, _str, _altId = _id) =>
 	createDivCss2Label(_id, _str, Object.assign(g_lblPosObj[_altId], {
-		siz: getFontSize(_str, g_sWidth, getBasicFont(), C_SIZ_MAIN),
+		siz: getFontSize(_str, g_sWidth, getBasicFont(), g_limitObj.mainSiz),
 	}));
 
 /*-----------------------------------------------------------*/
@@ -1031,8 +1031,8 @@ const setUserSelect = (_style, _value = C_DIS_NONE) => {
  * @param {object} _obj (x, y, w, h, siz, align, ...rest)
  * @param {...any} _classes 
  */
-const createDivCss2Label = (_id, _text, { x = 0, y = 0, w = C_LEN_SETLBL_WIDTH, h = C_LEN_SETLBL_HEIGHT,
-	siz = C_SIZ_SETLBL, align = C_ALIGN_CENTER, ...rest } = {}, ..._classes) => {
+const createDivCss2Label = (_id, _text, { x = 0, y = 0, w = g_limitObj.setLblWidth, h = g_limitObj.setLblHeight,
+	siz = g_limitObj.setLblSiz, align = C_ALIGN_CENTER, ...rest } = {}, ..._classes) => {
 	const div = createDiv(_id, x, y, w, h, [g_cssObj.title_base, ..._classes]);
 
 	const style = div.style;
@@ -1218,8 +1218,8 @@ const deleteDiv = (_parentId, _idName) => {
  * @param {object} _obj (x, y, w, h, siz, align, title, groupName, initDisabledFlg, ...rest)
  * @param {...any} _classes 
  */
-const createCss2Button = (_id, _text, _func = _ => true, { x = 0, y = g_sHeight - 100, w = g_sWidth / 3, h = C_BTN_HEIGHT,
-	siz = C_LBL_BTNSIZE, align = C_ALIGN_CENTER, title = ``, groupName = g_currentPage, initDisabledFlg = true,
+const createCss2Button = (_id, _text, _func = _ => true, { x = 0, y = g_sHeight - 100, w = g_sWidth / 3, h = g_limitObj.btnHeight,
+	siz = g_limitObj.btnSiz, align = C_ALIGN_CENTER, title = ``, groupName = g_currentPage, initDisabledFlg = true,
 	resetFunc = _ => true, cxtFunc = _ => true, ...rest } = {}, ..._classes) => {
 
 	const div = createDiv(_id, x, y, w, h, [`button_common`, ..._classes]);
@@ -1315,7 +1315,7 @@ const changeStyle = (_id, { x, y, w, h, siz, align, title, ...rest } = {}) => {
  * @param {number} _y 
  */
 const getTitleDivLabel = (_id, _titlename, _x, _y, ..._classes) =>
-	createDivCss2Label(_id, _titlename, { x: _x, y: _y, w: g_sWidth, h: 50, siz: C_LBL_BTNSIZE }, ..._classes);
+	createDivCss2Label(_id, _titlename, { x: _x, y: _y, w: g_sWidth, h: 50, siz: g_limitObj.btnSiz }, ..._classes);
 
 /**
  * キーコントロールの初期化
@@ -1803,8 +1803,8 @@ const getQueryParamVal = _name => {
  * ローディング文字用ラベルの作成
  */
 const getLoadingLabel = _ => createDivCss2Label(`lblLoading`, g_lblNameObj.nowLoading, {
-	x: 0, y: g_sHeight - 40, w: g_sWidth, h: C_LEN_SETLBL_HEIGHT,
-	siz: C_SIZ_SETLBL, align: C_ALIGN_RIGHT,
+	x: 0, y: g_sHeight - 40, w: g_sWidth, h: g_limitObj.setLblHeight,
+	siz: g_limitObj.setLblSiz, align: C_ALIGN_RIGHT,
 });
 
 /**
@@ -3930,7 +3930,7 @@ const titleInit = _ => {
 	const versionName = `&copy; 2018-${g_revisedDate.slice(0, 4)} ティックル, CW ${g_version}${g_alphaVersion}${customVersion}${releaseDate}`;
 
 	let reloadFlg = false;
-	const getLinkSiz = _name => getFontSize(_name, g_sWidth / 2 - 20, getBasicFont(), C_LBL_LNKSIZE, 12);
+	const getLinkSiz = _name => getFontSize(_name, g_sWidth / 2 - 20, getBasicFont(), g_limitObj.lnkSiz, 12);
 
 	/**
 	 * クレジット用リンク作成
@@ -3948,7 +3948,7 @@ const titleInit = _ => {
 
 		// Click Here
 		createCss2Button(`btnStart`, g_lblNameObj.clickHere, _ => clearTimeout(g_timeoutEvtTitleId), {
-			w: g_sWidth, siz: C_LBL_TITLESIZE, resetFunc: _ => optionInit(),
+			w: g_sWidth, siz: g_limitObj.titleSiz, resetFunc: _ => optionInit(),
 		}, g_cssObj.button_Start),
 
 		// Reset
@@ -4122,7 +4122,7 @@ const setWindowStyle = (_text, _bkColor, _textColor, _align = C_ALIGN_LEFT) => {
 
 	// ウィンドウ枠の行を取得するために一時的な枠を作成
 	const tmplbl = createDivCss2Label(`lblTmpWarning`, _text, {
-		x: 0, y: 70, w: g_sWidth, h: 20, siz: C_SIZ_MAIN, lineHeight: `15px`, fontFamily: getBasicFont(),
+		x: 0, y: 70, w: g_sWidth, h: 20, siz: g_limitObj.mainSiz, lineHeight: `15px`, fontFamily: getBasicFont(),
 		whiteSpace: `normal`,
 	});
 	divRoot.appendChild(tmplbl);
@@ -4133,7 +4133,7 @@ const setWindowStyle = (_text, _bkColor, _textColor, _align = C_ALIGN_LEFT) => {
 	const warnHeight = Math.min(150, Math.max(range.getClientRects().length,
 		_text.split(`<br>`).length + _text.split(`<p>`).length - 1) * 21);
 	const lbl = createDivCss2Label(`lblWarning`, _text, {
-		x: 0, y: 70, w: g_sWidth, h: warnHeight, siz: C_SIZ_MAIN, backgroundColor: _bkColor,
+		x: 0, y: 70, w: g_sWidth, h: warnHeight, siz: g_limitObj.mainSiz, backgroundColor: _bkColor,
 		opacity: 0.9, lineHeight: `15px`, color: _textColor, align: _align, fontFamily: getBasicFont(),
 		whiteSpace: `normal`,
 	});
@@ -4241,8 +4241,8 @@ const setSpriteList = _settingList => {
 	const spriteList = [];
 	_settingList.forEach(setting =>
 		spriteList[setting[0]] = createEmptySprite(optionsprite, `${setting[0]}Sprite`, {
-			x: 25, y: setting[1] * C_LEN_SETLBL_HEIGHT + setting[2] + 20,
-			w: optionWidth + setting[3], h: C_LEN_SETLBL_HEIGHT + setting[4],
+			x: 25, y: setting[1] * g_limitObj.setLblHeight + setting[2] + 20,
+			w: optionWidth + setting[3], h: g_limitObj.setLblHeight + setting[4],
 		}));
 	return spriteList;
 };
@@ -4344,7 +4344,7 @@ const createOptionWindow = _sprite => {
 				k++;
 			}
 		});
-		const overlength = pos * C_LEN_SETLBL_HEIGHT - parseInt(difList.style.height);
+		const overlength = pos * g_limitObj.setLblHeight - parseInt(difList.style.height);
 		difList.scrollTop = (overlength > 0 ? overlength : 0);
 	};
 
@@ -4366,7 +4366,7 @@ const createOptionWindow = _sprite => {
 				g_keyObj.prevKey = g_keyObj.currentKey;
 			}
 		}, {
-			x: 430 + _scrollNum * 10, y: 40, w: 20, h: 20, siz: C_SIZ_JDGCNTS,
+			x: 430 + _scrollNum * 10, y: 40, w: 20, h: 20, siz: g_limitObj.jdgCntsSiz,
 		}, g_cssObj.button_Mini);
 	};
 
@@ -4387,7 +4387,7 @@ const createOptionWindow = _sprite => {
 		difCover.appendChild(
 			makeDifLblCssButton(`difRandom`, `RANDOM`, 0, _ => {
 				nextDifficulty(Math.floor(Math.random() * g_headerObj.keyLabels.length));
-			}, { w: C_LEN_DIFCOVER_WIDTH })
+			}, { w: g_limitObj.difCoverWidth })
 		);
 
 		// 全リスト
@@ -4396,7 +4396,7 @@ const createOptionWindow = _sprite => {
 				resetDifWindow();
 				g_stateObj.filterKeys = ``;
 				createDifWindow();
-			}, { w: C_LEN_DIFCOVER_WIDTH, btnStyle: (g_stateObj.filterKeys === `` ? `Setting` : `Default`) })
+			}, { w: g_limitObj.difCoverWidth, btnStyle: (g_stateObj.filterKeys === `` ? `Setting` : `Default`) })
 		);
 
 		// キー別フィルタボタン作成
@@ -4407,13 +4407,13 @@ const createOptionWindow = _sprite => {
 					resetDifWindow();
 					g_stateObj.filterKeys = targetKey;
 					createDifWindow(targetKey);
-				}, { w: C_LEN_DIFCOVER_WIDTH, btnStyle: (g_stateObj.filterKeys === targetKey ? `Setting` : `Default`) })
+				}, { w: g_limitObj.difCoverWidth, btnStyle: (g_stateObj.filterKeys === targetKey ? `Setting` : `Default`) })
 			);
 			if (g_stateObj.filterKeys === targetKey) {
 				pos = m + 9;
 			}
 		});
-		const overlength = pos * C_LEN_SETLBL_HEIGHT - parseInt(difCover.style.height);
+		const overlength = pos * g_limitObj.setLblHeight - parseInt(difCover.style.height);
 		difCover.scrollTop = (overlength > 0 ? overlength : 0);
 
 		multiAppend(optionsprite, makeDifBtn(-1), makeDifBtn());
@@ -4432,7 +4432,7 @@ const createOptionWindow = _sprite => {
 		}
 	};
 	const lnkDifficulty = makeSettingLblCssButton(`lnkDifficulty`, ``, 0, _ => changeDifficulty(), {
-		y: -10, h: C_LEN_SETLBL_HEIGHT + 10, cxtFunc: _ => changeDifficulty(-1),
+		y: -10, h: g_limitObj.setLblHeight + 10, cxtFunc: _ => changeDifficulty(-1),
 	});
 
 	// 譜面選択ボタン（メイン、右回し、左回し）
@@ -4472,8 +4472,8 @@ const createOptionWindow = _sprite => {
 			const bkColor = window.getComputedStyle(textBaseObj, ``).backgroundColor;
 
 			graphObj.id = `graph${_name}`;
-			graphObj.width = C_LEN_GRAPH_WIDTH;
-			graphObj.height = C_LEN_GRAPH_HEIGHT;
+			graphObj.width = g_limitObj.graphWidth;
+			graphObj.height = g_limitObj.graphHeight;
 			graphObj.style.left = `125px`;
 			graphObj.style.top = `0px`;
 			graphObj.style.position = `absolute`;
@@ -4489,7 +4489,7 @@ const createOptionWindow = _sprite => {
 	if (g_headerObj.scoreDetailUse) {
 		spriteList.speed.appendChild(
 			createCss2Button(`btnGraph`, `i`, _ => true, {
-				x: -25, y: -60, w: 30, h: 30, siz: C_SIZ_JDGCHARA, title: g_msgObj.graph,
+				x: -25, y: -60, w: 30, h: 30, siz: g_limitObj.jdgCharaSiz, title: g_msgObj.graph,
 				resetFunc: _ => setScoreDetail(), cxtFunc: _ => setScoreDetail(),
 			}, g_cssObj.button_Mini)
 		);
@@ -4527,7 +4527,7 @@ const createOptionWindow = _sprite => {
 		);
 		g_settings.scoreDetails.forEach((sd, j) => {
 			scoreDetail.appendChild(
-				makeDifLblCssButton(`lnk${sd}G`, getStgDetailName(sd), j, _ => changeScoreDetail(j), { w: C_LEN_DIFCOVER_WIDTH, btnStyle: (g_stateObj.scoreDetail === sd ? `Setting` : `Default`) })
+				makeDifLblCssButton(`lnk${sd}G`, getStgDetailName(sd), j, _ => changeScoreDetail(j), { w: g_limitObj.difCoverWidth, btnStyle: (g_stateObj.scoreDetail === sd ? `Setting` : `Default`) })
 			);
 			createScText(document.getElementById(`lnk${sd}G`), `${sd}G`, { targetLabel: `lnk${sd}G`, x: -10 });
 		});
@@ -4577,8 +4577,8 @@ const createOptionWindow = _sprite => {
 		const startFrame = g_detailObj.startFrame[_scoreId];
 		const playingFrame = g_detailObj.playingFrameWithBlank[_scoreId];
 		const speedObj = {
-			speed: { frame: [0], speed: [1], cnt: 0, strokeColor: C_CLR_SPEEDGRAPH_SPEED },
-			boost: { frame: [0], speed: [1], cnt: 0, strokeColor: C_CLR_SPEEDGRAPH_BOOST }
+			speed: { frame: [0], speed: [1], cnt: 0, strokeColor: g_graphColorObj.speed },
+			boost: { frame: [0], speed: [1], cnt: 0, strokeColor: g_graphColorObj.boost }
 		};
 
 		Object.keys(speedObj).forEach(speedType => {
@@ -4608,7 +4608,7 @@ const createOptionWindow = _sprite => {
 			let preY;
 
 			for (let i = 0; i < speedObj[speedType].frame.length; i++) {
-				const x = speedObj[speedType].frame[i] * (C_LEN_GRAPH_WIDTH - 30) / playingFrame + 30;
+				const x = speedObj[speedType].frame[i] * (g_limitObj.graphWidth - 30) / playingFrame + 30;
 				const y = (speedObj[speedType].speed[i] - 1) * -90 + 105;
 
 				context.lineTo(x, preY);
@@ -4625,7 +4625,7 @@ const createOptionWindow = _sprite => {
 			context.moveTo(lineX, 215);
 			context.lineTo(lineX + 30, 215);
 			context.stroke();
-			context.font = `${C_SIZ_DIFSELECTOR}px ${getBasicFont()}`;
+			context.font = `${g_limitObj.difSelectorSiz}px ${getBasicFont()}`;
 			context.fillText(speedType, lineX + 35, 218);
 
 			updateScoreDetailLabel(`Speed`, `${speedType}S`, speedObj[speedType].cnt, j, g_lblNameObj[`s_${speedType}`]);
@@ -4663,7 +4663,7 @@ const createOptionWindow = _sprite => {
 			context.moveTo(lineX, 215);
 			context.lineTo(lineX + 20, 215);
 			context.stroke();
-			context.font = `${C_SIZ_DIFSELECTOR}px ${getBasicFont()}`;
+			context.font = `${g_limitObj.difSelectorSiz}px ${getBasicFont()}`;
 			context.fillText(lineNames[j], lineX + 20, 218);
 		});
 
@@ -4686,7 +4686,7 @@ const createOptionWindow = _sprite => {
 		const baseLabel = (_bLabel, _bLabelname, _bAlign) =>
 			document.querySelector(`#detail${_name}`).appendChild(
 				createDivCss2Label(`${_bLabel}`, `${_bLabelname}`, {
-					x: 10, y: 105 + _pos * 20, w: 100, h: 20, siz: C_SIZ_DIFSELECTOR, align: _bAlign,
+					x: 10, y: 105 + _pos * 20, w: 100, h: 20, siz: g_limitObj.difSelectorSiz, align: _bAlign,
 				})
 			);
 		if (document.querySelector(`#data${_label}`) === null) {
@@ -4703,7 +4703,7 @@ const createOptionWindow = _sprite => {
 	 * @param {number} _resolution 
 	 */
 	const drawBaseLine = (_context, _resolution = 10) => {
-		_context.clearRect(0, 0, C_LEN_GRAPH_WIDTH, C_LEN_GRAPH_HEIGHT);
+		_context.clearRect(0, 0, g_limitObj.graphWidth, g_limitObj.graphHeight);
 
 		for (let j = 0; j <= 2 * _resolution; j += 5) {
 			drawLine(_context, j / _resolution, `main`, 2);
@@ -4724,7 +4724,7 @@ const createOptionWindow = _sprite => {
 		const lineY = (_y - 1) * -90 + 105;
 		_context.beginPath();
 		_context.moveTo(30, lineY);
-		_context.lineTo(C_LEN_GRAPH_WIDTH, lineY);
+		_context.lineTo(g_limitObj.graphWidth, lineY);
 		_context.lineWidth = 1;
 
 		if (_lineType === `main`) {
@@ -4754,7 +4754,7 @@ const createOptionWindow = _sprite => {
 		 * @param {string} _data 
 		 * @param {object} _obj 
 		 */
-		const makeDifInfoLabel = (_lbl, _data, { x = 130, y = 25, w = 125, h = 35, siz = C_SIZ_DIFSELECTOR, ...rest } = {}) =>
+		const makeDifInfoLabel = (_lbl, _data, { x = 130, y = 25, w = 125, h = 35, siz = g_limitObj.difSelectorSiz, ...rest } = {}) =>
 			createDivCss2Label(_lbl, _data, { x, y, w, h, siz, align: C_ALIGN_LEFT, ...rest });
 
 		let printData = ``;
@@ -4818,7 +4818,7 @@ const createOptionWindow = _sprite => {
 		dataDouji.textContent = g_detailObj.toolDif[_scoreId].douji;
 		dataTate.textContent = g_detailObj.toolDif[_scoreId].tate;
 		lblArrowInfo2.innerHTML = g_lblNameObj.s_linecnts.split(`{0}`).join(g_detailObj.toolDif[_scoreId].push3cnt);
-		dataArrowInfo.innerHTML = `${arrowCnts + frzCnts} <span style="font-size:${C_SIZ_DIFSELECTOR}px;">(${arrowCnts} + ${frzCnts})</span>`;
+		dataArrowInfo.innerHTML = `${arrowCnts + frzCnts} <span style="font-size:${g_limitObj.difSelectorSiz}px;">(${arrowCnts} + ${frzCnts})</span>`;
 		dataArrowInfo2.innerHTML = `<br>(${g_detailObj.arrowCnt[_scoreId]})<br><br>
 			(${g_detailObj.frzCnt[_scoreId]})<br><br>
 			${push3CntStr}`.split(`,`).join(`/`);
@@ -5240,7 +5240,7 @@ const createOptionWindow = _sprite => {
 		// 譜面名設定 (Difficulty)
 		const difWidth = parseFloat(lnkDifficulty.style.width);
 		const difNames = [`${getKeyName(g_keyObj.currentKey)} ${getStgDetailName('key')} / ${g_headerObj.difLabels[g_stateObj.scoreId]}`];
-		lnkDifficulty.style.fontSize = `${getFontSize(difNames[0], difWidth, getBasicFont(), C_SIZ_SETLBL)}px`;
+		lnkDifficulty.style.fontSize = `${getFontSize(difNames[0], difWidth, getBasicFont(), g_limitObj.setLblSiz)}px`;
 
 		if (g_headerObj.makerView) {
 			difNames.push(`(${g_headerObj.creatorNames[g_stateObj.scoreId]})`);
@@ -5354,8 +5354,8 @@ const createGeneralSetting = (_obj, _settingName, { unitName = ``,
 		// 右回し・左回しボタン（最内側）
 		if (skipTerms[2] > 1) {
 			multiAppend(_obj,
-				makeMiniCssButton(linkId, `RRR`, 0, _ => setSetting(skipTerms[2], _settingName, unitName, roundNum), { dw: -C_LEN_SETMINI_WIDTH / 2 }),
-				makeMiniCssButton(linkId, `LLL`, 0, _ => setSetting(skipTerms[2] * (-1), _settingName, unitName, roundNum), { dw: -C_LEN_SETMINI_WIDTH / 2 }),
+				makeMiniCssButton(linkId, `RRR`, 0, _ => setSetting(skipTerms[2], _settingName, unitName, roundNum), { dw: -g_limitObj.setMiniWidth / 2 }),
+				makeMiniCssButton(linkId, `LLL`, 0, _ => setSetting(skipTerms[2] * (-1), _settingName, unitName, roundNum), { dw: -g_limitObj.setMiniWidth / 2 }),
 			);
 		}
 
@@ -5439,7 +5439,7 @@ const setSetting = (_scrollNum, _settingName, _unitName = ``, _roundNum = 0) => 
  */
 const makeDisabledLabel = (_id, _heightPos, _defaultStr) => {
 	return createDivCss2Label(_id, _defaultStr, {
-		x: C_LEN_SETLBL_LEFT, y: C_LEN_SETLBL_HEIGHT * _heightPos,
+		x: g_limitObj.setLblLeft, y: g_limitObj.setLblHeight * _heightPos,
 	}, g_cssObj.settings_Disabled);
 };
 
@@ -5522,11 +5522,11 @@ const getKeyCtrl = (_localStorage, _extraKeyName = ``) => {
  */
 const makeSettingLblCssButton = (_id, _name, _heightPos, _func, { x, y, w, h, siz, cxtFunc = _ => true, ...rest } = {}, ..._classes) => {
 	const tmpObj = {
-		x: x !== undefined ? x : C_LEN_SETLBL_LEFT,
-		y: y !== undefined ? y : C_LEN_SETLBL_HEIGHT * _heightPos,
-		w: w !== undefined ? w : C_LEN_SETLBL_WIDTH,
-		h: h !== undefined ? h : C_LEN_SETLBL_HEIGHT,
-		siz: siz !== undefined ? siz : C_SIZ_SETLBL,
+		x: x !== undefined ? x : g_limitObj.setLblLeft,
+		y: y !== undefined ? y : g_limitObj.setLblHeight * _heightPos,
+		w: w !== undefined ? w : g_limitObj.setLblWidth,
+		h: h !== undefined ? h : g_limitObj.setLblHeight,
+		siz: siz !== undefined ? siz : g_limitObj.setLblSiz,
 		cxtFunc: cxtFunc !== undefined ? cxtFunc : _ => true,
 	};
 	return createCss2Button(_id, _name, _func, { ...tmpObj, ...rest }, g_cssObj.button_Default, ..._classes);
@@ -5539,11 +5539,11 @@ const makeSettingLblCssButton = (_id, _name, _heightPos, _func, { x, y, w, h, si
  * @param {number} _heightPos 上からの配置順
  * @param {function} _func
  */
-const makeDifLblCssButton = (_id, _name, _heightPos, _func, { x = 0, w = C_LEN_DIFSELECTOR_WIDTH, btnStyle = `Default` } = {}) => {
+const makeDifLblCssButton = (_id, _name, _heightPos, _func, { x = 0, w = g_limitObj.difSelectorWidth, btnStyle = `Default` } = {}) => {
 	return createCss2Button(_id, _name, _func, {
-		x: x, y: C_LEN_SETLBL_HEIGHT * _heightPos,
-		w: w, h: C_LEN_SETLBL_HEIGHT,
-		siz: C_SIZ_DIFSELECTOR,
+		x: x, y: g_limitObj.setLblHeight * _heightPos,
+		w: w, h: g_limitObj.setLblHeight,
+		siz: g_limitObj.difSelectorSiz,
 		borderStyle: `solid`,
 	}, g_cssObj[`button_${btnStyle}`], g_cssObj.button_ON);
 };
@@ -5558,8 +5558,8 @@ const makeDifLblCssButton = (_id, _name, _heightPos, _func, { x = 0, w = C_LEN_D
 const makeMiniCssButton = (_id, _directionFlg, _heightPos, _func, { dx = 0, dy = 0, dw = 0, dh = 0, dsiz = 0, visibility = `visible` } = {}) => {
 	return createCss2Button(`${_id}${_directionFlg}`, g_settingBtnObj.chara[_directionFlg], _func, {
 		x: g_settingBtnObj.pos[_directionFlg] + dx,
-		y: C_LEN_SETLBL_HEIGHT * _heightPos + dy,
-		w: C_LEN_SETMINI_WIDTH + dw, h: C_LEN_SETLBL_HEIGHT + dh, siz: C_SIZ_SETLBL + dsiz,
+		y: g_limitObj.setLblHeight * _heightPos + dy,
+		w: g_limitObj.setMiniWidth + dw, h: g_limitObj.setLblHeight + dh, siz: g_limitObj.setLblSiz + dsiz,
 		visibility: visibility
 	}, g_cssObj.button_Mini);
 };
@@ -5646,8 +5646,8 @@ const createSettingsDisplayWindow = _sprite => {
 		 */
 		const makeDisabledDisplayLabel = (_id, _heightPos, _widthPos, _defaultStr, _flg) => {
 			return createDivCss2Label(_id, _defaultStr, {
-				x: 30 + 180 * _widthPos, y: 3 + C_LEN_SETLBL_HEIGHT * _heightPos,
-				w: 170, siz: C_SIZ_DIFSELECTOR,
+				x: 30 + 180 * _widthPos, y: 3 + g_limitObj.setLblHeight * _heightPos,
+				w: 170, siz: g_limitObj.difSelectorSiz,
 			}, g_cssObj[`button_Disabled${flg}`]);
 		};
 
@@ -5970,7 +5970,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 					setKeyConfigCursor();
 				}, {
 					x: keyconX, y: 50 + C_KYC_REPHEIGHT * k + keyconY,
-					w: C_ARW_WIDTH, h: C_KYC_REPHEIGHT, siz: C_SIZ_JDGCNTS,
+					w: C_ARW_WIDTH, h: C_KYC_REPHEIGHT, siz: g_limitObj.jdgCntsSiz,
 				}, g_cssObj.button_Default_NoColor, g_cssObj.title_base)
 			);
 
@@ -6064,7 +6064,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	 * @returns ボタン
 	 */
 	const makeKCButton = (_id, _text, _func, { x = g_sWidth * 5 / 6 - 20, y = 15, w = g_sWidth / 6, h = 18,
-		siz = C_SIZ_JDGCNTS, borderStyle = `solid`, cxtFunc, ...rest } = {}, _mainClass = g_cssObj.button_RevOFF, ..._classes) => {
+		siz = g_limitObj.jdgCntsSiz, borderStyle = `solid`, cxtFunc, ...rest } = {}, _mainClass = g_cssObj.button_RevOFF, ..._classes) => {
 		return makeSettingLblCssButton(_id, getStgDetailName(_text), 0, _func, { x, y, w, h, siz, cxtFunc, borderStyle, ...rest }, _mainClass, ..._classes);
 	};
 
@@ -6076,7 +6076,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	 * @param {*} object (x, y, w, h, siz) 
 	 * @returns 
 	 */
-	const makeMiniKCButton = (_id, _directionFlg, _func, { x = g_sWidth * 5 / 6 - 30, y = 15, w = 15, h = 20, siz = C_SIZ_MAIN } = {}) => {
+	const makeMiniKCButton = (_id, _directionFlg, _func, { x = g_sWidth * 5 / 6 - 30, y = 15, w = 15, h = 20, siz = g_limitObj.mainSiz } = {}) => {
 		return createCss2Button(`${_id}${_directionFlg}`, g_settingBtnObj.chara[_directionFlg], _func,
 			{ x, y, w, h, siz }, g_cssObj.button_Mini);
 	};
@@ -8729,7 +8729,7 @@ const mainInit = _ => {
 	const makerView = g_headerObj.makerView ? ` (${g_headerObj.creatorNames[g_stateObj.scoreId]})` : ``;
 	let difName = `[${getKeyName(g_headerObj.keyLabels[g_stateObj.scoreId])} / ${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}${shuffleName}${makerView}]`;
 	let creditName = `${musicTitle} / ${artistName}`;
-	if (checkMusicSiz(creditName, C_SIZ_MUSIC_TITLE) < 12) {
+	if (checkMusicSiz(creditName, g_limitObj.musicTitleSiz) < 12) {
 		creditName = `${musicTitle}`;
 		difName = `/ ${artistName} ` + difName;
 	}
@@ -8738,7 +8738,7 @@ const mainInit = _ => {
 
 		// ライフ（数字）
 		createDivCss2Label(`lblLife`, intLifeVal, {
-			x: 0, y: 30, w: 70, h: 20, siz: C_SIZ_JDGCNTS, display: g_workObj.lifegaugeDisp,
+			x: 0, y: 30, w: 70, h: 20, siz: g_limitObj.jdgCntsSiz, display: g_workObj.lifegaugeDisp,
 		}, lblInitColor),
 
 		// ライフ背景
@@ -8762,7 +8762,7 @@ const mainInit = _ => {
 		}, g_cssObj.life_Border, g_cssObj.life_BorderColor),
 
 		// 曲名・アーティスト名表示
-		createDivCss2Label(`lblCredit`, creditName, Object.assign(g_lblPosObj.lblCredit, { siz: checkMusicSiz(creditName, C_SIZ_MUSIC_TITLE) })),
+		createDivCss2Label(`lblCredit`, creditName, Object.assign(g_lblPosObj.lblCredit, { siz: checkMusicSiz(creditName, g_limitObj.musicTitleSiz) })),
 
 		// 譜面名表示
 		createDivCss2Label(`lblDifName`, difName, Object.assign(g_lblPosObj.lblDifName, { siz: checkMusicSiz(difName, 12) })),
@@ -8801,7 +8801,7 @@ const mainInit = _ => {
 		// キャラクタ表示
 		const charaJ = createDivCss2Label(`chara${jdg}`, ``, {
 			x: jdgX[j], y: jdgY[j],
-			w: C_LEN_JDGCHARA_WIDTH, h: C_LEN_JDGCHARA_HEIGHT, siz: C_SIZ_JDGCHARA,
+			w: g_limitObj.jdgCharaWidth, h: g_limitObj.jdgCharaHeight, siz: g_limitObj.jdgCharaSiz,
 			opacity: g_stateObj.opacity / 100, display: g_workObj.judgmentDisp,
 		}, g_cssObj.common_ii);
 		charaJ.setAttribute(`cnt`, 0);
@@ -8814,14 +8814,14 @@ const mainInit = _ => {
 			// コンボ表示
 			createDivCss2Label(`combo${jdg}`, ``, {
 				x: jdgX[j] + 170, y: jdgY[j],
-				w: C_LEN_JDGCHARA_WIDTH, h: C_LEN_JDGCHARA_HEIGHT, siz: C_SIZ_JDGCHARA,
+				w: g_limitObj.jdgCharaWidth, h: g_limitObj.jdgCharaHeight, siz: g_limitObj.jdgCharaSiz,
 				opacity: g_stateObj.opacity / 100, display: g_workObj.judgmentDisp,
 			}, g_cssObj[`common_${jdgCombos[j]}`]),
 
 			// Fast/Slow表示
 			createDivCss2Label(`diff${jdg}`, ``, {
 				x: jdgX[j] + 170, y: jdgY[j] + 25,
-				w: C_LEN_JDGCHARA_WIDTH, h: C_LEN_JDGCHARA_HEIGHT, siz: C_SIZ_MAIN,
+				w: g_limitObj.jdgCharaWidth, h: g_limitObj.jdgCharaHeight, siz: g_limitObj.mainSiz,
 				opacity: g_stateObj.opacity / 100, display: g_workObj.fastslowDisp,
 			}, g_cssObj.common_combo),
 
@@ -9652,7 +9652,7 @@ const mainInit = _ => {
 				} else if (/\[fontSize=\d+\]/.test(g_wordObj.wordDat)) {
 
 					// フォントサイズ変更
-					const fontSize = setIntVal(g_wordObj.wordDat.match(/\d+/)[0], C_SIZ_MAIN);
+					const fontSize = setIntVal(g_wordObj.wordDat.match(/\d+/)[0], g_limitObj.mainSiz);
 					g_wordSprite.style.fontSize = `${fontSize}px`;
 
 				} else {
@@ -9782,8 +9782,8 @@ const changeAppearanceFilter = (_appearance, _num = 10) => {
  */
 const makeCounterSymbol = (_id, _x, _class, _heightPos, _text, _display = C_DIS_INHERIT) => {
 	return createDivCss2Label(_id, _text, {
-		x: _x, y: C_LEN_JDGCNTS_HEIGHT * _heightPos,
-		w: C_LEN_JDGCNTS_WIDTH, h: C_LEN_JDGCNTS_HEIGHT, siz: C_SIZ_JDGCNTS, align: C_ALIGN_RIGHT,
+		x: _x, y: g_limitObj.jdgCntsHeight * _heightPos,
+		w: g_limitObj.jdgCntsWidth, h: g_limitObj.jdgCntsHeight, siz: g_limitObj.jdgCntsSiz, align: C_ALIGN_RIGHT,
 		display: _display,
 	}, _class);
 };
@@ -10749,9 +10749,9 @@ const resultInit = _ => {
  * @param {string} _text
  * @param {string} _align
  */
-const makeCssResultPlayData = (_id, _x, _class, _heightPos, _text, _align = C_ALIGN_CENTER, { w = 400, siz = C_SIZ_MAIN } = {}) =>
+const makeCssResultPlayData = (_id, _x, _class, _heightPos, _text, _align = C_ALIGN_CENTER, { w = 400, siz = g_limitObj.mainSiz } = {}) =>
 	createDivCss2Label(_id, _text, {
-		x: _x, y: C_SIZ_SETMINI * _heightPos, w, h: C_SIZ_SETMINI, siz, align: _align,
+		x: _x, y: g_limitObj.setMiniSiz * _heightPos, w, h: g_limitObj.setMiniSiz, siz, align: _align,
 	}, _class);
 
 /**
@@ -10764,7 +10764,7 @@ const makeCssResultPlayData = (_id, _x, _class, _heightPos, _text, _align = C_AL
  * @param {string} _align
  */
 const makeCssResultSymbol = (_id, _x, _class, _heightPos, _text, _align = C_ALIGN_LEFT) =>
-	makeCssResultPlayData(_id, _x, _class, _heightPos, _text, _align, { w: 150, siz: C_SIZ_JDGCNTS });
+	makeCssResultPlayData(_id, _x, _class, _heightPos, _text, _align, { w: 150, siz: g_limitObj.jdgCntsSiz });
 
 // ライセンス原文、以下は削除しないでください
 /*-----------------------------------------------------------*/

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -21,10 +21,12 @@ const C_VALIGN_TOP = `top`;
 const C_VALIGN_MIDDLE = `middle`;
 const C_VALIGN_BOTTOM = `bottom`;
 
+const C_LBL_BASICFONT = `"Meiryo UI", sans-serif`;
+
+/** 廃止予定の定数群 */
 const C_LBL_TITLESIZE = 32;
 const C_LBL_BTNSIZE = 28;
 const C_LBL_LNKSIZE = 16;
-const C_LBL_BASICFONT = `"Meiryo UI", sans-serif`;
 
 const C_BTN_HEIGHT = 50;
 const C_LNK_HEIGHT = 30;
@@ -41,6 +43,76 @@ const C_SIZ_SETMINI = 18;
 const C_SIZ_DIFSELECTOR = 14;
 const C_SIZ_MAIN = 14;
 const C_SIZ_MUSIC_TITLE = 13;
+
+const C_LEN_JDGCHARA_WIDTH = 200;
+const C_LEN_JDGCHARA_HEIGHT = 20;
+const C_SIZ_JDGCHARA = 20;
+
+const C_LEN_JDGCNTS_WIDTH = 100;
+const C_LEN_JDGCNTS_HEIGHT = 20;
+const C_SIZ_JDGCNTS = 16;
+
+const C_LEN_GRAPH_WIDTH = 286;
+const C_LEN_GRAPH_HEIGHT = 226;
+const C_CLR_SPEEDGRAPH_SPEED = `#cc3333`;
+const C_CLR_SPEEDGRAPH_BOOST = `#999900`;
+const C_CLR_DENSITY_MAX = `#990000cc`;
+const C_CLR_DENSITY_DEFAULT = `#999999cc`;
+const C_LEN_DENSITY_DIVISION = 16;
+
+const C_MAX_ADJUSTMENT = 30;
+
+/** 設定幅、位置などを管理するプロパティ */
+const g_limitObj = {
+
+    // Adjustment, HitPositionの設定幅
+    adjustment: 30,
+    hitPosition: 50,
+
+    // 譜面密度グラフの分割数、上位色付け数
+    densityDivision: 16,
+    densityMaxVals: 3,
+
+    // ボタン・リンクの高さ、フォントサイズ
+    btnHeight: 50,
+    btnSiz: 28,
+    lnkHeight: 30,
+    lnkSiz: 16,
+
+    // 設定画面用のボタンの位置、幅、高さ、フォントサイズ
+    setLblLeft: 160,
+    setLblWidth: 210,
+    setLblHeight: 22,
+    setLblSiz: 17,
+
+    // 設定画面の左右移動ボタンの幅、フォントサイズ
+    setMiniWidth: 40,
+    setMiniSiz: 18,
+
+    // 譜面選択エリアの幅、フォントサイズ
+    difSelectorWidth: 250,
+    difSelectorSiz: 14,
+    difCoverWidth: 110,
+
+    // 判定キャラクタの幅、高さ、フォントサイズ
+    jdgCharaWidth: 200,
+    jdgCharaHeight: 20,
+    jdgCharaSiz: 20,
+
+    // 判定数の幅、高さ、フォントサイズ
+    jdgCntsWidth: 100,
+    jdgCntsHeight: 20,
+    jdgCntsSiz: 16,
+
+    // グラフ表示部分の幅、高さ
+    graphWidth: 286,
+    graphHeight: 226,
+
+    // その他のフォントサイズ
+    titleSiz: 32,
+    mainSiz: 14,
+    musicTitleSiz: 13,
+};
 
 // スプライト（ムービークリップ相当）のルート
 const C_SPRITE_ROOT = `divRoot`;
@@ -98,7 +170,7 @@ const g_lblPosObj = {};
 const updateWindowSiz = _ => {
     Object.assign(g_windowObj, {
         optionSprite: { x: (g_sWidth - 450) / 2, y: 65 + (g_sHeight - 500) / 2, w: 450, h: 325 },
-        displaySprite: { x: 25, y: 30, w: (g_sWidth - 450) / 2, h: C_LEN_SETLBL_HEIGHT * 5 },
+        displaySprite: { x: 25, y: 30, w: (g_sWidth - 450) / 2, h: g_limitObj.setLblHeight * 5 },
         keyconSprite: { y: 88 + (g_sHeight - 500) / 2, h: g_sHeight, overflow: `auto` },
         loader: { y: g_sHeight - 10, h: 10, backgroundColor: `#333333` },
         playDataWindow: { x: g_sWidth / 2 - 225, y: 70 + (g_sHeight - 500) / 2, w: 450, h: 110 },
@@ -118,11 +190,11 @@ const updateWindowSiz = _ => {
             x: 0, y: g_sHeight - 150, w: 40, h: 40, siz: 30, title: g_msgObj.howto,
         },
         lnkMaker: {
-            x: 0, y: g_sHeight - 50, w: g_sWidth / 2, h: C_LNK_HEIGHT,
+            x: 0, y: g_sHeight - 50, w: g_sWidth / 2, h: g_limitObj.lnkHeight,
             align: C_ALIGN_LEFT, title: g_headerObj.creatorUrl,
         },
         lnkArtist: {
-            x: g_sWidth / 2, y: g_sHeight - 50, w: g_sWidth / 2, h: C_LNK_HEIGHT,
+            x: g_sWidth / 2, y: g_sHeight - 50, w: g_sWidth / 2, h: g_limitObj.lnkHeight,
             align: C_ALIGN_LEFT, title: g_headerObj.artistUrl,
         },
         lnkVersion: {
@@ -133,7 +205,7 @@ const updateWindowSiz = _ => {
             x: g_sWidth - 20, y: g_sHeight - 20, w: 20, h: 16, siz: 12, title: g_msgObj.security,
         },
         lblComment: {
-            x: 0, y: 70, w: g_sWidth, h: g_sHeight - 180, siz: C_SIZ_DIFSELECTOR, align: C_ALIGN_LEFT,
+            x: 0, y: 70, w: g_sWidth, h: g_sHeight - 180, siz: g_limitObj.difSelectorSiz, align: C_ALIGN_LEFT,
             overflow: `auto`, background: `#222222`, color: `#cccccc`, display: C_DIS_NONE,
             whiteSpace: `normal`,
         },
@@ -150,7 +222,7 @@ const updateWindowSiz = _ => {
             x: g_sWidth * 2 / 3,
         },
         btnSwitchSetting: {
-            x: g_sWidth / 2 + 175 - C_LEN_SETMINI_WIDTH / 2, y: 25, w: C_LEN_SETMINI_WIDTH, h: 40,
+            x: g_sWidth / 2 + 175 - g_limitObj.setMiniWidth / 2, y: 25, w: g_limitObj.setMiniWidth, h: 40,
         },
         btnSave: {
             x: 0, y: 5, w: g_sWidth / 5, h: 16, siz: 12,
@@ -158,22 +230,22 @@ const updateWindowSiz = _ => {
         },
 
         btnReverse: {
-            x: 160, y: 0, w: 90, h: 21, siz: C_SIZ_DIFSELECTOR, borderStyle: `solid`,
+            x: 160, y: 0, w: 90, h: 21, siz: g_limitObj.difSelectorSiz, borderStyle: `solid`,
         },
         lblGauge2: {
-            x: C_LEN_SETLBL_LEFT - 35, y: C_LEN_SETLBL_HEIGHT,
-            w: C_LEN_SETLBL_WIDTH + 60, h: C_LEN_SETLBL_HEIGHT * 2, siz: 11,
+            x: g_limitObj.setLblLeft - 35, y: g_limitObj.setLblHeight,
+            w: g_limitObj.setLblWidth + 60, h: g_limitObj.setLblHeight * 2, siz: 11,
         },
         lnkFadein: {
-            x: C_LEN_SETLBL_LEFT, y: 0,
+            x: g_limitObj.setLblLeft, y: 0,
         },
         lblFadeinBar: {
-            x: C_LEN_SETLBL_LEFT, y: 0,
+            x: g_limitObj.setLblLeft, y: 0,
         },
 
         /** 設定: 譜面明細子画面 */
         lblTooldif: {
-            y: 5, w: 250, siz: C_SIZ_JDGCNTS,
+            y: 5, w: 250, siz: g_limitObj.jdgCntsSiz,
         },
         dataTooldif: {
             x: 270, y: 3, w: 160, siz: 18,
@@ -189,10 +261,10 @@ const updateWindowSiz = _ => {
             x: 345, w: 160,
         },
         lblArrowInfo: {
-            x: 130, y: 45, w: 290, siz: C_SIZ_JDGCNTS,
+            x: 130, y: 45, w: 290, siz: g_limitObj.jdgCntsSiz,
         },
         dataArrowInfo: {
-            x: 270, y: 45, w: 160, siz: C_SIZ_JDGCNTS,
+            x: 270, y: 45, w: 160, siz: g_limitObj.jdgCntsSiz,
         },
         lblArrowInfo2: {
             x: 130, y: 70, w: 200, h: 90,
@@ -201,7 +273,7 @@ const updateWindowSiz = _ => {
             x: 140, y: 70, w: 275, h: 150, overflow: `auto`,
         },
         lnkDifInfo: {
-            w: C_LEN_DIFCOVER_WIDTH, borderStyle: `solid`,
+            w: g_limitObj.difCoverWidth, borderStyle: `solid`,
         },
 
         /** ディスプレイ画面 */
@@ -209,16 +281,16 @@ const updateWindowSiz = _ => {
             x: 0, y: g_sHeight - 45, w: g_sWidth, h: 20,
         },
         sdDesc: {
-            x: 0, y: 65, w: g_sWidth, h: 20, siz: C_SIZ_MAIN,
+            x: 0, y: 65, w: g_sWidth, h: 20, siz: g_limitObj.mainSiz,
         },
         lblAppearancePos: {
-            x: C_LEN_SETLBL_LEFT, y: 20, siz: 12, align: C_ALIGN_CENTER,
+            x: g_limitObj.setLblLeft, y: 20, siz: 12, align: C_ALIGN_CENTER,
         },
         lblAppearanceBar: {
-            x: C_LEN_SETLBL_LEFT, y: 15,
+            x: g_limitObj.setLblLeft, y: 15,
         },
         lnkLockBtn: {
-            x: C_LEN_SETLBL_LEFT + C_LEN_SETLBL_WIDTH - 40, y: 0, w: 40, h: C_LEN_SETLBL_HEIGHT, siz: 12,
+            x: g_limitObj.setLblLeft + g_limitObj.setLblWidth - 40, y: 0, w: 40, h: g_limitObj.setLblHeight, siz: 12,
             borderStyle: `solid`,
         },
 
@@ -227,7 +299,7 @@ const updateWindowSiz = _ => {
             x: 0, y: g_sHeight - 45, w: g_sWidth, h: 20,
         },
         kcMsg: {
-            x: 0, y: g_sHeight - 25, w: g_sWidth, h: 20, siz: C_SIZ_MAIN,
+            x: 0, y: g_sHeight - 25, w: g_sWidth, h: 20, siz: g_limitObj.mainSiz,
         },
         kcDesc: {
             x: 0, y: 68, w: g_sWidth, h: 20,
@@ -244,30 +316,30 @@ const updateWindowSiz = _ => {
 
         btnKcBack: {
             x: g_sWidth / 3, y: g_sHeight - 75,
-            w: g_sWidth / 3, h: C_BTN_HEIGHT / 2, siz: C_LBL_BTNSIZE * 2 / 3,
+            w: g_sWidth / 3, h: g_limitObj.btnHeight / 2, siz: g_limitObj.btnSiz * 2 / 3,
         },
         lblPattern: {
-            x: g_sWidth / 6, y: g_sHeight - 100, w: g_sWidth / 3, h: C_BTN_HEIGHT / 2,
+            x: g_sWidth / 6, y: g_sHeight - 100, w: g_sWidth / 3, h: g_limitObj.btnHeight / 2,
         },
         btnPtnChangeR: {
             x: g_sWidth / 2, y: g_sHeight - 100,
-            w: g_sWidth / 9, h: C_BTN_HEIGHT / 2, siz: C_LBL_BTNSIZE * 2 / 3,
+            w: g_sWidth / 9, h: g_limitObj.btnHeight / 2, siz: g_limitObj.btnSiz * 2 / 3,
         },
         btnPtnChangeL: {
             x: g_sWidth / 18, y: g_sHeight - 100,
-            w: g_sWidth / 9, h: C_BTN_HEIGHT / 2, siz: C_LBL_BTNSIZE * 2 / 3,
+            w: g_sWidth / 9, h: g_limitObj.btnHeight / 2, siz: g_limitObj.btnSiz * 2 / 3,
         },
         btnPtnChangeRR: {
             x: g_sWidth * 11 / 18, y: g_sHeight - 100,
-            w: g_sWidth / 18, h: C_BTN_HEIGHT / 2, siz: C_LBL_BTNSIZE * 2 / 3,
+            w: g_sWidth / 18, h: g_limitObj.btnHeight / 2, siz: g_limitObj.btnSiz * 2 / 3,
         },
         btnPtnChangeLL: {
             x: 0, y: g_sHeight - 100,
-            w: g_sWidth / 18, h: C_BTN_HEIGHT / 2, siz: C_LBL_BTNSIZE * 2 / 3,
+            w: g_sWidth / 18, h: g_limitObj.btnHeight / 2, siz: g_limitObj.btnSiz * 2 / 3,
         },
         btnKcReset: {
             x: 0, y: g_sHeight - 75,
-            w: g_sWidth / 3, h: C_BTN_HEIGHT / 2, siz: C_LBL_BTNSIZE * 2 / 3,
+            w: g_sWidth / 3, h: g_limitObj.btnHeight / 2, siz: g_limitObj.btnSiz * 2 / 3,
         },
 
         /** メイン画面 */
@@ -290,14 +362,14 @@ const updateWindowSiz = _ => {
             x: 125, y: g_sHeight - 16, w: g_headerObj.playingWidth, h: 20, align: C_ALIGN_LEFT,
         },
         lblTime1: {
-            x: 18, y: g_sHeight - 30, w: 40, h: 20, siz: C_SIZ_MAIN, align: C_ALIGN_RIGHT,
+            x: 18, y: g_sHeight - 30, w: 40, h: 20, siz: g_limitObj.mainSiz, align: C_ALIGN_RIGHT,
         },
         lblTime2: {
-            x: 60, y: g_sHeight - 30, w: 60, h: 20, siz: C_SIZ_MAIN,
+            x: 60, y: g_sHeight - 30, w: 60, h: 20, siz: g_limitObj.mainSiz,
         },
         lblWord: {
             x: 100, w: g_headerObj.playingWidth - 200, h: 50,
-            siz: C_SIZ_MAIN, align: C_ALIGN_LEFT, display: `block`, margin: `auto`,
+            siz: g_limitObj.mainSiz, align: C_ALIGN_LEFT, display: `block`, margin: `auto`,
         },
         finishView: {
             x: g_headerObj.playingWidth / 2 - 150, y: g_sHeight / 2 - 50, w: 300, h: 20, siz: 50,
@@ -317,21 +389,21 @@ const updateWindowSiz = _ => {
             x: g_sWidth / 2 + 50, y: 40, w: 200, h: 30, siz: 20,
         },
         btnRsBack: {
-            w: g_sWidth / 4, h: C_BTN_HEIGHT * 5 / 4, animationName: `smallToNormalY`,
+            w: g_sWidth / 4, h: g_limitObj.btnHeight * 5 / 4, animationName: `smallToNormalY`,
         },
         btnRsCopy: {
-            x: g_sWidth / 4, w: g_sWidth / 2, h: C_BTN_HEIGHT * 5 / 8, siz: 24, animationName: `smallToNormalY`,
+            x: g_sWidth / 4, w: g_sWidth / 2, h: g_limitObj.btnHeight * 5 / 8, siz: 24, animationName: `smallToNormalY`,
         },
         btnRsTweet: {
-            x: g_sWidth / 4, y: g_sHeight - 100 + C_BTN_HEIGHT * 5 / 8,
-            w: g_sWidth / 4, h: C_BTN_HEIGHT * 5 / 8, siz: 24, animationName: `smallToNormalY`,
+            x: g_sWidth / 4, y: g_sHeight - 100 + g_limitObj.btnHeight * 5 / 8,
+            w: g_sWidth / 4, h: g_limitObj.btnHeight * 5 / 8, siz: 24, animationName: `smallToNormalY`,
         },
         btnRsGitter: {
-            x: g_sWidth / 2, y: g_sHeight - 100 + C_BTN_HEIGHT * 5 / 8,
-            w: g_sWidth / 4, h: C_BTN_HEIGHT * 5 / 8, siz: 24, animationName: `smallToNormalY`,
+            x: g_sWidth / 2, y: g_sHeight - 100 + g_limitObj.btnHeight * 5 / 8,
+            w: g_sWidth / 4, h: g_limitObj.btnHeight * 5 / 8, siz: 24, animationName: `smallToNormalY`,
         },
         btnRsRetry: {
-            x: g_sWidth / 4 * 3, w: g_sWidth / 4, h: C_BTN_HEIGHT * 5 / 4, animationName: `smallToNormalY`,
+            x: g_sWidth / 4 * 3, w: g_sWidth / 4, h: g_limitObj.btnHeight * 5 / 4, animationName: `smallToNormalY`,
         },
     });
 };
@@ -516,14 +588,6 @@ const C_BLOCK_KEYS = [
 ];
 
 /** 設定・オプション画面用共通 */
-const C_LEN_GRAPH_WIDTH = 286;
-const C_LEN_GRAPH_HEIGHT = 226;
-const C_CLR_SPEEDGRAPH_SPEED = `#cc3333`;
-const C_CLR_SPEEDGRAPH_BOOST = `#999900`;
-const C_CLR_DENSITY_MAX = `#990000cc`;
-const C_CLR_DENSITY_DEFAULT = `#999999cc`;
-const C_LEN_DENSITY_DIVISION = 16;
-
 const g_graphColorObj = {
     max: `#993333cc`,
     default: `#999999cc`,
@@ -531,6 +595,9 @@ const g_graphColorObj = {
     default2Push: `#777777cc`,
     max3Push: `#003399cc`,
     default3Push: `#555555cc`,
+
+    speed: `#cc3333`,
+    boost: `#999900`,
 };
 
 const g_settingBtnObj = {
@@ -547,25 +614,17 @@ const g_settingBtnObj = {
         U: `↑`,
     },
     pos: {
-        L: C_LEN_SETLBL_LEFT - C_LEN_SETMINI_WIDTH,
-        LL: C_LEN_SETLBL_LEFT,
-        LLL: C_LEN_SETLBL_LEFT + C_LEN_SETMINI_WIDTH + 1,
-        HL: C_LEN_SETLBL_LEFT,
-        R: C_LEN_SETLBL_LEFT + C_LEN_SETLBL_WIDTH,
-        RR: C_LEN_SETLBL_LEFT + C_LEN_SETLBL_WIDTH - C_LEN_SETMINI_WIDTH,
-        RRR: C_LEN_SETLBL_LEFT + C_LEN_SETLBL_WIDTH - C_LEN_SETMINI_WIDTH * 3 / 2 - 1,
-        HR: C_LEN_SETLBL_LEFT + C_LEN_SETLBL_WIDTH - C_LEN_SETMINI_WIDTH,
+        L: g_limitObj.setLblLeft - g_limitObj.setMiniWidth,
+        LL: g_limitObj.setLblLeft,
+        LLL: g_limitObj.setLblLeft + g_limitObj.setMiniWidth + 1,
+        HL: g_limitObj.setLblLeft,
+        R: g_limitObj.setLblLeft + g_limitObj.setLblWidth,
+        RR: g_limitObj.setLblLeft + g_limitObj.setLblWidth - g_limitObj.setMiniWidth,
+        RRR: g_limitObj.setLblLeft + g_limitObj.setLblWidth - g_limitObj.setMiniWidth * 3 / 2 - 1,
+        HR: g_limitObj.setLblLeft + g_limitObj.setLblWidth - g_limitObj.setMiniWidth,
     }
 };
 
-const g_limitObj = {
-    adjustment: 30,
-    hitPosition: 50,
-
-    densityDivision: 16,
-    densityMaxVals: 3,
-};
-const C_MAX_ADJUSTMENT = 30;
 const C_MAX_SPEED = 10;
 const C_MIN_SPEED = 1;
 
@@ -590,14 +649,6 @@ const g_judgPosObj = {
 };
 
 const C_CLR_DUMMY = `#777777`;
-
-const C_LEN_JDGCHARA_WIDTH = 200;
-const C_LEN_JDGCHARA_HEIGHT = 20;
-const C_SIZ_JDGCHARA = 20;
-
-const C_LEN_JDGCNTS_WIDTH = 100;
-const C_LEN_JDGCNTS_HEIGHT = 20;
-const C_SIZ_JDGCNTS = 16;
 
 let C_FRM_HITMOTION = 4;
 let C_FRM_JDGMOTION = 60;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 定数を`g_limitObj`, `g_graphColorObj`へ移行しました。
現行の定数群は次のメジャーバージョンアップまでは保持する予定です。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Resolves #1453 
スキンで細かい位置調整をしたい場合に、現状ではそのまま上書きできないため。
また、オブジェクト化することで管理を容易にします。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
