### PR TITLE
improve: [0678] 共通設定ファイルにおけるカスタムキーでkeyExtraListの省略に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -373,7 +373,7 @@ const splitLF2 = (_str, _delim = `$`) => splitLF(_str).filter(val => val !== ``)
  * @returns 
  */
 const makeDedupliArray = (_array1, ..._arrays) =>
-	Array.from((new Set([..._array1, ..._arrays.flat()])).values());
+	Array.from((new Set([..._array1, ..._arrays.flat()])).values()).filter(val => val !== undefined);
 
 /**
  * 二次元配列のコピー
@@ -1917,8 +1917,7 @@ const initialControl = async () => {
 		importKeysData(g_presetObj.keysData);
 	}
 	g_headerObj.keyExtraList = keysConvert(g_rootObj, {
-		keyExtraList: (g_rootObj.keyExtraList !== undefined ?
-			makeDedupliArray(g_rootObj.keyExtraList.split(`,`), g_headerObj.undefinedKeyLists) : g_headerObj.undefinedKeyLists),
+		keyExtraList: makeDedupliArray(g_headerObj.undefinedKeyLists, g_rootObj.keyExtraList?.split(`,`)),
 	});
 
 	// デフォルトのカラー・シャッフルグループ設定を退避
@@ -2089,7 +2088,7 @@ const loadLocalStorage = _ => {
  * 譜面データを分割して値を取得
  * @param {string} _dos 譜面データ
  */
-const dosConvert = _dos => {
+const dosConvert = (_dos = ``) => {
 
 	const obj = {};
 	const paramsTmp = g_enableAmpersandSplit ? _dos.split(`&`).join(`|`) : _dos;
@@ -3493,10 +3492,16 @@ const getKeyName = _key => hasVal(g_keyObj[`keyName${_key}`]) ? g_keyObj[`keyNam
  * 一時的な追加キーの設定
  * @param {object} _dosObj 
  */
-const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList.split(`,`) } = {}) => {
+const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) } = {}) => {
 
 	if (keyExtraList === undefined) {
-		return [];
+		keyExtraList = [];
+		Object.keys(_dosObj).filter(val => val.startsWith(`chara`))
+			.forEach(keyName => keyExtraList.push(keyName.slice(`chara`.length)));
+
+		if (keyExtraList.length === 0) {
+			return [];
+		}
 	}
 
 	const existParam = (_data, _paramName) => !hasVal(_data) && g_keyObj[_paramName] !== undefined;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 共通設定ファイルにおけるカスタムキーでkeyExtraListが原則不要になりました。
既存キー、カスタムキーによらずcharaX (Xにはキー数が入る) が指定されていれば、今後は省略できます。
2. `makeDedupliArray`関数で、`undefined`が渡された場合に`undefined`を除外するように変更しました。
3. `dosConvert`関数で、引数の初期値として空を指定するよう変更しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 現状は共通設定ファイルのみとなったとはいえ、記述するのは手間のため。
※作品ページ内の`keyExtraList`指定は現状でも不要です。
2. 通常、`undefined`を配列に追加する必要があることは無いため。
3. `dosConvert`関数で`undefined`が渡されたとき、エラーとなることを避けるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- charaXが指定されている場合で、意図して特定のキーを外したい場合には
従来通り`keyExtraList`が使えます。