### PR TITLE
feat: [0758] 右シフトキーがUnknownと表記される問題への対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -571,7 +571,7 @@ const commonKeyDown = (_evt, _displayName, _func = _code => { }, _dfEvtFlg) => {
 		}
 		return blockCode(setCode);
 	}
-	_func(setCode);
+	_func(setCode, _evt.key);
 	return blockCode(setCode);
 };
 
@@ -6726,9 +6726,15 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	);
 
 	// キーボード押下時処理
-	setShortcutEvent(g_currentPage, setCode => {
+	setShortcutEvent(g_currentPage, (kbCode, kbKey) => {
 		const keyCdObj = document.querySelector(`#keycon${g_currentj}_${g_currentk}`);
-		let setKey = g_kCdN.findIndex(kCd => kCd === setCode);
+		let setKey = g_kCdN.findIndex(kCd => kCd === kbCode);
+
+		// 右シフトキー対応
+		if (setKey === 1 && kbKey === `Shift`) {
+			setKey = 260;
+			g_kCdNameObj.shiftRKey = ``;
+		}
 
 		// 全角切替、BackSpace、Deleteキー、Escキーは割り当て禁止
 		// また、直前と同じキーを押した場合(BackSpaceを除く)はキー操作を無効にする

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3890,7 +3890,21 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 		g_keyObj[`minWidth${newKey}`] = _dosObj[`minWidth${newKey}`] ?? g_keyObj[`minWidth${newKey}`] ?? g_keyObj.minWidthDefault;
 
 		// キーコンフィグ (keyCtrlX_Y)
-		g_keyObj.minPatterns = newKeyMultiParam(newKey, `keyCtrl`, toKeyCtrlArray, { errCd: `E_0104`, baseCopyFlg: true });
+		g_keyObj.minPatterns = newKeyMultiParam(newKey, `keyCtrl`, toKeyCtrlArray, {
+			errCd: `E_0104`, baseCopyFlg: true,
+			loopFunc: (k, keyheader) => {
+				const addShiftRKey = (_pattern = ``) => {
+					const keyCtrls = g_keyObj[`${keyheader}_${k + g_keyObj.dfPtnNum}${_pattern}`];
+					for (let j = 0; j < keyCtrls.length; j++) {
+						if (keyCtrls[j].includes(256) && !keyCtrls[j].includes(260)) {
+							keyCtrls[j].push(260);
+						}
+					}
+				};
+				addShiftRKey();
+				addShiftRKey(`d`);
+			},
+		});
 
 		// 読込変数の接頭辞 (charaX_Y)
 		newKeyMultiParam(newKey, `chara`, toString);
@@ -6216,8 +6230,8 @@ const keyConfigInit = (_kcType = g_kcType) => {
 					g_keycons.cursorNum = g_keycons.cursorNumList.findIndex(val => val === g_currentj);
 					setKeyConfigCursor();
 				}, {
-					x: keyconX, y: 50 + C_KYC_REPHEIGHT * k + keyconY,
-					w: C_ARW_WIDTH, h: C_KYC_REPHEIGHT, siz: g_limitObj.keySetSiz,
+					x: keyconX - 5, y: 50 + C_KYC_REPHEIGHT * k + keyconY,
+					w: C_ARW_WIDTH + 10, h: C_KYC_REPHEIGHT, siz: g_limitObj.keySetSiz,
 				}, g_cssObj.button_Default_NoColor, g_cssObj.title_base)
 			);
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1234,6 +1234,8 @@ g_kCd[240] = `CapsLk`;
 g_kCd[256] = `R)Shift`;
 g_kCd[257] = `R)Ctrl`;
 g_kCd[258] = `R)Alt`;
+g_kCd[259] = `Window`;
+g_kCd[260] = `R)Shift`;
 
 // 従来のキーコードとの変換用
 g_kCdN[0] = `- - -`; // 無効値
@@ -1352,6 +1354,7 @@ g_kCdN[256] = `ShiftRight`;
 g_kCdN[257] = `ControlRight`;
 g_kCdN[258] = `AltRight`;
 g_kCdN[259] = `MetaRight`;
+g_kCdN[260] = ``;
 
 const g_kCdNameObj = {
     shiftLKey: `ShiftLeft`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -112,7 +112,7 @@ const g_limitObj = {
     titleSiz: 32,
     mainSiz: 14,
     musicTitleSiz: 13,
-    keySetSiz: 16,
+    keySetSiz: 15,
 };
 
 /** 設定項目の位置 */
@@ -1235,7 +1235,7 @@ g_kCd[256] = `R)Shift`;
 g_kCd[257] = `R)Ctrl`;
 g_kCd[258] = `R)Alt`;
 g_kCd[259] = `Window`;
-g_kCd[260] = `R)Shift`;
+g_kCd[260] = `R-Shift`;
 
 // 従来のキーコードとの変換用
 g_kCdN[0] = `- - -`; // 無効値


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 右シフトキーがキーコンフィグで「Unknown」と表記される問題に対応しました。
今後はキーコンフィグ上、「R-Shift」と表示されるようになります。
（従来のものは「R)Shift」となり、別キーとして区別されます）
なお、キーコンフィグ画面ではkeyBoardEvent.keyまで見て変更していますが、
プレイ上ではkeyBoardEvent.keyは参照せず、keyBoardEvent.code=`''`だけを見て判断します。

2. カスタムキーで「ShiftRight」を指定した場合、自動で1.で追加した「R-Shift」も付加するようにしました。直接指定する場合は「260」を指定します。

3. キーコンフィグ画面で割り当てる文字のサイズを16pxから15pxに変更しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Chrome系ブラウザが`keyBoardEvent.code=ShiftRight`に対応しなくなったため。
2. ブラウザ対応により、当面両方が必要となると思われるため。
3. 割り当て文字の長さが長い場合、枠をはみ出るため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/38fb32b7-0139-49a8-b2b4-af267ea2bcf1" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 右シフトキーの場合、keyboardEvent.codeが空のキーが全て反応することになりますが、
そういったキーが阻害となることは少ないと思われるため、このままとします。
- 下記の例では、「R-Shift」と「Unknown」の2キーがありますが、実際の割り当ては同じです。
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/ac32e3c7-db6f-44cf-90cc-261d421afebe" width="50%">

- Chrome系ブラウザ
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/1879ab24-9237-4ed7-b4e2-ebd00e815f4f" width="70%">

- Firefoxブラウザ
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/586aa679-9c33-4359-b85d-01630cb89f71" width="70%">
