### PR TITLE
feat: [0767] 譜面リストに現在選択中譜面番号と総譜面数の表示を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4494,7 +4494,7 @@ const nextDifficulty = (_scrollNum = 1) => {
  * @param {string} _targetKey 
  */
 const makeDifList = (_difList, _targetKey = ``) => {
-	let k = 0, pos = 0;
+	let k = 0, pos = 0, curk = 0;
 	g_headerObj.viewLists.forEach(j => {
 		const keyLabel = g_headerObj.keyLabels[j];
 		if (_targetKey === `` || keyLabel === _targetKey) {
@@ -4506,10 +4506,17 @@ const makeDifList = (_difList, _targetKey = ``) => {
 				{ btnStyle: (j === g_stateObj.scoreId ? `Setting` : `Default`) }));
 			if (j === g_stateObj.scoreId) {
 				pos = k + 6 + (g_sHeight - 500) / 50;
+				curk = k;
 			}
 			k++;
 		}
 	});
+	if (document.getElementById(`lblDifCnt`) === null) {
+		difCover.appendChild(createDivCss2Label(`lblDifCnt`, ``, {
+			x: 0, y: 22.5, w: g_limitObj.difCoverWidth, h: 16, siz: 12, fontWeight: `bold`,
+		}));
+	}
+	lblDifCnt.innerHTML = `${_targetKey === '' ? 'ALL' : _targetKey + 'k'}: ${curk + 1} / ${k}`;
 	_difList.scrollTop = Math.max(pos * g_limitObj.setLblHeight - parseInt(_difList.style.height), 0);
 };
 
@@ -4554,7 +4561,7 @@ const createDifWindow = (_key = ``) => {
 
 	// 全リスト
 	difCover.appendChild(
-		makeDifLblCssButton(`keyFilter`, `ALL`, 1.5, _ => {
+		makeDifLblCssButton(`keyFilter`, `ALL`, 1.7, _ => {
 			resetDifWindow();
 			g_stateObj.filterKeys = ``;
 			createDifWindow();
@@ -4565,7 +4572,7 @@ const createDifWindow = (_key = ``) => {
 	let pos = 0;
 	g_headerObj.viewKeyLists.forEach((targetKey, m) => {
 		difCover.appendChild(
-			makeDifLblCssButton(`keyFilter${m}`, `${getKeyName(targetKey)} ${getStgDetailName('key')}`, m + 2.5, _ => {
+			makeDifLblCssButton(`keyFilter${m}`, `${getKeyName(targetKey)} ${getStgDetailName('key')}`, m + 2.7, _ => {
 				resetDifWindow();
 				g_stateObj.filterKeys = targetKey;
 				createDifWindow(targetKey);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 譜面リストに現在選択中譜面番号と総譜面数の表示を追加しました。
RANDOMボタンの下に配置しています。
この関係で、キー別フィルタボタン位置を若干下に動かしています。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 譜面数が多い場合に現在位置がわからなくなることがあるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/8a821a42-585a-464d-9b57-76491842e72e" width="40%"><img src="https://github.com/cwtickle/danoniplus/assets/44026291/e6423600-fc50-4abf-9bec-f54a282e89c3" width="40%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- g_headerObj.viewListsをベースにしているため、カスタムで絞り込みを行っていた場合でも問題はないはずです。