### PR TITLE
fix: [0693] 同じキー数の譜面が複数存在するときに譜面リストのフィルタが複数表示される問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5164,7 +5164,7 @@ const createOptionWindow = _sprite => {
 	// 譜面番号の再取得
 	g_stateObj.scoreId = getNextDifficulty(g_stateObj.scoreId, 0);
 	const keyLists = g_headerObj.viewLists.map(j => g_headerObj.keyLabels[j]);
-	g_headerObj.viewKeyLists = keyLists.sort((a, b) => parseInt(a) - parseInt(b));
+	g_headerObj.viewKeyLists = makeDedupliArray(keyLists.sort((a, b) => parseInt(a) - parseInt(b)));
 	g_headerObj.difSelectorUse = getDifSelectorUse(g_rootObj.difSelectorUse);
 
 	// 設定画面の一通りのオブジェクトを作成後に譜面・速度・ゲージ設定をまとめて行う

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5163,8 +5163,8 @@ const createOptionWindow = _sprite => {
 
 	// 譜面番号の再取得
 	g_stateObj.scoreId = getNextDifficulty(g_stateObj.scoreId, 0);
-	const keyLists = g_headerObj.viewLists.map(j => g_headerObj.keyLabels[j]);
-	g_headerObj.viewKeyLists = makeDedupliArray(keyLists.sort((a, b) => parseInt(a) - parseInt(b)));
+	const keyLists = makeDedupliArray(g_headerObj.viewLists.map(j => g_headerObj.keyLabels[j]));
+	g_headerObj.viewKeyLists = keyLists.sort((a, b) => parseInt(a) - parseInt(b));
 	g_headerObj.difSelectorUse = getDifSelectorUse(g_rootObj.difSelectorUse);
 
 	// 設定画面の一通りのオブジェクトを作成後に譜面・速度・ゲージ設定をまとめて行う


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 同じキー数の譜面が複数存在するときに譜面リストのフィルタが複数表示される問題を修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #1475 でキー数フィルタを定義する配列を変更しましたが、その配列の重複排除処理が抜けていました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
