### PR TITLE
improve: [0712] Excessiveの名前をconstantsから変更できるよう対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10198,14 +10198,14 @@ const judgeArrow = _j => {
 			stepDivHit.setAttribute(`cnt`, C_FRM_HITMOTION);
 		}
 
-		// 空押し判定
 		if (g_stateObj.excessive === C_FLG_ON && _difFrame <= g_judgObj.arrowJ[g_judgPosObj.uwan] && _difFrame > g_judgObj.arrowJ[g_judgPosObj.shobon]) {
+			// 空押し判定（有効かつ早押し時のみ）
 			displayDiff(_difFrame);
 			stepHitTargetArrow(`Excessive`);
 			return true;
 
-		// 通常判定
 		} else if (_difCnt <= g_judgObj.arrowJ[g_judgPosObj.shobon]) {
+			// 通常判定
 			const [resultFunc, resultJdg] = checkJudgment(_difCnt);
 			resultFunc(_difFrame);
 			displayDiff(_difFrame);
@@ -10578,7 +10578,7 @@ const resultInit = _ => {
 		rankMark = g_rankObj.rankMarkF;
 		rankColor = g_rankObj.rankColorF;
 		g_resultObj.spState = `failed`;
-	} else if (playingArrows === g_fullArrows && g_stateObj.autoAll === C_FLG_OFF && !(g_headerObj.excessiveJdgUse && g_stateObj.excessive === C_FLG_OFF) ) {
+	} else if (playingArrows === g_fullArrows && g_stateObj.autoAll === C_FLG_OFF && !(g_headerObj.excessiveJdgUse && g_stateObj.excessive === C_FLG_OFF)) {
 		if (g_resultObj.spState === ``) {
 			g_resultObj.spState = `cleared`;
 		}
@@ -10706,7 +10706,7 @@ const resultInit = _ => {
 		}
 		if (g_stateObj.excessive === C_FLG_ON) {
 			multiAppend(resultWindow,
-				makeCssResultSymbol(`lblExcessive`, 350, g_cssObj.common_kita, 6, `Excessive`),
+				makeCssResultSymbol(`lblExcessive`, 350, g_cssObj.common_kita, 6, g_lblNameObj.j_excessive),
 				makeCssResultSymbol(`lblExcessiveS`, 260, g_cssObj.score, 7, g_resultObj.excessive, C_ALIGN_RIGHT),
 			);
 		}

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2813,6 +2813,7 @@ const g_lang_lblNameObj = {
         j_iknai: "(・A・)ｲｸﾅｲ",
 
         j_adj: `推定Adj`,
+        j_excessive: `Excessive`,
 
         helpUrl: `https://github.com/cwtickle/danoniplus/wiki/AboutGameSystem`,
         securityUrl: `https://github.com/cwtickle/danoniplus/security/policy`,
@@ -2845,6 +2846,7 @@ const g_lang_lblNameObj = {
         j_iknai: ":( N.G.",
 
         j_adj: `Est-Adj.`,
+        j_excessive: `Excessive`,
 
         helpUrl: `https://github.com/cwtickle/danoniplus-docs/wiki/AboutGameSystem`,
         securityUrl: `https://github.com/cwtickle/danoniplus-docs/wiki/SecurityPolicy`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 結果画面で表示するExcessiveの名前をdanoni_constants.jsから変更できるよう対応しました。
Fast/Slow/推定Adjと同様、`g_presetObj.lblName.ja.j_excessive` 及び `g_presetObj.lblName.en.j_excessive` にて設定します。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #1503 関連。他機能との統一性のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/765a86a9-fcd7-466c-a445-550f068dbdef" width="70%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
