### PR TITLE
startFrameに空白を指定したときプレイ開始できない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7850,7 +7850,7 @@ const getFirstArrowFrame = (_dataObj, _keyCtrlPtn = `${g_keyObj.currentKey}_${g_
  * @param {number} _scoreId
  */
 const getStartFrame = (_lastFrame, _fadein = 0, _scoreId = g_stateObj.scoreId) => {
-	let frameNum = parseInt(g_headerObj.startFrame?.[_scoreId] ?? g_headerObj.startFrame?.[0] ?? 0);
+	let frameNum = setIntVal(g_headerObj.startFrame?.[_scoreId], setIntVal(g_headerObj.startFrame?.[0], 0));
 	if (_lastFrame >= frameNum) {
 		frameNum = Math.round(_fadein / 100 * (_lastFrame - frameNum)) + frameNum;
 	}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- startFrameに空白を指定したときプレイ開始できない問題を修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- `|startFrame=$0|`のように特定の譜面のstartFrameに空白を指定すると`g_scoreObj.frameNum`の値が`NaN`となり曲再生開始に失敗します。
#1573 以降発生していると思います。
- [くいなちゃんフュージョン](http://www.omission0.com/danoni/175-186-kuina/)で実際に発生していました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
