### PR TITLE
feat: [0795] 譜面別のハイスコア削除機能を実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5128,6 +5128,12 @@ const makeHighScore = _scoreId => {
 		}
 		const resultText = `${unEscapeHtml(tweetResultTmp)}`;
 		multiAppend(detailHighScore,
+			makeDifLblCssButton(`lnkResetHighScore`, g_lblNameObj.s_resetResult, 7, _ => {
+				if (window.confirm(g_msgObj.highscResetConfirm)) {
+					delete g_localStorage.highscores[scoreName];
+					makeHighScore(_scoreId);
+				}
+			}, Object.assign({ btnStyle: `Reset` }, g_lblPosObj.lnkHighScore)),
 			makeDifLblCssButton(`lnkHighScore`, g_lblNameObj.s_result, 8, _ => {
 				copyTextToClipboard(keyIsShift() ? resultCommon : resultText, g_msgInfoObj.I_0001);
 			}, g_lblPosObj.lnkHighScore),

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3067,6 +3067,7 @@ const g_lang_lblNameObj = {
         s_linecnts: `- 矢印 Arrow:<br><br>- 氷矢 Frz:<br><br>- 3つ押し位置 ({0}):`,
         s_print: `データ出力`,
         s_result: `CopyResult`,
+        s_resetResult: `Reset`,
         s_printTitle: `Dancing☆Onigiri レベル計算ツール+++`,
         s_printHeader: `難易度\t同時\t縦連\t総数\t矢印\t氷矢印\tAPM\t時間`,
 
@@ -3105,6 +3106,7 @@ const g_lang_lblNameObj = {
         s_linecnts: `- Arrow:<br><br>- Freeze Arrow:<br><br>- Polychord positions ({0}):`,
         s_print: `CopyData`,
         s_result: `CopyResult`,
+        s_resetResult: `Reset`,
         s_printTitle: `Dancing☆Onigiri Level Calculator+++`,
         s_printHeader: `Level\tChords\tJack\tAll\tArrow\tFrz\tAPM\tTime`,
 
@@ -3146,8 +3148,9 @@ const g_lang_msgObj = {
         github: `Dancing☆Onigiri (CW Edition)のGitHubページへ移動します。`,
         security: `Dancing☆Onigiri (CW Edition)のサポート情報ページへ移動します。`,
 
-        dataResetConfirm: `この作品のローカル設定をクリアします。よろしいですか？\n(ハイスコアやAdjustment等のデータがクリアされます)`,
+        dataResetConfirm: `この作品のローカル設定をクリアします。よろしいですか？\n(ハイスコアやAdjustment等のデータが全てクリアされます)`,
         keyResetConfirm: `キーを初期配置に戻します。よろしいですか？`,
+        highscResetConfirm: `この譜面のハイスコアを消去します。よろしいですか？`,
         colorCopyConfirm: `フリーズアローの配色を矢印色に置き換えます\n(通常・ヒット時双方を置き換えます)。よろしいですか？`,
 
         difficulty: `譜面を選択します。`,
@@ -3205,6 +3208,7 @@ const g_lang_msgObj = {
 
         dataResetConfirm: `Delete the local settings in this game. Is it OK?\n(High score, adjustment, volume and some settings will be initialized)`,
         keyResetConfirm: `Resets the assigned key to the initial state. Is it OK?`,
+        highscResetConfirm: `Erases the high score for this chart. Is it OK?`,
         colorCopyConfirm: `Replace freeze arrow color scheme with arrow color\n(replace both normal and hit). Is this OK?`,
 
         difficulty: `Select a chart.`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 譜面別のハイスコア削除機能を実装しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 現状は全消去しかなく、個別に削除したい場合に対応できていないため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/e4635224-53a0-415b-a7b9-0507f0d4f6f8" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
