### PR TITLE
fix: [0742] グラデーション記法のセパレート文字を見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -927,7 +927,7 @@ const makeColorGradation = (_colorStr, { _defaultColorgrd = g_headerObj.defaultC
 	const alphaVal = (_shadowFlg && _objType !== `frz`) ? `80` : (_objType === `titleArrow` ? `40` : ``);
 
 	let convertColorStr = ``;
-	const tmpBackgroundStr = _colorStr.split(`;`);
+	const tmpBackgroundStr = _colorStr.split(`;;`);
 
 	// 色情報以外の部分を退避
 	const addData = tmpBackgroundStr[1] !== undefined ? tmpBackgroundStr.slice(1).join(` `) : ``;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. グラデーション記法のセパレート文字を見直しました。
グラデーション指定以外の指定について、セパレート文字`;`から`;;`に変更しました。
```
|--background=;;url("../img/backgroundfile.png")|
|--background=none;;url("../img/backgroundfile.png")|
```

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. グラデーション記法のセパレート文字(`;`)について、別用途(色名;透明度)で使われているため
その部分が機能しなくなっていました。
仕様矛盾が発生しているため、仕様を見直します。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- ver33でのみ発生します。
PR #1519 