### PR TITLE
fix: [0765] keyGroupOrderが一部の譜面で空の場合、他の譜面にその設定が適用されてしまう問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3050,8 +3050,11 @@ const headerConvert = _dosObj => {
 
 	// 初期表示する部分キーの設定
 	obj.keyGroupOrder = [];
-	_dosObj.keyGroupOrder?.split(`$`).filter(val => val !== ``)
-		.forEach((val, j) => obj.keyGroupOrder[j] = val.split(`,`));
+	_dosObj.keyGroupOrder?.split(`$`).forEach((val, j) => {
+		if (val !== ``) {
+			obj.keyGroupOrder[j] = val.split(`,`);
+		}
+	});
 
 	// 最終演出表示有無（noneで無効化）
 	obj.finishView = _dosObj.finishView ?? ``;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. keyGroupOrderが一部の譜面で空で設定されている場合、
他の譜面にその設定が適用されてしまう問題を修正しました。

下記のように設定されていると、本来2譜面目に適用するはずの設定が
1譜面目に設定されてしまいます。
1譜面目ではkeyGroupを考慮していないため、
キーコンフィグ画面に何も表示されない状態になります。この問題を修正しています。
```
|keyGroupOrder=$11,11L|  // 本来は2譜面目に設定
```

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #1551 のコード考慮漏れです。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/4d5cb476-8c55-44e0-9b33-944e21f68cac" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- ver33.5.0以降で発生する問題です。