### PR TITLE
fix: [0680] 一部キーでスクロールの折り返しが外れてしまう問題を修正

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2065,9 +2065,10 @@ const g_keyObj = {
 // g_keyObj.defaultProp の上書きを禁止
 Object.defineProperty(g_keyObj, `defaultProp`, { writable: false });
 
-// charaX_Y, posX_Y, keyGroupX_Y, divX_Y, divMaxX_Yが未定義のときに0からの連番で補完する処理 (keyCtrlX_Yが定義されていることが前提)
-Object.keys(g_keyObj).filter(val => val.startsWith(g_keyObj.defaultProp)).forEach(charaPtn => {
-    setKeyDfVal(charaPtn.slice(g_keyObj.defaultProp.length));
+// charaX_Y, posX_Y, keyGroupX_Y, divX_Y, divMaxX_Yが未定義のときに0からの連番で補完する処理 (charaX_Yが定義されていることが前提)
+// この後g_copyKeyPtnにてデータコピーするため、ここのみcharaX_Yがあるものだけについて処理
+Object.keys(g_keyObj).filter(val => val.startsWith(`chara`)).forEach(charaPtn => {
+    setKeyDfVal(charaPtn.slice(`chara`.length));
 });
 
 // キーパターンのコピーリスト

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2065,12 +2065,6 @@ const g_keyObj = {
 // g_keyObj.defaultProp の上書きを禁止
 Object.defineProperty(g_keyObj, `defaultProp`, { writable: false });
 
-// charaX_Y, posX_Y, keyGroupX_Y, divX_Y, divMaxX_Yが未定義のときに0からの連番で補完する処理 (charaX_Yが定義されていることが前提)
-// この後g_copyKeyPtnにてデータコピーするため、ここのみcharaX_Yがあるものだけについて処理
-Object.keys(g_keyObj).filter(val => val.startsWith(`chara`)).forEach(charaPtn => {
-    setKeyDfVal(charaPtn.slice(`chara`.length));
-});
-
 // キーパターンのコピーリスト
 // ・コピー先：コピー元の順に指定する
 // ・上から順に処理する
@@ -2117,6 +2111,13 @@ const g_copyKeyPtn = {
     '15A_1': `15B_0`,
     '15B_1': `15A_0`,
 };
+
+// charaX_Y, posX_Y, keyGroupX_Y, divX_Y, divMaxX_Yが未定義のときに0からの連番で補完する処理 (charaX_Yが定義されていることが前提)
+// この後g_copyKeyPtnにてデータコピーするため、ここのみcharaX_Yがあるものだけについて処理
+Object.keys(g_keyObj).filter(val => val.startsWith(`chara`) &&
+    !Object.keys(g_copyKeyPtn).includes(val.slice(`chara`.length))).forEach(charaPtn => {
+        setKeyDfVal(charaPtn.slice(`chara`.length));
+    });
 
 // キーパターンのコピー処理
 // ただし、すでに定義済みの場合は定義済みのものを優先する


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 上下スクロールがあるキーで、キーパターン違いがあるときに
ステップゾーンの配置が想定と異なる問題を修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #1456 に対する考慮漏れ。

- `setKeyDfVal`について、keyCtrlX_Yが存在するものに対して初期化していましたが、
これにスクロールの折り返しを管理する`divX_Y`の初期化が含まれていました。
- keyCtrlX_Yが定義されているパターン(X, Y)の中には`divX_Y`がいないパターン(X, Y)があり、後で別パターンからコピーする仕様になっていましたが`setKeyDfVal`の時点で初期化されてしまうため、`divX_Y`が存在する状態となってしまい、コピーができませんでした。
※別パターンからのコピーは、`divX_Y`が未定義の場合のみ適用される
- この部分だけは、`charaX_Y`が存在するものを基準に初期化する必要がありました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- すでにリリース済みのバージョンには影響しません。