### PR TITLE
fix: [0729] 画像コピー用のテキストのエスケープ文字が戻されていない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10904,7 +10904,7 @@ const resultInit = _ => {
 		drawText(unEscapeHtml(mTitleForView[1]), { hy: 2 });
 		drawText(`📝 ${unEscapeHtml(g_headerObj.tuning)} / 🎵 ${unEscapeHtml(artistName)}`, { hy: mTitleForView[1] !== `` ? 3 : 2, siz: 12 });
 		drawText(unEscapeHtml(difDataForImage), { hy: 4 });
-		drawText(unEscapeHtml(playStyleData), { hy: 5 });
+		drawText(playStyleData, { hy: 5 });
 
 		Object.keys(jdgScoreObj).forEach(score => {
 			drawText(g_lblNameObj[`j_${score}`], { hy: 7 + jdgScoreObj[score].pos, color: jdgScoreObj[score].dfColor });

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10900,11 +10900,11 @@ const resultInit = _ => {
 		drawText(`ESULT`, { x: 57, dy: -5, hy: 0, siz: 25 });
 		drawText(`${g_lblNameObj.dancing}${g_lblNameObj.star}${g_lblNameObj.onigiri}`,
 			{ x: 280, dy: -15, hy: 0, siz: 20, color: `#999999`, align: C_ALIGN_CENTER });
-		drawText(mTitleForView[0], { hy: 1 });
-		drawText(mTitleForView[1], { hy: 2 });
-		drawText(`📝 ${g_headerObj.tuning} / 🎵 ${artistName}`, { hy: mTitleForView[1] !== `` ? 3 : 2, siz: 12 });
-		drawText(difDataForImage, { hy: 4 });
-		drawText(playStyleData, { hy: 5 });
+		drawText(unEscapeHtml(mTitleForView[0]), { hy: 1 });
+		drawText(unEscapeHtml(mTitleForView[1]), { hy: 2 });
+		drawText(`📝 ${unEscapeHtml(g_headerObj.tuning)} / 🎵 ${unEscapeHtml(artistName)}`, { hy: mTitleForView[1] !== `` ? 3 : 2, siz: 12 });
+		drawText(unEscapeHtml(difDataForImage), { hy: 4 });
+		drawText(unEscapeHtml(playStyleData), { hy: 5 });
 
 		Object.keys(jdgScoreObj).forEach(score => {
 			drawText(g_lblNameObj[`j_${score}`], { hy: 7 + jdgScoreObj[score].pos, color: jdgScoreObj[score].dfColor });


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 画像コピー用のテキストのエスケープ文字が戻されていない問題を修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #1521 の考慮漏れです。
X (Twitter)投稿用のテキストにはエスケープを元に戻す処理が入っていましたが、
リザルト画像用の方にはされていませんでした。
なお前者は全体に対してunEscapeHtmlを適用していますが、
後者はできないため、外部から入力する項目のみunEscapeHtmlを適用しています。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/c91d15b9-4a3a-4779-99b3-a3371364d932" width="40%">

(X (Twitter)投稿画像より)

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- ver33.1.0以降で発生する問題です。
- g_lblNameObjで変更可能な項目はエスケープの必要が無いため、対処していません。