### PR TITLE
feat: [0780] カスタムキーの略記指定の組み合わせに対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3729,7 +3729,7 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 	 */
 	const toSameValStr = _str => {
 		const nums = _str?.split(`@:`);
-		const groupStr = nums[0].split(`!`).join(`,`);
+		const groupStr = toFloatStr(nums[0]).split(`!`).join(`,`);
 		return nums.length === 2 && !isNaN(parseInt(nums[1])) ?
 			[...Array(Math.floor(parseInt(nums[1])))].fill(groupStr).join(`,`) : _str;
 	};
@@ -3788,7 +3788,7 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 				// |keyCtrl9j=Tab,7_0,Enter| -> |keyCtrl9j=Tab,S,D,F,Space,J,K,L,Enter| のように補完
 				// |pos9j=0..4,6..9| -> |pos9j=0,1,2,3,4,6,7,8,9|
 				g_keyObj[`${keyheader}_${k + dfPtn}`] =
-					toOriginalArray(tmpArray[k], toFloatStr).map(n =>
+					toOriginalArray(tmpArray[k], toSameValStr).map(n =>
 						structuredClone(g_keyObj[`${_name}${getKeyPtnName(n)}`]) ?? [_convFunc(n)]
 					).flat();
 				if (baseCopyFlg) {
@@ -3915,7 +3915,7 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 					// 部分的にキーパターン指定があった場合は既存パターンを展開 (例: |scroll9j=Cross::1,7_0,1|)
 					const tmpParamPair = pairs.split(`::`);
 					g_keyObj[pairName][tmpParamPair[0]] =
-						makeBaseArray(tmpParamPair[1]?.split(`,`).map(n =>
+						makeBaseArray(toOriginalArray(tmpParamPair[1], toSameValStr)?.map(n =>
 							structuredClone(g_keyObj[`${_pairName}${getKeyPtnName(n)}`]?.[tmpParamPair[0]]) ??
 							[n === `-` ? -1 : parseInt(n, 10)]
 						).flat(), g_keyObj[`${g_keyObj.defaultProp}${_key}_${k + dfPtn}`].length, _defaultVal);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3731,7 +3731,7 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 		const nums = _str?.split(`@:`);
 		const groupStr = toFloatStr(nums[0]).split(`!`).join(`,`);
 		return nums.length === 2 && !isNaN(parseInt(nums[1])) ?
-			[...Array(Math.floor(parseInt(nums[1])))].fill(groupStr).join(`,`) : _str;
+			[...Array(Math.floor(parseInt(nums[1])))].fill(groupStr).join(`,`) : groupStr;
 	};
 
 	/**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. カスタムキーの略記指定の組み合わせに対応しました。
PR #1614 の拡張です。**posX**だけ、**keyCtrlX**だけという制約が無くなり、単一選択を除くほぼすべての設定で略記指定が使えるようになります。

### 利用例
<pre>
|keyGroup25=0/1,0/1,0/1,0/1,0/1,0/1,0/2,0/2,0/2,0/2,0/2,0/2,0/3,0/3,0/3,0/1/2/3/4,0/3,0/3,0/3,0/4,0/4,0/4,0/4,0/4,0/4|
-> |keyGroup25=0/1<b>@:6</b>,0/2<b>@:6</b>,0/3<b>@:3</b>,0/1/2/3/4,0/3<b>@:3</b>,0/4<b>@:6</b>|
(0/1の組み合わせが6回、0/2の組み合わせが6回、...)

|scroll18=Flat::1,1,1,1,1,1,1,1,1,-,-,-,-,-,-,-,-,-|
-> |scroll18=Flat::1<b>@:9</b>,-<b>@:9</b>|

|color9n=0,1,2,3,0,1,2,3,4|
-> |color9n=<b>0...3@:2</b>,4|

|pos20=0,1,2,3,5,6,7,8,10,11,12,13,14,15,16,17,18,19,20,21|
-> |pos20=<b>0...3</b>,<b>5...8</b>,<b>10...21</b>|
-> |pos20=0...3,5...8,<b>10...13</b>,<b>b0...+11</b>|

|stepRtnXX=onigiri,onigiri,onigiri|
-> |stepRtnXX=onigiri<b>@:3</b>|

|stepRtnXX=0,-90,90,180,0,-90,90,180,0,-90,90,180|
-> |stepRtnXX=<b>0!-90!90!180@:3</b>|
</pre>
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

### この記法が使用可能な変数
- keyCtrlX, charaX, colorX, stepRtnX, posX, shuffleX, keyGroupX, keyGroupOrderX, scrollX, assistX

### 使用できない変数（単一項目）
- keyNameX, minWidthX, divX, blankX, scaleX, keyRetryX, keyTitleBackX, transKeyX

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 設定により略記指定が使える・使えないの線引きが煩雑なため。
以前の略記指定について、組み合わせ可能であることが確認できたため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
