### PR TITLE
fix: [0761] R-ShiftとUnknownキーが分離できていない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -545,7 +545,7 @@ const blockCode = _setCode => !C_BLOCK_KEYS.includes(_setCode);
 const switchKeyHit = (_evt, _keyHitFlg = false) => {
 	if (_evt.code === ``) {
 		g_inputKeyBuffer[''] = false;
-		g_inputKeyBuffer[_evt.key === `Shift` ? `ShiftRight` : `Unknown`] = _keyHitFlg;
+		g_inputKeyBuffer[_evt.key === `Shift` ? g_kCdNameObj.shiftRKey : g_kCdNameObj.unknownKey] = _keyHitFlg;
 	} else {
 		g_inputKeyBuffer[_evt.code] = _keyHitFlg;
 	}
@@ -8539,9 +8539,9 @@ const getArrowSettings = _ => {
 
 			// 内部のキーコードにより、KeyboardEvent.codeの値を切り替え
 			if (g_workObj.keyCtrl[j][k] === g_kCdObj.unknown) {
-				g_workObj.keyCtrlN[j][k] = `Unknown`;
+				g_workObj.keyCtrlN[j][k] = g_kCdNameObj.unknownKey;
 			} else if (g_workObj.keyCtrl[j][k] === g_kCdObj.shiftRAltKey) {
-				g_workObj.keyCtrlN[j][k] = `ShiftRight`;
+				g_workObj.keyCtrlN[j][k] = g_kCdNameObj.shiftRKey;
 			}
 			g_workObj.keyHitFlg[j][k] = false;
 		}
@@ -9134,7 +9134,7 @@ const mainInit = _ => {
 	const mainKeyDownActFunc = {
 
 		OFF: (_code, _key) => {
-			const convCode = (_code === `` ? (_key === `Shift` ? `ShiftRight` : `Unknown`) : _code);
+			const convCode = (_code === `` ? (_key === `Shift` ? g_kCdNameObj.shiftRKey : g_kCdNameObj.unknownKey) : _code);
 			const matchKeys = g_workObj.keyCtrlN;
 
 			for (let j = 0; j < keyNum; j++) {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1363,6 +1363,12 @@ const g_kCdNameObj = {
     metaRKey: `MetaRight`,
 };
 
+const g_kCdObj = {
+    unknown: 1,
+    shiftRkey: 256,
+    shiftRAltKey: 260,
+};
+
 // 画面別ショートカット
 const g_shortcutObj = {
     title: {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1361,6 +1361,7 @@ const g_kCdNameObj = {
     shiftRKey: `ShiftRight`,
     metaLKey: `MetaLeft`,
     metaRKey: `MetaRight`,
+    unknownKey: `Unknown`,
 };
 
 const g_kCdObj = {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. R-ShiftとUnknownキーが区別されず、どちらも反応してしまう問題を修正しました。
2. ローカルのキーコードを直に書いていた部分を定数化しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #1583 の考慮漏れです。
KeyboardEvent.codeが空のときに押した状態を保存していたため、「R-Shift」「Unknown」どちらでも反応するようになっていました。
KeyboardEvent.codeが空のときは押した状態をリセットし、
その後独自に割り当てたキーに割り当てるといった形を取るように変更しています。
2. ローカルのキーコードが変わったときに関係個所全てを直す必要があるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
