### PR TITLE
[ver31.7.1] 同じキー数の譜面が複数存在するときに譜面リストのキー別フィルタが重複表示される問題を修正

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ v24, v29の対応終了時期はv33リリース開始時を予定しています
 
 | Version | Supported          | Latest Version | Logs | First Release | End of Support |
 | ------- | ------------------ |----------------|------|---------------|----------------|
-| v31     | :heavy_check_mark: |[v31.7.0](https://github.com/cwtickle/danoniplus/releases/tag/v31.7.0)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-latest)|2023-03-20|-|
+| v31     | :heavy_check_mark: |[v31.7.1](https://github.com/cwtickle/danoniplus/releases/tag/v31.7.1)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-latest)|2023-03-20|-|
 | v30     | :heavy_check_mark: |[v30.6.2](https://github.com/cwtickle/danoniplus/releases/tag/v30.6.2)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v30)|2023-02-10|(At Release v33)|
 | v29 :anchor:    | :heavy_check_mark: |[v29.4.5](https://github.com/cwtickle/danoniplus/releases/tag/v29.4.5)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v29)|2022-11-05|(At Release v38)|
 | v28     | :x:                |[v28.6.7 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v28.6.7)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v28)|2022-08-21|2023-03-20|

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2023/05/03
+ * Revised : 2023/05/04
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 31.7.0`;
-const g_revisedDate = `2023/05/03`;
+const g_version = `Ver 31.7.1`;
+const g_revisedDate = `2023/05/04`;
 const g_alphaVersion = ``;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danoniplus",
-  "version": "31.7.0",
+  "version": "31.7.1",
   "description": "Dancing☆Onigiri (CW Edition) - Web-based Rhythm Game",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- #1477 
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
