### PR TITLE
fix: [0705] blankFrameが未指定のときにblankFrameが正しく反映されない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2854,15 +2854,13 @@ const headerConvert = _dosObj => {
 	}
 
 	// 無音のフレーム数
-	obj.blankFrame = 200;
-	obj.blankFrameDef = 200;
-	obj.blankFrameDefs = [];
+	obj.blankFrameDefs = [200];
 	if (isNaN(parseFloat(_dosObj.blankFrame))) {
 	} else {
 		obj.blankFrameDefs = _dosObj.blankFrame.split(`$`).map(val => parseInt(val));
-		obj.blankFrame = obj.blankFrameDefs[0];
-		obj.blankFrameDef = obj.blankFrameDefs[0];
 	}
+	obj.blankFrame = obj.blankFrameDefs[0];
+	obj.blankFrameDef = obj.blankFrameDefs[0];
 
 	// 開始フレーム数（0以外の場合はフェードインスタート）、終了フレーム数
 	[`startFrame`, `endFrame`].filter(tmpParam => hasVal(_dosObj[tmpParam])).forEach(param => {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. blankFrameが未指定のときにblankFrameが正しく反映されない問題を修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #1484 の際、`blankFrameDefs`という変数を作成しましたが、未指定のときに正しく値が入らないようになっていました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
下記で`blankFrameDefs`を使用しているため、未定義のときにg_headerObj.blankFrame が正しく入りません。
![image](https://github.com/cwtickle/danoniplus/assets/44026291/2352dc26-c7ef-4c97-9bdb-9556378c4b65)

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- ver32.1.0以降で発生する問題です。