### PR TITLE
feat: [0790] 歌詞・背景・マスクデータのタブや前後の半角スペースを自動除去するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1593,7 +1593,7 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 	let maxDepth = -1;
 
 	splitLF(_data).filter(data => hasVal(data)).forEach(tmpData => {
-		const tmpSpriteData = tmpData.split(`,`);
+		const tmpSpriteData = tmpData.split(`,`).map(val => trimStr(val));
 
 		// 深度が"-"の場合はスキップ
 		if (tmpSpriteData.length <= 1 || tmpSpriteData[1] === `-`) {
@@ -1677,7 +1677,7 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 const makeStyleData = (_data, _calcFrame = _frame => _frame) => {
 	const spriteData = [];
 	splitLF(_data).filter(data => hasVal(data)).forEach(tmpData => {
-		const tmpSpriteData = tmpData.split(`,`);
+		const tmpSpriteData = tmpData.split(`,`).map(val => trimStr(val));
 
 		// カスタムプロパティの名称(--始まり)で無い場合はコメントと見做してスキップ
 		if (tmpSpriteData.length <= 1 || !tmpSpriteData[1].startsWith(`--`)) {
@@ -7673,17 +7673,17 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 		if (hasVal(dosColorData) && g_stateObj.d_color === C_FLG_ON) {
 
 			splitLF(dosColorData).filter(data => hasVal(data)).forEach(tmpData => {
-				const tmpColorData = tmpData.split(`,`);
+				const tmpColorData = tmpData.split(`,`).map(val => trimStr(val));
 				if (!hasVal(tmpColorData[0]) || tmpColorData[1] === `-`) {
 					return;
 				}
-				const frame = calcFrame(setVal(trimStr(tmpColorData[0]), ``, C_TYP_CALC));
-				const colorCd = trimStr(tmpColorData[2]);
+				const frame = calcFrame(setVal(tmpColorData[0], ``, C_TYP_CALC));
+				const colorCd = tmpColorData[2];
 
 				// 色変化対象の取得
 				const pos = tmpColorData[1]?.indexOf(`:`);
 				const patternStr = pos > 0 ? [trimStr(tmpColorData[1].substring(0, pos)), trimStr(tmpColorData[1].substring(pos + 1))]
-					: [trimStr(tmpColorData[1])];
+					: [tmpColorData[1]];
 				const patterns = replaceStr(trimStr(patternStr[1]), g_escapeStr.colorPatternName)?.split(`/`) || [`Arrow`];
 
 				// 矢印番号の組み立て
@@ -7877,7 +7877,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 		}
 
 		tmpArrayData.filter(data => hasVal(data)).forEach(tmpData => {
-			const tmpWordData = tmpData.split(`,`);
+			const tmpWordData = tmpData.split(`,`).map(val => trimStr(val));
 			for (let k = 0; k < tmpWordData.length; k += 3) {
 				if (!hasVal(tmpWordData[k])) {
 					continue;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 歌詞・背景・マスクデータのタブや前後の半角スペースを自動除去するよう変更しました。
2. 上記の実装に合わせて、新仕様の色変化についても同様の実装を行いました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 歌詞・背景・マスクデータは項目が多くタブや半角スペースを入れた方が見やすいことがあるため。
2. コード実装の統一化によるものです。機能変更はありません。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
