### PR TITLE
fix: [0688] 譜面リスト選択時にキーコンフィグ画面で止まることがある問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4366,9 +4366,7 @@ const makeDifBtn = (_scrollNum = 1) => {
 		setDifficulty(true);
 		deleteChildspriteAll(`difList`);
 		makeDifList(difList, g_stateObj.filterKeys);
-		if (g_keyObj.prevKey !== g_keyObj.currentKey) {
-			g_keyObj.prevKey = g_keyObj.currentKey;
-		}
+		g_keyObj.prevKey = g_keyObj.currentKey;
 	}, {
 		x: 430 + _scrollNum * 10, y: 40, w: 20, h: 20, siz: g_limitObj.jdgCntsSiz,
 	}, g_cssObj.button_Mini);
@@ -4427,6 +4425,7 @@ const changeDifficulty = (_num = 1) => {
 	if (g_headerObj.difSelectorUse) {
 		g_stateObj.filterKeys = ``;
 		if (document.querySelector(`#difList`) === null) {
+			g_keyObj.prevKey = g_keyObj.currentKey;
 			createDifWindow();
 		} else {
 			resetDifWindow();


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 譜面リスト選択時にキーコンフィグ画面で止まることがある問題を修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 譜面リストを「L」キーで開き、一番最初から「↑」キーで一番最後に移動したときに発生します。
PR #1446 の修正漏れです。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/234578096-30310ce2-bb05-42b6-a678-eb1fb0009c0b.png" width="70%">
<img src="https://user-images.githubusercontent.com/44026291/234578227-17e83679-008b-4cc8-9b1f-8fb6ae5c159c.png" width="70%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
