### PR TITLE
feat: [0768] デフォルトのリザルトフォーマットの出力機能を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10791,6 +10791,7 @@ const resultInit = _ => {
 		[`[url]`, baseTwitUrl]
 	]);
 	let tweetResultTmp = makeResultText(g_headerObj.resultFormat);
+	let resultCommonTmp = makeResultText(g_templateObj.resultFormatDf);
 
 	if (g_presetObj.resultVals !== undefined) {
 		Object.keys(g_presetObj.resultVals).forEach(key =>
@@ -10799,7 +10800,6 @@ const resultInit = _ => {
 	const resultText = `${unEscapeHtml(tweetResultTmp)}`;
 	const tweetResult = `https://twitter.com/intent/tweet?text=${encodeURIComponent(resultText)}`;
 	const currentDateTime = new Date().toLocaleString();
-	let resultCommonTmp = makeResultText(`${g_templateObj.resultFormatCommon}|${currentDateTime}| `);
 
 	/**
 	 * リザルト画像をCanvasで作成しクリップボードへコピー

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3257,8 +3257,7 @@ const headerConvert = _dosObj => {
 	obj.justFrames = (g_isLocal) ? 0 : 1;
 
 	// リザルトデータのカスタマイズ
-	const resultFormatDefault = `【#danoni[hashTag]】[musicTitle]([keyLabel]) /[maker] /Rank:[rank]/Score:[score]/Playstyle:[playStyle]/[arrowJdg]/[frzJdg]/[maxCombo] [url]`;
-	obj.resultFormat = escapeHtmlForEnabledTag(_dosObj.resultFormat ?? g_presetObj.resultFormat ?? resultFormatDefault);
+	obj.resultFormat = escapeHtmlForEnabledTag(_dosObj.resultFormat ?? g_presetObj.resultFormat ?? g_templateObj.resultFormatDf);
 
 	// リザルト画像データのカスタム設定
 	obj.resultValsView = _dosObj.resultValsView?.split(`,`) ?? g_presetObj.resultValsView ?? Array.from(Object.keys(g_presetObj.resultVals ?? {}));
@@ -10778,7 +10777,7 @@ const resultInit = _ => {
 		tweetMaxCombo += `-${g_resultObj.fmaxCombo}`;
 	}
 
-	let tweetResultTmp = replaceStr(g_headerObj.resultFormat, [
+	const makeResultText = _format => replaceStr(_format, [
 		[`[hashTag]`, hashTag],
 		[`[musicTitle]`, musicTitle],
 		[`[keyLabel]`, tweetDifData],
@@ -10791,6 +10790,8 @@ const resultInit = _ => {
 		[`[maxCombo]`, tweetMaxCombo],
 		[`[url]`, baseTwitUrl]
 	]);
+	let tweetResultTmp = makeResultText(g_headerObj.resultFormat);
+
 	if (g_presetObj.resultVals !== undefined) {
 		Object.keys(g_presetObj.resultVals).forEach(key =>
 			tweetResultTmp = tweetResultTmp.split(`[${key}]`).join(g_resultObj[g_presetObj.resultVals[key]]));
@@ -10798,6 +10799,7 @@ const resultInit = _ => {
 	const resultText = `${unEscapeHtml(tweetResultTmp)}`;
 	const tweetResult = `https://twitter.com/intent/tweet?text=${encodeURIComponent(resultText)}`;
 	const currentDateTime = new Date().toLocaleString();
+	let resultCommonTmp = makeResultText(`${g_templateObj.resultFormatCommon}|${currentDateTime}| `);
 
 	/**
 	 * リザルト画像をCanvasで作成しクリップボードへコピー
@@ -10949,7 +10951,9 @@ const resultInit = _ => {
 		resetCommonBtn(`btnBack`, g_lblNameObj.b_back, g_lblPosObj.btnRsBack, titleInit, g_cssObj.button_Back),
 
 		// リザルトデータをクリップボードへコピー
-		createCss2Button(`btnCopy`, g_lblNameObj.b_copy, _ => copyTextToClipboard(resultText, g_msgInfoObj.I_0001),
+		createCss2Button(`btnCopy`, g_lblNameObj.b_copy, _ =>
+			copyTextToClipboard(keyIsDown(g_kCdNameObj.shiftLKey) || keyIsDown(g_kCdNameObj.shiftRKey) ?
+				unEscapeHtml(resultCommonTmp) : resultText, g_msgInfoObj.I_0001),
 			g_lblPosObj.btnRsCopy, g_cssObj.button_Setting),
 	);
 	makeLinkButton();

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -777,7 +777,6 @@ const g_rankObj = {
 
 const g_templateObj = {
     resultFormatDf: `【#danoni[hashTag]】[musicTitle]([keyLabel]) /[maker] /Rank:[rank]/Score:[score]/Playstyle:[playStyle]/[arrowJdg]/[frzJdg]/[maxCombo] [url]`,
-    resultFormatCommon: `【#danoni[hashTag]】Music:[musicTitle]([keyLabel])|Maker:[maker]|Rank:[rank]|Score:[score]|Playstyle:[playStyle]|[arrowJdg]/[frzJdg]/[maxCombo]`,
 };
 
 const g_pointAllocation = {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -775,6 +775,11 @@ const g_rankObj = {
     rankColorX: `#996600`
 };
 
+const g_templateObj = {
+    resultFormatDf: `【#danoni[hashTag]】[musicTitle]([keyLabel]) /[maker] /Rank:[rank]/Score:[score]/Playstyle:[playStyle]/[arrowJdg]/[frzJdg]/[maxCombo] [url]`,
+    resultFormatCommon: `【#danoni[hashTag]】Music:[musicTitle]([keyLabel])|Maker:[maker]|Rank:[rank]|Score:[score]|Playstyle:[playStyle]|[arrowJdg]/[frzJdg]/[maxCombo]`,
+};
+
 const g_pointAllocation = {
     ii: 8,
     shakin: 4,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. デフォルトのリザルトフォーマットの出力機能を追加しました。
リザルト画面で「Shift」キーを押しながら「CopyResult」もしくは「C」キーを押します。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->
```
【#danoni】(^^)(7k-Normal) /tickle /Rank:F/Score:0/Playstyle:1x, Hid&Sud+/0-0-0-0-0//0 
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. リザルトフォーマットについてはカスタムできるようになっており、
プレイヤーイベント時にデータ解析がカスタムパターン毎に必要となっていました。
互換性の問題を考慮し、デフォルトのリザルトフォーマットが出力できるようにしました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
