### PR TITLE
feat: [0770] 譜面番号固定時に他の譜面ファイル番号や譜面番号を参照できる機能を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2256,7 +2256,8 @@ const loadChartFile = async (_scoreId = g_stateObj.scoreId) => {
 		const fileBase = queryDos.match(/.+\..*/)[0];
 		const fileExtension = fileBase.split(`.`).pop();
 		const fileCommon = fileBase.split(`.${fileExtension}`)[0];
-		const filename = `${fileCommon}${g_stateObj.dosDivideFlg ? setScoreIdHeader(_scoreId) : ''}.${fileExtension}`;
+		const filename = `${fileCommon}${g_stateObj.dosDivideFlg ?
+			setDosIdHeader(_scoreId, g_stateObj.scoreLockFlg) : ''}.${fileExtension}`;
 
 		await loadScript2(`${filename}?${Date.now()}`, false, charset);
 		if (typeof externalDosInit === C_TYP_FUNCTION) {
@@ -2817,7 +2818,13 @@ const headerConvert = _dosObj => {
 		obj.lifeDamages = [];
 		obj.lifeInits = [];
 		obj.creatorNames = [];
+		obj.dosNos = [];
+		obj.scoreNos = [];
 		g_stateObj.scoreId = (g_stateObj.scoreId < difs.length ? g_stateObj.scoreId : 0);
+
+		if (hasVal(_dosObj.dosNo)) {
+			splitLF2(_dosObj.dosNo).map((val, j) => [obj.dosNos[j], obj.scoreNos[j]] = padArray(val.split(`,`), [j, 1]));
+		}
 
 		difs.forEach(dif => {
 			const difDetails = dif.split(`,`);
@@ -7182,8 +7189,31 @@ const loadingScoreInit = async () => {
 	}, 100);
 };
 
+/**
+ * 譜面番号の取得
+ * @param {number} _scoreId 
+ * @param {boolean} _scoreLockFlg 
+ * @returns 
+ */
 const setScoreIdHeader = (_scoreId = 0, _scoreLockFlg = false) => {
-	if (_scoreId > 0 && _scoreLockFlg === false) {
+	if (!_scoreLockFlg && _scoreId > 0) {
+		return Number(_scoreId) + 1;
+	} else if (_scoreLockFlg && g_headerObj.scoreNos?.[_scoreId] > 1) {
+		return g_headerObj.scoreNos[_scoreId];
+	}
+	return ``;
+};
+
+/**
+ * 譜面ファイル番号の取得
+ * @param {number} _scoreId 
+ * @param {boolean} _scoreLockFlg 
+ * @returns 
+ */
+const setDosIdHeader = (_scoreId = 0, _scoreLockFlg = false) => {
+	if (_scoreLockFlg && g_headerObj.dosNos?.[_scoreId] > 0) {
+		return g_headerObj.dosNos?.[_scoreId] > 1 ? g_headerObj.dosNos[_scoreId] : ``;
+	} else if (_scoreId > 0) {
 		return Number(_scoreId) + 1;
 	}
 	return ``;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2804,6 +2804,24 @@ const headerConvert = _dosObj => {
 	}
 	obj.tuningInit = obj.tuning;
 
+	obj.dosNos = [];
+	obj.scoreNos = [];
+	if (hasVal(_dosObj.dosNo)) {
+		splitLF2(_dosObj.dosNo).map((val, j) => [obj.dosNos[j], obj.scoreNos[j]] = val.split(`,`));
+		const dosNoCnt = {};
+		obj.dosNos.forEach((val, j) => {
+			if (dosNoCnt[val] === undefined) {
+				dosNoCnt[val] = 0;
+			}
+			if (obj.scoreNos[j] === undefined) {
+				dosNoCnt[val]++;
+				obj.scoreNos[j] = dosNoCnt[val];
+			} else {
+				dosNoCnt[val] = Number(obj.scoreNos[j]);
+			}
+		});
+	}
+
 	// 譜面情報
 	if (hasVal(_dosObj.difData)) {
 		const difs = splitLF2(_dosObj.difData);
@@ -2818,25 +2836,7 @@ const headerConvert = _dosObj => {
 		obj.lifeDamages = [];
 		obj.lifeInits = [];
 		obj.creatorNames = [];
-		obj.dosNos = [];
-		obj.scoreNos = [];
 		g_stateObj.scoreId = (g_stateObj.scoreId < difs.length ? g_stateObj.scoreId : 0);
-
-		if (hasVal(_dosObj.dosNo)) {
-			splitLF2(_dosObj.dosNo).map((val, j) => [obj.dosNos[j], obj.scoreNos[j]] = val.split(`,`));
-			const dosNoCnt = {};
-			obj.dosNos.forEach((val, j) => {
-				if (dosNoCnt[val] === undefined) {
-					dosNoCnt[val] = 0;
-				}
-				if (obj.scoreNos[j] === undefined) {
-					dosNoCnt[val]++;
-					obj.scoreNos[j] = dosNoCnt[val];
-				} else {
-					dosNoCnt[val] = Number(obj.scoreNos[j]);
-				}
-			});
-		}
 
 		difs.forEach(dif => {
 			const difDetails = dif.split(`,`);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2298,10 +2298,12 @@ const resetColorAndGauge = _scoreId => {
  */
 const copySetColor = (_baseObj, _scoreId) => {
 	const obj = {};
-	const scoreIdHeader = setScoreIdHeader(_scoreId);
+	const scoreIdHeader = setScoreIdHeader(_scoreId, g_stateObj.scoreLockFlg);
+	const idHeader = setScoreIdHeader(_scoreId);
 	[``, `Shadow`].forEach(pattern =>
 		[`set`, `frz`].filter(arrow => hasVal(_baseObj[`${arrow}${pattern}Color`]))
-			.forEach(arrow => obj[`${arrow}${pattern}Color${scoreIdHeader}`] = _baseObj[`${arrow}${pattern}Color`].concat()));
+			.forEach(arrow => obj[`${arrow}${pattern}Color${idHeader}`] =
+				(_baseObj[`${arrow}${pattern}Color${scoreIdHeader}`] ?? _baseObj[`${arrow}${pattern}Color`]).concat()));
 	return obj;
 };
 
@@ -3363,7 +3365,7 @@ const addGaugeFulls = _obj => _obj.map(key => g_gaugeOptionObj.customFulls[key] 
 const resetBaseColorList = (_baseObj, _dosObj, { scoreId = `` } = {}) => {
 
 	const obj = {};
-	const scoreIdHeader = setScoreIdHeader(scoreId);
+	const idHeader = setScoreIdHeader(scoreId);
 	const getRefData = (_header, _dataName) => {
 		const data = _dosObj[`${_header}${_dataName}`];
 		return data?.startsWith(_header) ? _dosObj[data] : data;
@@ -3373,13 +3375,13 @@ const resetBaseColorList = (_baseObj, _dosObj, { scoreId = `` } = {}) => {
 		const _arrowCommon = `set${pattern}Color`;
 		const _frzCommon = `frz${pattern}Color`;
 
-		const _name = `${_arrowCommon}${scoreIdHeader}`;
-		const _frzName = `${_frzCommon}${scoreIdHeader}`;
+		const _name = `${_arrowCommon}${idHeader}`;
+		const _frzName = `${_frzCommon}${idHeader}`;
 		const _arrowInit = `${_arrowCommon}Init`;
 		const _frzInit = `${_frzCommon}Init`;
 
-		const arrowColorTxt = getRefData(_arrowCommon, scoreIdHeader) || _dosObj[_arrowCommon];
-		const frzColorTxt = getRefData(_frzCommon, scoreIdHeader) || _dosObj[_frzCommon];
+		const arrowColorTxt = getRefData(_arrowCommon, idHeader) || _dosObj[_arrowCommon];
+		const frzColorTxt = getRefData(_frzCommon, idHeader) || _dosObj[_frzCommon];
 
 		// 矢印色
 		Object.keys(_baseObj.dfColorgrdSet).forEach(type => {
@@ -3591,7 +3593,7 @@ const getGaugeSetting = (_dosObj, _name, _difLength, { scoreId = 0 } = {}) => {
 	 */
 	const getGaugeDetailList = (_scoreId, _defaultGaugeList) => {
 		if (_scoreId > 0) {
-			const headerName = `gauge${_name}${setScoreIdHeader(_scoreId)}`;
+			const headerName = `gauge${_name}${setScoreIdHeader(_scoreId, g_stateObj.scoreLockFlg)}`;
 			if (hasVal(_dosObj[headerName])) {
 				return _dosObj[headerName].split(`,`);
 			}
@@ -6830,11 +6832,11 @@ const updateKeyInfo = (_header, _keyCtrlPtn) => {
  */
 const changeSetColor = _ => {
 	const isDefault = [`Default`, `Type0`].includes(g_colorType);
-	const scoreIdHeader = setScoreIdHeader(g_stateObj.scoreId);
-	const defaultType = scoreIdHeader + g_colorType;
+	const idHeader = setScoreIdHeader(g_stateObj.scoreId);
+	const defaultType = idHeader + g_colorType;
 	const currentTypes = {
 		'': (isDefault ? defaultType : g_colorType),
-		'Shadow': (isDefault ? defaultType : `${scoreIdHeader}Default`),
+		'Shadow': (isDefault ? defaultType : `${idHeader}Default`),
 	};
 	Object.keys(currentTypes).forEach(pattern => {
 		g_headerObj[`set${pattern}Color`] = structuredClone(g_headerObj[`set${pattern}Color${currentTypes[pattern]}`]);
@@ -6847,7 +6849,7 @@ const changeSetColor = _ => {
 	});
 
 	// 影矢印が未指定の場合はType1, Type2の影矢印指定を無くす
-	if (!hasVal(g_headerObj[`setShadowColor${scoreIdHeader}Default`][0]) && [`Type1`, `Type2`].includes(g_colorType)) {
+	if (!hasVal(g_headerObj[`setShadowColor${idHeader}Default`][0]) && [`Type1`, `Type2`].includes(g_colorType)) {
 		g_headerObj.setShadowColor = [...Array(g_headerObj.setColorInit.length)].fill(``);
 	}
 };

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2114,15 +2114,13 @@ const initialControl = async () => {
 		}
 	}
 
-	getScoreDetailData(0);
-
 	if (g_loadObj.main) {
 
 		// 譜面分割、譜面番号固定かどうかをチェック
 		g_stateObj.dosDivideFlg = setBoolVal(document.getElementById(`externalDosDivide`)?.value ?? getQueryParamVal(`dosDivide`));
 		g_stateObj.scoreLockFlg = setBoolVal(document.getElementById(`externalDosLock`)?.value ?? getQueryParamVal(`dosLock`));
 
-		for (let j = 1; j < g_headerObj.keyLabels.length; j++) {
+		for (let j = 0; j < g_headerObj.keyLabels.length; j++) {
 
 			// 譜面ファイルが分割されている場合、譜面詳細情報取得のために譜面をロード
 			if (g_stateObj.dosDivideFlg) {
@@ -2825,7 +2823,19 @@ const headerConvert = _dosObj => {
 		g_stateObj.scoreId = (g_stateObj.scoreId < difs.length ? g_stateObj.scoreId : 0);
 
 		if (hasVal(_dosObj.dosNo)) {
-			splitLF2(_dosObj.dosNo).map((val, j) => [obj.dosNos[j], obj.scoreNos[j]] = padArray(val.split(`,`), [j, 1]));
+			splitLF2(_dosObj.dosNo).map((val, j) => [obj.dosNos[j], obj.scoreNos[j]] = val.split(`,`));
+			const dosNoCnt = {};
+			obj.dosNos.forEach((val, j) => {
+				if (dosNoCnt[val] === undefined) {
+					dosNoCnt[val] = 0;
+				}
+				if (obj.scoreNos[j] === undefined) {
+					dosNoCnt[val]++;
+					obj.scoreNos[j] = dosNoCnt[val];
+				} else {
+					dosNoCnt[val] = Number(obj.scoreNos[j]);
+				}
+			});
 		}
 
 		difs.forEach(dif => {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 譜面番号固定時に他の譜面ファイル番号や譜面番号を参照できる機能を追加しました。

これまでは譜面番号固定時は譜面番号が１のときしかデータが取得できませんでした。
1譜面目はファイル1の1譜面目、2譜面目はファイル1の2譜面目、3譜面目はファイル2の1譜面目、
といった取り方ができるようになります。

譜面ヘッダーに「dosNo」を追加しています。$区切りで譜面毎の設定です。
譜面ファイル番号、譜面番号の順にカンマ区切りで指定します。
なお譜面番号は省略が可能で、その場合は同一譜面ファイル番号の連番が割り当てられます。
下記の2つの設定は同じ意味です。
```
|dosNo=1,1$1,2$2,1$2,2$3,1|
|dosNo=1$1$2$2$3|
```
この場合、読み込むファイルが「dos.txt」なら
1譜面目：「dos.txt」の1譜面目
2譜面目：「dos.txt」の2譜面目
3譜面目：「dos2.txt」の1譜面目
4譜面目：「dos2.txt」の2譜面目
5譜面目：「dos3.txt」の1譜面目
となります。

ただし、difDataについてはこれまで通り1ファイル目（上記ならdos.txt）に書く必要があります。
また、「externalDosDivide」「externalDosLock」がどちらも有効（true）で無いと「dosNo」は動作しません。
```html
<input type="hidden" name="externalDosDivide" id="externalDosDivide" value="true">
<input type="hidden" name="externalDosLock" id="externalDosLock" value="true">
```
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 複数の譜面ファイルを譜面番号固定の状態でまとめて管理したいとき、
あるファイルが2譜面以上存在した場合は2譜面目以降の譜面が取り込めない問題がありました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- `scoreIdHeader`という変数ですが、2つの違う意味で使われている箇所があり、
ややこしいため変数名を変えました。
    - `scoreIdHeader` : 読込元の譜面番号（譜面番号固定時は、実際の譜面番号と一致しない）
    - `idHeader` : 適用先の譜面番号（実際の譜面番号と基本一致）