### PR TITLE
feat: [0724] 画像コピー時の譜面作成者名の表記を見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -50,6 +50,8 @@ const g_rootPath = current().match(/(^.*\/)/)[0];
 const g_workPath = new URL(location.href).href.match(/(^.*\/)/)[0];
 const g_remoteFlg = g_rootPath.match(`^https://cwtickle.github.io/danoniplus/`) !== null;
 const g_randTime = Date.now();
+const g_isFile = location.href.match(/^file/);
+const g_isLocal = location.href.match(/^file/) || location.href.indexOf(`localhost`) !== -1;
 
 window.onload = async () => {
 	g_loadObj.main = true;
@@ -734,7 +736,9 @@ const importCssFile2 = (_href, { crossOrigin = `anonymous` } = {}) => {
 		const link = document.createElement(`link`);
 		link.rel = `stylesheet`;
 		link.href = _href;
-		link.crossOrigin = crossOrigin;
+		if (!g_isFile) {
+			link.crossOrigin = crossOrigin;
+		}
 		link.onload = _ => {
 			g_loadObj[baseUrl] = true;
 			resolve(link);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10612,12 +10612,14 @@ const resultInit = _ => {
 	const withOptions = (_flg, _defaultSet, _displayText = _flg) =>
 		(_flg !== _defaultSet ? getStgDetailName(_displayText) : ``);
 
-	let difData = [
+	const difDatas = [
 		`${getKeyName(g_headerObj.keyLabels[g_stateObj.scoreId])}${transKeyData} ${getStgDetailName('key')} / ${g_headerObj.difLabels[g_stateObj.scoreId]}`,
 		`${withOptions(g_autoPlaysBase.includes(g_stateObj.autoPlay), true, `-${getStgDetailName(g_stateObj.autoPlay)}${getStgDetailName('less')}`)}`,
 		`${withOptions(g_headerObj.makerView, false, `(${g_headerObj.creatorNames[g_stateObj.scoreId]})`)}`,
 		`${withOptions(g_stateObj.shuffle, C_FLG_OFF, `[${getStgDetailName(g_stateObj.shuffle)}]`)}`
-	].filter(value => value !== ``).join(` `);
+	];
+	let difData = difDatas.filter(value => value !== ``).join(` `);
+	const difDataForImage = difDatas.filter((value, j) => value !== `` && j !== 2).join(` `);
 
 	let playStyleData = [
 		`${g_stateObj.speed}${g_lblNameObj.multi}`,
@@ -10901,7 +10903,7 @@ const resultInit = _ => {
 		drawText(mTitleForView[0], { hy: 1 });
 		drawText(mTitleForView[1], { hy: 2 });
 		drawText(`📝 ${g_headerObj.tuning} / 🎵 ${artistName}`, { hy: mTitleForView[1] !== `` ? 3 : 2, siz: 12 });
-		drawText(difData, { hy: 4 });
+		drawText(difDataForImage, { hy: 4 });
 		drawText(playStyleData, { hy: 5 });
 
 		Object.keys(jdgScoreObj).forEach(score => {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10878,11 +10878,11 @@ const resultInit = _ => {
 		canvas.style.position = `absolute`;
 
 		const context = canvas.getContext(`2d`);
-		const drawText = (_text, { x, dx = 0, hy, siz = 15, color = `#cccccc`, align = C_ALIGN_LEFT, font } = {}) => {
+		const drawText = (_text, { x = 30, dy = 0, hy, siz = 15, color = `#cccccc`, align = C_ALIGN_LEFT, font } = {}) => {
 			context.font = `${siz}px ${getBasicFont(font)}`;
 			context.fillStyle = color;
 			context.textAlign = align;
-			context.fillText(_text, x, 35 + hy * 18 + dx);
+			context.fillText(_text, x, 35 + hy * 18 + dy);
 		};
 		const grd = context.createLinearGradient(0, 0, 0, canvas.height);
 		grd.addColorStop(0, `#000000`);
@@ -10890,18 +10890,18 @@ const resultInit = _ => {
 		context.fillStyle = grd;
 		context.fillRect(0, 0, g_sWidth, g_sHeight);
 
-		drawText(`R`, { x: 30, dx: -5, hy: 0, siz: 40, color: `#9999ff` });
-		drawText(`ESULT`, { x: 57, dx: -5, hy: 0, siz: 25 });
+		drawText(`R`, { dy: -5, hy: 0, siz: 40, color: `#9999ff` });
+		drawText(`ESULT`, { x: 57, dy: -5, hy: 0, siz: 25 });
 		drawText(`${g_lblNameObj.dancing}${g_lblNameObj.star}${g_lblNameObj.onigiri}`,
-			{ x: 280, dx: -15, hy: 0, siz: 20, color: `#999999`, align: C_ALIGN_CENTER });
-		drawText(mTitleForView[0], { x: 30, hy: 1 });
-		drawText(mTitleForView[1], { x: 30, hy: 2 });
-		drawText(`📝 ${g_headerObj.tuning} / 🎵 ${artistName}`, { x: 30, hy: mTitleForView[1] !== `` ? 3 : 2, siz: 12 });
-		drawText(difData, { x: 30, hy: 4 });
-		drawText(playStyleData, { x: 30, hy: 5 });
+			{ x: 280, dy: -15, hy: 0, siz: 20, color: `#999999`, align: C_ALIGN_CENTER });
+		drawText(mTitleForView[0], { hy: 1 });
+		drawText(mTitleForView[1], { hy: 2 });
+		drawText(`📝 ${g_headerObj.tuning} / 🎵 ${artistName}`, { hy: mTitleForView[1] !== `` ? 3 : 2, siz: 12 });
+		drawText(difData, { hy: 4 });
+		drawText(playStyleData, { hy: 5 });
 
 		Object.keys(jdgScoreObj).forEach(score => {
-			drawText(g_lblNameObj[`j_${score}`], { x: 30, hy: 7 + jdgScoreObj[score].pos, color: jdgScoreObj[score].dfColor });
+			drawText(g_lblNameObj[`j_${score}`], { hy: 7 + jdgScoreObj[score].pos, color: jdgScoreObj[score].dfColor });
 			drawText(g_resultObj[score], { x: 200, hy: 7 + jdgScoreObj[score].pos, align: C_ALIGN_RIGHT });
 		});
 
@@ -10925,8 +10925,8 @@ const resultInit = _ => {
 			}
 		}
 		drawText(rankMark, { x: 240, hy: 18, siz: 50, color: rankColor, font: `"Bookman Old Style"` });
-		drawText(baseTwitUrl, { x: 30, hy: 19, siz: 8 });
-		drawText(currentDateTime, { x: 30, hy: 20 });
+		drawText(baseTwitUrl, { hy: 19, siz: 8 });
+		drawText(currentDateTime, { hy: 20 });
 
 		tmpDiv.appendChild(canvas);
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -153,9 +153,6 @@ const g_userAgent = window.navigator.userAgent.toLowerCase(); // msie, edge, chr
 const g_isIos = listMatching(g_userAgent, [`iphone`, `ipad`, `ipod`]);
 const g_isMac = listMatching(g_userAgent, [`iphone`, `ipad`, `ipod`, `mac os`]);
 
-const g_isFile = location.href.match(/^file/);
-const g_isLocal = location.href.match(/^file/) || location.href.indexOf(`localhost`) !== -1;
-
 // 変数型
 const C_TYP_BOOLEAN = `boolean`;
 const C_TYP_NUMBER = `number`;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 画像コピー時の譜面作成者名の表記を見直しました。
makerViewが`true`のとき、譜面作成者名が譜面名として表示されてしまうため、その表記を止めました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 譜面作成者表記が重複するため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/8334a210-57c8-4214-bbcd-993294411315" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
