### PR TITLE
feat: [0789] 色変化仕様を見直し、フリーズアローの塗りつぶし部分の変化に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7687,7 +7687,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 				const patterns = replaceStr(trimStr(patternStr[1]), g_escapeStr.frzPatternName)?.split(`/`) || [`Arrow`];
 
 				const colorVals = [];
-				patternStr[0]?.split(`/`)?.forEach(val => {
+				replaceStr(patternStr[0], g_escapeStr.targetPatternName)?.split(`/`)?.forEach(val => {
 					if (val.startsWith('g')) {
 						const groupVal = setIntVal(val.slice(1));
 						for (let j = 0; j < keyNum; j++) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7692,16 +7692,16 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 						const groupVal = setIntVal(val.slice(1));
 						for (let j = 0; j < keyNum; j++) {
 							if (g_keyObj[`color${_keyCtrlPtn}`][j] === groupVal) {
-								colorVals.push(j + 1000);
+								colorVals.push(j);
 							}
 						}
 					} else if (val.indexOf(`...`) > 0) {
 						const [valMin, valMax] = [val.split(`...`)[0], val.split(`...`)[1]].map(val => setIntVal(val));
 						for (let k = valMin; k <= valMax; k++) {
-							colorVals.push(setIntVal(k) + 1000);
+							colorVals.push(setIntVal(k));
 						}
 					} else {
-						colorVals.push(setIntVal(val) + 1000);
+						colorVals.push(setIntVal(val));
 					}
 				});
 
@@ -8566,8 +8566,6 @@ const pushColors = (_header, _frame, _val, _colorCd, _allFlg, _pattern = ``) => 
 	const pushColor = (_baseStr, _cVal) => {
 		g_workObj[_baseStr][_frame]?.push(_cVal) || (g_workObj[_baseStr][_frame] = [_cVal]);
 		g_workObj[`${_baseStr}Cd`][_frame]?.push(colorCd) || (g_workObj[`${_baseStr}Cd`][_frame] = [colorCd]);
-		console.log(_baseStr)
-		console.log(g_workObj[`${_baseStr}Cd`][_frame])
 	};
 
 	/**
@@ -8592,7 +8590,7 @@ const pushColors = (_header, _frame, _val, _colorCd, _allFlg, _pattern = ``) => 
 			allUseTypes.push(`Frz`);
 		}
 		// 色変化情報の格納
-		baseHeaders.forEach(baseHeader => pushColor(baseHeader, g_workObj.replaceNums[_val % 1000] + addAll));
+		baseHeaders.forEach(baseHeader => pushColor(baseHeader, g_workObj.replaceNums[_val] + addAll));
 	};
 
 	/**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10412,6 +10412,8 @@ const changeFailedFrz = (_j, _k) => {
 	$id(`frzTop${frzNo}`).display = C_DIS_INHERIT;
 	$id(`frzTop${frzNo}`).background = `#cccccc`;
 	$id(`frzTopShadow${frzNo}`).opacity = 1;
+	$id(`frzTopShadow${frzNo}`).background = `#333333`;
+	$id(`frzBtmShadow${frzNo}`).background = `#333333`;
 	$id(`frzBar${frzNo}`).background = `#999999`;
 	$id(`frzBar${frzNo}`).opacity = 1;
 	$id(`frzBtm${frzNo}`).background = `#cccccc`;
@@ -10420,12 +10422,6 @@ const changeFailedFrz = (_j, _k) => {
 	const hitPos = g_workObj.hitPosition * g_workObj.scrollDir[_j];
 	$id(`frzTop${frzNo}`).top = wUnit(- hitPos);
 	$id(`frzTopShadow${frzNo}`).top = wUnit(- hitPos);
-
-	const colorPos = g_keyObj[`color${g_keyObj.currentKey}_${g_keyObj.currentPtn}`][_j];
-	if (g_headerObj.frzShadowColor[colorPos][0] !== ``) {
-		$id(`frzTopShadow${frzNo}`).background = `#333333`;
-		$id(`frzBtmShadow${frzNo}`).background = `#333333`;
-	}
 };
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7684,7 +7684,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 				const pos = tmpColorData[1]?.indexOf(`:`);
 				const patternStr = pos > 0 ? [trimStr(tmpColorData[1].substring(0, pos)), trimStr(tmpColorData[1].substring(pos + 1))]
 					: [trimStr(tmpColorData[1])];
-				const patterns = replaceStr(trimStr(patternStr[1]), g_escapeStr.frzPatternName)?.split(`/`) || [`Arrow`];
+				const patterns = replaceStr(trimStr(patternStr[1]), g_escapeStr.colorPatternName)?.split(`/`) || [`Arrow`];
 
 				const colorVals = [];
 				replaceStr(patternStr[0], g_escapeStr.targetPatternName)?.split(`/`)?.forEach(val => {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10293,8 +10293,7 @@ const changeColors = (_mkColor, _mkColorCd, _header, _name) => {
 		g_workObj[`${camelHeader}Colors`][targetj] = _mkColorCd[j];
 		if (tempj >= 1000) {
 			g_workObj[`${camelHeader}ColorsAll`][targetj] = _mkColorCd[j];
-			if ((camelHeader.indexOf(`frzHitBar`) !== -1 || camelHeader.indexOf(`frzHitShadow`) !== -1)
-				&& isNaN(Number(g_workObj.arrowRtn[targetj]))) {
+			if (camelHeader.indexOf(`frzHitBar`) !== -1 && isNaN(Number(g_workObj.arrowRtn[targetj]))) {
 				$id(`frzHitTop${targetj}`).background = _mkColorCd[j];
 			}
 		}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -247,6 +247,12 @@ const convertStrToVal = _str => {
 	return convStrs;
 };
 
+/**
+ * 半角スペース、タブを文字列から除去
+ * @param {string} _str 
+ */
+const trimStr = _str => _str?.split(`\t`).join(``).trimStart().trimEnd();
+
 /*-----------------------------------------------------------*/
 /* 値や配列のチェック・変換                                    */
 /*-----------------------------------------------------------*/
@@ -7662,7 +7668,6 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 			Arrow: [], Normal: [], NormalBar: [], NormalShadow: [],
 			Hit: [], HitBar: [], HitShadow: [],
 		};
-		const trimStr = _str => _str?.split(`\t`).join(``).split(`　`).join(``).trimStart().trimEnd();
 
 		if (hasVal(dosColorData) && g_stateObj.d_color === C_FLG_ON) {
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9513,12 +9513,12 @@ const mainInit = _ => {
 			const changeColor = (_type, _baseObj, _baseObj2) => {
 				const cFrzColor = g_workObj[`${_name}${_state}${_type}Colors`][_j];
 				const cFrzColorAll = g_workObj[`${_name}${_state}${_type}ColorsAll`][_j];
-				if (_baseObj.getAttribute(`color`) !== cFrzColorAll && cFrzColor === cFrzColorAll) {
+				if (_baseObj.getAttribute(`color${_state}`) !== cFrzColor && cFrzColorAll === cFrzColor) {
 					if (_baseObj2 && _state === `Normal`) {
 						_baseObj2.style.background = cFrzColorAll;
 					}
 					_baseObj.style.background = cFrzColorAll;
-					_baseObj.setAttribute(`color`, cFrzColorAll);
+					_baseObj.setAttribute(`color${_state}`, cFrzColorAll);
 				}
 			};
 
@@ -10393,13 +10393,14 @@ const changeHitFrz = (_j, _k, _name, _difFrame = 0) => {
 
 	styfrzBar.top = wUnit(currentFrz.barY);
 	styfrzBar.height = wUnit(currentFrz.frzBarLength);
-	styfrzBar.background = currentFrz.HitBar;
+	styfrzBar.background = g_workObj[`${_name}HitBarColors`][_j];
 	styfrzBtm.top = wUnit(currentFrz.btmY);
-	styfrzBtm.background = currentFrz.Hit;
+	styfrzBtm.background = g_workObj[`${_name}HitColors`][_j];
 	styfrzTopShadow.opacity = 0;
 	styfrzBtmShadow.top = styfrzBtm.top;
 	if (_name === `frz`) {
-		styfrzBtmShadow.background = currentFrz.HitShadow === `Default` ? currentFrz.Hit : currentFrz.HitShadow;
+		styfrzBtmShadow.background = g_workObj[`${_name}HitShadowColors`][_j] === `Default` ?
+			g_workObj[`${_name}HitColors`][_j] : g_workObj[`${_name}HitShadowColors`][_j];
 		$id(`frzHit${_j}`).opacity = 0.9;
 		$id(`frzTop${frzNo}`).display = C_DIS_NONE;
 		if (isNaN(parseFloat(g_workObj.arrowRtn[_j]))) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7662,6 +7662,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 			Arrow: [], Normal: [], NormalBar: [], NormalShadow: [],
 			Hit: [], HitBar: [], HitShadow: [],
 		};
+		const trimStr = _str => _str?.split(`\t`).join(``).split(`　`).join(``).trim();
 
 		if (hasVal(dosColorData) && g_stateObj.d_color === C_FLG_ON) {
 
@@ -7676,9 +7677,9 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 				const colorCd = tmpColorData[2];
 
 				const pos = tmpColorData[1]?.indexOf(`:`);
-				const patternStr = pos > 0 ? [tmpColorData[1].substring(0, pos).trim(), tmpColorData[1].substring(pos + 1).trim()]
-					: [tmpColorData[1]?.trim()];
-				const patterns = replaceStr(patternStr[1]?.trim(), g_escapeStr.frzPatternName)?.split(`/`) || [`Arrow`];
+				const patternStr = pos > 0 ? [trimStr(tmpColorData[1].substring(0, pos)), trimStr(tmpColorData[1].substring(pos + 1))]
+					: [trimStr(tmpColorData[1])];
+				const patterns = replaceStr(trimStr(patternStr[1]), g_escapeStr.frzPatternName)?.split(`/`) || [`Arrow`];
 
 				const colorVals = [];
 				patternStr[0]?.split(`/`)?.forEach(val => {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8799,9 +8799,6 @@ const getArrowSettings = _ => {
 			});
 		});
 	}
-	console.log(g_workObj[`frzNormalColors`])
-	console.log(g_workObj[`frzHitColors`])
-	console.log(g_workObj[`frzHitBarColors`])
 	g_workObj.scrollDirDefault = g_workObj.scrollDir.concat();
 
 	Object.keys(g_resultObj).forEach(judgeCnt => g_resultObj[judgeCnt] = 0);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7710,7 +7710,11 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 
 				// フレーム数、色番号、カラーコード、全体色変化フラグ、変更対象をセットとして配列化し、色変化対象ごとのプロパティへ追加
 				patterns.forEach(pattern => {
-					colorVals.forEach(val => colorData[pattern].push([frame, val, colorCd, hasVal(tmpColorData[3]), pattern]));
+					try {
+						colorVals.forEach(val => colorData[pattern].push([frame, val, colorCd, hasVal(tmpColorData[3]), pattern]));
+					} catch (error) {
+						makeWarningWindow(g_msgInfoObj.E_0201.split(`{0}`).join(pattern));
+					}
 				});
 			});
 			// 色変化対象ごとにフレーム数をキーにソートしてフラット化

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7662,7 +7662,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 			Arrow: [], Normal: [], NormalBar: [], NormalShadow: [],
 			Hit: [], HitBar: [], HitShadow: [],
 		};
-		const trimStr = _str => _str?.split(`\t`).join(``).split(`　`).join(``).trim();
+		const trimStr = _str => _str?.split(`\t`).join(``).split(`　`).join(``).trimStart().trimEnd();
 
 		if (hasVal(dosColorData) && g_stateObj.d_color === C_FLG_ON) {
 
@@ -7673,8 +7673,8 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 				} else if (tmpColorData[1] === `-`) {
 					return;
 				}
-				const frame = calcFrame(setVal(tmpColorData[0].trim(), ``, C_TYP_CALC));
-				const colorCd = tmpColorData[2];
+				const frame = calcFrame(setVal(trimStr(tmpColorData[0]), ``, C_TYP_CALC));
+				const colorCd = trimStr(tmpColorData[2]);
 
 				const pos = tmpColorData[1]?.indexOf(`:`);
 				const patternStr = pos > 0 ? [trimStr(tmpColorData[1].substring(0, pos)), trimStr(tmpColorData[1].substring(pos + 1))]

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7672,12 +7672,13 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 				} else if (tmpColorData[1] === `-`) {
 					return;
 				}
