### PR TITLE
feat: [0749] musicTitleの曲名及びアーティスト名で部分的にカンマがそのまま使えるよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -369,6 +369,13 @@ const splitLF = _str => _str?.split(`\r`).join(`\n`).split(`\n`);
 const splitLF2 = (_str, _delim = `$`) => splitLF(_str)?.filter(val => val !== ``).join(_delim).split(_delim);
 
 /**
+ * カンマ区切り処理
+ * （ただし、カンマ+半角スペースの組の場合は区切り文字と見做さない）
+ * @param {string} _str 
+ */
+const splitComma = _str => _str?.split(`, `).join(`*comma* `).split(`,`);
+
+/**
  * 重複を排除した配列の生成
  * @param {array} _array1 
  * @param {...any} _arrays
@@ -2743,7 +2750,7 @@ const headerConvert = _dosObj => {
 		}
 
 		for (let j = 0; j < musicData.length; j++) {
-			const musics = musicData[j].split(`,`);
+			const musics = splitComma(musicData[j]);
 
 			if (obj.musicNos.length >= j) {
 				obj.musicTitles[j] = escapeHtml(getMusicNameSimple(musics[0]));
@@ -2751,7 +2758,7 @@ const headerConvert = _dosObj => {
 				obj.artistNames[j] = escapeHtml(musics[1] ?? ``);
 			}
 		}
-		const musics = musicData[0].split(`,`);
+		const musics = splitComma(musicData[0]);
 		obj.musicTitle = obj.musicTitles[0];
 		obj.musicTitleForView = obj.musicTitlesForView[0];
 		obj.artistName = obj.artistNames[0] ?? ``;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. musicTitleの曲名及びアーティスト名で条件付きでカンマがそのまま使えるようにしました。
カンマ+半角スペースの組み合わせがあれば、区切り文字で無いカンマと見做します。
```
|musicTitle=Hello, world,test,https://...|
-> |musicTitle=Hello*comma* world,test,https://...|  <- 自動でエスケープ処理
```

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 曲名・アーティスト名でカンマを使うケースがそれなりにあるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 他の部分にも転用は可能ですが、区切り文字としてのカンマとそれ以外の区別がつかなくなるため、現状はタイトルと歌詞表示限定にします。
- 区切り文字としてのカンマで、カンマ直後に半角スペースを入れることは通常考えにくいためこの仕様としました。