### PR TITLE
improve: [0802] 譜面明細画面の各ボタンのオンマウス説明文追加　他

### DIFF
--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -514,6 +514,18 @@ input[type="color"] {
 	color: var(--keyconfig-colorType-x, #ffdd99);
 }
 
+.keyconfig_ColorGroup::first-letter {
+	color: var(--keyconfig-colorType-x, #ffdd99);
+}
+
+.keyconfig_ShuffleGroup::first-letter {
+	color: var(--settings-shuffle-x, #99ff99);
+}
+
+.keyconfig_StepRtnGroup::first-letter {
+	color: var(--settings-adjustment-x, #99ffff);
+}
+
 .keyconfig_Changekey {
 	color: var(--keyconfig-changekey-x, #ffff00);
 }

--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -515,15 +515,15 @@ input[type="color"] {
 }
 
 .keyconfig_ColorGroup::first-letter {
-	color: var(--keyconfig-colorType-x, #ffdd99);
+	color: var(--keyconfig-colorG-x, var(--keyconfig-colorType-x, #ffdd99));
 }
 
 .keyconfig_ShuffleGroup::first-letter {
-	color: var(--settings-shuffle-x, #99ff99);
+	color: var(--keyconfig-shuffleG-x, var(--settings-shuffle-x, #99ff99));
 }
 
 .keyconfig_StepRtnGroup::first-letter {
-	color: var(--settings-adjustment-x, #99ffff);
+	color: var(--keyconfig-stepRtnG-x, var(--settings-adjustment-x, #99ffff));
 }
 
 .keyconfig_Changekey {

--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -470,6 +470,23 @@ input[type="color"] {
 	color: var(--settings-fadeinBar-x, #ffffff);
 }
 
+.settings_Difficulty:hover,
+.settings_Speed:hover,
+.settings_Motion:hover,
+.settings_Reverse:hover,
+.settings_Scroll:hover,
+.settings_Shuffle:hover,
+.settings_AutoPlay:hover,
+.settings_Gauge:hover,
+.settings_Adjustment:hover,
+.settings_Fadein:hover,
+.settings_Volume:hover,
+.settings_Appearance:hover,
+.settings_Opacity:hover,
+.settings_HitPosition:hover {
+	border-bottom: solid 1px;
+}
+
 /* 設定画面：ゲージ設定詳細 */
 .settings_lifeVal {
 	color: var(--settings-lifeVal-x, #ff9966);

--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -514,16 +514,16 @@ input[type="color"] {
 	color: var(--keyconfig-colorType-x, #ffdd99);
 }
 
-.keyconfig_ColorGroup::first-letter {
-	color: var(--keyconfig-colorG-x, var(--keyconfig-colorType-x, #ffdd99));
+.keyconfig_ColorGr::first-letter {
+	color: var(--keyconfig-colorGr-x, var(--keyconfig-colorType-x, #ffdd99));
 }
 
-.keyconfig_ShuffleGroup::first-letter {
-	color: var(--keyconfig-shuffleG-x, var(--settings-shuffle-x, #99ff99));
+.keyconfig_ShuffleGr::first-letter {
+	color: var(--keyconfig-shuffleGr-x, var(--settings-shuffle-x, #99ff99));
 }
 
-.keyconfig_StepRtnGroup::first-letter {
-	color: var(--keyconfig-stepRtnG-x, var(--settings-adjustment-x, #99ffff));
+.keyconfig_StepRtnGr::first-letter {
+	color: var(--keyconfig-stepRtnGr-x, var(--settings-adjustment-x, #99ffff));
 }
 
 .keyconfig_Changekey {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6685,9 +6685,9 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	}
 
 	// カラー/シャッフルグループ切替ボタン（カラー/シャッフルパターンが複数ある場合のみ）
-	makeGroupButton(`color`, { cssName: g_cssObj.keyconfig_ColorType });
-	makeGroupButton(`shuffle`, { baseX: g_btnX(11 / 12) - 10, cssName: g_cssObj.keyconfig_ShuffleGroup });
-	makeGroupButton(`stepRtn`, { baseY: 37, cssName: g_cssObj.keyconfig_StepRtnGroup });
+	makeGroupButton(`color`, { cssName: g_cssObj.keyconfig_ColorGr });
+	makeGroupButton(`shuffle`, { baseX: g_btnX(11 / 12) - 10, cssName: g_cssObj.keyconfig_ShuffleGr });
+	makeGroupButton(`stepRtn`, { baseY: 37, cssName: g_cssObj.keyconfig_StepRtnGr });
 
 	/**
 	 * カーソル位置の設定

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5455,7 +5455,10 @@ const createOptionWindow = _sprite => {
 		);
 		g_settings.scoreDetails.forEach((sd, j) => {
 			scoreDetail.appendChild(
-				makeDifLblCssButton(`lnk${sd}G`, getStgDetailName(sd), j, _ => changeScoreDetail(j), { w: g_limitObj.difCoverWidth, h: 20, btnStyle: (g_stateObj.scoreDetail === sd ? `Setting` : `Default`) })
+				makeDifLblCssButton(`lnk${sd}G`, getStgDetailName(sd), j, _ => changeScoreDetail(j), {
+					w: g_limitObj.difCoverWidth, h: 20, title: g_msgObj[`s_${sd}`],
+					btnStyle: (g_stateObj.scoreDetail === sd ? `Setting` : `Default`),
+				})
 			);
 			createScText(document.getElementById(`lnk${sd}G`), `${sd}G`, { targetLabel: `lnk${sd}G`, x: -5 });
 		});
@@ -6076,9 +6079,10 @@ const makeSettingLblCssButton = (_id, _name, _heightPos, _func, { x, y, w, h, si
  * @param {number} _heightPos 上からの配置順
  * @param {function} _func
  */
-const makeDifLblCssButton = (_id, _name, _heightPos, _func, { x = 0, w = g_limitObj.difSelectorWidth, h = g_limitObj.setLblHeight, btnStyle = `Default` } = {}) =>
+const makeDifLblCssButton = (_id, _name, _heightPos, _func,
+	{ x = 0, w = g_limitObj.difSelectorWidth, h = g_limitObj.setLblHeight, btnStyle = `Default` } = {}) =>
 	createCss2Button(_id, _name, _func, {
-		x, y: h * _heightPos, w, h, siz: g_limitObj.difSelectorSiz, borderStyle: `solid`,
+		x, y: h * _heightPos, w, h, siz: g_limitObj.difSelectorSiz, borderStyle: `solid`, title: g_msgObj[_id] ?? ``,
 	}, g_cssObj[`button_${btnStyle}`], g_cssObj.button_ON);
 
 /**
@@ -6682,8 +6686,8 @@ const keyConfigInit = (_kcType = g_kcType) => {
 
 	// カラー/シャッフルグループ切替ボタン（カラー/シャッフルパターンが複数ある場合のみ）
 	makeGroupButton(`color`, { cssName: g_cssObj.keyconfig_ColorType });
-	makeGroupButton(`shuffle`, { baseX: g_btnX(11 / 12) - 10, cssName: g_cssObj.settings_Shuffle });
-	makeGroupButton(`stepRtn`, { baseY: 37, cssName: g_cssObj.settings_Adjustment });
+	makeGroupButton(`shuffle`, { baseX: g_btnX(11 / 12) - 10, cssName: g_cssObj.keyconfig_ShuffleGroup });
+	makeGroupButton(`stepRtn`, { baseY: 37, cssName: g_cssObj.keyconfig_StepRtnGroup });
 
 	/**
 	 * カーソル位置の設定

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1799,9 +1799,9 @@ const g_cssObj = {
     keyconfig_warning: `keyconfig_warning`,
     keyconfig_ConfigType: `keyconfig_ConfigType`,
     keyconfig_ColorType: `keyconfig_ColorType`,
-    keyconfig_ColorGroup: `keyconfig_ColorGroup`,
-    keyconfig_ShuffleGroup: `keyconfig_ShuffleGroup`,
-    keyconfig_StepRtnGroup: `keyconfig_StepRtnGroup`,
+    keyconfig_ColorGr: `keyconfig_ColorGr`,
+    keyconfig_ShuffleGr: `keyconfig_ShuffleGr`,
+    keyconfig_StepRtnGr: `keyconfig_StepRtnGr`,
     keyconfig_Changekey: `keyconfig_Changekey`,
     keyconfig_Defaultkey: `keyconfig_Defaultkey`,
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -200,9 +200,9 @@ const g_lblPosObj = {};
 const updateWindowSiz = _ => {
     Object.assign(g_windowObj, {
         optionSprite: { x: (g_sWidth - 450) / 2, y: 65, w: 450, h: 325 },
-        difList: { x: 165, y: 60, w: 280, h: 261 + g_sHeight - 500, overflow: `auto` },
-        difCover: { x: 25, y: 60, w: 140, h: 261 + g_sHeight - 500, opacity: 0.95 },
-        difFilter: { x: 0, y: 61, w: 140, h: 200 + g_sHeight - 500, overflow: `auto` },
+        difList: { x: 165, y: 60, w: 280, h: 265 + g_sHeight - 500, overflow: `auto` },
+        difCover: { x: 20, y: 60, w: 145, h: 265 + g_sHeight - 500, opacity: 0.95 },
+        difFilter: { x: 0, y: 61, w: 140, h: 204 + g_sHeight - 500, overflow: `auto` },
         displaySprite: { x: 25, y: 30, w: (g_sWidth - 450) / 2, h: g_limitObj.setLblHeight * 5 },
         scoreDetail: { x: 20, y: 85, w: (g_sWidth - 500) / 2 + 420, h: 240, visibility: `hidden` },
         detailObj: { w: (g_sWidth - 500) / 2 + 420, h: 230, visibility: `hidden` },
@@ -1799,6 +1799,9 @@ const g_cssObj = {
     keyconfig_warning: `keyconfig_warning`,
     keyconfig_ConfigType: `keyconfig_ConfigType`,
     keyconfig_ColorType: `keyconfig_ColorType`,
+    keyconfig_ColorGroup: `keyconfig_ColorGroup`,
+    keyconfig_ShuffleGroup: `keyconfig_ShuffleGroup`,
+    keyconfig_StepRtnGroup: `keyconfig_StepRtnGroup`,
     keyconfig_Changekey: `keyconfig_Changekey`,
     keyconfig_Defaultkey: `keyconfig_Defaultkey`,
 
@@ -2861,7 +2864,7 @@ const g_lang_msgInfoObj = {
         E_0012: `The song title information is not set. (E-0012)<br>
         |musicTitle=Song title,Artist name,Artist's site URL|`,
         E_0021: `Music information is not set or the format is incorrect.(E-0021)<br>
-        |difData=Keys' name,chart's name,Specified speed|`,
+        |difData=Key type's name,chart's name,Specified speed|`,
         E_0022: `The format of the external music file is incorrect.(E-0022)<br>
         function externalDosInit() { g_externalDos = \`(Chart data)\`; }`,
         E_0023: `Music information is not set. (E-0023)<br>
@@ -3253,6 +3256,14 @@ const g_lang_msgObj = {
         d_arroweffect: `矢印・フリーズアローモーションの有効化設定`,
         d_special: `作品固有の特殊演出の有効化設定`,
 
+        lnkSpeedG: `譜面の進行別の速度変化状況を表示`,
+        lnkDensityG: `譜面の密度状況を表示`,
+        lnkToolDifG: `譜面の難易度、矢印・フリーズアローの分布状況を表示`,
+        lnkHighScoreG: `譜面のハイスコアを表示`,
+        lnkDifInfo: `譜面の難易度、矢印・フリーズアローの分布状況をクリップボードへコピー`,
+        lnkResetHighScore: `譜面のハイスコア情報を消去`,
+        lnkHighScore: `譜面のハイスコアをクリップボードへコピー`,
+
         appearance: `流れる矢印の見え方を制御します。`,
         opacity: `判定キャラクタ、コンボ数、Fast/Slow、Hidden+/Sudden+の\n境界線表示の透明度を設定します。`,
         hitPosition: `判定位置にズレを感じる場合、\n数値を変えることで判定の中央位置を1px単位(プラス:手前, マイナス:奥側)で調整することができます。\n早押し・遅押し傾向にある場合に使用します。`,
@@ -3314,6 +3325,14 @@ const g_lang_msgObj = {
         d_background: `Enable background images and animations`,
         d_arroweffect: `Enable sequences' animations`,
         d_special: `Enable setting of special effects to the work`,
+
+        lnkSpeedG: `Displays the speed change status by progression of the chart.`,
+        lnkDensityG: `Displays the density status of the chart.`,
+        lnkToolDifG: `Displays the difficulty level of the chart and the distribution of arrows and freeze arrows.`,
+        lnkHighScoreG: `Displays the high score of the chart.`,
+        lnkDifInfo: `Copy the difficulty of the chart and the distribution of arrows and freeze arrows to the clipboard.`,
+        lnkResetHighScore: `Erase the high score information in the chart.`,
+        lnkHighScore: `Copies the high score of the chart to the clipboard.`,
 
         appearance: `Controls how the flowing sequences look.`,
         opacity: `Set the transparency of some objects such as judgment, combo counts, fast and slow`,

--- a/skin/danoni_skin_default.css
+++ b/skin/danoni_skin_default.css
@@ -67,6 +67,9 @@
 	--keyconfig-colorType-x: #ffdd99;
 	--keyconfig-changekey-x: #ffff00;
 	--keyconfig-defaultkey-x: #99ccff;
+	/* --keyconfig-colorG-x: var(--settings-colorType-x); */
+	/* --keyconfig-shuffleG-x: var(--settings-shuffle-x); */
+	/* --keyconfig-stepRtnG-x: var(--settings-adjustment-x); */
 
 	/* 判定 */
 	--common-ii: #66ffff;

--- a/skin/danoni_skin_default.css
+++ b/skin/danoni_skin_default.css
@@ -67,9 +67,9 @@
 	--keyconfig-colorType-x: #ffdd99;
 	--keyconfig-changekey-x: #ffff00;
 	--keyconfig-defaultkey-x: #99ccff;
-	/* --keyconfig-colorG-x: var(--settings-colorType-x); */
-	/* --keyconfig-shuffleG-x: var(--settings-shuffle-x); */
-	/* --keyconfig-stepRtnG-x: var(--settings-adjustment-x); */
+	/* --keyconfig-colorGr-x: var(--settings-colorType-x); */
+	/* --keyconfig-shuffleGr-x: var(--settings-shuffle-x); */
+	/* --keyconfig-stepRtnGr-x: var(--settings-adjustment-x); */
 
 	/* 判定 */
 	--common-ii: #66ffff;

--- a/skin/danoni_skin_light.css
+++ b/skin/danoni_skin_light.css
@@ -67,6 +67,9 @@
 	--keyconfig-colorType-x: #773300;
 	--keyconfig-changekey-x: #999900;
 	--keyconfig-defaultkey-x: #000099;
+	/* --keyconfig-colorG-x: var(--settings-colorType-x); */
+	/* --keyconfig-shuffleG-x: var(--settings-shuffle-x); */
+	/* --keyconfig-stepRtnG-x: var(--settings-adjustment-x); */
 
 	/* 判定 */
 	--common-ii: #009999;

--- a/skin/danoni_skin_light.css
+++ b/skin/danoni_skin_light.css
@@ -67,9 +67,9 @@
 	--keyconfig-colorType-x: #773300;
 	--keyconfig-changekey-x: #999900;
 	--keyconfig-defaultkey-x: #000099;
-	/* --keyconfig-colorG-x: var(--settings-colorType-x); */
-	/* --keyconfig-shuffleG-x: var(--settings-shuffle-x); */
-	/* --keyconfig-stepRtnG-x: var(--settings-adjustment-x); */
+	/* --keyconfig-colorGr-x: var(--settings-colorType-x); */
+	/* --keyconfig-shuffleGr-x: var(--settings-shuffle-x); */
+	/* --keyconfig-stepRtnGr-x: var(--settings-adjustment-x); */
 
 	/* 判定 */
 	--common-ii: #009999;

--- a/skin/danoni_skin_skyblue.css
+++ b/skin/danoni_skin_skyblue.css
@@ -67,6 +67,9 @@
 	--keyconfig-colorType-x: #773300;
 	--keyconfig-changekey-x: #999900;
 	--keyconfig-defaultkey-x: #000099;
+	/* --keyconfig-colorG-x: var(--settings-colorType-x); */
+	/* --keyconfig-shuffleG-x: var(--settings-shuffle-x); */
+	/* --keyconfig-stepRtnG-x: var(--settings-adjustment-x); */
 
 	/* 判定 */
 	--common-ii: #009999;

--- a/skin/danoni_skin_skyblue.css
+++ b/skin/danoni_skin_skyblue.css
@@ -67,9 +67,9 @@
 	--keyconfig-colorType-x: #773300;
 	--keyconfig-changekey-x: #999900;
 	--keyconfig-defaultkey-x: #000099;
-	/* --keyconfig-colorG-x: var(--settings-colorType-x); */
-	/* --keyconfig-shuffleG-x: var(--settings-shuffle-x); */
-	/* --keyconfig-stepRtnG-x: var(--settings-adjustment-x); */
+	/* --keyconfig-colorGr-x: var(--settings-colorType-x); */
+	/* --keyconfig-shuffleGr-x: var(--settings-shuffle-x); */
+	/* --keyconfig-stepRtnGr-x: var(--settings-adjustment-x); */
 
 	/* 判定 */
 	--common-ii: #009999;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 設定画面の各項目のオンマウスで下線が出るよう変更しました。
2. 譜面明細画面の各ボタンのオンマウス説明文を追加しました。
3. 譜面明細画面と譜面選択リストの組み合わせにより、ウィンドウの端が見えてしまう問題を修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. オンマウス説明文がどこに対するものかがわかりにくいため。
2. 譜面明細ボタン毎のオンマウス説明文がこれまで無く、タイトルだけではわかりにくい場合があるため。
3. レイアウトの調整です。譜面明細画面のレイアウトを拡張したことで位置ズレが出ていたので見直しました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/ea56262e-90f3-4d1a-862b-5a601a774436" width="50%"><img src="https://github.com/cwtickle/danoniplus/assets/44026291/20f15fe7-501c-44ac-b95a-a5b1f2a8cb18" width="50%">
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/beade2c4-45b4-4abc-ae5a-eaaf63ae8387" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- レイアウトの調整はありますが、実処理には影響しない範囲だと思います。
- ColorGroup, ShuffleGroup, StepRtnGroupのCSSクラスを分離しました。
- スキンCSSファイルはテンプレートの更新だけで、更新は必須ではありません。