### PR TITLE
fix: [0727] 背景・マスクモーションのフレーム計算誤りを修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7685,7 +7685,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 */
 	const makeBackgroundData = (_header, _scoreNo, { resultTypes = [] } = {}) => {
 		const dataList = [];
-		const calcFrameFunc = resultTypes.length > 0 ? calcFrame : undefined;
+		const calcFrameFunc = resultTypes.length > 0 ? undefined : calcFrame;
 		const addDataList = (_type = ``) => dataList.push(...getPriorityList(_header, _type, _scoreNo));
 		getPriorityHeader(resultTypes).forEach(val => addDataList(val));
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 背景・マスクモーションのフレーム計算誤りを修正しました。
タイトル/リザルト時の背景・マスクと、本体の背景・マスクの計算方法が逆になっていました。
（後者は、AdjustmentやplaybackRateに合わせてフレーム数の修正が必要）
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #1519 でコード集約した際のコード誤りです。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
- コード中の「resultType」というのはタイトル/リザルトモーションのことを指します。
- 下記修正で、`const calcFrameFunc = resultTypes.length > 0 ? calcFrame : undefined;`としていますが
これだとタイトル/リザルトモーションに対してフレーム補正が掛かってしまいます。
本当に必要なのは本体の方なので、条件式が逆です。

<img src="https://github.com/cwtickle/danoniplus/assets/44026291/7740bbf7-2c65-4c4f-a64b-8d437b6723d6" width="100%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
