### PR TITLE
feat: [0700] 譜面明細画面の部分表示に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3105,7 +3105,8 @@ const headerConvert = _dosObj => {
 	obj.resultMotionSet = setBoolVal(_dosObj.resultMotionSet, true);
 
 	// 譜面明細の使用可否
-	obj.scoreDetailUse = setBoolVal(_dosObj.scoreDetailUse, true);
+	g_settings.scoreDetails = _dosObj.scoreDetailUse?.split(`,`).filter(val => hasVal(val) && val !== `false`) || g_settings.scoreDetailDefs;
+	g_stateObj.scoreDetail = g_settings.scoreDetails[0] || ``;
 
 	// 判定位置をBackgroundのON/OFFと連動してリセットする設定
 	obj.jdgPosReset = setBoolVal(_dosObj.jdgPosReset, true);
@@ -4897,7 +4898,7 @@ const setDifficulty = (_initFlg) => {
 
 	// 速度設定 (Speed)
 	setSetting(0, `speed`, ` ${g_lblNameObj.multi}`);
-	if (g_headerObj.scoreDetailUse) {
+	if (g_settings.scoreDetails.length > 0) {
 		drawSpeedGraph(g_stateObj.scoreId);
 		drawDensityGraph(g_stateObj.scoreId);
 		makeDifInfo(g_stateObj.scoreId);
@@ -5014,7 +5015,7 @@ const createOptionWindow = _sprite => {
 		return detailObj;
 	};
 
-	if (g_headerObj.scoreDetailUse) {
+	if (g_settings.scoreDetails.length > 0) {
 		spriteList.speed.appendChild(
 			createCss2Button(`btnGraph`, `i`, _ => true, {
 				x: -25, y: -60, w: 30, h: 30, siz: g_limitObj.jdgCharaSiz, title: g_msgObj.graph,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -910,7 +910,8 @@ const g_settings = {
 
     opacitys: [10, 25, 50, 75, 100],
 
-    scoreDetails: [`Speed`, `Density`, `ToolDif`],
+    scoreDetailDefs: [`Speed`, `Density`, `ToolDif`],
+    scoreDetails: [],
     scoreDetailCursors: [],
 };
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 譜面明細画面の部分表示に対応しました。既定はすべて表示です。
なお、`|scoreDetailUse=true|`は廃止しました。
```
|scoreDetailUse=false|   // 非表示
|scoreDetailUse=Density,ToolDif|  // 譜面密度、ツール値のみ表示
```

設定可能値は次の通りです。カンマ区切りで複数の項目を表示します。

|設定可能値|意味|
|----|----|
|false|非表示|
|Speed|速度変化グラフを表示|
|Density|譜面密度グラフを表示|
|ToolDif|譜面情報を表示|

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 譜面明細画面の全部を非表示にする状況がほぼ無く、一部のみ非表示にする方が利用しやすいため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/b2a1bd72-eee1-4ab3-9864-36e946894825" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- クリア状況で全部表示したいといった場合は、customjsが必要となります。