### PR TITLE
fix: [0728] フリーズアローの終点と次のフリーズアローの始点が近い場合の判定不具合を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9414,7 +9414,7 @@ const mainInit = _ => {
 
 		frzOFF: (_j, _k, _cnt) => {
 
-			if (g_workObj.judgFrzCnt[_j] === _k - 1 && _cnt <= g_judgObj.frzJ[g_judgPosObj.sfsf]) {
+			if (g_workObj.judgFrzCnt[_j] === _k - 1) {
 				const prevFrzName = `frz${_j}_${g_workObj.judgFrzCnt[_j]}`;
 				const prevFrz = g_attrObj[prevFrzName];
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. フリーズアローの終点と次のフリーズアローの始点が近い場合に、
後のフリーズアローの判定がスルーされる場合がある問題を修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Resolves #1529 

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- フリーズアローのFast/Slow実装時 ( PR #1352 ) の考慮漏れと思われます。v29.0.0以降が対象。
- 判定対象のフリーズアローより前の同レーンのフリーズアローは自動消去する仕様です。