### PR TITLE
improve: [0732] 画面の上下に共通の枠線を一律追加するよう対応

### DIFF
--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -356,8 +356,8 @@ input[type="color"] {
 
 /* 背景 */
 #canvas-frame {
-	border-top: 1px solid #666666;
-	border-bottom: 1px solid #666666;
+	border-top: 1px solid var(--back-border-x, #666666);
+	border-bottom: 1px solid var(--back-border-x, #666666);
 }
 
 #divBack {

--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -355,6 +355,11 @@ input[type="color"] {
 /* スキン定義 ------------------------------------------------------------*/
 
 /* 背景 */
+#canvas-frame {
+	border-top: 1px solid #666666;
+	border-bottom: 1px solid #666666;
+}
+
 #divBack {
 	background: var(--background, linear-gradient(#000000, #222222));
 }


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 画面の上下に共通の枠線を一律追加するよう対応しました。
CSSカスタムプロパティ上は`--back-border-x`にて定義しています。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 画面の境界線がわかりにくいため。また、v9以前のcanvas描画との互換性のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
- 上下に `#666666` の境界枠を追加しています。

<img src="https://github.com/cwtickle/danoniplus/assets/44026291/16151717-25a7-41d1-98d8-e86d50ca7aa5" width="70%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