-				const frame = calcFrame(setVal(tmpColorData[0], ``, C_TYP_CALC));
+				const frame = calcFrame(setVal(tmpColorData[0].trim(), ``, C_TYP_CALC));
 				const colorCd = tmpColorData[2];
 
 				const pos = tmpColorData[1]?.indexOf(`:`);
-				const patternStr = pos > 0 ? [tmpColorData[1].substring(0, pos), tmpColorData[1].substring(pos + 1)] : [tmpColorData[1]];
-				const patterns = replaceStr(patternStr[1], g_escapeStr.frzPatternName)?.split(`/`) || [`Arrow`];
+				const patternStr = pos > 0 ? [tmpColorData[1].substring(0, pos).trim(), tmpColorData[1].substring(pos + 1).trim()]
+					: [tmpColorData[1]?.trim()];
+				const patterns = replaceStr(patternStr[1]?.trim(), g_escapeStr.frzPatternName)?.split(`/`) || [`Arrow`];
 
 				const colorVals = [];
 				patternStr[0]?.split(`/`)?.forEach(val => {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -678,8 +678,8 @@ const g_escapeStr = {
         [`Quote`, `Ja-Colon`], [`BracketLeft`, `Ja-@`], [`BracketRight`, `Ja-[`],
         [`Backslash`, `Ja-]`], [`Equal`, `Ja-^`],
     ],
-    frzPatternName: [
-        [`AS`, `ArrowShadow`],
+    colorPatternName: [
+        [`AR`, `Arrow`], [`AS`, `ArrowShadow`],
         [`NA`, `Normal`], [`NB`, `NormalBar`], [`NS`, `NormalShadow`],
         [`HA`, `Hit`], [`HB`, `HitBar`], [`HS`, `HitShadow`],
         [`FN`, `Normal/NormalBar`], [`FH`, `Hit/HitBar`], [`FS`, `NormalShadow/HitShadow`],

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -616,10 +616,11 @@ let g_imgExtensions = [`png`, `gif`, `bmp`, `jpg`, `jpeg`, `svg`];
 const g_typeLists = {
     arrow: [`arrow`, `dummyArrow`, `frz`, `dummyFrz`],
     color: [`color`, `acolor`],
+    arrowColor: [``, `Shadow`],
     frzColor: [`Normal`, `NormalBar`, `Hit`, `HitBar`, `NormalShadow`, `HitShadow`],
     dataList: [
         `Arrow`, `FrzArrow`, `FrzLength`,
-        `Color`, `ColorCd`, `ScrollchArrow`, `ScrollchStep`, `ScrollchArrowDir`, `ScrollchStepDir`,
+        `Color`, `ColorCd`, `ColorShadow`, `ColorShadowCd`, `ScrollchArrow`, `ScrollchStep`, `ScrollchArrowDir`, `ScrollchStepDir`,
         `FColorNormal`, `FColorNormalCd`, `FColorNormalBar`, `FColorNormalBarCd`,
         `FColorNormalShadow`, `FColorNormalShadowCd`,
         `FColorHit`, `FColorHitCd`, `FColorHitBar`, `FColorHitBarCd`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -679,6 +679,11 @@ const g_escapeStr = {
         [`Backslash`, `Ja-]`], [`Equal`, `Ja-^`],
     ],
     frzPatternName: [
+        [`AS`, `ArrowShadow`],
+        [`NA`, `Normal`], [`NB`, `NormalBar`], [`NS`, `NormalShadow`],
+        [`HA`, `Hit`], [`HB`, `HitBar`], [`HS`, `HitShadow`],
+        [`FN`, `Normal/NormalBar`], [`FH`, `Hit/HitBar`], [`FS`, `NormalShadow/HitShadow`],
+        [`AF`, `Arrow/Normal/NormalBar/Hit/HitBar`],
         [`FrzNormal`, `Normal/NormalBar`], [`FrzHit`, `Hit/HitBar`],
         [`FrzShadow`, `NormalShadow/HitShadow`],
         [`Frz`, `Normal/NormalBar/Hit/HitBar`],

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2756,6 +2756,8 @@ const g_lang_msgInfoObj = {
         E_0104: `新しいキー:{0}の[keyCtrl]が未定義です。(E-0104)<br>
         |keyCtrl{0}=75,79,76,80,187,32/0|`,
 
+        E_0201: `色変化データで指定した色変化対象が存在しません。[pattern={0}] (E-0201)`,
+
         I_0001: `リザルトデータをクリップボードにコピーしました！`,
         I_0002: `入力したキーは割り当てできません。他のキーを指定してください。`,
         I_0003: `各譜面の明細情報をクリップボードにコピーしました！`,
@@ -2802,6 +2804,8 @@ const g_lang_msgInfoObj = {
         |stepRtn{0}=0,45,-90,135,180,onigiri|`,
         E_0104: `New key: {0} [keyCtrl] is not set. (E-0104)<br>
         |keyCtrl{0}=75,79,76,80,187,32/0|`,
+
+        E_0201: `The color change target specified in the color change data does not exist. [pattern={0}] (E-0201)`,
 
         I_0001: `Your result data is copied to the clipboard!`,
         I_0002: `The specified key cannot be assigned. Please specify another key.`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -616,12 +616,14 @@ let g_imgExtensions = [`png`, `gif`, `bmp`, `jpg`, `jpeg`, `svg`];
 const g_typeLists = {
     arrow: [`arrow`, `dummyArrow`, `frz`, `dummyFrz`],
     color: [`color`, `acolor`],
-    frzColor: [`Normal`, `NormalBar`, `Hit`, `HitBar`],
+    frzColor: [`Normal`, `NormalBar`, `Hit`, `HitBar`, `NormalShadow`, `HitShadow`],
     dataList: [
         `Arrow`, `FrzArrow`, `FrzLength`,
         `Color`, `ColorCd`, `ScrollchArrow`, `ScrollchStep`, `ScrollchArrowDir`, `ScrollchStepDir`,
         `FColorNormal`, `FColorNormalCd`, `FColorNormalBar`, `FColorNormalBarCd`,
+        `FColorNormalShadow`, `FColorNormalShadowCd`,
         `FColorHit`, `FColorHitCd`, `FColorHitBar`, `FColorHitBarCd`,
+        `FColorHitShadow`, `FColorHitShadowCd`,
         `ArrowCssMotion`, `ArrowCssMotionName`,
         `FrzCssMotion`, `FrzCssMotionName`,
         `ArrowColorChangeAll`, `FrzColorChangeAll`,
@@ -674,6 +676,11 @@ const g_escapeStr = {
         [`Multiply`, `*`], [`Add`, `+`], [`Subtract`, `-`], [`Decimal`, `.`], [`Divide`, `Div`],
         [`Quote`, `Ja-Colon`], [`BracketLeft`, `Ja-@`], [`BracketRight`, `Ja-[`],
         [`Backslash`, `Ja-]`], [`Equal`, `Ja-^`],
+    ],
+    frzPatternName: [
+        [`FrzNormal`, `Normal/NormalBar`], [`FrzHit`, `Hit/HitBar`],
+        [`FrzShadow`, `NormalShadow/HitShadow`],
+        [`Frz`, `Normal/NormalBar/Hit/HitBar`],
     ],
 };
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -683,6 +683,9 @@ const g_escapeStr = {
         [`FrzShadow`, `NormalShadow/HitShadow`],
         [`Frz`, `Normal/NormalBar/Hit/HitBar`],
     ],
+    targetPatternName: [
+        [`all`, `g0/g1/g2/g3/g4`],
+    ],
 };
 
 /** 設定・オプション画面用共通 */


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 色変化仕様を全体的に見直しました。
矢印・フリーズアローの塗りつぶし部分の変化に対応しました。
フリーズアローについて、矢印同様レーン個別の色指定を可能にしました。

### 色変化仕様の考え方
- 従来の色変化の方法を踏襲しつつ、複雑になっていたグループ番号の仕様を変更。
- 個別/全体色変化の区別をなくし、色変化の中の1設定として追加。
- 「ncolor_data」として実装することで従来の「color_data」「acolor_data」との互換性を保持する。
- 従来の3つで1セットという区切り方は廃止。改行区切りのみとする。

#### 留意点
- フリーズアローのヒット時の個別色変化について、これまで例外的にフレーム数から出現時までの遡りを行わずに、指定したフレーム数で変わるようにしていましたが、その例外処置を止めました。
- 従来のcolor_data/acolor_dataでこの変更をそのまま適用すると影響が出るため、
フリーズアローのヒット時の色が個別色変化（color_data）として指定された場合、
全体色変化（acolor_data）扱いとなるよう処理を変更しています。
この設定を解除する場合は、|colorDataType=v6|を設定すれば`ncolor_data`と同じ扱いになります。

### 記述フォーマット
- `フレーム数,矢印番号:色変化対象,カラーコードor色名,即時適用フラグ`

#### 矢印番号（必須）
- 左上を0として数えた場合の矢印位置。カスタムキー定義で言うところの**posX**に当たる。
- スラッシュ区切りで複数指定が可能。例：`0/2/4/6`
また連続した範囲であれば`0...7`のように`...`を入れれば0～7までが自動適用される。
- 従来のグループ（20～24）は、g0, g1, g2, g3, g4にそれぞれ対応する。
フリーズアローについてもg0～g4でグループ指定が可能。
g0～g4全てを適用したい場合は`all`と指定すれば全てを対象にできる。
- フリーズアロー用のグループ番号（30以降）は廃止。代わりに下記の色変化対象パターンで指定する。
- `-`を指定すると、以後をコメントとして扱える（従来通り）。

#### 色変化対象
- `Arrow`のみ、単一指定時に限り省略が可能です。（1/3/5:Arrow と 1/3/5 の意味は同じ）
- 矢印番号同様、複数パターンを同時に指定したいときはスラッシュ区切りにします。
例：`Arrow/ArrowShadow`, `Arrow/Frz`

|パターン名(略名)|意味|
|----|----|
|Arrow (AR)|矢印の枠|
|ArrowShadow (AS)|矢印の塗りつぶし部分|
|Normal (NA)|フリーズアロー（通常時）の始点・終点矢印の枠|
|NormalBar (NB)|フリーズアロー（通常時）の帯|
|NormalShadow (NS)|フリーズアロー（通常時）の始点・終点矢印の塗りつぶし部分|
|Hit (HA)|フリーズアロー（ヒット時）の始点・終点矢印の枠|
|HitBar (HB)|フリーズアロー（ヒット時）の帯|
|HitShadow (HS)|フリーズアロー（ヒット時）の始点・終点矢印の塗りつぶし部分|
|**FrzNormal** (FN)|フリーズアロー（通常時）の始点・終点矢印の枠＋帯<br>※Normal+NormalBar|
|**FrzHit** (FH)|フリーズアロー（ヒット時）の始点・終点矢印の枠＋帯<br>※Hit+HitBar|
|**FrzShadow** (FS)|フリーズアロー（通常/ヒット時）の始点・終点矢印の塗りつぶし部分<br>※NormalShadow+HitShadow|
|**Frz**|フリーズアロー（通常/ヒット時）の始点・終点矢印の枠＋帯<br>※Normal+NormalBar+Hit+HitBar|

#### 即時適用フラグ（省略可）
- 「all」「ALL」を入れると全体色変化として扱う。指定が無い場合は個別色変化（矢印出現時から適用）となる。

### 具体例
- 複数同時指定により可読性が落ちるため、タブや半角スペースは読込時にカットするように変えています。
全角スペースはNGです。
```
|ncolor_data=
200,0...7          ,#ffff99
// 200フレーム以降に出現する矢印1～7に対し、「#ffff99」に変更
300,0...7:frzNormal,#ff9999:#ffff99
// 300フレーム以降に出現するフリーズアロー(通常時)の矢印枠・帯を「#ff9999と#ffff99」のグラデーションに変更
400,3    :frzShadow,#333333
// 400フレーム以降に出現するフリーズアローの矢印塗りつぶし部分を「#333333」に変更
500,1/3/5/7        ,#99ffff,all
// 矢印1, 3, 5, 7について500フレームのタイミングで一斉に「#99ffff」に変更（全体色変化）
|
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. Resolves #1637 

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- |frzScopeFromAC=Normal,Hit|との併用は可能です。
