### PR TITLE
feat: [0748] 歌詞表示で途中にカンマがある場合でも、後ろが数字以外ならカンマと見做す処理を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7623,6 +7623,14 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 					wordMaxDepth = tmpWordData[k + 1];
 				}
 
+				// 同一行数で数字が取得できるまでは歌詞表示と見做して結合
+				let m = 3;
+				while (hasVal(tmpWordData[m]) && isNaN(parseInt(tmpWordData[m])) && m < tmpWordData.length) {
+					tmpWordData[k + 2] += `,${tmpWordData[k + m]}`;
+					tmpWordData.splice(k + m, 1);
+				}
+
+				// 歌詞表示データの格納
 				let dataCnts = 0;
 				[wordData[tmpWordData[k]], dataCnts] =
 					checkDuplicatedObjects(wordData[tmpWordData[k]]);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 歌詞表示で途中にカンマがある場合でも、後ろが数字以外ならカンマと見做す処理を追加しました。
```
8945,0,They search my face in a silky voice, <br>but they&#039;re scared of me at the bottom of their heart.
9097,0,It makes me annoyed tremendously...<br>Their behavior disgusts me !
```

### 補足
- 末尾がカンマで、それを区切り文字としたくない場合はカンマの後に半角スペースを入れる必要があります。
- 連続してカンマがある場合は、一つのカンマに集約される仕様です。
- カンマの次の項目が数字でないことを条件に文字結合しています。
このため、歌詞非表示でカンマで囲われた数字をフレーム数としてみなしたくない場合はスペースを入れるか、従来通りカンマの特殊文字指定を行う必要があります。

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. カンマは英語歌詞では多く発生するため、カンマをそのまま使えるようにすることで利便性が上がります。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
