### PR TITLE
improve: [0686] キー数名称（key）を変更した場合に、その名前が譜面リストのキー数フィルタ名にも反映されるよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4407,7 +4407,7 @@ const createDifWindow = (_key = ``) => {
 	let pos = 0;
 	g_headerObj.keyLists.forEach((targetKey, m) => {
 		difCover.appendChild(
-			makeDifLblCssButton(`keyFilter${m}`, `${getKeyName(targetKey)} key`, m + 2.5, _ => {
+			makeDifLblCssButton(`keyFilter${m}`, `${getKeyName(targetKey)} ${getStgDetailName('key')}`, m + 2.5, _ => {
 				resetDifWindow();
 				g_stateObj.filterKeys = targetKey;
 				createDifWindow(targetKey);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. キー数名称（key）を変更した場合に、その名前が譜面リストのキー数フィルタ名にも反映されるよう変更しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 譜面リストのキー数フィルタ名のみ、名前が反映されていなかったため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/234541412-f28d2a56-29d8-4314-83bb-0eb980e3b48e.png" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
