### PR TITLE
fix: [0723] Firefoxでドメイン外のCSSファイルを読み込んだ場合、起動できない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1485,23 +1485,10 @@ const getCssCustomProperties = _ => {
 			}
 		}
 	} catch (error) {
+
 		// FirefoxではcomputedStyleMapが使えないため、
-		// CSSの全スタイルシート定義から :root がセレクタのルールを抽出し、カスタムプロパティを抽出
-		const sheets = document.styleSheets;
-		for (const sheet of sheets) {
-			if (!g_isFile && sheet.cssRules) {
-				for (const rule of sheet.cssRules) {
-					if (rule.selectorText === ':root') {
-						for (let i = 0; i < rule.style.length; i++) {
-							const propertyName = rule.style.item(i);
-							if (/^--/.test(propertyName)) {
-								g_cssBkProperties[propertyName] = rule.style.getPropertyValue(propertyName);
-							}
-						}
-					}
-				}
-			}
-		}
+		// g_cssBkProperties は未定義にする
+
 	}
 }
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -726,7 +726,7 @@ const loadScript2 = (_url, _requiredFlg = true, _charset = `UTF-8`) => {
  * デフォルトは danoni_skin_default.css を読み込む
  * @param {url} _href 
  */
-const importCssFile2 = _href => {
+const importCssFile2 = (_href, { crossOrigin = `anonymous` } = {}) => {
 	const baseUrl = _href.split(`?`)[0];
 	g_loadObj[baseUrl] = false;
 
@@ -734,6 +734,7 @@ const importCssFile2 = _href => {
 		const link = document.createElement(`link`);
 		link.rel = `stylesheet`;
 		link.href = _href;
+		link.crossOrigin = crossOrigin;
 		link.onload = _ => {
 			g_loadObj[baseUrl] = true;
 			resolve(link);
@@ -1486,9 +1487,26 @@ const getCssCustomProperties = _ => {
 		}
 	} catch (error) {
 
-		// FirefoxではcomputedStyleMapが使えないため、
-		// g_cssBkProperties は未定義にする
-
+		try {
+			// FirefoxではcomputedStyleMapが使えないため、
+			// CSSの全スタイルシート定義から :root がセレクタのルールを抽出し、カスタムプロパティを抽出
+			const sheets = document.styleSheets;
+			Array.from(sheets).filter(sheet => !g_isFile && sheet.href !== null &&
+				sheet.href.includes(`danoni_skin_`) && sheet.cssRules).forEach(sheet => {
+					for (const rule of sheet.cssRules) {
+						if (rule.selectorText === ':root') {
+							for (let i = 0; i < rule.style.length; i++) {
+								const propertyName = rule.style.item(i);
+								if (/^--/.test(propertyName)) {
+									g_cssBkProperties[propertyName] = rule.style.getPropertyValue(propertyName);
+								}
+							}
+						}
+					}
+				});
+		} catch (error) {
+			// 上記でもNGの場合は何もしない
+		}
 	}
 }
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. Firefoxでドメイン外のCSSファイルを読み込んだ場合、起動できない問題を修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #1519 にてCSSをリセットするためにFirefoxのみ別処理にしましたが、ドメイン外（フォントなど）を読み込んだ場合、CORSに引っ掛かり起動できない問題が発生していました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
