### PR TITLE
improve: [0773] デフォルトのタイトル矢印がImgTypeによらず初期値を表示されるよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2707,7 +2707,9 @@ const headerConvert = _dosObj => {
 
 	// サーバ上の場合、画像セットを再読込（ローカルファイル時は読込済みのためスキップ）
 	if (!g_isFile) {
-		updateImgType(obj.imgType[0]);
+		updateImgType(obj.imgType[0], true);
+	} else {
+		g_imgObj.titleArrow = C_IMG_ARROW;
 	}
 
 	// ラベルテキスト、オンマウステキスト、確認メッセージ定義の上書き設定
@@ -3347,7 +3349,10 @@ const getMusicNameMultiLine = _musicName => {
  * 画像セットの入れ替え処理
  * @param {array} _imgType 
  */
-const updateImgType = _imgType => {
+const updateImgType = (_imgType, _initFlg = false) => {
+	if (_initFlg) {
+		C_IMG_TITLE_ARROW = `../img/${_imgType.name}arrow.${_imgType.extension}`;
+	}
 	resetImgs(_imgType.name, _imgType.extension);
 	reloadImgObj();
 	Object.keys(g_imgObj).forEach(key => g_imgObj[key] = `${g_rootPath}${g_imgObj[key]}`);
@@ -4039,7 +4044,7 @@ const titleInit = _ => {
 				background: makeColorGradation(g_headerObj.titlearrowgrds[0] || g_headerObj.setColorOrg[0], {
 					_defaultColorgrd: [false, `#eeeeee`],
 					_objType: `titleArrow`,
-				}), rotate: 180,
+				}), rotate: `titleArrow:180`,
 			})
 		);
 	}

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -477,6 +477,7 @@ let C_IMG_CURSOR = `../img/cursor.svg`;
 let C_IMG_FRZBAR = `../img/frzbar.svg`;
 let C_IMG_LIFEBAR = `../img/frzbar.svg`;
 let C_IMG_LIFEBORDER = `../img/borderline.svg`;
+let C_IMG_TITLE_ARROW;
 
 if (typeof loadBinary === C_TYP_FUNCTION) {
     loadBinary();
@@ -585,6 +586,8 @@ const reloadImgObj = _ => {
     g_imgObj.frzBar = C_IMG_FRZBAR;
     g_imgObj.lifeBar = C_IMG_LIFEBAR;
     g_imgObj.lifeBorder = C_IMG_LIFEBORDER;
+
+    g_imgObj.titleArrow = C_IMG_TITLE_ARROW;
 };
 reloadImgObj();
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. デフォルトのタイトル矢印について、ImgTypeの変更によらず初期値を表示するようにしました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. デフォルトのタイトル矢印をデザインとして使っている場合、ImgTypeを変更すると意図と外れてしまうため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/2610e18e-fced-4b71-9413-566859ed1bfb" width="50%">


## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
