### PR TITLE
feat: [0698] 曲開始までの空白フレーム数設定(blankFrame)の複数譜面対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2848,10 +2848,12 @@ const headerConvert = _dosObj => {
 	// 無音のフレーム数
 	obj.blankFrame = 200;
 	obj.blankFrameDef = 200;
+	obj.blankFrameDefs = [];
 	if (isNaN(parseFloat(_dosObj.blankFrame))) {
 	} else {
-		obj.blankFrame = parseInt(_dosObj.blankFrame);
-		obj.blankFrameDef = parseInt(_dosObj.blankFrame);
+		obj.blankFrameDefs = _dosObj.blankFrame.split(`$`).map(val => parseInt(val));
+		obj.blankFrame = obj.blankFrameDefs[0];
+		obj.blankFrameDef = obj.blankFrameDefs[0];
 	}
 
 	// 開始フレーム数（0以外の場合はフェードインスタート）、終了フレーム数
@@ -6862,6 +6864,7 @@ const loadingScoreInit = async () => {
 	await loadChartFile();
 	const tkObj = getKeyInfo();
 	const [keyCtrlPtn, keyNum] = [tkObj.keyCtrlPtn, tkObj.keyNum];
+	g_headerObj.blankFrameDef = setVal(g_headerObj.blankFrameDefs[g_stateObj.scoreId], g_headerObj.blankFrameDefs[0]);
 	g_headerObj.blankFrame = g_headerObj.blankFrameDef;
 
 	// ユーザカスタムイベント


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 曲開始までの空白フレーム数設定(blankFrame)の複数譜面別設定に対応しました。
```
|blankFrame=300|     // 全譜面共通
|blankFrame=200$300| // 譜面別の設定（$区切り、譜面別）
```
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 曲が変わると本来は曲開始までの空白フレーム数も変える可能性があるため。
読み込む楽曲別にすることも考えましたが、
途中フェードインを前提とした譜面が考えられることから譜面別としました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
