### PR TITLE
feat: [0699] ボタンのデフォルト処理を参照する機能を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -120,6 +120,10 @@ const g_presetObj = {
 let g_headerObj = {};
 let g_scoreObj = {};
 let g_attrObj = {};
+
+const g_btnFunc = {
+	base: {}, reset: {}, cxt: {},
+};
 let g_btnAddFunc = {};
 let g_btnDeleteFlg = {};
 let g_cxtAddFunc = {};
@@ -1268,6 +1272,8 @@ const createCss2Button = (_id, _text, _func = _ => true, { x = 0, y = g_sHeight 
 			resetFunc(evt);
 		}
 	});
+	g_btnFunc.base[_id] = _func;
+	g_btnFunc.reset[_id] = resetFunc;
 
 	// 右クリック時の処理
 	div.oncontextmenu = evt => {
@@ -1278,6 +1284,8 @@ const createCss2Button = (_id, _text, _func = _ => true, { x = 0, y = g_sHeight 
 			if (typeof g_cxtAddFunc[_id] === C_TYP_FUNCTION) {
 				g_cxtAddFunc[_id](evt, cxtFunc);
 			}
+			g_btnFunc.cxt[_id] = cxtFunc;
+
 		} else if (typeof g_cxtAddFunc[_id] === C_TYP_FUNCTION) {
 			g_cxtAddFunc[_id](evt);
 		}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. ボタンのデフォルト処理を参照する機能を追加しました。
```javascript
g_btnFunc.base.lnkDificulty;  // lnkDifficultyのボタン処理
g_btnFunc.reset.lnkDificulty;  // lnkDifficultyのボタン処理（画面遷移系）
g_btnFunc.cxt.linkDifficulty;   // lnkDifficultyの右クリック時処理
```

これを使うと、次のようにボタンを押したときの処理をコピーすることができます。
```javascript
const newBtn = createCss2Button(`newId`, (`btnStart`, g_lblNameObj.clickHere, g_btnFunc.base.lnkDificulty, {
	w: g_sWidth, siz: g_limitObj.titleSiz, resetFunc: g_btnFunc.reset.lnkDificulty,
}, g_cssObj.button_Start),
```

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 既存ボタンの機能をつぶして、他のボタンで代用させたいときに現状はその手段が無いため。
座標系は`cloneNode`で対処できるが、処理系はコピーすることができませんでした。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
