### PR TITLE
feat: [0782] カスタムキーパターン略記の拡張

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1843,6 +1843,7 @@ const g_keyObj = {
     chara8_2: [`sleft`, `left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
 
     // 頻度の高い譜面データ名パターン
+    // 後で chara4A, chara4A_a, chara4A_b, ... に変換する
     ptchara4A: [`left`, `down`, `up`, `right`],
     ptchara3S: [`left`, `leftdia`, `down`],
     ptchara3J: [`up`, `rightdia`, `right`],

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1843,11 +1843,10 @@ const g_keyObj = {
     chara8_2: [`sleft`, `left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
 
     // 頻度の高い譜面データ名パターン
-    // 後で chara4A, chara4A_a, chara4A_b, ... に変換する
     ptchara4A: [`left`, `down`, `up`, `right`],
     ptchara3S: [`left`, `leftdia`, `down`],
     ptchara3J: [`up`, `rightdia`, `right`],
-    ptchara7: [`left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
+    ptchara7S: [`left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
 
     // ColorGroup - 1
     //  - 同じ数字が同じグループになる

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1846,7 +1846,7 @@ const g_keyObj = {
     ptchara4A: [`left`, `down`, `up`, `right`],
     ptchara3S: [`left`, `leftdia`, `down`],
     ptchara3J: [`up`, `rightdia`, `right`],
-    ptchara7S: [`left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
+    ptchara7: [`left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
 
     // ColorGroup - 1
     //  - 同じ数字が同じグループになる


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. **charaX**におけるカスタムキーパターン略記を拡張しました。
部分キー定義だけでなく標準実装キー、既存定義キーにも使えるようになり、拡張性が上がりました。
    - `|charaX=a>7_0|` -> `|charaX=aleft,aleftdia,adown,aspace,aup,arightdia,aright|`
    - `|charaX=b>5_0|` -> `|charaX=bleft,bdown,bup,bright,bspace|`
    - `|charaX=c>4A|` -> `|charaX=cleft,cdown,cup,cright|`
 
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. カスタムキー定義の簡潔な記述ができるようにすることで利用しやすくするため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 従来の部分キー定義の拡張記法 `4A_a`, `3S_b` は、`a>4A`, `b>3S`に置き換え可能なため、
ver36以降は廃止することを予定しています。
- `g_keyObj.ptChara7`は、今回の変更で`7_0`や`a>7_0`に置き換え可能なため、ver36以降は廃止する予定です。