### PR TITLE
feat: [0775] ウィンドウサイズとステップゾーン位置により基準速度を変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3036,6 +3036,9 @@ const headerConvert = _dosObj => {
 	g_posObj.arrowHeight = obj.playingHeight + g_posObj.stepYR - g_posObj.stepDiffY * 2;
 	obj.bottomWordSetFlg = setBoolVal(_dosObj.bottomWordSet);
 
+	// ウィンドウサイズ(高さ)とステップゾーン位置の組み合わせで基準速度を変更
+	obj.baseSpeed = (g_posObj.distY - (g_posObj.stepY - C_STEP_Y) * 2) / (500 - C_STEP_Y);
+
 	// 矢印・フリーズアロー判定位置補正
 	g_diffObj.arrowJdgY = (isNaN(parseFloat(_dosObj.arrowJdgY)) ? 0 : parseFloat(_dosObj.arrowJdgY));
 	g_diffObj.frzJdgY = (isNaN(parseFloat(_dosObj.frzJdgY)) ? 0 : parseFloat(_dosObj.frzJdgY));
@@ -7924,11 +7927,11 @@ const getStartFrame = (_lastFrame, _fadein = 0, _scoreId = g_stateObj.scoreId) =
 const setSpeedOnFrame = (_speedData, _lastFrame) => {
 
 	const speedOnFrame = [];
-	let currentSpeed = g_stateObj.speed * 2;
+	let currentSpeed = g_stateObj.speed * g_headerObj.baseSpeed * 2;
 
 	for (let frm = 0, s = 0; frm <= _lastFrame; frm++) {
 		while (frm >= _speedData?.[s]) {
-			currentSpeed = _speedData[s + 1] * g_stateObj.speed * 2;
+			currentSpeed = _speedData[s + 1] * g_stateObj.speed * g_headerObj.baseSpeed * 2;
 			s += 2;
 		}
 		speedOnFrame[frm] = currentSpeed;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2731,10 +2731,9 @@ const headerConvert = _dosObj => {
 		$id(`canvas-frame`).width = wUnit(g_sWidth);
 	}
 	// 高さ設定
-	if (hasVal(_dosObj.windowHeight || g_presetObj.autoMinHeight)
-		|| (getQueryParamVal(`h`) !== null && (_dosObj.heightVariable || g_presetObj.heightVariable || false))) {
-		g_sHeight = Math.max(setIntVal(_dosObj.windowHeight, g_sHeight),
-			setIntVal(g_presetObj.autoMinHeight, g_sHeight),
+	obj.heightVariable = getQueryParamVal(`h`) !== null && (_dosObj.heightVariable || g_presetObj.heightVariable || false);
+	if (hasVal(_dosObj.windowHeight || g_presetObj.autoMinHeight) || obj.heightVariable) {
+		g_sHeight = Math.max(setIntVal(_dosObj.windowHeight, g_presetObj.autoMinHeight ?? g_sHeight),
 			setIntVal(getQueryParamVal(`h`), g_sHeight), g_sHeight);
 		$id(`canvas-frame`).height = wUnit(g_sHeight);
 	}
@@ -3024,11 +3023,13 @@ const headerConvert = _dosObj => {
 
 	// プレイサイズ(X方向, Y方向)
 	obj.playingWidth = setIntVal(_dosObj.playingWidth, g_presetObj.playingWidth ?? `default`);
-	obj.playingHeight = setIntVal(_dosObj.playingHeight, g_presetObj.playingHeight ?? g_sHeight);
+	const tmpPlayingHeight = setIntVal(_dosObj.playingHeight, g_presetObj.playingHeight ?? g_sHeight);
+	obj.playingHeight = Math.max(obj.heightVariable ?
+		setIntVal(getQueryParamVal(`h`) - (g_sHeight - tmpPlayingHeight), tmpPlayingHeight) : tmpPlayingHeight, 400);
 
 	// プレイ左上位置(X座標, Y座標)
 	obj.playingX = setIntVal(_dosObj.playingX, g_presetObj.playingX ?? 0);
-	obj.playingY = setIntVal(_dosObj.playingY, g_presetObj.playingY ?? 0);
+	obj.playingY = setIntVal(_dosObj.playingY, g_presetObj.playingY ?? Math.max((g_sHeight - obj.playingHeight) / 2, 0));
 
 	// ステップゾーン位置
 	g_posObj.stepY = (isNaN(parseFloat(_dosObj.stepY)) ? C_STEP_Y : parseFloat(_dosObj.stepY));

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3029,7 +3029,7 @@ const headerConvert = _dosObj => {
 
 	// プレイ左上位置(X座標, Y座標)
 	obj.playingX = setIntVal(_dosObj.playingX, g_presetObj.playingX ?? 0);
-	obj.playingY = setIntVal(_dosObj.playingY, g_presetObj.playingY ?? Math.max((g_sHeight - obj.playingHeight) / 2, 0));
+	obj.playingY = setIntVal(_dosObj.playingY, g_presetObj.playingY ?? 0);
 
 	// ステップゾーン位置
 	g_posObj.stepY = (isNaN(parseFloat(_dosObj.stepY)) ? C_STEP_Y : parseFloat(_dosObj.stepY));

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3041,7 +3041,7 @@ const headerConvert = _dosObj => {
 	obj.bottomWordSetFlg = setBoolVal(_dosObj.bottomWordSet);
 
 	// ウィンドウサイズ(高さ)とステップゾーン位置の組み合わせで基準速度を変更
-	obj.baseSpeed = (g_posObj.distY - (g_posObj.stepY - C_STEP_Y) * 2) / (500 - C_STEP_Y);
+	obj.baseSpeed = 1 + ((g_posObj.distY - (g_posObj.stepY - C_STEP_Y) * 2) / (500 - C_STEP_Y) - 1) * 0.85;
 
 	// 矢印・フリーズアロー判定位置補正
 	g_diffObj.arrowJdgY = (isNaN(parseFloat(_dosObj.arrowJdgY)) ? 0 : parseFloat(_dosObj.arrowJdgY));

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1062,6 +1062,15 @@ const g_hidSudObj = {
         'Sudden+': { OFF: 1, ON: 0, },
         'Hid&Sud+': { OFF: 1, ON: 0, },
     },
+    distH: {
+        'Visible': _ => ``,
+        'Hidden': _ => `50${g_lblNameObj.percent} (${Math.round(g_posObj.arrowHeight * 50 / 100)}px)`,
+        'Hidden+': (_filterPos) => `${_filterPos}${g_lblNameObj.percent} (${Math.min(Math.round(g_posObj.arrowHeight * (100 - _filterPos) / 100), g_posObj.arrowHeight - g_posObj.stepY)}px)`,
+        'Sudden': _ => `40${g_lblNameObj.percent} (${Math.round(g_posObj.arrowHeight * 60 / 100) - g_posObj.stepY}px)`,
+        'Sudden+': (_filterPos) => `${_filterPos}${g_lblNameObj.percent} (${Math.max(Math.round(g_posObj.arrowHeight * (100 - _filterPos) / 100) - g_posObj.stepY, 0)}px)`,
+        'Hid&Sud+': (_filterPos) => `${_filterPos}${g_lblNameObj.percent} (${Math.max(Math.max(Math.round(g_posObj.arrowHeight * (100 - _filterPos) / 100) - g_posObj.stepY, 0)
+            - (g_posObj.arrowHeight - g_posObj.stepY - Math.min(Math.round(g_posObj.arrowHeight * (100 - _filterPos) / 100), g_posObj.arrowHeight - g_posObj.stepY)), 0)}px)`,
+    },
 };
 
 // ステップゾーン位置、到達距離(後で指定)

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1032,6 +1032,13 @@ let g_storeSettingsEx = [`d_stepzone`, `d_judgment`, `d_fastslow`, `d_lifegauge`
 
 let g_canDisabledSettings = [`motion`, `scroll`, `shuffle`, `autoPlay`, `gauge`, `excessive`, `appearance`];
 
+const g_hidSudFunc = {
+    filterPos: _filterPos => `${_filterPos}${g_lblNameObj.percent}`,
+    range: _ => `${Math.round(g_posObj.arrowHeight - g_posObj.stepY)}px`,
+    hidden: _filterPos => `${Math.min(Math.round(g_posObj.arrowHeight * (100 - _filterPos) / 100), g_posObj.arrowHeight - g_posObj.stepY)}`,
+    sudden: _filterPos => `${Math.max(Math.round(g_posObj.arrowHeight * (100 - _filterPos) / 100) - g_posObj.stepY, 0)}`,
+};
+
 const g_hidSudObj = {
     filterPos: 10,
 
@@ -1064,12 +1071,12 @@ const g_hidSudObj = {
     },
     distH: {
         'Visible': _ => ``,
-        'Hidden': _ => `50${g_lblNameObj.percent} (${Math.round(g_posObj.arrowHeight * 50 / 100)}px)`,
-        'Hidden+': (_filterPos) => `${_filterPos}${g_lblNameObj.percent} (${Math.min(Math.round(g_posObj.arrowHeight * (100 - _filterPos) / 100), g_posObj.arrowHeight - g_posObj.stepY)}px)`,
-        'Sudden': _ => `40${g_lblNameObj.percent} (${Math.round(g_posObj.arrowHeight * 60 / 100) - g_posObj.stepY}px)`,
-        'Sudden+': (_filterPos) => `${_filterPos}${g_lblNameObj.percent} (${Math.max(Math.round(g_posObj.arrowHeight * (100 - _filterPos) / 100) - g_posObj.stepY, 0)}px)`,
-        'Hid&Sud+': (_filterPos) => `${_filterPos}${g_lblNameObj.percent} (${Math.max(Math.max(Math.round(g_posObj.arrowHeight * (100 - _filterPos) / 100) - g_posObj.stepY, 0)
-            - (g_posObj.arrowHeight - g_posObj.stepY - Math.min(Math.round(g_posObj.arrowHeight * (100 - _filterPos) / 100), g_posObj.arrowHeight - g_posObj.stepY)), 0)}px)`,
+        'Hidden': _ => `${g_hidSudFunc.filterPos(50)} (${g_hidSudFunc.hidden(50)} / ${g_hidSudFunc.range()})`,
+        'Hidden+': (_filterPos) => `${g_hidSudFunc.filterPos(_filterPos)} (${g_hidSudFunc.hidden(_filterPos)} / ${g_hidSudFunc.range()})`,
+        'Sudden': _ => `${g_hidSudFunc.filterPos(40)} (${g_hidSudFunc.sudden(40)} / ${g_hidSudFunc.range()})`,
+        'Sudden+': (_filterPos) => `${g_hidSudFunc.filterPos(_filterPos)} (${g_hidSudFunc.sudden(_filterPos)} / ${g_hidSudFunc.range()})`,
+        'Hid&Sud+': (_filterPos) => `${g_hidSudFunc.filterPos(_filterPos)} (${Math.max(g_hidSudFunc.sudden(_filterPos)
+            - (g_posObj.arrowHeight - g_posObj.stepY - g_hidSudFunc.hidden(_filterPos)), 0)} / ${g_hidSudFunc.range()})`,
     },
 };
 

--- a/js/template/danoni_setting.js
+++ b/js/template/danoni_setting.js
@@ -32,6 +32,9 @@ g_presetObj.tuningUrl = `https://www.google.co.jp/`;
 /** 個人サイト別の最小高さ設定 */
 //g_presetObj.autoMinHeight = 500;
 
+/** 個人サイト別の高さ可変設定 (true: 有効、false: 無効 / デフォルトは false)*/
+//g_presetObj.heightVariable = true;
+
 /** 個人サイト別のウィンドウ位置 (left:左寄せ, center:中央, right:右寄せ)*/
 //g_presetObj.windowAlign = `center`;
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
### 1. ウィンドウサイズ（高さ）とステップゾーン位置により基準速度を変更
- 表記上の速度は1x～10xですが、同じ1xでもウィンドウサイズ(高さ)とステップゾーン位置によって1フレームあたりに進む速度が変わるようになります。
- 言い換えると、同じ1xであればウィンドウサイズやステップゾーン位置が変わっても
矢印の可視時間が同じになるように調整されます。
    - Appearanceのオプションには依存しません。
    - playingHeight, windowHeight, stepY, stepYRという可視範囲の初期値を変えるような場合にのみ、上記ルールが適用されます。

### 計算式
- 基準速度 = (ウィンドウサイズやステップゾーン位置を加味した矢印の移動距離) / (高さ:500px、ステップゾーン位置が標準のときの移動距離)

```javascript
obj.baseSpeed = 1 + ((g_posObj.distY - (g_posObj.stepY - C_STEP_Y) * 2) / (500 - C_STEP_Y) - 1) * 0.85;
```

### 2. Appearance設定で可視範囲を表示するよう対応

### 計算式
- Hidden+ : `矢印の移動距離 × (100% - フィルタ位置[%] )` と `矢印の移動距離 - ステップゾーン位置` のどちらか大きい方
- Sudden+ : `矢印の移動距離 × (100% - フィルタ位置[%] ) - ステップゾーン位置`
- Hid&Sud+ : `(Sudden+の可視範囲) - (矢印の移動距離 - ステップゾーン位置 - Hidden+の可視範囲)`

### 3. ウィンドウの高さをパラメータ`h`から変更できる機能を追加
- 合わせて、意図して変更できないようにする設定も追加しています。
- 譜面ヘッダーと共通設定は下記の通りです。どちらもデフォルトは`false`(高さ変更不可)です。
```
|heightVariable=false|
```
```javascript
g_presetObj.heightVariable = true;
```
- パラメータ`h`が500pxに満たない場合、高さは500pxにしつつプレイ時の高さが縮小されるように設定されます。この最小値は400pxです。
- 譜面ヘッダー: `playingHeight`が設定されている場合、`windowHeight`もしくはウィンドウの高さとの差を維持するように画面の高さを調整します。
`windowHeight`= 600px、`playingHeight`= 500px で 外部パラメータ`h=650`なら、
`windowHeight`= 650px、`playingHeight`= 550px となるように修正されます。

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 矢印の見える範囲により、体感の速度が変わるため。
2. Appearance設定における可視範囲を表示する方法が無かったため。
3. プレイ方法の多様性への対応のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
- 高さが500pxと700pxのときに速度:1xとしたときの矢印の速度の例です。

<img src="https://github.com/cwtickle/danoniplus/assets/44026291/a06802c4-7607-40ab-9d2e-51c04b8310e5" width="45%"><img src="https://github.com/cwtickle/danoniplus/assets/44026291/f286fa47-a31b-4479-9b1d-32fa99db17b2" width="45%">

<img src="https://github.com/cwtickle/danoniplus/assets/44026291/880ae92e-0f6b-4152-baed-9047bc263454" width="45%"><img src="https://github.com/cwtickle/danoniplus/assets/44026291/f85af8b9-bc1d-4e0c-ae07-625f95322d95" width="45%">


## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- パラメータ`h`により動的に高さを変える設定では、歌詞表示やライフゲージ、楽曲情報表示は画面追従しますが、背景・マスクはY座標を`g_sHeight`や`g_headerObj.playingHeight`等で指定していない限り、追従しません。このため、既定は無効としています。