### PR TITLE
feat: [0801] 空押し設定が変更不可かつ有効のときに設定画面にその旨を表示するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5560,6 +5560,12 @@ const createOptionWindow = _sprite => {
 					title: g_msgObj.excessive, cxtFunc: evt => setExcessive(evt.target),
 				}), g_cssObj.button_Default, g_cssObj[`button_Rev${g_stateObj.excessive}`])
 		);
+	} else if (g_headerObj.excessiveJdgUse) {
+		spriteList.gauge.appendChild(
+			createDivCss2Label(`lnkExcessive`, `${g_lblNameObj.Excessive}:${C_FLG_ON}`,
+				Object.assign(g_lblPosObj.btnExcessive, { x: 0, w: 100, border: C_DIS_NONE }), g_cssObj[`button_Disabled${C_FLG_ON}`]
+			)
+		);
 	}
 
 	// ---------------------------------------------------


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1.  空押し設定（Excessive）が変更不可かつ有効のときに設定画面にその旨を表示するよう変更しました。

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. この場合、設定画面上は空押し設定が有効かどうかが判断できないため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/732bcf16-de86-4b38-90b5-2f5d8de90f26" width="50%"><img src="https://github.com/cwtickle/danoniplus/assets/44026291/a1a6ff0a-07f6-4aeb-a904-b8155efa05dd" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
