### PR TITLE
feat: [0683] 別キーモード、ミラー時のハイスコア保存に対応　他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2066,7 +2066,7 @@ const loadLocalStorage = _ => {
 	if (checkStorage) {
 		g_localStorage = JSON.parse(checkStorage);
 
-		// Adjustment, Volume, Appearance, Opacity, hitPosition初期値設定
+		// Adjustment, Volume, Appearance, Opacity, HitPosition初期値設定
 		checkLocalParam(`adjustment`, C_TYP_FLOAT, g_settings.adjustmentNum);
 		checkLocalParam(`volume`, C_TYP_NUMBER, g_settings.volumes.length - 1);
 		checkLocalParam(`appearance`);
@@ -8405,7 +8405,7 @@ const getArrowSettings = _ => {
 	g_finishFlg = true;
 
 	if (g_stateObj.dataSaveFlg) {
-		// ローカルストレージへAdjustment, hitPosition, Volume設定を保存
+		// ローカルストレージへAdjustment, HitPosition, Volume設定を保存
 		g_storeSettings.forEach(setting => g_localStorage[setting] = g_stateObj[setting]);
 		localStorage.setItem(g_localStorageUrl, JSON.stringify(g_localStorage));
 	}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7028,6 +7028,20 @@ const applyMirror = (_keyNum, _shuffleGroup, _asymFlg = false) => {
 };
 
 /**
+ * Turningの適用
+ * @param {number} _keyNum 
+ * @param {array} _shuffleGroup 
+ */
+const applyTurning = (_keyNum, _shuffleGroup) => {
+	const mirrorOrNot = _array => Math.random() >= 0.5 ? _array.reverse() : _array;
+	const style = structuredClone(_shuffleGroup).map(_group => {
+		const startNum = Math.floor(Math.random() * (_group.length - 1)) + 1;
+		return mirrorOrNot(makeDedupliArray(_group.slice(startNum), _group.slice(0, startNum)));
+	});
+	applyShuffle(_keyNum, _shuffleGroup, style);
+};
+
+/**
  * Randomの適用
  * @param {number} _keyNum
  * @param {array} _shuffleGroup

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7037,9 +7037,7 @@ const applyRandom = (_keyNum, _shuffleGroup) => {
 	const style = structuredClone(_shuffleGroup).map(_group => {
 		for (let i = _group.length - 1; i > 0; i--) {
 			const random = Math.floor(Math.random() * (i + 1));
-			const tmp = _group[i];
-			_group[i] = _group[random];
-			_group[random] = tmp;
+			[_group[i], _group[random]] = [_group[random], _group[i]];
 		}
 		return _group;
 	});

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -989,7 +989,7 @@ let g_displays = [`stepZone`, `judgment`, `fastSlow`, `lifeGauge`, `score`, `mus
     `speed`, `color`, `lyrics`, `background`, `arrowEffect`, `special`];
 
 // ローカルストレージ保存対象
-let g_storeSettings = [`appearance`, `opacity`];
+let g_storeSettings = [`adjustment`, `volume`, `appearance`, `opacity`, `hitPosition`];
 
 // 廃棄対象のリスト(過去の登録対象をリスト化。ここに乗せるとローカルストレージから自動消去される)
 let g_storeSettingsEx = [`d_stepzone`, `d_judgment`, `d_fastslow`, `d_lifegauge`,
@@ -2708,7 +2708,7 @@ const g_lang_lblNameObj = {
         kcNoShuffleDesc: `矢印をクリックでカラーグループを変更`,
         sdDesc: `[クリックでON/OFFを切替、灰色でOFF]`,
         kcShortcutDesc: `プレイ中ショートカット：「{0}」タイトルバック / 「{1}」リトライ`,
-        transKeyDesc: `別キーモードではハイスコア、キーコンフィグ等は保存されません`,
+        transKeyDesc: `別キーモードではキーコンフィグ、ColorType等は保存されません`,
         sdShortcutDesc: `Hid+/Sud+時ショートカット：「pageUp」カバーを上へ / 「pageDown」下へ`,
 
         s_level: `Level`,
@@ -2740,7 +2740,7 @@ const g_lang_lblNameObj = {
         kcNoShuffleDesc: `Click the arrow to change the color group.`,
         sdDesc: `[Click to switch, gray to OFF]`,
         kcShortcutDesc: `Shortcut during play: "{0}" Return to title / "{1}" Retry the game`,
-        transKeyDesc: `High score, key config, etc. are not saved in another key mode`,
+        transKeyDesc: `Key config, Color type, etc. are not saved in another key mode`,
         sdShortcutDesc: `When "Hidden+" or "Sudden+" select, "pageUp" cover up / "pageDown" cover down`,
 
         s_level: `Level`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -879,7 +879,7 @@ const g_settings = {
     scrollNum: 0,
     scrollFlat: [`Flat`, `R-Flat`],
 
-    shuffles: [C_FLG_OFF, `Mirror`, `Asym-Mirror`, `Random`, `Random+`, `S-Random`, `S-Random+`],
+    shuffles: [C_FLG_OFF, `Mirror`, `Asym-Mirror`, `Turning`, `Random`, `Random+`, `S-Random`, `S-Random+`],
     shuffleNum: 0,
 
     gauges: [],
@@ -931,6 +931,7 @@ const g_shuffleFunc = {
     'OFF': _ => true,
     'Mirror': (keyNum, shuffleGroup) => applyMirror(keyNum, shuffleGroup),
     'Asym-Mirror': (keyNum, shuffleGroup) => applyMirror(keyNum, shuffleGroup, true),
+    'Turning': (keyNum, shuffleGroup) => applyTurning(keyNum, shuffleGroup),
     'Random': (keyNum, shuffleGroup) => applyRandom(keyNum, shuffleGroup),
     'Random+': keyNum => applyRandom(keyNum, [[...Array(keyNum).keys()]]),
     'S-Random': (keyNum, shuffleGroup) => {
@@ -2614,6 +2615,7 @@ const g_lblNameObj = {
 
     'u_Mirror': `Mirror`,
     'u_Asym-Mirror': `Asym-Mirror`,
+    'u_Turning': `Turning`,
     'u_Random': `Random`,
     'u_Random+': `Random+`,
     'u_S-Random': `S-Random`,
@@ -2829,7 +2831,7 @@ const g_lang_msgObj = {
         colorType: `矢印・フリーズアローの配色セットをあらかじめ定義されたリストから選択できます。\nType1～4選択時は色変化が自動でOFFになり、カラーピッカーから好きな色に変更できます。\n[Type0] グラデーション切替, [Type1～4] デフォルトパターン`,
         imgType: `矢印・フリーズアローなどのオブジェクトの見た目を変更します。`,
         colorGroup: `矢印・フリーズアロー色グループの割り当てパターンを変更します。`,
-        shuffleGroup: `Mirror/Asym-Mirror/Random/S-Random選択時、シャッフルするグループを変更します。\n矢印の上にある同じ数字同士でシャッフルします。`,
+        shuffleGroup: `Mirror/Asym-Mirror/Turning/Random/S-Random選択時、シャッフルするグループを変更します。\n矢印の上にある同じ数字同士でシャッフルします。`,
         stepRtnGroup: `矢印などノーツの種類、回転に関するパターンを切り替えます。\nあらかじめ設定されている場合のみ変更可能です。`,
 
         pickArrow: `色番号ごとの矢印色（枠、塗りつぶし）、通常時のフリーズアロー色（枠、帯）を\nカラーピッカーから選んで変更できます。`,
@@ -2885,7 +2887,7 @@ const g_lang_msgObj = {
         colorType: `Change the color scheme set for arrows and freeze-arrows from the predefined set.\nWhen Type1 to 4 is selected, color change is automatically turned off and can be changed to any color from the color picker.\n[Type0] Switch the sequences color gradations, [Type1～4] default color scheme`,
         imgType: `Change the appearance of sequences.`,
         colorGroup: `Change the sequences color group assignment pattern.`,
-        shuffleGroup: `Change the shuffle group when Mirror, Asym-Mirror, Random or S-Random are selected.\nShuffle with the same numbers listed above.`,
+        shuffleGroup: `Change the shuffle group when Mirror, Asym-Mirror, Turning, Random or S-Random are selected.\nShuffle with the same numbers listed above.`,
         stepRtnGroup: `Switches the type of notes, such as arrows, and the pattern regarding rotation.\nThis can only be changed if it has been set in advance.`,
 
         pickArrow: `Change the frame or fill of arrow color and the frame or bar of normal freeze-arrow color\nfor each color number from the color picker.`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 別キーモード、ミラー（Mirror, Asym-Mirror）時のハイスコア保存に対応しました。
なお、Mirror, Asym-Mirrorのハイスコアは区別されず「Mirror」として保存します。
別キーモードは KeyPattern表示時に明記されるキー（**transKeyX**での指定キー）毎に保存します。
2. 別キーモードのときローカル保存が有効になっていれば、Appearance, Opacity, HitPosition, Adjustment, Volume を保存するように挙動を変更しました。
3. Shuffle設定に「Turning」を追加しました。他ゲーで言うところの「R-Random」に相当します。
グループレーンごとに流れてくるレーンが左右にずれて流れてきます。ミラーになることもあります。
例1）1,2,3,4,5,6,7 -> 3,4,5,6,7,1,2
例2）1,2,3,4,5,6,7 -> 5,4,3,2,1,7,6
グループレーンが複数ある場合は、あるグループが正順で、
別のグループがミラーといったことも起こりえます。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 別譜面として独立した譜面と見做せるため。
なお、RandomやS-Random系については一意の譜面にすることができないため、
今後もハイスコアの更新対象からは外します。
    - 厳密には、シャッフルグループが個別に変更できるためミラーでも一意に特定はできません。
    通常のプレイではハイスコア管理を一つにしても大きな支障にならないと思われるため、
    今回実装しています。
2. 別キーモードのとき、ローカル保存の有無によらず常に無効となっていましたが、
実際には環境設定など有効にした方が良い設定も含まれているため。
3. 従来の「Random」だとグループレーンごとにランダムになってしまうため、レーンが散る傾向にありました。
「Turning」では固まりが移動するため、「Random」より散りづらくなります。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/232265942-95ade78b-05a7-4a76-8209-63f6376eede2.png" width="70%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 別キーモード時のメッセージについて、ハイスコアを保存するようになったため変更しています。
<img src="https://user-images.githubusercontent.com/44026291/232265962-14376413-9b8c-4353-9653-cee3be34be5e.png" width="70%">