### PR TITLE
feat: [0733] デフォルトスキン時、Canvas背景を有効化するかどうかの設定を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2649,7 +2649,7 @@ const preheaderConvert = _dosObj => {
 	// 外部スキンファイルの指定
 	const tmpSkinType = _dosObj.skinType ?? g_presetObj.skinType ?? `default`;
 	const tmpSkinTypes = tmpSkinType.split(`,`);
-	obj.defaultSkinFlg = tmpSkinTypes.includes(`default`);
+	obj.defaultSkinFlg = tmpSkinTypes.includes(`default`) && setBoolVal(_dosObj.bgCanvasUse ?? g_presetObj.bgCanvasUse, true);
 	setJsFiles(tmpSkinTypes, C_DIR_SKIN, `skin`);
 
 	// 外部jsファイルの指定

--- a/js/template/danoni_setting.js
+++ b/js/template/danoni_setting.js
@@ -42,6 +42,9 @@ g_presetObj.tuningUrl = `https://www.google.co.jp/`;
 /** 既定スキン (デフォルトは default) */
 g_presetObj.skinType = `default`;
 
+/** skinTypeがdefaultのとき、Canvas背景を有効にするかどうかのフラグ (デフォルトは有効(true)。falseで無効化) */
+//g_presetObj.bgCanvasUse = false;
+
 /** 既定カスタムJs (デフォルトは danoni_custom.js) */
 //g_presetObj.customJs = `danoni_custom.js,danoni_init.js`;
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. デフォルトスキン時、Canvas背景を有効化するかどうかの設定を追加しました。
作品別/共通共に`bgCanvasUse`で制御します。初期値は有効(true)です。

### 譜面ヘッダー（作品別）
```
|bgCanvasUse=false|  // スキンDefault時、Canvas背景を無効にする
```
### 共通設定 (danoni_setting.js)
```js
g_presetObj.bgCanvasUse = false;   // スキンDefault時、Canvas背景を無効にする（全体）
```

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. ページ共通化の影響でCanvasタグを外せない場合があるため。
別スキン化すれば問題ないのですが、
スキン定義更新時の手間とCSSキャッシュの問題を考慮してこの実装にしました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- v9以前の互換性用の設定です。通常は無視して問題ありません。
- スキンをDefault以外にした場合は、Canvas背景は強制的に無効です。（従来通り）