### PR TITLE
improve: [0716] Excessive設定に対してショートカットキーを割り当て

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1360,6 +1360,7 @@ const g_shortcutObj = {
         ShiftLeft_KeyG: { id: `lnkGaugeL` },
         ShiftRight_KeyG: { id: `lnkGaugeL` },
         KeyG: { id: `lnkGaugeR` },
+        KeyE: { id: `lnkExcessive` },
 
         AltLeft_ShiftLeft_Semicolon: { id: `lnkAdjustmentHR` },
         AltLeft_ShiftRight_Semicolon: { id: `lnkAdjustmentHR` },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. Excessive設定に対してショートカットキーを割り当てました。
「E」キーで切り替えが可能です。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 設定画面では基本的にショートカットキーが割り当てされているが、
Excessive設定に対するショートカットキーが無かったため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->