### PR TITLE
improve: [0695] カスタムキーの部分略記に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3702,8 +3702,10 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 						// 通常の指定方法（例：|scroll8i=Cross::1,1,1,-1,-1,-1,1,1/Split::1,1,1,1,-1,-1,-1,-1|）から取り込み
 						const tmpParamPair = pairs.split(`::`);
 						g_keyObj[pairName][tmpParamPair[0]] =
-							makeBaseArray(tmpParamPair[1].split(`,`).map(n => parseInt(n, 10)),
-								g_keyObj[`${g_keyObj.defaultProp}${_key}_${k + dfPtn}`].length, _defaultVal);
+							makeBaseArray(tmpParamPair[1].split(`,`).map(n =>
+								g_keyObj[`${_pairName}${getKeyPtnName(n)}`] !== undefined ?
+									structuredClone(g_keyObj[`${_pairName}${getKeyPtnName(n)}`][tmpParamPair[0]]) : [parseInt(n, 10)]
+							).flat(), g_keyObj[`${g_keyObj.defaultProp}${_key}_${k + dfPtn}`].length, _defaultVal);
 					}
 				});
 			}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3578,9 +3578,11 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 				if (existParam(tmpArray[k], `${keyheader}_${k + dfPtn}`)) {
 					continue;
 				}
-				const keyPtn = getKeyPtnName(tmpArray[k]);
-				g_keyObj[`${keyheader}_${k + dfPtn}`] = g_keyObj[`${_name}${keyPtn}`] !== undefined ?
-					structuredClone(g_keyObj[`${_name}${keyPtn}`]) : tmpArray[k].split(`,`).map(n => _convFunc(n));
+				g_keyObj[`${keyheader}_${k + dfPtn}`] =
+					tmpArray[k].split(`,`).map(n =>
+						g_keyObj[`${_name}${getKeyPtnName(n)}`] !== undefined ?
+							structuredClone(g_keyObj[`${_name}${getKeyPtnName(n)}`]) : [_convFunc(n)]
+					).flat();
 				if (baseCopyFlg) {
 					g_keyObj[`${keyheader}_${k + dfPtn}d`] = structuredClone(g_keyObj[`${keyheader}_${k + dfPtn}`]);
 				}
@@ -3628,8 +3630,10 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 					} else {
 						// 通常の指定方法 (例: |shuffle8i=1,1,1,2,0,0,0,0/1,1,1,1,0,0,0,0| )の場合の取り込み
 						g_keyObj[`${keyheader}_${k + dfPtn}_${ptnCnt}`] =
-							makeBaseArray(list.split(`,`).map(n => isNaN(parseInt(n)) ? n : parseInt(n, 10)),
-								g_keyObj[`${g_keyObj.defaultProp}${_key}_${k + dfPtn}`].length, 0);
+							makeBaseArray(list.split(`,`).map(n =>
+								g_keyObj[`${_name}${getKeyPtnName(n)}`] !== undefined ?
+									structuredClone(g_keyObj[`${_name}${getKeyPtnName(n)}`]) : [isNaN(parseInt(n)) ? n : parseInt(n, 10)]
+							).flat(), g_keyObj[`${g_keyObj.defaultProp}${_key}_${k + dfPtn}`].length, 0);
 						ptnCnt++;
 					}
 				});

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3578,6 +3578,7 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 				if (existParam(tmpArray[k], `${keyheader}_${k + dfPtn}`)) {
 					continue;
 				}
