### PR TITLE
improve: [0682] カスタムキーのposXに空が指定されたときに初期化されるよう処理を改善

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3530,7 +3530,7 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 
 	const existParam = (_data, _paramName) => !hasVal(_data) && g_keyObj[_paramName] !== undefined;
 	const toString = _str => _str;
-	const toFloat = _num => parseFloat(_num);
+	const toFloat = _num => isNaN(_num) ? parseFloat(_num) : _num;
 	const toKeyCtrlArray = _str =>
 		makeBaseArray(_str.split(`/`).map(n => getKeyCtrlVal(n)), g_keyObj.minKeyCtrlNum, 0);
 	const toSplitArrayStr = _str => _str.split(`/`).map(n => n);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3530,7 +3530,7 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 
 	const existParam = (_data, _paramName) => !hasVal(_data) && g_keyObj[_paramName] !== undefined;
 	const toString = _str => _str;
-	const toFloat = _num => isNaN(_num) ? parseFloat(_num) : _num;
+	const toFloat = _num => isNaN(parseFloat(_num)) ? _num : parseFloat(_num);
 	const toKeyCtrlArray = _str =>
 		makeBaseArray(_str.split(`/`).map(n => getKeyCtrlVal(n)), g_keyObj.minKeyCtrlNum, 0);
 	const toSplitArrayStr = _str => _str.split(`/`).map(n => n);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. カスタムキーのposXに空が指定されたときに初期化できない問題を改善しました。
具体的には下記のように一部譜面が無指定の場合、ステップゾーン位置が正しく表示されませんでした。
```
|pos10=$$0,1,2,3,4,5,6,7,8,9|
```

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 部分的に未指定にする場合も正しく表示されるように動く想定だったため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
