### PR TITLE
feat: [0774] タイトル矢印の回転・種別を自由に決められるよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2705,9 +2705,14 @@ const headerConvert = _dosObj => {
 	g_stateObj.rotateEnabled = obj.imgType[0].rotateEnabled;
 	g_stateObj.flatStepHeight = obj.imgType[0].flatStepHeight;
 
+	const [titleArrowName, titleArrowRotate] = padArray(_dosObj.titleArrowName?.split(`:`), [`Original`, 180]);
+	obj.titleArrowNo = roundZero(g_keycons.imgTypes.findIndex(imgType => imgType === titleArrowName));
+	obj.titleArrowRotate = titleArrowRotate;
+
 	// サーバ上の場合、画像セットを再読込（ローカルファイル時は読込済みのためスキップ）
 	if (!g_isFile) {
-		updateImgType(obj.imgType[0], true);
+		updateImgType(obj.imgType[obj.titleArrowNo], true);
+		updateImgType(obj.imgType[0]);
 	} else {
 		g_imgObj.titleArrow = C_IMG_ARROW;
 	}
@@ -3351,7 +3356,7 @@ const getMusicNameMultiLine = _musicName => {
  */
 const updateImgType = (_imgType, _initFlg = false) => {
 	if (_initFlg) {
-		C_IMG_TITLE_ARROW = `../img/${_imgType.name}arrow.${_imgType.extension}`;
+		C_IMG_TITLE_ARROW = `../img/${_imgType.name}/arrow.${_imgType.extension}`;
 	}
 	resetImgs(_imgType.name, _imgType.extension);
 	reloadImgObj();
@@ -4044,7 +4049,7 @@ const titleInit = _ => {
 				background: makeColorGradation(g_headerObj.titlearrowgrds[0] || g_headerObj.setColorOrg[0], {
 					_defaultColorgrd: [false, `#eeeeee`],
 					_objType: `titleArrow`,
-				}), rotate: `titleArrow:180`,
+				}), rotate: `titleArrow:${g_headerObj.titleArrowRotate}`,
 			})
 		);
 	}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. タイトル矢印の回転・種別を自由に決められるよう変更しました。
コロン(`:`)区切りでImgType、矢印の回転量を指定する。
デフォルトは`Original`、180度。
```
|titleArrowName=classic:90|
```
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. タイトル矢印の種類を変更する方法がこれまで無かったため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/f9cacacb-bdd8-45f8-a3df-569403b5e408" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- ImgTypeはローカルファイルの場合は強制的に`Original`のみとなります。（従来通り）