+				// |keyCtrl9j=Tab,7_0,Enter| -> |keyCtrl9j=Tab,S,D,F,Space,J,K,L,Enter| のように補完
 				g_keyObj[`${keyheader}_${k + dfPtn}`] =
 					tmpArray[k].split(`,`).map(n =>
 						g_keyObj[`${_name}${getKeyPtnName(n)}`] !== undefined ?
@@ -3620,7 +3621,8 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 						g_keyObj[`${keyheader}_${k + dfPtn}_${ptnCnt}`] = [...Array(g_keyObj[`${g_keyObj.defaultProp}${_key}_${k + dfPtn}`].length)].fill(0);
 
 					} else if (g_keyObj[`${_name}${keyPtn}_0`] !== undefined) {
-						// 他のキーパターン (例: |shuffle8i=8_0| ) を指定した場合、該当があれば既存パターンからコピー
+						// 他のキーパターン (例: |shuffle8i=8_0| ) を直接指定した場合、該当があれば既存パターンからコピー
+						// 既存パターンが複数ある場合、全てコピーする
 						let m = 0;
 						while (g_keyObj[`${_name}${keyPtn}_${m}`] !== undefined) {
 							g_keyObj[`${keyheader}_${k + dfPtn}_${ptnCnt}`] = structuredClone(g_keyObj[`${_name}${keyPtn}_${m}`]);
@@ -3629,10 +3631,12 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 						}
 					} else {
 						// 通常の指定方法 (例: |shuffle8i=1,1,1,2,0,0,0,0/1,1,1,1,0,0,0,0| )の場合の取り込み
+						// 部分的にキーパターン指定があった場合は既存パターンを展開 (例: |shuffle9j=2,7_0_0,2|)
 						g_keyObj[`${keyheader}_${k + dfPtn}_${ptnCnt}`] =
 							makeBaseArray(list.split(`,`).map(n =>
 								g_keyObj[`${_name}${getKeyPtnName(n)}`] !== undefined ?
-									structuredClone(g_keyObj[`${_name}${getKeyPtnName(n)}`]) : [isNaN(parseInt(n)) ? n : parseInt(n, 10)]
+									structuredClone(g_keyObj[`${_name}${getKeyPtnName(n)}`]) :
+									[isNaN(parseInt(n)) ? n : parseInt(n, 10)]
 							).flat(), g_keyObj[`${g_keyObj.defaultProp}${_key}_${k + dfPtn}`].length, 0);
 						ptnCnt++;
 					}
@@ -3699,12 +3703,14 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 						// 他のキーパターン指定時、該当があればプロパティを全コピー
 						Object.assign(g_keyObj[pairName], g_keyObj[`${_pairName}${keyPtn}`]);
 					} else {
-						// 通常の指定方法（例：|scroll8i=Cross::1,1,1,-1,-1,-1,1,1/Split::1,1,1,1,-1,-1,-1,-1|）から取り込み
+						// 通常の指定方法（例：|scroll8i=Cross::1,1,1,-,-,-,1,1/Split::1,1,1,1,-,-,-,-|）から取り込み
+						// 部分的にキーパターン指定があった場合は既存パターンを展開 (例: |scroll9j=Cross::1,7_0,1|)
 						const tmpParamPair = pairs.split(`::`);
 						g_keyObj[pairName][tmpParamPair[0]] =
 							makeBaseArray(tmpParamPair[1].split(`,`).map(n =>
 								g_keyObj[`${_pairName}${getKeyPtnName(n)}`] !== undefined ?
-									structuredClone(g_keyObj[`${_pairName}${getKeyPtnName(n)}`][tmpParamPair[0]]) : [n === `-` ? -1 : parseInt(n, 10)]
+									structuredClone(g_keyObj[`${_pairName}${getKeyPtnName(n)}`][tmpParamPair[0]]) :
+									[n === `-` ? -1 : parseInt(n, 10)]
 							).flat(), g_keyObj[`${g_keyObj.defaultProp}${_key}_${k + dfPtn}`].length, _defaultVal);
 					}
 				});

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3704,7 +3704,7 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 						g_keyObj[pairName][tmpParamPair[0]] =
 							makeBaseArray(tmpParamPair[1].split(`,`).map(n =>
 								g_keyObj[`${_pairName}${getKeyPtnName(n)}`] !== undefined ?
-									structuredClone(g_keyObj[`${_pairName}${getKeyPtnName(n)}`][tmpParamPair[0]]) : [parseInt(n, 10)]
+									structuredClone(g_keyObj[`${_pairName}${getKeyPtnName(n)}`][tmpParamPair[0]]) : [n === `-` ? -1 : parseInt(n, 10)]
 							).flat(), g_keyObj[`${g_keyObj.defaultProp}${_key}_${k + dfPtn}`].length, _defaultVal);
 					}
 				});


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. カスタムキーの部分略記に対応しました。
下記のような略記指定が使えるようになります。
使用できる対象は、「keyCtrlX」「charaX」「colorX」「stepRtnX」「posX」「shuffleX」「keyGroupX」「scrollX」「assistX」です。

