### PR TITLE
fix: [0807] 背景・マスクで深度が空のときに[loop][jump]コマンドがスキップされる問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1582,7 +1582,8 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 		const tmpSpriteData = tmpData.split(`,`).map(val => trimStr(val));
 
 		// 深度が"-"の場合はスキップ
-		if (!hasVal(tmpSpriteData[1], `-`)) {
+		if (tmpSpriteData[1] === undefined || tmpSpriteData[1] === `-` ||
+			(tmpSpriteData[1] === `` && ![`[loop]`, `[jump]`].includes(tmpSpriteData[2]))) {
 			return;
 		}
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 背景・マスクで深度が空のときに[loop][jump]コマンドがスキップされる問題を修正しました。- 
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. hasVal関数の拡張時に #1650 にてコード整理をしたときの影響漏れです。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- 従来と同じ書き方ではなく、深度が空のときは`[loop]`もしくは`[jump]`のキーワードが入っていることをチェックするようにしました。