### PR TITLE
fix: [0703] 譜面明細画面でQキーを押してもカーソル移動しない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3107,6 +3107,8 @@ const headerConvert = _dosObj => {
 	// 譜面明細の使用可否
 	g_settings.scoreDetails = _dosObj.scoreDetailUse?.split(`,`).filter(val => hasVal(val) && val !== `false`) || g_settings.scoreDetailDefs;
 	g_stateObj.scoreDetail = g_settings.scoreDetails[0] || ``;
+	g_settings.scoreDetailCursors = g_settings.scoreDetails.map(val => `lnk${val}G`);
+	g_settings.scoreDetailCursors.push(`btnGraph`);
 
 	// 判定位置をBackgroundのON/OFFと連動してリセットする設定
 	obj.jdgPosReset = setBoolVal(_dosObj.jdgPosReset, true);

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -918,8 +918,6 @@ const g_settings = {
 
 g_settings.volumeNum = g_settings.volumes.length - 1;
 g_settings.opacityNum = g_settings.opacitys.length - 1;
-g_settings.scoreDetailCursors = g_settings.scoreDetails.map(val => `lnk${val}G`);
-g_settings.scoreDetailCursors.push(`btnGraph`);
 
 /**
  * 設定画面間移動


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 譜面明細画面でQキーを押してもカーソル移動しない問題を修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #1487 で`g_settings.scoreDetails`が可変になったため、それに合わせて`g_settings.scoreDetailCursors`も連動する必要がありました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- ver32.2.0のみで発生する問題です。