### PR TITLE
fix: [0806] 不要な文字までトリムしてしまう問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -242,7 +242,7 @@ const convertStrToVal = _str => {
  * 半角スペース、タブを文字列から除去
  * @param {string} _str 
  */
-const trimStr = _str => _str?.split(`\t`).join(``).trimStart().trimEnd();
+const trimStr = _str => _str?.split(`\t`).join(``).replace(/^ +| +$/g, ``);
 
 /*-----------------------------------------------------------*/
 /* 値や配列のチェック・変換                                    */


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 色変化、歌詞表示、背景・マスクモーションにおけるトリム処理において、
全角空白や改行など本来不要なトリムまで行われている問題を修正しました。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. トリムを行う際にtrimStart/trimEndを使っていましたが、適用範囲に認識違いがありました。
このため、単純にタブと前後の半角スペースだけ取るように関数を見直しました。
https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/String/trim

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- #1638, #1639 関連です。過去バージョンには影響ありません。
