### PR TITLE
feat: [0702] 速度変化の平均値表示を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4532,9 +4532,11 @@ const drawSpeedGraph = _scoreId => {
 	drawBaseLine(context);
 
 	const avgX = [0, 0];
+	const avgSubX = [0, 0];
 	Object.keys(speedObj).forEach((speedType, j) => {
 		context.beginPath();
 		let preY;
+		let avgSubFrame = playingFrame;
 
 		for (let i = 0; i < speedObj[speedType].frame.length; i++) {
 			const x = speedObj[speedType].frame[i] * (g_limitObj.graphWidth - 30) / playingFrame + 30;
@@ -4543,9 +4545,17 @@ const drawSpeedGraph = _scoreId => {
 			context.lineTo(x, preY);
 			context.lineTo(x, y);
 			preY = y;
-			avgX[j] += (speedObj[speedType].frame[i] - (speedObj[speedType].frame[i - 1] ?? startFrame)) * (speedObj[speedType].speed[i - 1] ?? 1);
+
+			const deltaFrame = speedObj[speedType].frame[i] - (speedObj[speedType].frame[i - 1] ?? startFrame);
+			avgX[j] += deltaFrame * (speedObj[speedType].speed[i - 1] ?? 1);
+			if ((speedObj[speedType].speed[i - 1] ?? 1) === 1) {
+				avgSubFrame -= deltaFrame;
+			} else {
+				avgSubX[j] += deltaFrame * (speedObj[speedType].speed[i - 1] - 1);
+			}
 		}
 		avgX[j] /= playingFrame;
+		avgSubX[j] /= Math.max(avgSubFrame, 1);
 
 		context.lineWidth = 1;
 		context.strokeStyle = speedObj[speedType].strokeColor;
@@ -4560,6 +4570,7 @@ const drawSpeedGraph = _scoreId => {
 		context.fillText(speedType, lineX + 35, 218);
 
 		updateScoreDetailLabel(`Speed`, `${speedType}S`, speedObj[speedType].cnt, j, g_lblNameObj[`s_${speedType}`]);
+		updateScoreDetailLabel(`Speed`, `avgD${speedType}`, `${avgSubX[j] > 0 ? '+' : ''}${(avgSubX[j]).toFixed(2)}`, j + 4, g_lblNameObj[`s_avgD${speedType}`]);
 	});
 	updateScoreDetailLabel(`Speed`, `avgS`, `${(avgX[0] * avgX[1]).toFixed(2)}x`, 2, g_lblNameObj.s_avg);
 };

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4532,7 +4532,7 @@ const drawSpeedGraph = _scoreId => {
 	drawBaseLine(context);
 
 	const avgX = [0, 0];
-	const avgSubX = [0, 0];
+	const avgSubX = [1, 1];
 	Object.keys(speedObj).forEach((speedType, j) => {
 		context.beginPath();
 		let preY;
@@ -4551,7 +4551,7 @@ const drawSpeedGraph = _scoreId => {
 			if ((speedObj[speedType].speed[i - 1] ?? 1) === 1) {
 				avgSubFrame -= deltaFrame;
 			} else {
-				avgSubX[j] += deltaFrame * (speedObj[speedType].speed[i - 1] - 1);
+				avgSubX[j] += deltaFrame * (speedObj[speedType].speed[i - 1]);
 			}
 		}
 		avgX[j] /= playingFrame;
@@ -4570,7 +4570,7 @@ const drawSpeedGraph = _scoreId => {
 		context.fillText(speedType, lineX + 35, 218);
 
 		updateScoreDetailLabel(`Speed`, `${speedType}S`, speedObj[speedType].cnt, j, g_lblNameObj[`s_${speedType}`]);
-		updateScoreDetailLabel(`Speed`, `avgD${speedType}`, `${avgSubX[j] > 0 ? '+' : ''}${(avgSubX[j]).toFixed(2)}`, j + 4, g_lblNameObj[`s_avgD${speedType}`]);
+		updateScoreDetailLabel(`Speed`, `avgD${speedType}`, `${(avgSubX[j]).toFixed(2)}x`, j + 4, g_lblNameObj[`s_avgD${speedType}`]);
 	});
 	updateScoreDetailLabel(`Speed`, `avgS`, `${(avgX[0] * avgX[1]).toFixed(2)}x`, 2, g_lblNameObj.s_avg);
 };

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4531,6 +4531,7 @@ const drawSpeedGraph = _scoreId => {
 	const context = canvas.getContext(`2d`);
 	drawBaseLine(context);
 
+	const avgX = [0, 0];
 	Object.keys(speedObj).forEach((speedType, j) => {
 		context.beginPath();
 		let preY;
@@ -4542,7 +4543,9 @@ const drawSpeedGraph = _scoreId => {
 			context.lineTo(x, preY);
 			context.lineTo(x, y);
 			preY = y;
+			avgX[j] += (speedObj[speedType].frame[i] - (speedObj[speedType].frame[i - 1] ?? startFrame)) * (speedObj[speedType].speed[i - 1] ?? 1);
 		}
+		avgX[j] /= playingFrame;
 
 		context.lineWidth = 1;
 		context.strokeStyle = speedObj[speedType].strokeColor;
@@ -4558,6 +4561,7 @@ const drawSpeedGraph = _scoreId => {
 
 		updateScoreDetailLabel(`Speed`, `${speedType}S`, speedObj[speedType].cnt, j, g_lblNameObj[`s_${speedType}`]);
 	});
+	updateScoreDetailLabel(`Speed`, `avgS`, `${(avgX[0] * avgX[1]).toFixed(2)}x`, 2, g_lblNameObj.s_avg);
 };
 
 /**

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2636,6 +2636,9 @@ const g_lblNameObj = {
     s_speed: `Speed`,
     s_boost: `Boost`,
     s_avg: `Avg.`,
+    s_avgDspeed: `(dS)`,
+    s_avgDboost: `(dB)`,
+
     s_apm: `APM`,
     s_time: `Time`,
     s_arrow: `Arrow`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2636,8 +2636,8 @@ const g_lblNameObj = {
     s_speed: `Speed`,
     s_boost: `Boost`,
     s_avg: `Avg.`,
-    s_avgDspeed: `(dS)`,
-    s_avgDboost: `(dB)`,
+    s_avgDspeed: `AvgS)`,
+    s_avgDboost: `AvgB)`,
 
     s_apm: `APM`,
     s_time: `Time`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2635,6 +2635,7 @@ const g_lblNameObj = {
 
     s_speed: `Speed`,
     s_boost: `Boost`,
+    s_avg: `Avg.`,
     s_apm: `APM`,
     s_time: `Time`,
     s_arrow: `Arrow`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 速度変化の平均値表示を追加しました。次の表示が増えています。

|表示項目|表示内容|
|----|----|
|Avg.|全体加速(Speed)の平均×個別加速(Boost)の平均の値を小数第2位で表示します。|
|AvgS)|全体加速(Speed)に**1倍以外が掛かっている部分**について、平均値を小数第2位で表示します。|
|AvgB)|個別加速(Boost)に**1倍以外が掛かっている部分**について、平均値を小数第2位で表示します。|
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 速度変化グラフがありますが、平均してどのくらいの速度変化があるかはわかりにくいため。
また平均の情報だけでは不十分と思われるため、実際に速度変化が掛かっている部分のみを取り出して
その平均も表示するようにしました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/c8220af8-e7df-4bc5-8ebf-11a21eb2023c" width="60%">
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/754142e5-de58-4595-ac23-4548e1daed8b" width="60%">
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/6e5f0f01-c413-4ab6-a530-c2def177cba0" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
