### PR TITLE
improve: [0711] 譜面明細表示の順番、名称を変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3109,7 +3109,7 @@ const headerConvert = _dosObj => {
 
 	g_stateObj.scoreDetail = g_settings.scoreDetails[0] || ``;
 	g_settings.scoreDetailCursors = g_settings.scoreDetails.map(val => `lnk${val}G`);
-	g_settings.scoreDetailCursors.push(`btnGraph`);
+	g_settings.scoreDetailCursors.push(`btnGraphB`);
 	[`option`, `difSelector`].forEach(page => g_shortcutObj[page].KeyQ.id = g_settings.scoreDetailCursors[0]);
 
 	// 判定位置をBackgroundのON/OFFと連動してリセットする設定
@@ -5035,7 +5035,10 @@ const createOptionWindow = _sprite => {
 	};
 
 	if (g_settings.scoreDetails.length > 0) {
-		spriteList.speed.appendChild(
+		multiAppend(spriteList.speed,
+			createCss2Button(`btnGraphB`, ``, _ => true, {
+				x: -25, y: -60, w: 0, h: 0, opacity: 0, resetFunc: _ => setScoreDetail(true),
+			}, g_cssObj.button_Mini),
 			createCss2Button(`btnGraph`, `i`, _ => true, {
 				x: -25, y: -60, w: 30, h: 30, siz: g_limitObj.jdgCharaSiz, title: g_msgObj.graph,
 				resetFunc: _ => setScoreDetail(), cxtFunc: _ => setScoreDetail(),
@@ -5084,7 +5087,7 @@ const createOptionWindow = _sprite => {
 	/**
 	 * 譜面明細表示／非表示ボタンの処理
 	 */
-	const setScoreDetail = _ => {
+	const setScoreDetail = (_resetFlg = false) => {
 		if (g_currentPage === `difSelector`) {
 			resetDifWindow();
 			g_stateObj.scoreDetailViewFlg = false;
@@ -5099,7 +5102,9 @@ const createOptionWindow = _sprite => {
 		detailObj.style.visibility = visibles[Number(g_stateObj.scoreDetailViewFlg)];
 
 		// Qキーを押したときのカーソル位置を先頭に初期化
-		g_shortcutObj.option.KeyQ.id = g_settings.scoreDetailCursors[0];
+		if (_resetFlg) {
+			g_shortcutObj.option.KeyQ.id = g_settings.scoreDetailCursors[0];
+		}
 	};
 
 	// ---------------------------------------------------

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4565,10 +4565,10 @@ const drawSpeedGraph = _scoreId => {
 		const lineX = (speedType === `speed`) ? 125 : 210;
 		context.beginPath();
 		context.moveTo(lineX, 215);
-		context.lineTo(lineX + 30, 215);
+		context.lineTo(lineX + 25, 215);
 		context.stroke();
 		context.font = `${g_limitObj.difSelectorSiz}px ${getBasicFont()}`;
-		context.fillText(speedType, lineX + 35, 218);
+		context.fillText(g_lblNameObj[`s_${speedType}`], lineX + 30, 218);
 
 		updateScoreDetailLabel(`Speed`, `${speedType}S`, speedObj[speedType].cnt, j, g_lblNameObj[`s_${speedType}`]);
 		updateScoreDetailLabel(`Speed`, `avgD${speedType}`, avgSubX[j] === 1 ? `----` : `${(avgSubX[j]).toFixed(2)}x`, j + 4, g_lblNameObj[`s_avgD${speedType}`]);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3103,10 +3103,14 @@ const headerConvert = _dosObj => {
 	obj.resultMotionSet = setBoolVal(_dosObj.resultMotionSet, true);
 
 	// 譜面明細の使用可否
-	g_settings.scoreDetails = _dosObj.scoreDetailUse?.split(`,`).filter(val => hasVal(val) && val !== `false`) || g_settings.scoreDetailDefs;
+	const tmpDetails = _dosObj.scoreDetailUse?.split(`,`).filter(val => hasVal(val) && val !== `false`)
+		.map(val => replaceStr(val, g_settings.scoreDetailTrans));
+	g_settings.scoreDetails = g_settings.scoreDetailDefs.filter(val => tmpDetails?.includes(val) || tmpDetails === undefined);
+
 	g_stateObj.scoreDetail = g_settings.scoreDetails[0] || ``;
 	g_settings.scoreDetailCursors = g_settings.scoreDetails.map(val => `lnk${val}G`);
 	g_settings.scoreDetailCursors.push(`btnGraph`);
+	[`option`, `difSelector`].forEach(page => g_shortcutObj[page].KeyQ.id = g_settings.scoreDetailCursors[0]);
 
 	// 判定位置をBackgroundのON/OFFと連動してリセットする設定
 	obj.jdgPosReset = setBoolVal(_dosObj.jdgPosReset, true);

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -911,7 +911,7 @@ const g_settings = {
 
     opacitys: [10, 25, 50, 75, 100],
 
-    scoreDetailDefs: [`Speed`, `Density`, `ToolDif`],
+    scoreDetailDefs: [`Density`, `Speed`, `ToolDif`],
     scoreDetails: [],
     scoreDetailCursors: [],
 };
@@ -1395,13 +1395,13 @@ const g_shortcutObj = {
         KeyV: { id: `lnkVolumeR` },
 
         KeyI: { id: `btnGraph` },
-        Digit1: { id: `lnkSpeedG` },
-        Digit2: { id: `lnkDensityG` },
+        Digit1: { id: `lnkDensityG` },
+        Digit2: { id: `lnkSpeedG` },
         Digit3: { id: `lnkToolDifG` },
-        Numpad1: { id: `lnkSpeedG` },
-        Numpad2: { id: `lnkDensityG` },
+        Numpad1: { id: `lnkDensityG` },
+        Numpad2: { id: `lnkSpeedG` },
         Numpad3: { id: `lnkToolDifG` },
-        KeyQ: { id: `lnkSpeedG` },
+        KeyQ: { id: `lnkDensityG` },
         KeyP: { id: `lnkDifInfo` },
         KeyZ: { id: `btnSave` },
 
@@ -1423,13 +1423,13 @@ const g_shortcutObj = {
         ArrowUp: { id: `btnDifU` },
 
         KeyI: { id: `btnGraph` },
-        Digit1: { id: `lnkSpeedG` },
-        Digit2: { id: `lnkDensityG` },
+        Digit1: { id: `lnkDensityG` },
+        Digit2: { id: `lnkSpeedG` },
         Digit3: { id: `lnkToolDifG` },
-        Numpad1: { id: `lnkSpeedG` },
-        Numpad2: { id: `lnkDensityG` },
+        Numpad1: { id: `lnkDensityG` },
+        Numpad2: { id: `lnkSpeedG` },
         Numpad3: { id: `lnkToolDifG` },
-        KeyQ: { id: `lnkSpeedG` },
+        KeyQ: { id: `lnkDensityG` },
         KeyP: { id: `lnkDifInfo` },
 
         Escape: { id: `btnBack` },

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2717,7 +2717,7 @@ const g_lblNameObj = {
 
     'u_Speed': `Velocity`,
     'u_Density': `Density`,
-    'u_ToolDif': `ToolDif`,
+    'u_ToolDif': `DifLevel`,
 
     'u_Main': `Main`,
     'u_Replaced': `Replaced`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -914,6 +914,8 @@ const g_settings = {
     scoreDetailDefs: [`Density`, `Speed`, `ToolDif`],
     scoreDetails: [],
     scoreDetailCursors: [],
+
+    scoreDetailTrans: [[`Velocity`, `Speed`], [`DifLevel`, `ToolDif`]],
 };
 
 g_settings.volumeNum = g_settings.volumes.length - 1;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2876,7 +2876,7 @@ const g_lang_msgObj = {
         fadein: `譜面を途中から再生します。\n途中から開始した場合はハイスコアを保存しません。`,
         volume: `ゲーム内の音量を設定します。`,
 
-        graph: `速度変化や譜面密度状況、\n譜面の難易度など譜面の詳細情報を表示します。`,
+        graph: `譜面密度や速度変化状況、\n譜面の難易度などの情報を表示します。`,
         dataSave: `ハイスコア、リバース設定、\nキーコンフィグの保存の有無を設定します。`,
         toDisplay: `プレイ画面上のオブジェクトの\n表示・非表示（一部透明度）を設定します。`,
         toSettings: `SETTINGS画面へ戻ります。`,
@@ -2932,7 +2932,7 @@ const g_lang_msgObj = {
         fadein: `Plays the chart from the middle.\nIf you start in the middle, the high score will not be saved.`,
         volume: `Set the in-game volume.`,
 
-        graph: `Displays detailed information about the chart, such as sequences' speed changes, chart's density status, and chart's difficulty.`,
+        graph: `Displays detailed information about the chart, such as chart's density status, sequences' velocity changes, and chart's difficulty.`,
         dataSave: `Set whether to save the high score, reverse setting, and key config.`,
         toDisplay: `Set the display or non-display (partial transparency) of objects on the play screen.`,
         toSettings: `Return to the SETTINGS screen.`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2634,10 +2634,10 @@ const g_lblNameObj = {
     g_damage: `Damage`,
     g_rate: `Accuracy`,
 
-    s_speed: `Speed`,
+    s_speed: `Overall`,
     s_boost: `Boost`,
     s_avg: `Avg.`,
-    s_avgDspeed: `AvgS)`,
+    s_avgDspeed: `AvgO)`,
     s_avgDboost: `AvgB)`,
 
     s_apm: `APM`,
@@ -2715,7 +2715,7 @@ const g_lblNameObj = {
     'u_Sudden+': `Sudden+`,
     'u_Hid&Sud+': `Hid&Sud+`,
 
-    'u_Speed': `Speed`,
+    'u_Speed': `Velocity`,
     'u_Density': `Density`,
     'u_ToolDif': `ToolDif`,
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 譜面明細表示の順番について、「Speed」と「Density」の位置を入れ替えました。
ショートカットも入れ替えています。
2. 速度変化グラフの名前を「Speed」から「Velocity」に変更しました。
また、全体加速を表す「Speed」を「Overall」に変更しました。
3. 難易度レベル表示の名前を「ToolDif」から「DifLevel」に変更しました。
4. 譜面ヘッダーの「scoreDetailUse」について、変更後の名前「Velocity」「DifLevel」が使えるように対応しました。
下記はどちらも動作し、同じ意味です。
```
|scoreDetailUse=Velocity,DifLevel|
|scoreDetailUse=Speed,ToolDif|
```
5. 譜面明細部分の「i」部分をON/OFFした場合で、「Q」キー動作時に動かなくなることがある問題を改善しました。

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 速度変化状況よりも、矢印数やプレイ時間、密度といった情報の方が参照時に便利と思われるため。
ToolDif（ツール値やレーン別の矢印数）については、どちらかと言えばわかる人向けの機能のため、据え置きます。
2. Flash時代の名前をそのまま引き継いでおりわかりにくい名前になっているため。
    - Speedは速さ、Velocityは速度(＝速さ＋向き)を表します。マイナス表記があるため後者が適切と考えました。
    - Speed/Boostの表記は譜面データ由来です(speed_data, boost_data)。
    前者は全体的な加速を意味するため「Overall」が適切と考えました。
    後者は押し上げるという意味の「Boost」で違和感はないため、そのままとしています。
3. 従来はレベル計算ツールという意味での「Tool」でしたが、現状一体化されています。
本来は「Difficulty Level Information」のため、それを略し「DifLevel」としました。
4. 2及び3の変更は名称の変更だけで、物理的なID名を変えていないため。
「g_settings.scoreDetailTrans」に物理的なIDとリンクする名前を定義することで
新しい名前が使用できるようにしています。
5. 上述の通りです。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/bd972cc6-30c4-419a-9b39-1db91e0ccf20" width="50%"><img src="https://github.com/cwtickle/danoniplus/assets/44026291/8623e53a-9775-4091-aafa-d6955291d36b" width="50%">
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/e54f7d6f-76a6-4bf6-835b-e4990dd0ea13" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 機能としての変更点はありません。