### PR TITLE
feat: [0722] 結果画面のSNS投稿用画像コピー機能を実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10853,6 +10853,7 @@ const resultInit = _ => {
 	}
 	const resultText = `${unEscapeHtml(tweetResultTmp)}`;
 	const tweetResult = `https://twitter.com/intent/tweet?text=${encodeURIComponent(resultText)}`;
+	const currentDateTime = new Date().toLocaleString();
 
 	// クリップボードコピー
 	const copyResultImageData = _msg => {
@@ -10865,7 +10866,6 @@ const resultInit = _ => {
 		canvas.style.left = `100px`;
 		canvas.style.top = `5px`;
 		canvas.style.position = `absolute`;
-		canvas.style.opacity = 0;
 
 		const context = canvas.getContext(`2d`);
 		const drawText = (_text, { x, dx = 0, hy, siz = 15, color = `#cccccc`, align = C_ALIGN_LEFT, font } = {}) => {
@@ -10916,7 +10916,7 @@ const resultInit = _ => {
 		}
 		drawText(rankMark, { x: 240, hy: 18, siz: 50, color: rankColor, font: `"Bookman Old Style"` });
 		drawText(baseTwitUrl, { x: 30, hy: 19, siz: 8 });
-		drawText(new Date().toLocaleString(), { x: 30, hy: 20 });
+		drawText(currentDateTime, { x: 30, hy: 20 });
 
 		divRoot.appendChild(canvas);
 
@@ -10932,38 +10932,28 @@ const resultInit = _ => {
 					})
 				]);
 			});
