### PR TITLE
feat [0764]: 譜面情報表示の仕様変更

### DIFF
--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -477,7 +477,7 @@ input[type="color"] {
 
 /* 設定画面：レーンごとの矢印数 */
 .settings_maxArrowCnts {
-	color: var(--settings-maxArrowCnts-x, var(--common-kita));
+	color: var(--settings-maxArrowCnts-x, var(--common-uwan));
 }
 
 .settings_minArrowCnts {

--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -475,6 +475,15 @@ input[type="color"] {
 	color: var(--settings-lifeVal-x, #ff9966);
 }
 
+/* 設定画面：レーンごとの矢印数 */
+.settings_maxArrowCnts {
+	color: var(--settings-maxArrowCnts-x, var(--common-kita));
+}
+
+.settings_minArrowCnts {
+	color: var(--settings-maxArrowCnts-x, var(--common-ii));
+}
+
 /* キーコンフィグ */
 .keyconfig_warning {
 	color: var(--keyconfig-warning-x, #ffff99);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4899,21 +4899,18 @@ const makeDifInfo = _scoreId => {
 	<span style="font-size:${wUnit(g_limitObj.difSelectorSiz)};">(${arrowCnts} + ${frzCnts}${g_headerObj.frzStartjdgUse ? ' <span class="common_bold">x 2</span>' : ''})</span>`;
 
 	const makeArrowCntsView = (_cntlist) => {
+		const targetKey = g_headerObj.keyLabels[_scoreId];
 		const cntlist = [
 			_cntlist.filter((val, j) =>
-				g_keyObj[`pos${g_headerObj.keyLabels[_scoreId]}_0`][j] <
-				g_keyObj[`div${g_headerObj.keyLabels[_scoreId]}_0`]),
+				g_keyObj[`pos${targetKey}_0`][j] < g_keyObj[`div${targetKey}_0`]),
 			_cntlist.filter((val, j) =>
-				g_keyObj[`pos${g_headerObj.keyLabels[_scoreId]}_0`][j] >=
-				g_keyObj[`div${g_headerObj.keyLabels[_scoreId]}_0`])
+				g_keyObj[`pos${targetKey}_0`][j] >= g_keyObj[`div${targetKey}_0`])
 		];
-		const getMaxVal = _list => _list.reduce((a, b) => Math.max(a, b));
-		const getMinVal = _list => _list.reduce((a, b) => Math.min(a, b));
 
 		let cntlistStr = ``;
 		cntlist.filter(array => array.length > 0).forEach(array => {
-			const maxVal = getMaxVal(array);
-			const minVal = getMinVal(array);
+			const maxVal = array.reduce((a, b) => Math.max(a, b));
+			const minVal = array.reduce((a, b) => Math.min(a, b));
 
 			cntlistStr += `[ `;
 			array.forEach((val, j) => {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4913,9 +4913,11 @@ const makeDifInfo = _scoreId => {
 
 			cntlistStr += `[ `;
 			array.forEach((val, j) => {
-				array[j] = val === minVal ?
-					`<span class="settings_minArrowCnts">${val}</span>` :
-					(val === maxVal ? `<span class="settings_maxArrowCnts common_bold">${val}</span>` : val);
+				if (maxVal !== minVal) {
+					array[j] = (val === minVal) ?
+						`<span class="settings_minArrowCnts">${val}</span>` :
+						(val === maxVal ? `<span class="settings_maxArrowCnts common_bold">${val}</span>` : val);
+				}
 			});
 			cntlistStr += array.join(`, `) + ` ]`;
 		});

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -431,13 +431,12 @@ const padArray = (_array, _baseArray) => {
  * @param {number} _num
  */
 const getMaxValIdxs = (_array, _num = 1) => {
-	const getMaxVal = (_a, _b) => Math.max(_a, _b);
 	let baseArray = _array.concat();
 	const maxIdxs = [];
 
 	for (let j = 0; j < _num; j++) {
 		maxIdxs[j] = [];
-		const maxVal = baseArray.reduce((a, b) => getMaxVal(a, b));
+		const maxVal = baseArray.reduce((a, b) => Math.max(a, b));
 		_array.map((val, idx) => {
 			if (val === maxVal) {
 				maxIdxs[j].push(idx);
@@ -4899,16 +4898,22 @@ const makeDifInfo = _scoreId => {
 	<span style="font-size:${wUnit(g_limitObj.difSelectorSiz)};">(${arrowCnts} + ${frzCnts}${g_headerObj.frzStartjdgUse ? ' <span class="common_bold">x 2</span>' : ''})</span>`;
 
 	const makeArrowCntsView = (_cntlist) => {
-		const maxPos = getMaxValIdxs(_cntlist, g_limitObj.densityMaxVals).flat();
 		const cntlist = structuredClone(_cntlist);
+		const maxVal = _cntlist.reduce((a, b) => Math.max(a, b));
+		const minVal = _cntlist.reduce((a, b) => Math.min(a, b));
+
 		let divFlg = false;
-		_cntlist.forEach((val, j) => {
-			cntlist[j] = maxPos.includes(j) && val > 0 ? `<span class="common_kita common_bold">${_cntlist[j]}</span>` : _cntlist[j];
-			if (!divFlg && g_keyObj[`div${g_headerObj.keyLabels[_scoreId]}_0`] <= g_keyObj[`pos${g_headerObj.keyLabels[_scoreId]}_0`][j + 1]) {
-				cntlist[j] += ` /`;
-				divFlg = true;
-			}
-		});
+		if (maxVal !== minVal) {
+			_cntlist.forEach((val, j) => {
+				cntlist[j] = val === minVal ?
+					`<span class="settings_minArrowCnts">${val}</span>` :
+					(val === maxVal ? `<span class="settings_maxArrowCnts common_bold">${val}</span>` : val);
+				if (!divFlg && g_keyObj[`div${g_headerObj.keyLabels[_scoreId]}_0`] <= g_keyObj[`pos${g_headerObj.keyLabels[_scoreId]}_0`][j + 1]) {
+					cntlist[j] += ` /`;
+					divFlg = true;
+				}
+			});
+		}
 		return cntlist;
 	}
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4885,7 +4885,7 @@ const makeDifInfo = _scoreId => {
 
 	const arrowCnts = sumData(g_detailObj.arrowCnt[_scoreId]);
 	const frzCnts = sumData(g_detailObj.frzCnt[_scoreId]);
-	const push3CntStr = (g_detailObj.toolDif[_scoreId].push3.length === 0 ? `None` : `(${g_detailObj.toolDif[_scoreId].push3.split(',').join(', ')})`);
+	const push3CntStr = (g_detailObj.toolDif[_scoreId].push3.length === 0 ? `None` : `(${g_detailObj.toolDif[_scoreId].push3.join(', ')})`);
 
 	if (document.getElementById(`lblTooldif`) === null) {
 		makeDifInfoLabels(_scoreId);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4904,17 +4904,17 @@ const makeDifInfo = _scoreId => {
 		const minVal = _cntlist.reduce((a, b) => Math.min(a, b));
 
 		let divFlg = false;
-		if (maxVal !== minVal) {
-			_cntlist.forEach((val, j) => {
+		_cntlist.forEach((val, j) => {
+			if (maxVal !== minVal) {
 				cntlist[j] = val === minVal ?
 					`<span class="settings_minArrowCnts">${val}</span>` :
 					(val === maxVal ? `<span class="settings_maxArrowCnts common_bold">${val}</span>` : val);
-				if (!divFlg && g_keyObj[`div${g_headerObj.keyLabels[_scoreId]}_0`] <= g_keyObj[`pos${g_headerObj.keyLabels[_scoreId]}_0`][j + 1]) {
-					cntlist[j] += ` /`;
-					divFlg = true;
-				}
-			});
-		}
+			}
+			if (!divFlg && g_keyObj[`div${g_headerObj.keyLabels[_scoreId]}_0`] <= g_keyObj[`pos${g_headerObj.keyLabels[_scoreId]}_0`][j + 1]) {
+				cntlist[j] += ` /`;
+				divFlg = true;
+			}
+		});
 		return cntlist;
 	}
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4900,8 +4900,12 @@ const makeDifInfo = _scoreId => {
 
 	const makeArrowCntsView = (_cntlist) => {
 		const cntlist = [
-			_cntlist.filter((val, j) => g_keyObj[`pos${g_headerObj.keyLabels[_scoreId]}_0`][j] < g_keyObj[`div${g_headerObj.keyLabels[_scoreId]}_0`]),
-			_cntlist.filter((val, j) => g_keyObj[`pos${g_headerObj.keyLabels[_scoreId]}_0`][j] >= g_keyObj[`div${g_headerObj.keyLabels[_scoreId]}_0`])
+			_cntlist.filter((val, j) =>
+				g_keyObj[`pos${g_headerObj.keyLabels[_scoreId]}_0`][j] <
+				g_keyObj[`div${g_headerObj.keyLabels[_scoreId]}_0`]),
+			_cntlist.filter((val, j) =>
+				g_keyObj[`pos${g_headerObj.keyLabels[_scoreId]}_0`][j] >=
+				g_keyObj[`div${g_headerObj.keyLabels[_scoreId]}_0`])
 		];
 		const getMaxVal = _list => _list.reduce((a, b) => Math.max(a, b));
 		const getMinVal = _list => _list.reduce((a, b) => Math.min(a, b));

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2586,9 +2586,9 @@ const calcLevel = _scoreObj => {
 		// 同時押し補正
 		douji: calcDifLevel(twoPushCount),
 		// 3つ押し数
-		push3cnt: push3Cnt,
+		push3cnt: makeDedupliArray(push3List)?.length ?? 0,
 		// 3つ押しリスト
-		push3: push3List,
+		push3: makeDedupliArray(push3List),
 	};
 };
 
@@ -4897,9 +4897,24 @@ const makeDifInfo = _scoreId => {
 	lblArrowInfo2.innerHTML = g_lblNameObj.s_linecnts.split(`{0}`).join(g_detailObj.toolDif[_scoreId].push3cnt);
 	dataArrowInfo.innerHTML = `${arrowCnts + frzCnts * (g_headerObj.frzStartjdgUse ? 2 : 1)} 
 	<span style="font-size:${wUnit(g_limitObj.difSelectorSiz)};">(${arrowCnts} + ${frzCnts}${g_headerObj.frzStartjdgUse ? ' <span class="common_bold">x 2</span>' : ''})</span>`;
-	dataArrowInfo2.innerHTML = `<br>(${g_detailObj.arrowCnt[_scoreId]})<br><br>
-			(${g_detailObj.frzCnt[_scoreId]})<br><br>
-			${push3CntStr}`.split(`,`).join(`/`);
+
+	const makeArrowCntsView = (_cntlist) => {
+		const maxPos = getMaxValIdxs(_cntlist, g_limitObj.densityMaxVals).flat();
+		const cntlist = structuredClone(_cntlist);
+		let divFlg = false;
+		_cntlist.forEach((val, j) => {
+			cntlist[j] = maxPos.includes(j) && val > 0 ? `<span class="common_kita common_bold">${_cntlist[j]}</span>` : _cntlist[j];
+			if (!divFlg && g_keyObj[`div${g_headerObj.keyLabels[_scoreId]}_0`] <= g_keyObj[`pos${g_headerObj.keyLabels[_scoreId]}_0`][j + 1]) {
+				cntlist[j] += ` /`;
+				divFlg = true;
+			}
+		});
+		return cntlist;
+	}
+
+	dataArrowInfo2.innerHTML = `<br>(${makeArrowCntsView(g_detailObj.arrowCnt[_scoreId])})<br><br>
+			(${makeArrowCntsView(g_detailObj.frzCnt[_scoreId])})<br><br>
+			${push3CntStr}`.split(`,`).join(`, `).split(`/,`).join(`/`);
 };
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4914,9 +4914,8 @@ const makeDifInfo = _scoreId => {
 			cntlistStr += `[ `;
 			array.forEach((val, j) => {
 				if (maxVal !== minVal) {
-					array[j] = (val === minVal) ?
-						`<span class="settings_minArrowCnts">${val}</span>` :
-						(val === maxVal ? `<span class="settings_maxArrowCnts common_bold">${val}</span>` : val);
+					array[j] = (val === minVal ? `<span class="settings_minArrowCnts">${val}</span>` :
+						(val === maxVal ? `<span class="settings_maxArrowCnts common_bold">${val}</span>` : val));
 				}
 			});
 			cntlistStr += array.join(`, `) + ` ]`;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2585,7 +2585,7 @@ const calcLevel = _scoreObj => {
 		// 同時押し補正
 		douji: calcDifLevel(twoPushCount),
 		// 3つ押し数
-		push3cnt: makeDedupliArray(push3List)?.length ?? 0,
+		push3cnt: push3Cnt,
 		// 3つ押しリスト
 		push3: makeDedupliArray(push3List),
 	};
@@ -4893,7 +4893,8 @@ const makeDifInfo = _scoreId => {
 	dataTooldif.textContent = g_detailObj.toolDif[_scoreId].tool;
 	dataDouji.textContent = g_detailObj.toolDif[_scoreId].douji;
 	dataTate.textContent = g_detailObj.toolDif[_scoreId].tate;
-	lblArrowInfo2.innerHTML = g_lblNameObj.s_linecnts.split(`{0}`).join(g_detailObj.toolDif[_scoreId].push3cnt);
+	lblArrowInfo2.innerHTML = g_lblNameObj.s_linecnts.split(`{0}`)
+		.join(`${makeDedupliArray(g_detailObj.toolDif[_scoreId].push3).length} /cnt:${g_detailObj.toolDif[_scoreId].push3cnt}`);
 	dataArrowInfo.innerHTML = `${arrowCnts + frzCnts * (g_headerObj.frzStartjdgUse ? 2 : 1)} 
 	<span style="font-size:${wUnit(g_limitObj.difSelectorSiz)};">(${arrowCnts} + ${frzCnts}${g_headerObj.frzStartjdgUse ? ' <span class="common_bold">x 2</span>' : ''})</span>`;
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4885,7 +4885,7 @@ const makeDifInfo = _scoreId => {
 
 	const arrowCnts = sumData(g_detailObj.arrowCnt[_scoreId]);
 	const frzCnts = sumData(g_detailObj.frzCnt[_scoreId]);
-	const push3CntStr = (g_detailObj.toolDif[_scoreId].push3.length === 0 ? `None` : `(${g_detailObj.toolDif[_scoreId].push3})`);
+	const push3CntStr = (g_detailObj.toolDif[_scoreId].push3.length === 0 ? `None` : `(${g_detailObj.toolDif[_scoreId].push3.split(',').join(', ')})`);
 
 	if (document.getElementById(`lblTooldif`) === null) {
 		makeDifInfoLabels(_scoreId);
@@ -4899,28 +4899,32 @@ const makeDifInfo = _scoreId => {
 	<span style="font-size:${wUnit(g_limitObj.difSelectorSiz)};">(${arrowCnts} + ${frzCnts}${g_headerObj.frzStartjdgUse ? ' <span class="common_bold">x 2</span>' : ''})</span>`;
 
 	const makeArrowCntsView = (_cntlist) => {
-		const cntlist = structuredClone(_cntlist);
-		const maxVal = _cntlist.reduce((a, b) => Math.max(a, b));
-		const minVal = _cntlist.reduce((a, b) => Math.min(a, b));
+		const cntlist = [
+			_cntlist.filter((val, j) => g_keyObj[`pos${g_headerObj.keyLabels[_scoreId]}_0`][j] < g_keyObj[`div${g_headerObj.keyLabels[_scoreId]}_0`]),
+			_cntlist.filter((val, j) => g_keyObj[`pos${g_headerObj.keyLabels[_scoreId]}_0`][j] >= g_keyObj[`div${g_headerObj.keyLabels[_scoreId]}_0`])
+		];
+		const getMaxVal = _list => _list.reduce((a, b) => Math.max(a, b));
+		const getMinVal = _list => _list.reduce((a, b) => Math.min(a, b));
 
-		let divFlg = false;
-		_cntlist.forEach((val, j) => {
-			if (maxVal !== minVal) {
-				cntlist[j] = val === minVal ?
+		let cntlistStr = ``;
+		cntlist.filter(array => array.length > 0).forEach(array => {
+			const maxVal = getMaxVal(array);
+			const minVal = getMinVal(array);
+
+			cntlistStr += `[ `;
+			array.forEach((val, j) => {
+				array[j] = val === minVal ?
 					`<span class="settings_minArrowCnts">${val}</span>` :
 					(val === maxVal ? `<span class="settings_maxArrowCnts common_bold">${val}</span>` : val);
-			}
-			if (!divFlg && g_keyObj[`div${g_headerObj.keyLabels[_scoreId]}_0`] <= g_keyObj[`pos${g_headerObj.keyLabels[_scoreId]}_0`][j + 1]) {
-				cntlist[j] += ` /`;
-				divFlg = true;
-			}
+			});
+			cntlistStr += array.join(`, `) + ` ]`;
 		});
-		return cntlist;
+
+		return cntlistStr;
 	}
 
-	dataArrowInfo2.innerHTML = `<br>[ ${makeArrowCntsView(g_detailObj.arrowCnt[_scoreId])} ]<br><br>
-			[ ${makeArrowCntsView(g_detailObj.frzCnt[_scoreId])} ]<br><br>
-			${push3CntStr}`.split(`,`).join(`, `).split(`/,`).join(`][`);
+	dataArrowInfo2.innerHTML = `<br>${makeArrowCntsView(g_detailObj.arrowCnt[_scoreId])}<br><br>
+			${makeArrowCntsView(g_detailObj.frzCnt[_scoreId])}<br><br>${push3CntStr}`;
 };
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4918,9 +4918,9 @@ const makeDifInfo = _scoreId => {
 		return cntlist;
 	}
 
-	dataArrowInfo2.innerHTML = `<br>(${makeArrowCntsView(g_detailObj.arrowCnt[_scoreId])})<br><br>
-			(${makeArrowCntsView(g_detailObj.frzCnt[_scoreId])})<br><br>
-			${push3CntStr}`.split(`,`).join(`, `).split(`/,`).join(`/`);
+	dataArrowInfo2.innerHTML = `<br>[ ${makeArrowCntsView(g_detailObj.arrowCnt[_scoreId])} ]<br><br>
+			[ ${makeArrowCntsView(g_detailObj.frzCnt[_scoreId])} ]<br><br>
+			${push3CntStr}`.split(`,`).join(`, `).split(`/,`).join(`][`);
 };
 
 /**

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -292,7 +292,7 @@ const updateWindowSiz = _ => {
             x: 130, y: 70, w: 200, h: 90,
         },
         dataArrowInfo2: {
-            x: 140, y: 70, w: (g_sWidth - 500) / 2 + 285, h: 150, overflow: `auto`,
+            x: 140, y: 70, w: (g_sWidth - 500) / 2 + 275, h: 150, overflow: `auto`,
         },
         lnkDifInfo: {
             w: g_limitObj.difCoverWidth, borderStyle: `solid`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -176,9 +176,6 @@ const g_windowObj = {
     divRoot: { margin: `auto`, letterSpacing: `normal` },
     divBack: { background: `linear-gradient(#000000, #222222)` },
 
-    scoreDetail: { x: 20, y: 85, w: 420, h: 236, visibility: `hidden` },
-    detailObj: { w: 420, h: 230, visibility: `hidden` },
-
     colorPickSprite: { x: 0, y: 90, w: 50, h: 280 },
 };
 
@@ -191,6 +188,8 @@ const updateWindowSiz = _ => {
         difList: { x: 165, y: 60, w: 280, h: 261 + g_sHeight - 500, overflow: `auto` },
         difCover: { x: 25, y: 60, w: 140, h: 261 + g_sHeight - 500, overflow: `auto`, opacity: 0.95 },
         displaySprite: { x: 25, y: 30, w: (g_sWidth - 450) / 2, h: g_limitObj.setLblHeight * 5 },
+        scoreDetail: { x: 20, y: 85, w: (g_sWidth - 500) / 2 + 420, h: 236, visibility: `hidden` },
+        detailObj: { w: (g_sWidth - 500) / 2 + 420, h: 230, visibility: `hidden` },
         keyconSprite: { y: 88, h: g_sHeight, overflow: `auto` },
         loader: { y: g_sHeight - 10, h: 10, backgroundColor: `#333333` },
         playDataWindow: { x: g_sWidth / 2 - 225, y: 70, w: 450, h: 110 },
@@ -293,7 +292,7 @@ const updateWindowSiz = _ => {
             x: 130, y: 70, w: 200, h: 90,
         },
         dataArrowInfo2: {
-            x: 140, y: 70, w: 275, h: 150, overflow: `auto`,
+            x: 140, y: 70, w: (g_sWidth - 500) / 2 + 285, h: 150, overflow: `auto`,
         },
         lnkDifInfo: {
             w: g_limitObj.difCoverWidth, borderStyle: `solid`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 設定画面の譜面情報表示（DifLevel）にて、レーン別の矢印数・フリーズアロー数の最大・最小値に色を付け、上下段位置の折り返し位置がわかるように変更しました。
最大・最小値についてはCSSカスタムプロパティを定義しています。
```css
/* 設定画面：レーンごとの矢印数 */
.settings_maxArrowCnts {
	color: var(--settings-maxArrowCnts-x, var(--common-kita));
}

.settings_minArrowCnts {
	color: var(--settings-maxArrowCnts-x, var(--common-ii));
}
```

2. 設定画面の譜面情報表示（DifLevel）の3つ以上の位置が複数あった場合でも、1つにまとめるように変更しました。
3. 譜面明細表示（scoreDetail）の横幅について、画面横幅に合わせて右に拡張するよう変更しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 数字の羅列だけではわかりにくいため。
2. 3つ押し表示位置と3つ押し数は本来異なるため。
3. キー数が多くなると横スクロールがほぼ必須となっていたため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/8a06f702-0a4b-4fa4-8628-b365d3ce735f" width="80%">
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/3fbb8ec1-9be1-4f0b-8087-fa3740ee2131" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 上下段の区分けは現在のレーン別の矢印数、フリーズアロー数表示に合わせて
キーパターン：１を基準にしています。