### PR TITLE
improve: [0741] forEach周りのコード整理

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2466,7 +2466,7 @@ const calcLevel = _scoreObj => {
 
 	allScorebook.sort((a, b) => a - b);
 	allScorebook.unshift(allScorebook[0] - 100);
-	allScorebook.push(allScorebook[allScorebook.length - 1] + 100);
+	allScorebook.push(allScorebook.at(-1) + 100);
 	const allCnt = allScorebook.length;
 
 	frzEndData.push(allScorebook[allCnt - 1]);
@@ -4486,9 +4486,10 @@ const nextDifficulty = (_scrollNum = 1) => {
  */
 const makeDifList = (_difList, _targetKey = ``) => {
 	let k = 0, pos = 0;
-	g_headerObj.viewLists.filter(j => _targetKey === `` || _targetKey === g_headerObj.keyLabels[j])
-		.forEach(j => {
-			let text = `${getKeyName(g_headerObj.keyLabels[j])} / ${g_headerObj.difLabels[j]}`;
+	g_headerObj.viewLists.forEach(j => {
+		const keyLabel = g_headerObj.keyLabels[j];
+		if (_targetKey === `` || keyLabel === _targetKey) {
+			let text = `${getKeyName(keyLabel)} / ${g_headerObj.difLabels[j]}`;
 			if (g_headerObj.makerView) {
 				text += ` (${g_headerObj.creatorNames[j]})`;
 			}
@@ -4498,7 +4499,8 @@ const makeDifList = (_difList, _targetKey = ``) => {
 				pos = k + 6;
 			}
 			k++;
-		});
+		}
+	});
 	_difList.scrollTop = Math.max(pos * g_limitObj.setLblHeight - parseInt(_difList.style.height), 0);
 };
 
@@ -4624,7 +4626,7 @@ const drawSpeedGraph = _scoreId => {
 				speedObj[speedType].cnt++;
 			}
 			frame.push(playingFrame);
-			speed.push(speed[speed.length - 1]);
+			speed.push(speed.at(-1));
 		}
 	});
 
@@ -7796,8 +7798,11 @@ const getLastFrame = (_dataObj, _keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj
 			_dataObj.dummyFrzData[j]
 		];
 
-		data.filter(data => hasVal(data) && data?.[data.length - 1] > tmpLastNum)
-			.forEach(_objData => tmpLastNum = _objData[_objData.length - 1]);
+		data.filter(data => hasVal(data)).forEach(_objData => {
+			if (_objData.at(-1) > tmpLastNum) {
+				tmpLastNum = _objData.at(-1);
+			}
+		});
 	}
 	return tmpLastNum;
 };
@@ -7820,8 +7825,11 @@ const getFirstArrowFrame = (_dataObj, _keyCtrlPtn = `${g_keyObj.currentKey}_${g_
 			_dataObj.dummyFrzData[j]
 		];
 
-		data.filter(data => hasVal(data) && data[0] !== `` && data[0] < tmpFirstNum && data[0] + g_limitObj.adjustment > 0)
-			.forEach(_objData => tmpFirstNum = _objData[0]);
+		data.filter(data => hasVal(data)).forEach(_objData => {
+			if (data[0] !== `` && data[0] < tmpFirstNum && data[0] + g_limitObj.adjustment > 0) {
+				tmpFirstNum = _objData[0];
+			}
+		});
 	}
 	return (tmpFirstNum === Infinity ? 0 : tmpFirstNum);
 };


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. forEach周りのコード整理を行いました。
`forEach...if` の組み合わせについて、`filter...forEach`となるように見直しました。
また合わせて、for文から`filter...forEach`に変更できる部分を変更しています。
2. `array[array.length - 1]` を `array.at(-1)` の記述に置き換えました。
https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/at
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. if文が多いことでコードの見通しが悪くなっていたため。
2. 記述の簡素化のため。
`array.at`は現在のブラウザで利用可能なため、今回より使用することにしました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- filterの後のforEachで配列番号を使用する場合、
filterすると番号が変わってしまうためその部分は据え置きにしています。
- 逆に、filterで配列番号を使用していても、その後のforEachで配列番号を使っていない場合は
影響が無いため、変更対象としています。