### PR TITLE
feat: [0745] 共通設定ファイルに画面位置調整を行う設定を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2718,8 +2718,9 @@ const headerConvert = _dosObj => {
 		$id(`canvas-frame`).width = `${g_sWidth}px`;
 	}
 	// 高さ設定
-	if (hasVal(_dosObj.windowHeight)) {
-		g_sHeight = Math.max(setIntVal(_dosObj.windowHeight, g_sHeight), g_sHeight);
+	if (hasVal(_dosObj.windowHeight) || hasVal(g_presetObj.autoMinHeight)) {
+		g_sHeight = Math.max(setIntVal(_dosObj.windowHeight, g_sHeight),
+			setIntVal(g_presetObj.autoMinHeight, g_sHeight), g_sHeight);
 		$id(`canvas-frame`).height = `${g_sHeight}px`;
 	}
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2990,12 +2990,12 @@ const headerConvert = _dosObj => {
 	}
 
 	// プレイサイズ(X方向, Y方向)
-	obj.playingWidth = setIntVal(_dosObj.playingWidth, `default`);
-	obj.playingHeight = setIntVal(_dosObj.playingHeight, g_sHeight);
+	obj.playingWidth = setIntVal(_dosObj.playingWidth, g_presetObj.playingWidth ?? `default`);
+	obj.playingHeight = setIntVal(_dosObj.playingHeight, g_presetObj.playingHeight ?? g_sHeight);
 
 	// プレイ左上位置(X座標, Y座標)
-	obj.playingX = setIntVal(_dosObj.playingX);
-	obj.playingY = setIntVal(_dosObj.playingY);
+	obj.playingX = setIntVal(_dosObj.playingX, g_presetObj.playingX ?? 0);
+	obj.playingY = setIntVal(_dosObj.playingY, g_presetObj.playingY ?? 0);
 
 	// ステップゾーン位置
 	g_posObj.stepY = (isNaN(parseFloat(_dosObj.stepY)) ? C_STEP_Y : parseFloat(_dosObj.stepY));

--- a/js/template/danoni_setting.js
+++ b/js/template/danoni_setting.js
@@ -297,6 +297,7 @@ g_presetObj.stockForceDelList = {
 
 /**
  * プレイ画面の位置調整
+ * - 譜面ヘッダーのplayingX, playingY, playingWidth, playingHeightと同じ
  */
 //g_presetObj.playingX = 0;
 //g_presetObj.playingY = 0;

--- a/js/template/danoni_setting.js
+++ b/js/template/danoni_setting.js
@@ -29,6 +29,9 @@ g_presetObj.tuningUrl = `https://www.google.co.jp/`;
 /** 個人サイト別の最小横幅設定 */
 //g_presetObj.autoMinWidth = 600;
 
+/** 個人サイト別の最小高さ設定 */
+//g_presetObj.autoMinHeight = 500;
+
 /** 個人サイト別のウィンドウ位置 (left:左寄せ, center:中央, right:右寄せ)*/
 //g_presetObj.windowAlign = `center`;
 

--- a/js/template/danoni_setting.js
+++ b/js/template/danoni_setting.js
@@ -295,6 +295,14 @@ g_presetObj.stockForceDelList = {
  */
 //g_presetObj.playingLayout = `left`;
 
+/**
+ * プレイ画面の位置調整
+ */
+//g_presetObj.playingX = 0;
+//g_presetObj.playingY = 0;
+//g_presetObj.playingWidth = 600;
+//g_presetObj.playingHeight = 500;
+
 /*
 ------------------------------------------------------------------------
    リザルトデータ


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 共通設定ファイルに画面位置調整を行う設定を追加しました。
いずれも譜面ヘッダーに存在する設定の共通版です。
```js
/** 個人サイト別の最小高さ設定 */
g_presetObj.autoMinHeight = 550;

/**
 * プレイ画面の位置調整
 * - 譜面ヘッダーのplayingX, playingY, playingWidth, playingHeightと同じ
 */
g_presetObj.playingX = 0;
g_presetObj.playingY = 0;
g_presetObj.playingWidth = 600;
g_presetObj.playingHeight = 500;
```
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. カスタムで配置しているテキスト等の関係でずらすことを考慮すると、共通設定できた方が利便性が高いため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
