### PR TITLE
improve: [0799] ncolor_dataの対象「all」についてグループ指定を最大50個まで拡張

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -720,8 +720,8 @@ const g_escapeStr = {
         [`Frz`, `Normal/NormalBar/Hit/HitBar`],
     ],
     targetPatternName: [
-        [`all`, `g0/g1/g2/g3/g4`],
-    ],
+        [`all`, [...Array(50).keys()].map(i => `g${i}`).join(`/`)],
+    ]
 };
 
 /** 設定・オプション画面用共通 */


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. ncolor_dataの対象「all」についてグループ指定を最大50個まで拡張しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #1650 にてカラーグループ数を拡張しましたが、ncolor_dataの対象「all」について拡張できていなかったため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
