### PR TITLE
fix: [0731] stockForceDel使用中に背景・マスクのanimationNameが空の場合、エラーになる問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8169,8 +8169,8 @@ const pushArrows = (_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 
 		const isExceptData = {
 			word: (_exceptList, _j) => listMatching(_data[startNum][_j][1], _exceptList.word),
-			back: (_exceptList, _j) => listMatching(_data[startNum][_j].animationName, _exceptList.back),
-			mask: (_exceptList, _j) => listMatching(_data[startNum][_j].animationName, _exceptList.mask),
+			back: (_exceptList, _j) => listMatching(_data[startNum][_j].animationName || ``, _exceptList.back),
+			mask: (_exceptList, _j) => listMatching(_data[startNum][_j].animationName || ``, _exceptList.mask),
 			style: (_exceptList, _j) => listMatching(_data[startNum][_j].depth, _exceptList.style),
 		};
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8168,10 +8168,10 @@ const pushArrows = (_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 				_data[startNum][_j].depth === _data[startNum][_k].depth);
 
 		const isExceptData = {
-			word: (_exceptList, _j) => listMatching(_data[startNum][_j][1], _exceptList.word),
+			word: (_exceptList, _j) => listMatching(_data[startNum][_j][1] || ``, _exceptList.word),
 			back: (_exceptList, _j) => listMatching(_data[startNum][_j].animationName || ``, _exceptList.back),
 			mask: (_exceptList, _j) => listMatching(_data[startNum][_j].animationName || ``, _exceptList.mask),
-			style: (_exceptList, _j) => listMatching(_data[startNum][_j].depth, _exceptList.style),
+			style: (_exceptList, _j) => listMatching(_data[startNum][_j].depth || ``, _exceptList.style),
 		};
 
 		const getLength = _list =>


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. stockForceDelを使用中に、背景・マスクモーションで使用しているanimationNameが空の場合、
エラーになる問題を修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Discordでの指摘より。
背景・マスクモーションでアニメーションを利用しない場合があり、backStockForceDel（もしくはmaskStockForceDel）と併用したときに問題になっていました。
アニメーション名抽出の際に`listMatching`という関数を使っていますが、
文字列がundefinedの場合は受け付けないため、エラーとなっていました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
