### PR TITLE
feat: [0718] リザルトコピー用画像のプレビュー機能を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10989,24 +10989,7 @@ const resultInit = _ => {
 
 		tmpDiv.appendChild(canvas);
 
-		try {
-			if (ClipboardItem === undefined) {
-				throw new Error(`error`);
-			}
-			// Canvas の内容を PNG 画像として取得
-			canvas.toBlob(async blob => {
-				await navigator.clipboard.write([
-					new ClipboardItem({
-						'image/png': blob
-					})
-				]);
-			});
-			tmpDiv.removeChild(canvas);
-			divRoot.removeChild(tmpDiv);
-			makeInfoWindow(_msg, `leftToRightFade`);
-
-		} catch (err) {
-			// 画像をクリップボードへコピーできないときは代替で画像保存可能な画面を表示
+		const viewResultImage = _ => {
 			if (document.getElementById(`tmpClose`) === null) {
 				divRoot.oncontextmenu = _ => true;
 				makeLinkButton(tmpDiv, `Tmp`);
@@ -11020,6 +11003,31 @@ const resultInit = _ => {
 					}), g_cssObj.button_Back));
 				tmpDiv.appendChild(createDescDiv(`resultImageDesc`, g_lblNameObj.resultImageDesc));
 			}
+		};
+
+		try {
+			if (ClipboardItem === undefined) {
+				throw new Error(`error`);
+			}
+			if (keyIsDown(g_kCdNameObj.shiftLKey) || keyIsDown(g_kCdNameObj.shiftRKey)) {
+				viewResultImage();
+			} else {
+				// Canvas の内容を PNG 画像として取得
+				canvas.toBlob(async blob => {
+					await navigator.clipboard.write([
+						new ClipboardItem({
+							'image/png': blob
+						})
+					]);
+				});
+				tmpDiv.removeChild(canvas);
+				divRoot.removeChild(tmpDiv);
+				makeInfoWindow(_msg, `leftToRightFade`);
+			}
+
+		} catch (err) {
+			// 画像をクリップボードへコピーできないときは代替で画像保存可能な画面を表示
+			viewResultImage();
 		}
 	};
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. https環境向けにリザルトコピー用画像のプレビュー機能を追加しました。
「Shift」キーを押しながら「:camera:」ボタンもしくは「P」キーでプレビューができます。
http環境もしくはFirefox時は特に変わりません。

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 通常は不要ですが、ローカル環境などでの確認用や何らかの理由でコピーができないときのため。
機能としてはhttp環境時に表示するものと同じ機能を使っています。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/449e07e4-f80d-46c5-a8d2-0545b7b58675" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
