### PR TITLE
[ver34.7.1] 背景矢印でカラーコードを0x始まりにしたときにアルファが適用されない問題を修正

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,8 +18,8 @@ v32の対応終了時期はv35リリース開始時を予定しています。�
 
 | Version | Supported          | Latest Version | Logs | First Release | End of Support |
 | ------- | ------------------ |----------------|------|---------------|----------------|
-| v34 :anchor:    | :heavy_check_mark: |[v34.7.0](https://github.com/cwtickle/danoniplus/releases/tag/v34.7.0)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-latest)|2023-09-24|(At Release v43)|
-| v33     | :heavy_check_mark: |[v33.7.5](https://github.com/cwtickle/danoniplus/releases/tag/v33.7.5)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v33)|2023-07-29|(At Release v36)|
+| v34 :anchor:    | :heavy_check_mark: |[v34.7.1](https://github.com/cwtickle/danoniplus/releases/tag/v34.7.1)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-latest)|2023-09-24|(At Release v43)|
+| v33     | :heavy_check_mark: |[v33.7.6](https://github.com/cwtickle/danoniplus/releases/tag/v33.7.6)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v33)|2023-07-29|(At Release v36)|
 | v32     | :warning:          |[v32.7.7](https://github.com/cwtickle/danoniplus/releases/tag/v32.7.7)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v32)|2023-05-07|(At Release v35)|
 | v31     | :x:                |[v31.7.7 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v31.7.7)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v31)|2023-03-20|2023-09-24|
 | v30     | :x:                |[v30.6.3 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v30.6.3)          |[:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v30)|2023-02-10|2023-07-29|

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2024/01/12
+ * Revised : 2024/01/27
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 34.7.0`;
-const g_revisedDate = `2024/01/12`;
+const g_version = `Ver 34.7.1`;
+const g_revisedDate = `2024/01/27`;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
 let g_localVersion = ``;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danoniplus",
-  "version": "34.7.0",
+  "version": "34.7.1",
   "description": "Dancing☆Onigiri (CW Edition) - Web-based Rhythm Game",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- #1609 
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
