### PR TITLE
フリーズアローの判定処理を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9549,7 +9549,7 @@ const mainInit = _ => {
 
 		frzOFF: (_j, _k, _cnt) => {
 
-			if (g_workObj.judgFrzCnt[_j] === _k - 1) {
+			if (g_workObj.judgFrzCnt[_j] === _k - 1 && _cnt <= g_judgObj.frzJ[g_judgPosObj.sfsf]) {
 				const prevFrzName = `frz${_j}_${g_workObj.judgFrzCnt[_j]}`;
 				const prevFrz = g_attrObj[prevFrzName];
 
@@ -10311,9 +10311,16 @@ const judgeArrow = _j => {
 	const currentArrow = g_attrObj[arrowName];
 	const existJudgArrow = document.getElementById(arrowName) !== null;
 
-	const fcurrentNo = g_workObj.judgFrzCnt[_j];
-	const frzName = `frz${_j}_${fcurrentNo}`;
-	const currentFrz = g_attrObj[frzName];
+	let fcurrentNo = g_workObj.judgFrzCnt[_j];
+	let frzName = `frz${_j}_${fcurrentNo}`;
+	let currentFrz = g_attrObj[frzName];
+
+	if (currentFrz?.judgEndFlg) {
+		fcurrentNo = g_workObj.judgFrzCnt[_j] + 1;
+		frzName = `frz${_j}_${fcurrentNo}`;
+		currentFrz = g_attrObj[frzName];
+	}
+
 	const existJudgFrz = document.getElementById(frzName) !== null;
 
 	const judgeTargetArrow = _difFrame => {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9553,10 +9553,10 @@ const mainInit = _ => {
 				const prevFrzName = `frz${_j}_${g_workObj.judgFrzCnt[_j]}`;
 				const prevFrz = g_attrObj[prevFrzName];
 
-				if (prevFrz.isMoving && !prevFrz.judgEndFlg && prevFrz.cnt < (-1) * g_judgObj.frzJ[g_judgPosObj.kita]) {
+				if (prevFrz.isMoving && prevFrz.cnt < (-1) * g_judgObj.frzJ[g_judgPosObj.kita]) {
 
 					// 自身より前のフリーズアローが未判定の場合、強制的に枠外判定を行いフリーズアローを削除
-					if (prevFrz.cnt >= (-1) * g_judgObj.frzJ[g_judgPosObj.iknai]) {
+					if (prevFrz.cnt >= (-1) * g_judgObj.frzJ[g_judgPosObj.iknai] && !prevFrz.judgEndFlg) {
 						judgeIknai(prevFrz.cnt);
 						if (g_headerObj.frzStartjdgUse) {
 							judgeUwan(prevFrz.cnt);
@@ -10311,16 +10311,9 @@ const judgeArrow = _j => {
 	const currentArrow = g_attrObj[arrowName];
 	const existJudgArrow = document.getElementById(arrowName) !== null;
 
-	let fcurrentNo = g_workObj.judgFrzCnt[_j];
-	let frzName = `frz${_j}_${fcurrentNo}`;
-	let currentFrz = g_attrObj[frzName];
-
-	if (currentFrz?.judgEndFlg) {
-		fcurrentNo = g_workObj.judgFrzCnt[_j] + 1;
-		frzName = `frz${_j}_${fcurrentNo}`;
-		currentFrz = g_attrObj[frzName];
-	}
-
+	const fcurrentNo = g_workObj.judgFrzCnt[_j];
+	const frzName = `frz${_j}_${fcurrentNo}`;
+	const currentFrz = g_attrObj[frzName];
 	const existJudgFrz = document.getElementById(frzName) !== null;
 
 	const judgeTargetArrow = _difFrame => {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- フリーズの終点と次のフリーズの始点が近いとき、キーを押しても次のフリーズが判定されないことがあるバグを修正
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

フリーズAの終点と次のフリーズBの始点が近いとき、
Aを見逃しイクナイで判定するとBの始点でキーを押しても反応しないというバグが報告される https://github.com/cwtickle/danoniplus/issues/1529
（途中離しイクナイなら反応し、早押しイクナイは実質的に見逃しイクナイと同等の処理になるので反応しない）

↓

https://github.com/cwtickle/danoniplus/pull/1530 にて修正される

↓

Speedの速さなどにより、Bが作成済みか否かで現象が分岐するようになる
1. Bが作成済みのとき、Aが削除されるので反応する
2. Bが未作成のとき、Aが削除されないので反応しない
おそらく1の条件のみをチェックしたのでプルリクが取り込まれてしまった

↓

Aを削除するのではなく、judgeArrow にて判定を次のフリーズに移すことで対応しました

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
