### PR TITLE
fix: [0784] 環境によりタイトルの背景矢印が表示されない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3363,7 +3363,8 @@ const getMusicNameMultiLine = _musicName => {
  */
 const updateImgType = (_imgType, _initFlg = false) => {
 	if (_initFlg) {
-		C_IMG_TITLE_ARROW = `../img/${_imgType.name}/arrow.${_imgType.extension}`;
+		const baseDir = (_imgType.name === `` ? `` : `${_imgType.name}/`);
+		C_IMG_TITLE_ARROW = `../img/${baseDir}arrow.${_imgType.extension}`;
 	}
 	resetImgs(_imgType.name, _imgType.extension);
 	reloadImgObj();


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 環境によりタイトルの背景矢印が表示されない問題を修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 発生条件はわかっていないですが、404ページを別に用意している場合で
矢印種類がOriginalの場合だけ発生する可能性があります。
`(ドメイン名)/danoni/img//arrow.svg` のように、矢印種類がOriginalの場合だけ
パスに二重スラッシュが入るようになっていました。
この部分だけ他と実装方法が違うため、実装方法を合わせた形です。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
