### PR TITLE
dospath external url

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2221,8 +2221,9 @@ const loadChartFile = async (_scoreId = g_stateObj.scoreId) => {
 
 	const dosInput = document.querySelector(`#dos`);
 	const divRoot = document.querySelector(`#divRoot`);
+	const queryDospath = getQueryParamVal(`dospath`) || 'dos/';
 	const queryDos = getQueryParamVal(`dos`) !== null ?
-		`dos/${getQueryParamVal('dos')}.txt` : encodeURI(document.querySelector(`#externalDos`)?.value ?? ``);
+		queryDospath + `${getQueryParamVal('dos')}.txt` : encodeURI(document.querySelector(`#externalDos`)?.value ?? ``);
 
 	if (dosInput === null && queryDos === ``) {
 		makeWarningWindow(g_msgInfoObj.E_0023);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2223,7 +2223,7 @@ const loadChartFile = async (_scoreId = g_stateObj.scoreId) => {
 	const divRoot = document.querySelector(`#divRoot`);
 	const queryDospath = getQueryParamVal(`dospath`) || 'dos/';
 	const queryDos = getQueryParamVal(`dos`) !== null ?
-		queryDospath + `${getQueryParamVal('dos')}.txt` : encodeURI(document.querySelector(`#externalDos`)?.value ?? ``);
+		queryDospath + `${getQueryParamVal('dos')}` : encodeURI(document.querySelector(`#externalDos`)?.value ?? ``);
 
 	if (dosInput === null && queryDos === ``) {
 		makeWarningWindow(g_msgInfoObj.E_0023);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

Adding a dospath query variable to fetch daa from external url

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

To simplify danoni plus upgrade I would love to have data from external web service.
Upgrading the code is then possible with deployment as data is external

for instance : http://localhost:8080/danoni/danoni0.html?dos=hello.txt&dospath=https://localhost:8081/

## :pencil: その他コメント / Other Comments

if that PR idea is approved I believe similar things should be done for : songs, settings, customs, skins.... :)
