### PR TITLE
improve: [0694] カスタムキーの拡張スクロール設定でリバースの略記指定を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3698,7 +3698,7 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 						// 通常の指定方法（例：|scroll8i=Cross::1,1,1,-1,-1,-1,1,1/Split::1,1,1,1,-1,-1,-1,-1|）から取り込み
 						const tmpParamPair = pairs.split(`::`);
 						g_keyObj[pairName][tmpParamPair[0]] =
-							makeBaseArray(tmpParamPair[1].split(`,`).map(n => parseInt(n, 10)),
+							makeBaseArray(tmpParamPair[1].split(`,`).map(n => n === `-` ? -1 : parseInt(n, 10)),
 								g_keyObj[`${g_keyObj.defaultProp}${_key}_${k + dfPtn}`].length, _defaultVal);
 					}
 				});


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. カスタムキーの拡張スクロール設定でリバースの略記指定を追加しました。
スクロールをリバースとして設定する際、「-1」の代わりに「-」が使えるようになります。
```
|scroll9j=9A_0/Cross::1,1,1,-,-,-,1,1,1/AA-Split::1,-,-,-,1,-,-,-,1$9A_0$9A_1$9A_2|
```
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 毎回「-1」を指定するのが手間と感じることがあるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
