### PR TITLE
feat: [0697] カスタムキー指定でblank, scaleなどの略記指定に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3660,14 +3660,19 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 	 * @param {string} _key キー数
 	 * @param {string} _name 名前
 	 * @param {string} _type float, number, string, boolean
+	 * @param {string} _defaultVal
 	 */
-	const newKeySingleParam = (_key, _name, _type) => {
+	const newKeySingleParam = (_key, _name, _type, _defaultVal) => {
 		const keyheader = _name + _key;
 		const dfPtn = setIntVal(g_keyObj.dfPtnNum);
 		if (_dosObj[keyheader] !== undefined) {
 			const tmps = _dosObj[keyheader].split(`$`);
 			for (let k = 0; k < tmps.length; k++) {
-				g_keyObj[`${keyheader}_${k + dfPtn}`] = setVal(g_keyObj[`${_name}${tmps[k]}`], setVal(tmps[k], ``, _type));
+				g_keyObj[`${keyheader}_${k + dfPtn}`] = setVal(g_keyObj[`${_name}${getKeyPtnName(tmps[k])}`],
+					tmps[k].indexOf(`_`) !== -1 ? _defaultVal : setVal(tmps[k], ``, _type));
+			}
+			for (let k = tmps.length; k < g_keyObj.minPatterns; k++) {
+				g_keyObj[`${keyheader}_${k + dfPtn}`] = g_keyObj[`${keyheader}_0`];
 			}
 		}
 	};
@@ -3783,19 +3788,19 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 		}
 
 		// ステップゾーン間隔 (blankX_Y)
-		newKeySingleParam(newKey, `blank`, C_TYP_FLOAT);
+		newKeySingleParam(newKey, `blank`, C_TYP_FLOAT, g_keyObj.blank_def);
 
 		// 矢印群の倍率 (scaleX_Y)
-		newKeySingleParam(newKey, `scale`, C_TYP_FLOAT);
+		newKeySingleParam(newKey, `scale`, C_TYP_FLOAT, g_keyObj.scale_def);
 
 		// プレイ中ショートカット：リトライ (keyRetryX_Y)
-		newKeySingleParam(newKey, `keyRetry`, C_TYP_STRING);
+		newKeySingleParam(newKey, `keyRetry`, C_TYP_STRING, C_KEY_RETRY);
 
 		// プレイ中ショートカット：タイトルバック (keyTitleBackX_Y)
-		newKeySingleParam(newKey, `keyTitleBack`, C_TYP_STRING);
+		newKeySingleParam(newKey, `keyTitleBack`, C_TYP_STRING, C_KEY_TITLEBACK);
 
 		// 別キーフラグ (transKeyX_Y)
-		newKeySingleParam(newKey, `transKey`, C_TYP_STRING);
+		newKeySingleParam(newKey, `transKey`, C_TYP_STRING, ``);
 
 		// シャッフルグループ (shuffleX_Y)
 		newKeyTripleParam(newKey, `shuffle`);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. カスタムキー指定でblankX, scaleX, keyRetryX, keyTitleBackX, transKeyXの略記指定に対応しました。
```
|keyCtrl9g=F1,F2,F3,F4,F5,F6,F7,F8,Enter/ShiftRight$D1,D2,D3,D4,D5,D6,D7,D8,Enter/ShiftRight|
|blank9g=52.5|  -> |blank9g=52.5$52.5|     // 省略時はパターン1のものをコピー

|append12=true|
|keyCtrl12=F1,F2,F3,F4,F5,F6,F7,F8,F9,F10,F11,F12$Q,W,E,R,T,Y,U,I,O,P,Ja-@,Ja-[|
|blank12=50$12_(0)|  -> |blank12=50$50|    // パターン名指定時はそのパターンの情報をコピー
```
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 複数パターン別指定のうち、これらのみ略記指定ができなかったため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
