### PR TITLE
improve: [0772] キー別フィルター、譜面リストのカーソル位置調整

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4523,7 +4523,7 @@ const makeDifList = (_difList, _targetKey = ``) => {
 			_difList.appendChild(makeDifLblCssButton(`dif${k}`, text, k, _ => nextDifficulty(j - g_stateObj.scoreId),
 				{ btnStyle: (j === g_stateObj.scoreId ? `Setting` : `Default`) }));
 			if (j === g_stateObj.scoreId) {
-				pos = k + 6 + (g_sHeight - 500) / 50;
+				pos = k + 6.5 * (g_sHeight - 239) / 261;
 				curk = k;
 			}
 			k++;
@@ -4598,10 +4598,10 @@ const createDifWindow = (_key = ``) => {
 			}, { w: g_limitObj.difCoverWidth, btnStyle: (g_stateObj.filterKeys === targetKey ? `Setting` : `Default`) })
 		);
 		if (g_stateObj.filterKeys === targetKey) {
-			pos = m + 7;
+			pos = m + 5 * (g_sHeight - 300) / 200;
 		}
 	});
-	difFilter.scrollTop = Math.max(pos * g_limitObj.setLblHeight - parseInt(difCover.style.height), 0);
+	difFilter.scrollTop = Math.max(pos * g_limitObj.setLblHeight - parseInt(difFilter.style.height), 0);
 
 	multiAppend(optionsprite, makeDifBtn(-1), makeDifBtn());
 };


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. キー別フィルター、譜面リストのカーソル位置を画面縦長に合わせて調整しました。
下記の計算式に沿って表示するように変えています。
    - 選択中の位置+500px縦幅のときの中央値×
    (今回の縦幅時のdiv要素の高さ / 500px縦幅時のdiv要素の高さ)
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. それぞれ、画面の縦長に合わせたカーソル位置になっていなかったため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/22373801-8588-4bba-bd1c-6f4917a982a7" width="40%">
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/5966a12c-dd07-47a7-9077-a3de7d6af452" width="20%">
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/94e287fb-a1ac-4d74-9c7f-9a63f0c76981" width="40%"><img src="https://github.com/cwtickle/danoniplus/assets/44026291/47ffc553-f2b4-43b0-8c70-24d8be5fc374" width="15%">



## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
