### PR TITLE
feat: [0690] フリーズアローヒット時の割込み処理を実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9917,8 +9917,10 @@ const changeStepY = (_frameNum) => {
  * フリーズアローヒット時の描画変更
  * @param {number} _j 
  * @param {number} _k 
+ * @param {string} _name
+ * @param {number} _difFrame
  */
-const changeHitFrz = (_j, _k, _name) => {
+const changeHitFrz = (_j, _k, _name, _difFrame = 0) => {
 	const frzNo = `${_j}_${_k}`;
 	const frzName = `${_name}${frzNo}`;
 	const currentFrz = g_attrObj[frzName];
@@ -10055,7 +10057,7 @@ const judgeArrow = _j => {
 			}
 
 			if (_difCnt <= g_judgObj.frzJ[g_judgPosObj.sfsf]) {
-				changeHitFrz(_j, fcurrentNo, `frz`);
+				changeHitFrz(_j, fcurrentNo, `frz`, _difFrame);
 			} else {
 				changeFailedFrz(_j, fcurrentNo);
 				if (g_headerObj.frzStartjdgUse) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9967,6 +9967,8 @@ const changeHitFrz = (_j, _k, _name) => {
 			$id(`frzHitTop${_j}`).background = g_workObj.frzHitColors[_j];
 		}
 	}
+
+	g_customJsObj[`judg_${_name}Hit`].forEach(func => func(_difFrame));
 };
 
 /**

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2946,6 +2946,9 @@ const g_customJsObj = {
     judg_kita: [],
     judg_iknai: [],
 
+    judg_frzHit: [],
+    judg_dummyFrzHit: [],
+
     mainEnterFrame: [],
     result: [],
     resultEnterFrame: [],


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. フリーズアローヒット時の割込み処理を実装しました。
下記のカスタム関数オブジェクトに関数を追加することで実装します。
    - 通常のフリーズアロー： `g_customJsObj.judg_frzHit`
    - ダミーフリーズアロー： `g_customJsObj.judg_dummyFrzHit`

### 使い方
- 引数にジャスト時からの差分フレーム数を指定できます。
```javascript
function addProcessInFrzHit(_difFrame) {
    // 割込み処理を記述
}
// 定義した関数を追加
g_customJsObj.judg_frzHit.push(addProcessInFrzHit);
```

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 判定時の処理割り込みはありましたが、フリーズアローヒット時の処理割り込みは無かったため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- `changeHitFrz`関数の処理末尾に追加する形となります。