### PR TITLE
improve: [0715] Difficultyを変更するごとにGaugeを初期化しないよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4902,15 +4902,10 @@ const setDifficulty = (_initFlg) => {
 		g_autoPlaysBase.concat(Object.keys(g_keyObj[`assistPos${g_keyObj.currentKey}_${g_keyObj.currentPtn}`])) :
 		g_autoPlaysBase.concat());
 
-	// ゲージ設定 (Gauge)
-	const defaultCustomGauge = g_gaugeOptionObj.custom0 || g_gaugeOptionObj.customDefault;
-	if (hasVal(defaultCustomGauge)) {
-		g_gaugeOptionObj.custom = (g_gaugeOptionObj[`custom${g_stateObj.scoreId}`] || defaultCustomGauge).concat();
-		g_gaugeOptionObj.varCustom = (g_gaugeOptionObj[`varCustom${g_stateObj.scoreId}`] || g_gaugeOptionObj.varCustom0 || g_gaugeOptionObj.varCustomDefault).concat();
-	}
+	// ゲージ設定及びカーソル位置調整
 	setGauge(0, true);
 
-	// 速度、ゲージ、スクロール、アシスト設定のカーソル位置調整
+	// 速度、スクロール、アシスト設定のカーソル位置調整
 	if (_initFlg) {
 		g_stateObj.speed = g_headerObj.initSpeeds[g_stateObj.scoreId];
 		g_settings.speedNum = getCurrentNo(g_settings.speeds, g_stateObj.speed);
@@ -5433,7 +5428,7 @@ const setGauge = (_scrollNum, _gaugeInitFlg = false) => {
 
 	// ゲージ初期化
 	if (_gaugeInitFlg) {
-		initializeGauges(g_settings.gaugeNum);
+		initializeGauges();
 	}
 	setSetting(_scrollNum, `gauge`);
 
@@ -5459,12 +5454,21 @@ const changeLifeMode = (_baseObj) => {
 
 /**
  * ゲージ配列の初期化
- * @param {number} _gaugeNum 
  */
-const initializeGauges = _gaugeNum => {
+const initializeGauges = _ => {
+
+	// カスタムゲージの設定取得
+	const defaultCustomGauge = g_gaugeOptionObj.custom0 || g_gaugeOptionObj.customDefault;
+	if (hasVal(defaultCustomGauge)) {
+		g_gaugeOptionObj.custom = (g_gaugeOptionObj[`custom${g_stateObj.scoreId}`] || defaultCustomGauge).concat();
+		g_gaugeOptionObj.varCustom = (g_gaugeOptionObj[`varCustom${g_stateObj.scoreId}`] || g_gaugeOptionObj.varCustom0 || g_gaugeOptionObj.varCustomDefault).concat();
+	}
+
+	// ゲージタイプの設定
 	changeLifeMode(g_headerObj);
 	g_gaugeType = (g_gaugeOptionObj.custom.length > 0 ? C_LFE_CUSTOM : g_stateObj.lifeMode);
 
+	// ゲージ配列を入れ替え
 	g_settings.gauges = structuredClone(g_gaugeOptionObj[g_gaugeType.toLowerCase()]);
 	g_settings.gaugeNum = getCurrentNo(g_settings.gauges, g_stateObj.gauge);
 	g_stateObj.gauge = g_settings.gauges[g_settings.gaugeNum];

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5487,13 +5487,15 @@ const setGauge = (_scrollNum, _gaugeInitFlg = false) => {
 	// デフォルトゲージの設定を適用（g_gaugeOptionObjから取得）
 	if (g_gaugeOptionObj.custom.length === 0 ||
 		g_gaugeOptionObj.defaultList.includes(g_gaugeOptionObj[`defaultGauge${g_stateObj.scoreId}`])) {
+
 		const gType = (g_gaugeType === C_LFE_CUSTOM ?
 			toCapitalize(g_gaugeOptionObj[`defaultGauge${g_stateObj.scoreId}`]) : g_gaugeType);
-		g_stateObj.lifeMode = g_gaugeOptionObj[`type${gType}`][g_settings.gaugeNum];
-		g_stateObj.lifeBorder = g_gaugeOptionObj[`clear${gType}`][g_settings.gaugeNum];
-		g_stateObj.lifeInit = g_gaugeOptionObj[`init${gType}`][g_settings.gaugeNum];
-		g_stateObj.lifeRcv = g_gaugeOptionObj[`rcv${gType}`][g_settings.gaugeNum];
-		g_stateObj.lifeDmg = g_gaugeOptionObj[`dmg${gType}`][g_settings.gaugeNum];
+		const getGaugeVal = _type => g_gaugeOptionObj[`${_type}${gType}`][g_settings.gaugeNum];
+		g_stateObj.lifeMode = getGaugeVal(`type`);
+		g_stateObj.lifeBorder = getGaugeVal(`clear`);
+		g_stateObj.lifeInit = getGaugeVal(`init`);
+		g_stateObj.lifeRcv = getGaugeVal(`rcv`);
+		g_stateObj.lifeDmg = getGaugeVal(`dmg`);
 	}
 
 	// デフォルトゲージの初期設定（Light, Easyでは回復量を2倍にする）


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. Difficultyを変更するごとにGaugeを初期化しないよう変更しました。
例えばGauge:「Hard」を選択し、Difficultyを変更した場合に
次の譜面のゲージ設定にGauge:「Hard」があれば、ゲージ設定を変更しません。
2. ゲージ設定周りのコードを見直しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. ゲージ設定のみ、譜面を変えると初期化するようになっていたため。
2. ゲージ設定を制御する`gaugeChange`関数について、ゲージ設定配列を入れ替える処理とゲージ明細を設定する処理が一緒になっており、使いづらい処理になっていたため分離しました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