### 略記指定例：1階層
```
|keyCtrl9j=Tab,7_0,Enter|
-> |keyCtrl9j=Tab,S,D,F,Space,J,K,L,Enter|            // "keyCtrl7_0=S,D,F,Space,J,K,L" を補完
|stepRtn9j=giko,7_0,iyo|
-> |stepRtn9j=giko,0,-45,-90,onigiri,90,135,180,iyo|  // "stepRtn7_0=0,-45,-90,onigiri,90,135,180" を補完
|color9j=2,7_0,2|
-> |color9j=2,0,1,0,2,0,1,0,2|                        // "color7_0=0,1,0,2,0,1,0" を補完
```
### 略記指定例：2階層ある場合
- ただし、「colorX」「shuffleX」「stepRtnX」については複数グループ分存在する場合があります。
この場合、「(キー数) _ (キーパターン -1) _ (グループ -1)」のように指定することができます。
```
|color10=9B_0_1,2|
-> |color9j=4,3,1,0,2,0,1,3,4,2|                      // "color9_0_1=4,3,1,0,2,0,1,3,4" を補完
```

### 略記指定例：scrollX, assistXの場合
- scrollX, assistXの場合は、対応する名前のパターンが存在する場合、値補完します。
```
|scroll10=Alternate::9B_0,-1|
-> |scroll10=Alternate::1,-1,1,-1,1,-1,1,-1,1,-1|     // "scroll9B=Alternate/1,-1,1,-1,1,-1,1,-1,1" を補完
```

2. カスタムキーの拡張スクロール設定でリバースの略記指定を追加しました。
スクロールをリバースとして設定する際、「-1」の代わりに「-」が使えるようになります。
```
|scroll9j=9A_0/Cross::1,1,1,-,-,-,1,1,1/AA-Split::1,-,-,-,1,-,-,-,1$9A_0$9A_1$9A_2|
```

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. キー変化作品で部分キーを多数定義する場合に、できるだけ簡略化して定義できた方が良いため。
2. 毎回「-1」を指定するのが手間と感じることがあるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- キー変化作品の場合、事前にダミー部分キーを定義することでそれを組み合わせるといったことができます。
ただし、譜面側で定義すると現状ではdifDataで指定したキーしか読み込まれません。
もし譜面側で定義する場合は、keyExtraListへ部分キーの定義追加が必要です。
（通常、下記の例以外で`keyExtraList`を使わなければならないのは稀です）
※下記の例で、`keyCtrlX`を定義している理由は`keyCtrlX`がカスタムキー定義上必須項目であるためです。

```
|keyExtraList=5T,7iT,Tr|

// ダミー部分キー（5keyの例）
|chara5T=aleft,adown,aup,aright,aspace|
|keyCtrl5T=5_0|
|pos5T=1,2,3,4,5|
|div5T=7|
|shuffle5T=5_0_0|

// ダミー部分キー（7ikeyの例）
|chara7iT=bleft,bleftdia,bdown,bspace,bup,brightdia,bright|
|keyCtrl7iT=7i_0|
|shuffle7iT=2,2,2,3,3,3,3|

// 実際に定義するトランスキーの一部に部分キーの設定を適用
|charaTr=5T_0,7iT_0|
|keyCtrlTr=5T_0,7iT_0|
|posTr=5T_0,7iT_0|
|shuffleTr=5T_0,7iT_0|

|keyGroupTr=5,5,5,5,5,7i,7i,7i,7i,7i,7i,7i|  // keyGroupはトランスキー用設定のため、個別指定
|colorTr=5_0,7i_0|                           // color, stepRtn, divは既存キーから流用
|stepRtnTr=5_0,7i_0|
|divTr=7|
```