### PR TITLE
feat: [0777] keyGroupOrderをカスタムキーの1項目として追加　他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3977,6 +3977,9 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 		// キーグループ (keyGroupX_Y)
 		newKeyMultiParam(newKey, `keyGroup`, toSplitArrayStr);
 
+		// キーグループの表示制御 (keyGroupOrderX_Y)
+		newKeyMultiParam(newKey, `keyGroupOrder`, toString);
+
 		// スクロールパターン (scrollX_Y)
 		// |scroll(newKey)=Cross::1,1,-1,-1,-1,1,1/Split::1,1,1,-1,-1,-1,-1$...|
 		newKeyPairParam(newKey, `scroll`, `scrollDir`, `---`, 1);
@@ -6148,7 +6151,8 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	const maxLeftX = Math.min(0, (kWidth - C_ARW_WIDTH) / 2 - maxLeftPos * g_keyObj.blank);
 
 	g_keycons.cursorNumList = [...Array(keyNum).keys()].map(i => i);
-	const configKeyGroupList = g_headerObj.keyGroupOrder[g_stateObj.scoreId] ?? tkObj.keyGroupList;
+	const configKeyGroupList = g_headerObj.keyGroupOrder[g_stateObj.scoreId] ??
+		g_keyObj[`keyGroupOrder${keyCtrlPtn}`] ?? tkObj.keyGroupList;
 
 	/**
 	 * keyconSpriteのスクロール位置調整
@@ -6534,14 +6538,18 @@ const keyConfigInit = (_kcType = g_kcType) => {
 				appearConfigView(j, C_DIS_INHERIT);
 			}
 		}
-		changeConfigCursor(0);
+		if (g_keycons.cursorNumList.length === 0) {
+			appearConfigSteps(0);
+		} else {
+			changeConfigCursor(0);
 
-		// keySwitchボタンを一旦非選択にして、選択中のものを再度色付け
-		if (configKeyGroupList.length > 1) {
-			for (let j = 0; j < configKeyGroupList.length; j++) {
-				document.getElementById(`key${j}`).classList.replace(g_cssObj.button_Next, g_cssObj.button_Mini);
+			// keySwitchボタンを一旦非選択にして、選択中のものを再度色付け
+			if (configKeyGroupList.length > 1) {
+				for (let j = 0; j < configKeyGroupList.length; j++) {
+					document.getElementById(`key${j}`).classList.replace(g_cssObj.button_Next, g_cssObj.button_Mini);
+				}
+				document.getElementById(`key${_num}`).classList.replace(g_cssObj.button_Mini, g_cssObj.button_Next);
 			}
-			document.getElementById(`key${_num}`).classList.replace(g_cssObj.button_Mini, g_cssObj.button_Next);
 		}
 	};
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. keyGroupOrder（キーグループの表示制御）をカスタムキーの1項目として追加しました。
譜面ヘッダー側と併用した場合は、譜面ヘッダーの方が優先されます。

＜利用例＞
- デフォルトのキーグループが`0`に割り当てされることを利用して、
部分キーグループを1～4に割り当て、キーコンフィグ上は1～4のグループのみを表示する例です。
```
|keyCtrl25=D2,D3,D4,D7,D8,D9,W,E,R,U,I,O,7_0,Z,X,C,M,Comma,Period|
|chara25=aleft,aleftdia,adown,aup,arightdia,aright,bleft,bleftdia,bdown,bup,brightdia,bright,7_0,cleft,cleftdia,cdown,cup,crightdia,cright|
|color25=4,4,4,4,4,4,3,3,3,3,3,3,0,0,0,2,0,0,0,1,1,1,1,1,1|
|stepRtn25=0,-45,-90,90,135,180,0,-45,-90,90,135,180,7_0_0,0,-45,-90,90,135,180|
|pos25=0,1,2,4,5,6,0.01,1.01,2.01,4.01,5.01,6.01,0.02,1.02,2.02,3.02,4.02,5.02,6.02,0.03,1.03,2.03,4.03,5.03,6.03|
|keyGroup25=0/1,0/1,0/1,0/1,0/1,0/1,0/2,0/2,0/2,0/2,0/2,0/2,0/3,0/3,0/3,0/1/2/3/4,0/3,0/3,0/3,0/4,0/4,0/4,0/4,0/4,0/4|
|keyGroupOrder25=1,2,3,4|
```

2. 複数のキーパターンでキーグループ数が異なる場合にエラーで止まることがある問題を修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. トランスキー以外でkeyGroupOrderを使う可能性が考えられるため。
2. 複数パターンがあり、片方のキーグループが存在しないグループを選択している場合にエラーが発生していました。ただ、通常は発生しえない状況だと思います。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/acac9784-5d56-4a84-8f0a-0ece8d4d11e1" width="50%"><img src="https://github.com/cwtickle/danoniplus/assets/44026291/36c42626-fdcd-4b4f-ae65-4b66567c0f59" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 譜面ヘッダーのkeyGroupOrderはパターン毎に定義できないため、過去バージョンに2.の修正を反映する必要はありません。今回の変更用の対応です。
- なお、ステップゾーンは従来通り重ねる実装になっているため、空押しした場合には一番上に表示されているステップゾーンのみが光ります。あくまでキーコン上の見た目を解消する変更です。
上記の例では、posXを0.01ずつずらすことでうっすら見えるようにしています。