### PR TITLE
feat: [0735] リザルト画像用にカスタム変数を追加できるよう対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10931,6 +10931,14 @@ const resultInit = _ => {
 				drawText(g_lblNameObj.j_excessive, { x: 240, hy: 10, color: `#ffff99` });
 				drawText(g_resultObj.excessive, { x: 360, hy: 10, align: C_ALIGN_RIGHT });
 			}
+			if (g_presetObj.resultVals !== undefined) {
+				Object.keys(g_presetObj.resultVals)
+					.filter(key => hasVal(g_resultObj[g_presetObj.resultVals[key]]))
+					.forEach((key, j) => {
+						drawText(g_presetObj.resultVals[key], { x: 240, hy: j + 12, color: `#ffffff` });
+						drawText(g_resultObj[g_presetObj.resultVals[key]], { x: 360, hy: j + 12, align: C_ALIGN_RIGHT });
+					});
+			}
 		}
 		drawText(rankMark, { x: 240, hy: 18, siz: 50, color: rankColor, font: `"Bookman Old Style"` });
 		drawText(baseTwitUrl, { hy: 19, siz: 8 });

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3274,6 +3274,9 @@ const headerConvert = _dosObj => {
 	const resultFormatDefault = `【#danoni[hashTag]】[musicTitle]([keyLabel]) /[maker] /Rank:[rank]/Score:[score]/Playstyle:[playStyle]/[arrowJdg]/[frzJdg]/[maxCombo] [url]`;
 	obj.resultFormat = escapeHtmlForEnabledTag(_dosObj.resultFormat ?? g_presetObj.resultFormat ?? resultFormatDefault);
 
+	// リザルト画像データのカスタム設定
+	obj.resultValsView = _dosObj.resultValsView?.split(`,`) ?? g_presetObj.resultValsView ?? Array.from(Object.keys(g_presetObj.resultVals ?? {}));
+
 	// フェードイン時にそれ以前のデータを蓄積しない種別(word, back, mask)を指定
 	obj.unStockCategories = (_dosObj.unStockCategory ?? ``).split(`,`);
 	if (g_presetObj.unStockCategories !== undefined) {
@@ -10931,14 +10934,12 @@ const resultInit = _ => {
 				drawText(g_lblNameObj.j_excessive, { x: 240, hy: 10, color: `#ffff99` });
 				drawText(g_resultObj.excessive, { x: 360, hy: 10, align: C_ALIGN_RIGHT });
 			}
-			if (g_presetObj.resultVals !== undefined) {
-				Object.keys(g_presetObj.resultVals)
-					.filter(key => hasVal(g_resultObj[g_presetObj.resultVals[key]]))
-					.forEach((key, j) => {
-						drawText(g_presetObj.resultVals[key], { x: 240, hy: j + 12, color: `#ffffff` });
-						drawText(g_resultObj[g_presetObj.resultVals[key]], { x: 360, hy: j + 12, align: C_ALIGN_RIGHT });
-					});
-			}
+			g_headerObj.resultValsView
+				.filter(key => hasVal(g_resultObj[g_presetObj.resultVals[key]]))
+				.forEach((key, j) => {
+					drawText(g_presetObj.resultVals[key], { x: 240, hy: j + 12, color: `#ffffff` });
+					drawText(g_resultObj[g_presetObj.resultVals[key]], { x: 360, hy: j + 12, align: C_ALIGN_RIGHT });
+				});
 		}
 		drawText(rankMark, { x: 240, hy: 18, siz: 50, color: rankColor, font: `"Bookman Old Style"` });
 		drawText(baseTwitUrl, { hy: 19, siz: 8 });

--- a/js/template/danoni_setting.js
+++ b/js/template/danoni_setting.js
@@ -316,6 +316,11 @@ g_presetObj.resultVals = {
 	// exScore: `exScore`,
 };
 
+/* 
+	リザルトカスタムデータの表示設定
+	g_presetObj.resultVals から、リザルト画像データに表示したい項目を列挙します。
+ */
+//g_presetObj.resultValsView = [`exScore`];
 
 /*
 ------------------------------------------------------------------------


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. リザルト画像用にカスタム変数を追加できるよう対応しました。
`resultFormat`で使用する`g_presetObj.resultVals`を定義していれば、そこで定義した値を
リザルト画像へ反映するようになります。
ただし、`g_presetObj.resultVals`で定義した名前を`g_resultObj`のプロパティで定義していなかったり、
そのプロパティの値が空の場合は印字されません。
参考：https://github.com/cwtickle/danoniplus/wiki/dos-h0072-resultFormat
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->
### 追加設定
- 譜面ヘッダーもしくは共通設定で、カスタムで表示する項目を制御できます。
```javascript
g_presetObj.resultVals = {
    exScore: `exScores`,   // g_resultObj.exScores として定義
    extra: `extraMark`,     // g_resultObj.extraMark として定義
};
```

#### 譜面ヘッダー（作品別）
※カンマ区切りで定義します。
```
|resultValsView=exScore,extra|
```

#### 共通設定（danoni_setting.js）
※配列で指定します。
```javascript
g_presetObj.resultValsView = [`exScore`];
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 現状のリザルト画像はカスタム用の変数を表示する方法が無いため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/2ba43b21-1782-4f8c-bd3f-46868aa96917" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 現状は`g_presetObj.resultVals`及びそれに対応する`g_resultObj`が定義されている場合、表示します。