+			divRoot.removeChild(canvas);
 
 		} catch (err) {
-			const selectText = _element => {
-				if (document.body.createTextRange) {
-					const range = document.body.createTextRange();
-					range.moveToElementText(_element);
-					range.select();
-				} else if (window.getSelection) {
-					const selection = window.getSelection();
-					const range = document.createRange();
-					range.selectNodeContents(_element);
-					selection.removeAllRanges();
-					selection.addRange(range);
-				}
-			};
+			divRoot.removeChild(canvas);
 			const img = document.createElement(`img`);
 			img.src = canvas.toDataURL();
-			document.body.appendChild(img);
 
 			const div = document.createElement(`div`);
 			div.contentEditable = true;
 			div.appendChild(img);
-			document.body.appendChild(div);
+			divRoot.appendChild(div);
 
-			selectText(div);
+			const selection = window.getSelection();
+			const range = document.createRange();
+			range.selectNodeContents(div);
+			selection.removeAllRanges();
+			selection.addRange(range);
+
 			document.execCommand(`copy`);
-			window.getSelection().removeAllRanges();
-			div.contentEditable = false;
-			document.body.removeChild(div);
+			divRoot.removeChild(div);
 
 		} finally {
-			divRoot.removeChild(canvas);
 			makeInfoWindow(_msg, `leftToRightFade`);
 		}
 	};

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10855,7 +10855,10 @@ const resultInit = _ => {
 	const tweetResult = `https://twitter.com/intent/tweet?text=${encodeURIComponent(resultText)}`;
 	const currentDateTime = new Date().toLocaleString();
 
-	// クリップボードコピー
+	/**
+	 * リザルト画像をCanvasで作成しクリップボードへコピー
+	 * @param {string} _msg 
+	 */
 	const copyResultImageData = _msg => {
 		const tmpDiv = createEmptySprite(divRoot, `tmpDiv`, { x: 0, y: 0, w: g_sWidth, h: g_sHeight });
 		tmpDiv.style.background = `#000000cc`;
@@ -10939,6 +10942,7 @@ const resultInit = _ => {
 			makeInfoWindow(_msg, `leftToRightFade`);
 
 		} catch (err) {
+			// 画像をクリップボードへコピーできないときは代替で画像保存可能な画面を表示
 			if (document.getElementById(`tmpClose`) === null) {
 				divRoot.oncontextmenu = _ => true;
 				makeLinkButton(tmpDiv, `Tmp`);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10823,6 +10823,7 @@ const resultInit = _ => {
 	}
 	const twiturl = new URL(g_localStorageUrl);
 	twiturl.searchParams.append(`scoreId`, g_stateObj.scoreId);
+	const baseTwitUrl = g_isLocal ? `` : `${twiturl.toString()}`.replace(/[\t\n]/g, ``);
 
 	const tweetExcessive = (g_stateObj.excessive === C_FLG_ON) ? `(+${g_resultObj.excessive})` : ``;
 
@@ -10844,7 +10845,7 @@ const resultInit = _ => {
 		[`[arrowJdg]`, `${g_resultObj.ii}-${g_resultObj.shakin}-${g_resultObj.matari}-${g_resultObj.shobon}-${g_resultObj.uwan}${tweetExcessive}`],
 		[`[frzJdg]`, tweetFrzJdg],
 		[`[maxCombo]`, tweetMaxCombo],
-		[`[url]`, g_isLocal ? `` : `${twiturl.toString()}`.replace(/[\t\n]/g, ``)]
+		[`[url]`, baseTwitUrl]
 	]);
 	if (g_presetObj.resultVals !== undefined) {
 		Object.keys(g_presetObj.resultVals).forEach(key =>
@@ -10852,6 +10853,113 @@ const resultInit = _ => {
 	}
 	const resultText = `${unEscapeHtml(tweetResultTmp)}`;
 	const tweetResult = `https://twitter.com/intent/tweet?text=${encodeURIComponent(resultText)}`;
+
+	// クリップボードコピー
+	const copyResultImageData = _msg => {
+		const resultImageObj = document.createElement(`canvas`);
+
+		resultImageObj.id = `resultImage`;
+		resultImageObj.width = 400;
+		resultImageObj.height = 400;
+		resultImageObj.style.left = `100px`;
+		resultImageObj.style.top = `5px`;
+		resultImageObj.style.position = `absolute`;
+		resultImageObj.style.opacity = 0;
+
+		const context = resultImageObj.getContext(`2d`);
+		const drawText = (_text, { x, dx = 0, hy, siz = 15, color = `#cccccc`, align = C_ALIGN_LEFT, font } = {}) => {
+			context.font = `${siz}px ${getBasicFont(font)}`;
+			context.fillStyle = color;
+			context.textAlign = align;
+			context.fillText(_text, x, 35 + hy * 18 + dx);
+		};
+		const grd = context.createLinearGradient(0, 0, 0, resultImageObj.height);
+		grd.addColorStop(0, `#000000`);
+		grd.addColorStop(1, `#222222`);
+		context.fillStyle = grd;
+		context.fillRect(0, 0, g_sWidth, g_sHeight);
+
+		drawText(`R`, { x: 30, dx: -5, hy: 0, siz: 40, color: `#9999ff` });
+		drawText(`ESULT`, { x: 57, dx: -5, hy: 0, siz: 25 });
+		drawText(`${g_lblNameObj.dancing}${g_lblNameObj.star}${g_lblNameObj.onigiri}`,
+			{ x: 280, dx: -15, hy: 0, siz: 20, color: `#999999`, align: C_ALIGN_CENTER });
+		drawText(mTitleForView[0], { x: 30, hy: 1 });
+		drawText(mTitleForView[1], { x: 30, hy: 2 });
+		drawText(difData, { x: 30, hy: 3 });
+		drawText(playStyleData, { x: 30, hy: 4 });
+
+		drawText(g_lblNameObj.j_ii, { x: 30, hy: 6, color: `#66ffff` });
+		drawText(g_resultObj.ii, { x: 200, hy: 6, align: C_ALIGN_RIGHT });
+		drawText(g_lblNameObj.j_shakin, { x: 30, hy: 7, color: `#99ff99` });
+		drawText(g_resultObj.shakin, { x: 200, hy: 7, align: C_ALIGN_RIGHT });
+		drawText(g_lblNameObj.j_matari, { x: 30, hy: 8, color: `#ff9966` });
+		drawText(g_resultObj.matari, { x: 200, hy: 8, align: C_ALIGN_RIGHT });
+		drawText(g_lblNameObj.j_shobon, { x: 30, hy: 9, color: `#ccccff` });
+		drawText(g_resultObj.shobon, { x: 200, hy: 9, align: C_ALIGN_RIGHT });
+		drawText(g_lblNameObj.j_uwan, { x: 30, hy: 10, color: `#ff9999` });
+		drawText(g_resultObj.uwan, { x: 200, hy: 10, align: C_ALIGN_RIGHT });
+		drawText(g_lblNameObj.j_kita, { x: 30, hy: 11, color: `#ffff99` });
+		drawText(g_resultObj.kita, { x: 200, hy: 11, align: C_ALIGN_RIGHT });
+		drawText(g_lblNameObj.j_iknai, { x: 30, hy: 12, color: `#99ff66` });
+		drawText(g_resultObj.iknai, { x: 200, hy: 12, align: C_ALIGN_RIGHT });
+		drawText(g_lblNameObj.j_maxCombo, { x: 30, hy: 13, color: `#ffffff` });
+		drawText(g_resultObj.maxCombo, { x: 200, hy: 13, align: C_ALIGN_RIGHT });
+		drawText(g_lblNameObj.j_fmaxCombo, { x: 30, hy: 14, color: `#ffffff` });
+		drawText(g_resultObj.fmaxCombo, { x: 200, hy: 14, align: C_ALIGN_RIGHT });
+		drawText(g_lblNameObj.j_score, { x: 30, hy: 16, color: `#ffffff` });
+		drawText(g_resultObj.score, { x: 200, hy: 16, align: C_ALIGN_RIGHT });
+
+		if (highscoreCondition) {
+			drawText(`(${highscoreDfObj.score >= 0 ? '+' : '-'} ${Math.abs(highscoreDfObj.score)})`,
+				{ x: 206, hy: 17, color: highscoreDfObj.score > 0 ? `#ffff99` : `#cccccc`, align: C_ALIGN_RIGHT });
+		}
+
+		if (g_stateObj.autoAll === C_FLG_OFF) {
+			drawText(g_lblNameObj.j_fast, { x: 240, hy: 6, color: `#ff9966` });
+			drawText(g_resultObj.fast, { x: 360, hy: 6, align: C_ALIGN_RIGHT });
+			drawText(g_lblNameObj.j_slow, { x: 240, hy: 7, color: `#ccccff` });
+			drawText(g_resultObj.slow, { x: 360, hy: 7, align: C_ALIGN_RIGHT });
+			if (estimatedAdj !== ``) {
+				drawText(g_lblNameObj.j_adj, { x: 240, hy: 8, color: `#99ff99` });
+				drawText(getDiffFrame(estimatedAdj), { x: 360, hy: 8, align: C_ALIGN_RIGHT });
+			}
+			if (g_stateObj.excessive === C_FLG_ON) {
+				drawText(g_lblNameObj.j_excessive, { x: 240, hy: 9, color: `#ffff99` });
+				drawText(g_resultObj.excessive, { x: 360, hy: 9, align: C_ALIGN_RIGHT });
+			}
+		}
+		drawText(rankMark, { x: 240, hy: 17, siz: 50, color: rankColor, font: `"Bookman Old Style"` });
+		drawText(baseTwitUrl, { x: 30, hy: 18 });
+		drawText(new Date().toLocaleString(), { x: 30, hy: 19 });
+
+		divRoot.appendChild(resultImageObj);
+
+		// Canvas の内容を PNG 画像として取得
+		let png = resultImageObj.toDataURL('image/png');
+		png = png.replace(/^.*,/, '');
+
+		// バイナリ変換
+		const bin = atob(png);
+		const buffer = new Uint8Array(bin.length);
+		for (let i = 0; i < bin.length; i++) {
+			buffer[i] = bin.charCodeAt(i);
+		}
+		// イメージバッファから Blob を生成
+		const blob = new Blob([buffer], { type: 'image/png' });
+
+		try {
+			navigator.clipboard.write([
+				new ClipboardItem({
+					'image/png': blob
+				})
+			]);
+
+		} catch (err) {
+			console.log(err);
+		} finally {
+			makeInfoWindow(_msg, `leftToRightFade`);
+		}
+	};
 
 	/** 音源、ループ処理の停止 */
 	const resetCommonBtn = (_id, _name, _posObj, _func, _cssClass) =>
@@ -10885,6 +10993,11 @@ const resultInit = _ => {
 
 		// リトライ
 		resetCommonBtn(`btnRetry`, g_lblNameObj.b_retry, g_lblPosObj.btnRsRetry, loadMusic, g_cssObj.button_Reset),
+
+		createCss2Button(`btnCopyImage`, `📷`, _ => true,
+			Object.assign(g_lblPosObj.btnRsCopyImage, {
+				resetFunc: _ => copyResultImageData(g_msgInfoObj.I_0001),
+			}), g_cssObj.button_Default_NoColor),
 	);
 
 	// マスクスプライトを作成

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10929,7 +10929,7 @@ const resultInit = _ => {
 			}
 		}
 		drawText(rankMark, { x: 240, hy: 17, siz: 50, color: rankColor, font: `"Bookman Old Style"` });
-		drawText(baseTwitUrl, { x: 30, hy: 18 });
+		drawText(baseTwitUrl, { x: 30, hy: 18, siz: 8 });
 		drawText(new Date().toLocaleString(), { x: 30, hy: 19 });
 
 		divRoot.appendChild(resultImageObj);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10661,16 +10661,16 @@ const resultInit = _ => {
 
 	// キャラクタ、スコア描画のID共通部、色CSS名、スコア変数名
 	const jdgScoreObj = {
-		ii: { pos: 0, id: `Ii`, color: `ii`, label: g_lblNameObj.j_ii, },
-		shakin: { pos: 1, id: `Shakin`, color: `shakin`, label: g_lblNameObj.j_shakin, },
-		matari: { pos: 2, id: `Matari`, color: `matari`, label: g_lblNameObj.j_matari, },
-		shobon: { pos: 3, id: `Shobon`, color: `shobon`, label: g_lblNameObj.j_shobon, },
-		uwan: { pos: 4, id: `Uwan`, color: `uwan`, label: g_lblNameObj.j_uwan, },
-		kita: { pos: 5, id: `Kita`, color: `kita`, label: g_lblNameObj.j_kita, },
-		iknai: { pos: 6, id: `Iknai`, color: `iknai`, label: g_lblNameObj.j_iknai, },
-		maxCombo: { pos: 7, id: `MCombo`, color: `combo`, label: g_lblNameObj.j_maxCombo, },
-		fmaxCombo: { pos: 8, id: `FCombo`, color: `combo`, label: g_lblNameObj.j_fmaxCombo, },
-		score: { pos: 10, id: `Score`, color: `score`, label: g_lblNameObj.j_score, },
+		ii: { pos: 0, id: `Ii`, color: `ii`, label: g_lblNameObj.j_ii, dfColor: `#66ffff`, },
+		shakin: { pos: 1, id: `Shakin`, color: `shakin`, label: g_lblNameObj.j_shakin, dfColor: `#99ff99`, },
+		matari: { pos: 2, id: `Matari`, color: `matari`, label: g_lblNameObj.j_matari, dfColor: `#ff9966`, },
+		shobon: { pos: 3, id: `Shobon`, color: `shobon`, label: g_lblNameObj.j_shobon, dfColor: `#ccccff`, },
+		uwan: { pos: 4, id: `Uwan`, color: `uwan`, label: g_lblNameObj.j_uwan, dfColor: `#ff9999`, },
+		kita: { pos: 5, id: `Kita`, color: `kita`, label: g_lblNameObj.j_kita, dfColor: `#ffff99`, },
+		iknai: { pos: 6, id: `Iknai`, color: `iknai`, label: g_lblNameObj.j_iknai, dfColor: `#99ff66`, },
+		maxCombo: { pos: 7, id: `MCombo`, color: `combo`, label: g_lblNameObj.j_maxCombo, dfColor: `#ffffff`, },
+		fmaxCombo: { pos: 8, id: `FCombo`, color: `combo`, label: g_lblNameObj.j_fmaxCombo, dfColor: `#ffffff`, },
+		score: { pos: 10, id: `Score`, color: `score`, label: g_lblNameObj.j_score, dfColor: `#ffffff`, },
 	};
 
 	// キャラクタ、スコア描画
@@ -10857,10 +10857,11 @@ const resultInit = _ => {
 	// クリップボードコピー
 	const copyResultImageData = _msg => {
 		const resultImageObj = document.createElement(`canvas`);
+		const artistName = g_headerObj.artistNames[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.artistName;
 
 		resultImageObj.id = `resultImage`;
 		resultImageObj.width = 400;
-		resultImageObj.height = 400;
+		resultImageObj.height = 410;
 		resultImageObj.style.left = `100px`;
 		resultImageObj.style.top = `5px`;
 		resultImageObj.style.position = `absolute`;
@@ -10885,52 +10886,37 @@ const resultInit = _ => {
 			{ x: 280, dx: -15, hy: 0, siz: 20, color: `#999999`, align: C_ALIGN_CENTER });
 		drawText(mTitleForView[0], { x: 30, hy: 1 });
 		drawText(mTitleForView[1], { x: 30, hy: 2 });
-		drawText(difData, { x: 30, hy: 3 });
-		drawText(playStyleData, { x: 30, hy: 4 });
+		drawText(`📝 ${g_headerObj.tuning} / 🎵 ${artistName}`, { x: 30, hy: mTitleForView[1] !== `` ? 3 : 2, siz: 12 });
+		drawText(difData, { x: 30, hy: 4 });
+		drawText(playStyleData, { x: 30, hy: 5 });
 
-		drawText(g_lblNameObj.j_ii, { x: 30, hy: 6, color: `#66ffff` });
-		drawText(g_resultObj.ii, { x: 200, hy: 6, align: C_ALIGN_RIGHT });
-		drawText(g_lblNameObj.j_shakin, { x: 30, hy: 7, color: `#99ff99` });
-		drawText(g_resultObj.shakin, { x: 200, hy: 7, align: C_ALIGN_RIGHT });
-		drawText(g_lblNameObj.j_matari, { x: 30, hy: 8, color: `#ff9966` });
-		drawText(g_resultObj.matari, { x: 200, hy: 8, align: C_ALIGN_RIGHT });
-		drawText(g_lblNameObj.j_shobon, { x: 30, hy: 9, color: `#ccccff` });
-		drawText(g_resultObj.shobon, { x: 200, hy: 9, align: C_ALIGN_RIGHT });
-		drawText(g_lblNameObj.j_uwan, { x: 30, hy: 10, color: `#ff9999` });
-		drawText(g_resultObj.uwan, { x: 200, hy: 10, align: C_ALIGN_RIGHT });
-		drawText(g_lblNameObj.j_kita, { x: 30, hy: 11, color: `#ffff99` });
-		drawText(g_resultObj.kita, { x: 200, hy: 11, align: C_ALIGN_RIGHT });
-		drawText(g_lblNameObj.j_iknai, { x: 30, hy: 12, color: `#99ff66` });
-		drawText(g_resultObj.iknai, { x: 200, hy: 12, align: C_ALIGN_RIGHT });
-		drawText(g_lblNameObj.j_maxCombo, { x: 30, hy: 13, color: `#ffffff` });
-		drawText(g_resultObj.maxCombo, { x: 200, hy: 13, align: C_ALIGN_RIGHT });
-		drawText(g_lblNameObj.j_fmaxCombo, { x: 30, hy: 14, color: `#ffffff` });
-		drawText(g_resultObj.fmaxCombo, { x: 200, hy: 14, align: C_ALIGN_RIGHT });
-		drawText(g_lblNameObj.j_score, { x: 30, hy: 16, color: `#ffffff` });
-		drawText(g_resultObj.score, { x: 200, hy: 16, align: C_ALIGN_RIGHT });
+		Object.keys(jdgScoreObj).forEach(score => {
+			drawText(g_lblNameObj[`j_${score}`], { x: 30, hy: 7 + jdgScoreObj[score].pos, color: jdgScoreObj[score].dfColor });
+			drawText(g_resultObj[score], { x: 200, hy: 7 + jdgScoreObj[score].pos, align: C_ALIGN_RIGHT });
+		});
 
 		if (highscoreCondition) {
 			drawText(`(${highscoreDfObj.score >= 0 ? '+' : '-'} ${Math.abs(highscoreDfObj.score)})`,
-				{ x: 206, hy: 17, color: highscoreDfObj.score > 0 ? `#ffff99` : `#cccccc`, align: C_ALIGN_RIGHT });
+				{ x: 206, hy: 18, color: highscoreDfObj.score > 0 ? `#ffff99` : `#cccccc`, align: C_ALIGN_RIGHT });
 		}
 
 		if (g_stateObj.autoAll === C_FLG_OFF) {
-			drawText(g_lblNameObj.j_fast, { x: 240, hy: 6, color: `#ff9966` });
-			drawText(g_resultObj.fast, { x: 360, hy: 6, align: C_ALIGN_RIGHT });
-			drawText(g_lblNameObj.j_slow, { x: 240, hy: 7, color: `#ccccff` });
-			drawText(g_resultObj.slow, { x: 360, hy: 7, align: C_ALIGN_RIGHT });
+			drawText(g_lblNameObj.j_fast, { x: 240, hy: 7, color: `#ff9966` });
+			drawText(g_resultObj.fast, { x: 360, hy: 7, align: C_ALIGN_RIGHT });
+			drawText(g_lblNameObj.j_slow, { x: 240, hy: 8, color: `#ccccff` });
+			drawText(g_resultObj.slow, { x: 360, hy: 8, align: C_ALIGN_RIGHT });
 			if (estimatedAdj !== ``) {
-				drawText(g_lblNameObj.j_adj, { x: 240, hy: 8, color: `#99ff99` });
-				drawText(getDiffFrame(estimatedAdj), { x: 360, hy: 8, align: C_ALIGN_RIGHT });
+				drawText(g_lblNameObj.j_adj, { x: 240, hy: 9, color: `#99ff99` });
+				drawText(getDiffFrame(estimatedAdj), { x: 360, hy: 9, align: C_ALIGN_RIGHT });
 			}
 			if (g_stateObj.excessive === C_FLG_ON) {
-				drawText(g_lblNameObj.j_excessive, { x: 240, hy: 9, color: `#ffff99` });
-				drawText(g_resultObj.excessive, { x: 360, hy: 9, align: C_ALIGN_RIGHT });
+				drawText(g_lblNameObj.j_excessive, { x: 240, hy: 10, color: `#ffff99` });
+				drawText(g_resultObj.excessive, { x: 360, hy: 10, align: C_ALIGN_RIGHT });
 			}
 		}
-		drawText(rankMark, { x: 240, hy: 17, siz: 50, color: rankColor, font: `"Bookman Old Style"` });
-		drawText(baseTwitUrl, { x: 30, hy: 18, siz: 8 });
-		drawText(new Date().toLocaleString(), { x: 30, hy: 19 });
+		drawText(rankMark, { x: 240, hy: 18, siz: 50, color: rankColor, font: `"Bookman Old Style"` });
+		drawText(baseTwitUrl, { x: 30, hy: 19, siz: 8 });
+		drawText(new Date().toLocaleString(), { x: 30, hy: 20 });
 
 		divRoot.appendChild(resultImageObj);
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -434,6 +434,12 @@ const updateWindowSiz = _ => {
         btnRsCopyImage: {
             x: g_sWidth - 40, y: 0, w: 40, h: 40, siz: 30,
         },
+        btnRsCopyClose: {
+            x: g_sWidth - 80, y: 0, w: 80, h: 40, siz: 20,
+        },
+        resultImageDesc: {
+            x: 0, y: g_sHeight - 30, w: g_sWidth, h: 20, siz: g_limitObj.mainSiz,
+        },
     });
 };
 
@@ -2646,6 +2652,7 @@ const g_lblNameObj = {
     b_tweet: `Tweet`,
     b_gitter: `Gitter`,
     b_retry: `Retry`,
+    b_close: `Close`,
 
     Difficulty: `Difficulty`,
     Speed: `Speed`,
@@ -2826,6 +2833,7 @@ const g_lang_lblNameObj = {
         kcShortcutDesc: `プレイ中ショートカット：「{0}」タイトルバック / 「{1}」リトライ`,
         transKeyDesc: `別キーモードではキーコンフィグ、ColorType等は保存されません`,
         sdShortcutDesc: `Hid+/Sud+時ショートカット：「pageUp」カバーを上へ / 「pageDown」下へ`,
+        resultImageDesc: `画像を右クリックしてコピーできます`,
 
         s_level: `Level`,
         s_douji: `同時補正`,
@@ -2859,6 +2867,7 @@ const g_lang_lblNameObj = {
         kcShortcutDesc: `Shortcut during play: "{0}" Return to title / "{1}" Retry the game`,
         transKeyDesc: `Key config, Color type, etc. are not saved in another key mode`,
         sdShortcutDesc: `When "Hidden+" or "Sudden+" select, "pageUp" cover up / "pageDown" cover down`,
+        resultImageDesc: `You can copy the image by right-clicking on it.`,
 
         s_level: `Level`,
         s_douji: `Chords`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -431,6 +431,9 @@ const updateWindowSiz = _ => {
         btnRsRetry: {
             x: g_sWidth / 4 * 3, w: g_sWidth / 4, h: g_limitObj.btnHeight * 5 / 4, animationName: `smallToNormalY`,
         },
+        btnRsCopyImage: {
+            x: g_sWidth - 40, y: 0, w: 40, h: 40, siz: 30,
+        },
     });
 };
 
@@ -1522,6 +1525,7 @@ const g_shortcutObj = {
         KeyC: { id: `btnCopy`, reset: true },
         KeyT: { id: `btnTweet`, reset: true },
         KeyG: { id: `btnGitter`, reset: true },
+        KeyP: { id: `btnCopyImage` },
         Backspace: { id: `btnRetry` },
     },
 };


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 結果画面のSNS投稿用画像コピー機能を実装しました。
右上のスクリーンショットボタンからコピーできます。
ショートカットは「P」キーを割り当てています。
※現行のFirefox及びhttp環境ではコピー用の画像が表示されます。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 元々html2canvasで実装することを考えていましたが、
余計な項目が多いため新たにCanvasを作ってそこに必要データを埋め込む形で実装しました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/69d5d467-94fd-4504-8bbd-fd87c6a32d87" width="60%">
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/66562ecb-680e-4557-8667-04c7ef302418" width="60%">
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/a31e1fbe-0e35-43f3-8430-cc6f10338156" width="60%">

### Firefox、httpの場合
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/1434fe0b-721d-4c5e-aa08-7ccdb8c06f6a" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- customFontで指定したフォントは反映されます。
- All Perfect, Perfect, FullCombo, Failedといった表記と、Displayオプションは表示していません。
- 横幅が変わっても、画像サイズは400x410で固定です。