### PR TITLE
fix: [0726] フォントサイズが小さいものに対してbackground-clip:textを取り止め

### DIFF
--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -569,35 +569,35 @@ input[type="color"] {
 
 /* 結果画面：判定名 */
 .common_ii {
-	background: var(--common-ii, #66ffff);
+	color: var(--common-ii, #66ffff);
 }
 
 .common_shakin {
-	background: var(--common-shakin, #99ff99);
+	color: var(--common-shakin, #99ff99);
 }
 
 .common_matari {
-	background: var(--common-matari, #ff9966);
+	color: var(--common-matari, #ff9966);
 }
 
 .common_shobon {
-	background: var(--common-shobon, #ccccff);
+	color: var(--common-shobon, #ccccff);
 }
 
 .common_uwan {
-	background: var(--common-uwan, #ff9999);
+	color: var(--common-uwan, #ff9999);
 }
 
 .common_kita {
-	background: var(--common-kita, #ffff99);
+	color: var(--common-kita, #ffff99);
 }
 
 .common_iknai {
-	background: var(--common-iknai, #99ff66);
+	color: var(--common-iknai, #99ff66);
 }
 
 .common_combo {
-	background: var(--common-combo, #ffffff);
+	color: var(--common-combo, #ffffff);
 }
 
 .common_score {
@@ -605,27 +605,27 @@ input[type="color"] {
 }
 
 .common_comboJ {
-	background: var(--common-comboJ, var(--common-kita));
+	color: var(--common-comboJ, var(--common-kita));
 }
 
 .common_comboFJ {
-	background: var(--common-comboFJ, var(--common-ii));
+	color: var(--common-comboFJ, var(--common-ii));
 }
 
 .common_diffFast {
-	background: var(--common-diffFast, var(--common-matari));
+	color: var(--common-diffFast, var(--common-matari));
 }
 
 .common_diffSlow {
-	background: var(--common-diffSlow, var(--common-shobon));
+	color: var(--common-diffSlow, var(--common-shobon));
 }
 
 .common_estAdj {
-	background: var(--common-estAdj, var(--common-shakin));
+	color: var(--common-estAdj, var(--common-shakin));
 }
 
 .common_excessive {
-	background: var(--common-excessive, var(--common-kita));
+	color: var(--common-excessive, var(--common-kita));
 }
 
 /* 結果画面：枠 */
@@ -817,20 +817,6 @@ input[type="color"] {
 .settings_Title2::first-letter,
 .settings_TitleStar,
 .settings_Display::first-letter,
-.common_ii,
-.common_shakin,
-.common_matari,
-.common_shobon,
-.common_uwan,
-.common_kita,
-.common_iknai,
-.common_combo,
-.common_comboJ,
-.common_comboFJ,
-.common_diffFast,
-.common_diffSlow,
-.common_estAdj,
-.common_excessive,
 .result_AllPerfect,
 .result_Perfect,
 .result_FullCombo,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. フォントサイズが小さいものに対してbackground-clip:textを取り止めました。

```
.common_ii
.common_shakin
.common_matari
.common_shobon
.common_uwan
.common_kita
.common_iknai
.common_combo
.common_comboJ
.common_comboFJ
.common_diffFast
.common_diffSlow
.common_estAdj
.common_excessive
```
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Discord指摘より。
cssのbackground-clip:textで文字のくり抜きによる色付けを行う場合、
塗りつぶし範囲が違う（おそらく文字の内側を塗りつぶす）ため、文字色が細く見えることから
文字サイズが小さいものについてはこの方法を取り止めました。
これに伴い、上記に指定したものについてはグラデーション指定が無効となります。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/d000302b-a98a-4ed6-aa39-f958fe4154ae" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- CSSカスタムプロパティ名は変更しません。