### PR TITLE
feat: [0696] Shift, Ctrl, Altキーの左右キーの割り当てを分離　他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -543,7 +543,7 @@ const commonKeyDown = (_evt, _displayName, _func = _code => { }, _dfEvtFlg) => {
 	if (!_dfEvtFlg) {
 		_evt.preventDefault();
 	}
-	const setCode = transCode(_evt.code);
+	const setCode = _evt.code;
 	if (_evt.repeat && (g_unrepeatObj.page.includes(_displayName) || g_unrepeatObj.key.includes(setCode))) {
 		return blockCode(setCode);
 	}
@@ -576,8 +576,9 @@ const commonKeyDown = (_evt, _displayName, _func = _code => { }, _dfEvtFlg) => {
  * @param {object} _evt 
  */
 const commonKeyUp = _evt => {
-	g_inputKeyBuffer[g_kCdNameObj.metaKey] = false;
-	g_inputKeyBuffer[transCode(_evt.code)] = false;
+	g_inputKeyBuffer[g_kCdNameObj.metaLKey] = false;
+	g_inputKeyBuffer[g_kCdNameObj.metaRKey] = false;
+	g_inputKeyBuffer[_evt.code] = false;
 };
 
 /**
@@ -1335,7 +1336,7 @@ const resetKeyControl = _ => {
 	document.onkeyup = _ => { };
 	document.onkeydown = evt => {
 		evt.preventDefault();
-		return blockCode(transCode(evt.code));
+		return blockCode(evt.code);
 	};
 	g_inputKeyBuffer = {};
 };
@@ -6020,7 +6021,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 					setKeyConfigCursor();
 				}, {
 					x: keyconX, y: 50 + C_KYC_REPHEIGHT * k + keyconY,
-					w: C_ARW_WIDTH, h: C_KYC_REPHEIGHT, siz: g_limitObj.jdgCntsSiz,
+					w: C_ARW_WIDTH, h: C_KYC_REPHEIGHT, siz: g_limitObj.keySetSiz,
 				}, g_cssObj.button_Default_NoColor, g_cssObj.title_base)
 			);
 
@@ -6546,12 +6547,13 @@ const keyConfigInit = (_kcType = g_kcType) => {
 
 		// 全角切替、BackSpace、Deleteキー、Escキーは割り当て禁止
 		// また、直前と同じキーを押した場合(BackSpaceを除く)はキー操作を無効にする
-		const disabledKeys = [229, 240, 242, 243, 244, 91, 29, 28, 27, g_prevKey];
+		const disabledKeys = [229, 240, 242, 243, 244, 91, 29, 28, 27, 259, g_prevKey];
 		if (disabledKeys.includes(setKey) || g_kCdN[setKey] === undefined) {
 			makeInfoWindow(g_msgInfoObj.I_0002, `fadeOut0`);
 			return;
 		} else if ((setKey === C_KEY_TITLEBACK && g_currentk === 0) ||
-			(keyIsDown(g_kCdNameObj.metaKey) && keyIsDown(g_kCdNameObj.shiftKey))) {
+			((keyIsDown(g_kCdNameObj.metaLKey) || keyIsDown(g_kCdNameObj.metaRKey)) &&
+				(keyIsDown(g_kCdNameObj.shiftLKey) || keyIsDown(g_kCdNameObj.shiftRKey)))) {
 			return;
 		}
 
@@ -8969,7 +8971,7 @@ const mainInit = _ => {
 	// キー操作イベント
 	document.onkeydown = evt => {
 		evt.preventDefault();
-		const setCode = transCode(evt.code);
+		const setCode = evt.code;
 
 		if (evt.repeat && !g_mainRepeatObj.key.includes(setCode)) {
 			return blockCode(setCode);
@@ -8998,7 +9000,7 @@ const mainInit = _ => {
 		} else if (setCode === g_kCdN[g_headerObj.keyTitleBack]) {
 			g_audio.pause();
 			clearTimeout(g_timeoutEvtId);
-			if (keyIsDown(g_kCdNameObj.shiftKey)) {
+			if (keyIsDown(g_kCdNameObj.shiftLKey) || keyIsDown(g_kCdNameObj.shiftRKey)) {
 				if (g_currentArrows !== g_fullArrows || g_stateObj.lifeMode === C_LFE_BORDER && g_workObj.lifeVal < g_workObj.lifeBorder) {
 					g_gameOverFlg = true;
 					g_finishFlg = false;
@@ -9037,7 +9039,7 @@ const mainInit = _ => {
 	};
 
 	document.onkeyup = evt => {
-		const setCode = transCode(evt.code);
+		const setCode = evt.code;
 		g_inputKeyBuffer[setCode] = false;
 		mainKeyUpActFunc[g_stateObj.autoAll]();
 	};

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8983,7 +8983,7 @@ const mainInit = _ => {
 		// 曲中リトライ、タイトルバック
 		if (setCode === g_kCdN[g_headerObj.keyRetry]) {
 
-			if (g_isMac && keyIsDown(g_kCdNameObj.shiftKey)) {
+			if (g_isMac && (keyIsDown(g_kCdNameObj.shiftLKey) || keyIsDown(g_kCdNameObj.shiftRKey))) {
 				// Mac OS、IPad OSはDeleteキーが無いためShift+BSで代用
 				g_audio.pause();
 				clearTimeout(g_timeoutEvtId);

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -112,6 +112,7 @@ const g_limitObj = {
     titleSiz: 32,
     mainSiz: 14,
     musicTitleSiz: 13,
+    keySetSiz: 16,
 };
 
 /** 設定項目の位置 */
@@ -638,8 +639,11 @@ const g_escapeStr = {
         [`space`, `frzSpace`], [`iyo`, `frzIyo`], [`gor`, `frzGor`], [`oni`, `foni`],
     ],
     keyCtrlName: [
-        [`Left`, ``], [`Digit`, `D`], [`Numpad`, `N`], [`Semicolon`, `;`],
+        [`ShiftLeft`, `Shift`], [`ControlLeft`, `Control`], [`AltLeft`, `Alt`],
+        [`Digit`, `D`], [`Numpad`, `N`], [`Semicolon`, `;`],
         [`Multiply`, `*`], [`Add`, `+`], [`Subtract`, `-`], [`Decimal`, `.`], [`Divide`, `Div`],
+        [`Quote`, `Ja-Colon`], [`BracketLeft`, `Ja-@`], [`BracketRight`, `Ja-[`],
+        [`Backslash`, `Ja-]`], [`Equal`, `Ja-^`],
     ],
 };
 
@@ -1056,7 +1060,7 @@ let g_prevKey = -1;
 // キーコード
 const g_kCd = [];
 const g_kCdN = [];
-for (let j = 0; j < 255; j++) {
+for (let j = 0; j < 260; j++) {
     g_kCd[j] = ``;
     g_kCdN[j] = ``;
 }
@@ -1068,9 +1072,9 @@ g_kCd[8] = (g_isMac ? `Delete` : `BackSpace`);
 g_kCd[9] = `Tab`;
 g_kCd[12] = `Clear`;
 g_kCd[13] = `Enter`;
-g_kCd[16] = `Shift`;
-g_kCd[17] = `Ctrl`;
-g_kCd[18] = `Alt`;
+g_kCd[16] = `L)Shift`;
+g_kCd[17] = `L)Ctrl`;
+g_kCd[18] = `L)Alt`;
 g_kCd[19] = `Pause`;
 g_kCd[27] = `Esc`;
 g_kCd[28] = `Conv`;
@@ -1174,6 +1178,9 @@ g_kCd[222] = `^ ~`;
 g_kCd[226] = `\\ _`;
 g_kCd[229] = `IME`;
 g_kCd[240] = `CapsLk`;
+g_kCd[256] = `R)Shift`;
+g_kCd[257] = `R)Ctrl`;
+g_kCd[258] = `R)Alt`;
 
 // 従来のキーコードとの変換用
 g_kCdN[0] = `- - -`; // 無効値
@@ -1288,10 +1295,16 @@ g_kCdN[222] = `Equal`;
 g_kCdN[226] = `IntlRo`;
 g_kCdN[229] = `Backquote`;
 g_kCdN[240] = `CapsLock`;
+g_kCdN[256] = `ShiftRight`;
+g_kCdN[257] = `ControlRight`;
+g_kCdN[258] = `AltRight`;
+g_kCdN[259] = `MetaRight`;
 
 const g_kCdNameObj = {
-    shiftKey: `ShiftLeft`,
-    metaKey: `MetaLeft`,
+    shiftLKey: `ShiftLeft`,
+    shiftRKey: `ShiftRight`,
+    metaLKey: `MetaLeft`,
+    metaRKey: `MetaRight`,
 };
 
 // 画面別ショートカット
@@ -1306,47 +1319,79 @@ const g_shortcutObj = {
     },
     option: {
         ShiftLeft_KeyD: { id: `lnkDifficultyL` },
+        ShiftRight_KeyD: { id: `lnkDifficultyL` },
         KeyD: { id: `lnkDifficultyR` },
+
         ShiftLeft_ArrowRight: { id: `lnkSpeedR` },
+        ShiftRight_ArrowRight: { id: `lnkSpeedR` },
         AltLeft_ArrowRight: { id: `lnkSpeedHR` },
+        AltRight_ArrowRight: { id: `lnkSpeedHR` },
         ArrowRight: { id: `lnkSpeedRR` },
         ShiftLeft_ArrowLeft: { id: `lnkSpeedL` },
+        ShiftRight_ArrowLeft: { id: `lnkSpeedL` },
         AltLeft_ArrowLeft: { id: `lnkSpeedHL` },
+        AltRight_ArrowLeft: { id: `lnkSpeedHL` },
         ArrowLeft: { id: `lnkSpeedLL` },
+
         KeyL: { id: `lnkDifficulty` },
 
         ShiftLeft_KeyM: { id: `lnkMotionL` },
+        ShiftRight_KeyM: { id: `lnkMotionL` },
         KeyM: { id: `lnkMotionR` },
         ArrowUp: { id: `lnkScrollL` },
         ArrowDown: { id: `lnkScrollR` },
         KeyR: { id: `lnkReverseR`, dfId: `lnkReverseR`, exId: `btnReverse` },
 
         ShiftLeft_KeyS: { id: `lnkShuffleL` },
+        ShiftRight_KeyS: { id: `lnkShuffleL` },
         KeyS: { id: `lnkShuffleR` },
         ShiftLeft_KeyA: { id: `lnkAutoPlayL` },
+        ShiftRight_KeyA: { id: `lnkAutoPlayL` },
         KeyA: { id: `lnkAutoPlayR` },
         ShiftLeft_KeyG: { id: `lnkGaugeL` },
+        ShiftRight_KeyG: { id: `lnkGaugeL` },
         KeyG: { id: `lnkGaugeR` },
 
         AltLeft_ShiftLeft_Semicolon: { id: `lnkAdjustmentHR` },
+        AltLeft_ShiftRight_Semicolon: { id: `lnkAdjustmentHR` },
+        AltRight_ShiftLeft_Semicolon: { id: `lnkAdjustmentHR` },
+        AltRight_ShiftRight_Semicolon: { id: `lnkAdjustmentHR` },
         ShiftLeft_Semicolon: { id: `lnkAdjustmentR` },
+        ShiftRight_Semicolon: { id: `lnkAdjustmentR` },
         AltLeft_Semicolon: { id: `lnkAdjustmentRRR` },
+        AltRight_Semicolon: { id: `lnkAdjustmentRRR` },
         Semicolon: { id: `lnkAdjustmentRR` },
         AltLeft_ShiftLeft_Minus: { id: `lnkAdjustmentHL` },
+        AltLeft_ShiftRight_Minus: { id: `lnkAdjustmentHL` },
+        AltRight_ShiftLeft_Minus: { id: `lnkAdjustmentHL` },
+        AltRight_ShiftRight_Minus: { id: `lnkAdjustmentHL` },
         ShiftLeft_Minus: { id: `lnkAdjustmentL` },
+        ShiftRight_Minus: { id: `lnkAdjustmentL` },
         AltLeft_Minus: { id: `lnkAdjustmentLLL` },
+        AltRight_Minus: { id: `lnkAdjustmentLLL` },
         Minus: { id: `lnkAdjustmentLL` },
 
         AltLeft_ShiftLeft_NumpadAdd: { id: `lnkAdjustmentHR` },
+        AltLeft_ShiftRight_NumpadAdd: { id: `lnkAdjustmentHR` },
+        AltRight_ShiftLeft_NumpadAdd: { id: `lnkAdjustmentHR` },
+        AltRight_ShiftRight_NumpadAdd: { id: `lnkAdjustmentHR` },
         ShiftLeft_NumpadAdd: { id: `lnkAdjustmentR` },
+        ShiftRight_NumpadAdd: { id: `lnkAdjustmentR` },
         AltLeft_NumpadAdd: { id: `lnkAdjustmentRRR` },
+        AltRight_NumpadAdd: { id: `lnkAdjustmentRRR` },
         NumpadAdd: { id: `lnkAdjustmentRR` },
         AltLeft_ShiftLeft_NumpadSubtract: { id: `lnkAdjustmentHL` },
+        AltLeft_ShiftRight_NumpadSubtract: { id: `lnkAdjustmentHL` },
+        AltRight_ShiftLeft_NumpadSubtract: { id: `lnkAdjustmentHL` },
+        AltRight_ShiftRight_NumpadSubtract: { id: `lnkAdjustmentHL` },
         ShiftLeft_NumpadSubtract: { id: `lnkAdjustmentL` },
+        ShiftRight_NumpadSubtract: { id: `lnkAdjustmentL` },
         AltLeft_NumpadSubtract: { id: `lnkAdjustmentLLL` },
+        ShiftRight_NumpadSubtract: { id: `lnkAdjustmentL` },
         NumpadSubtract: { id: `lnkAdjustmentLL` },
 
         ShiftLeft_KeyV: { id: `lnkVolumeL` },
+        ShiftRight_KeyV: { id: `lnkVolumeL` },
         KeyV: { id: `lnkVolumeR` },
 
         KeyI: { id: `btnGraph` },
@@ -1365,10 +1410,12 @@ const g_shortcutObj = {
         Enter: { id: `btnPlay` },
         NumpadEnter: { id: `btnPlay` },
         ShiftLeft_Tab: { id: `btnBack` },
+        ShiftRight_Tab: { id: `btnBack` },
         Tab: { id: `btnDisplay` },
     },
     difSelector: {
         ShiftLeft_KeyD: { id: `lnkDifficultyL` },
+        ShiftRight_KeyD: { id: `lnkDifficultyL` },
         KeyD: { id: `lnkDifficultyR` },
         KeyR: { id: `difRandom` },
         KeyL: { id: `lnkDifficulty` },
@@ -1390,17 +1437,22 @@ const g_shortcutObj = {
         Enter: { id: `lnkDifficulty` },
         NumpadEnter: { id: `lnkDifficulty` },
         ShiftLeft_Tab: { id: `btnBack` },
+        ShiftRight_Tab: { id: `btnBack` },
         Tab: { id: `btnDisplay` },
     },
     settingsDisplay: {
         ShiftLeft_KeyA: { id: `lnkAppearanceL` },
+        ShiftRight_KeyA: { id: `lnkAppearanceL` },
         KeyA: { id: `lnkAppearanceR` },
         ShiftLeft_KeyO: { id: `lnkOpacityL` },
+        ShiftRight_KeyO: { id: `lnkOpacityL` },
         KeyO: { id: `lnkOpacityR` },
 
         ShiftLeft_KeyB: { id: `lnkHitPositionR` },
+        ShiftRight_KeyB: { id: `lnkHitPositionR` },
         KeyB: { id: `lnkHitPositionRR` },
         ShiftLeft_KeyT: { id: `lnkHitPositionL` },
+        ShiftRight_KeyT: { id: `lnkHitPositionL` },
         KeyT: { id: `lnkHitPositionLL` },
 
         Digit1: { id: `lnkstepZone` },
@@ -1437,6 +1489,7 @@ const g_shortcutObj = {
         Enter: { id: `btnPlay` },
         NumpadEnter: { id: `btnPlay` },
         ShiftLeft_Tab: { id: `btnBack` },
+        ShiftRight_Tab: { id: `btnBack` },
         Tab: { id: `btnSettings` },
     },
     keyConfig: {
@@ -1451,7 +1504,9 @@ const g_shortcutObj = {
     result: {
         Escape: { id: `btnBack` },
         ShiftLeft_Tab: { id: `btnBack` },
+        ShiftRight_Tab: { id: `btnBack` },
         ControlLeft_KeyC: { id: `` },
+        ControlRight_KeyC: { id: `` },
         KeyC: { id: `btnCopy`, reset: true },
         KeyT: { id: `btnTweet`, reset: true },
         KeyG: { id: `btnGitter`, reset: true },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. Shift, Ctrl, Altキーの左右キーの割り当てを分離しました。
画面中で使用できるショートカットキーは例外的に左右両方使えるようにしています。
なお、従来のキーコードは左側のキーに対応します。対応状況は下記の通りです。

|KeyCode|KeyboardEvent.code|
|----|----|
|16|ShiftLeft|
|17|ControlLeft|
|18|AltLeft|
|256|ShiftRight|
|257|ControlRight|
|258|AltRight|

2. カスタムキー定義で使用できるキー名を一部拡張しました。
主に日本語キーボードを意識した変更です。

|KeyCode|KeyboardEvent.code|対応している名称|
|----|----|----|
|186|Quote|Quote, **Ja-Colon**|
|192|BracketLeft|BracketLeft, **Ja-@**|
|219|BracketRight|BracketRight, **Ja-[**|
|221|Backslash|Backslash, **Ja-]**|
|222|Equal|Equal, **Ja-^**|

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 左右キーどちらも反応することで、意図しない誤爆が起こる可能性があるため。
また左右キーを分離することにより、分離性を活かしたキーが作成できる可能性がありそうなため。
2. KeyboardEvent.codeそのままの場合、直感的で無いため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://user-images.githubusercontent.com/44026291/236628807-ee7a8696-0829-4c0f-a8f1-cf4b845cbd59.png" width="70%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 既存キーについては現状左シフトキーのみに割り当てています。
代替キーに右シフトキーを割り当てれば、両方に対応させることも可能です。