### PR TITLE
feat: [0808] 矢印・フリーズアローが散らばるS-Randomの設定を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7667,7 +7667,7 @@ const applySRandom = (_keyNum, _shuffleGroup, _arrowHeader, _frzHeader) => {
 			}
 			// ランダムに配置
 			const random = Math.floor(Math.random() * freeSpaces.length);
-			tmpFrzData[freeSpaces[random]].push(_freeze);
+			tmpFrzData[currentFreeSpaces[random]].push(_freeze);
 		});
 
 		// 通常矢印の配置
@@ -7685,9 +7685,9 @@ const applySRandom = (_keyNum, _shuffleGroup, _arrowHeader, _frzHeader) => {
 
 			// 置ける場所を検索
 			const freeSpacesFlat = _group.filter(_key =>
-				// フリーズと重ならない(前後10フレーム)
+				// フリーズと重ならない (前後10フレーム)
 				tmpFrzData[_key].find(_freeze => _arrow >= _freeze.begin - scatterFrame && _arrow <= _freeze.end + scatterFrame) === undefined
-				// 通常矢印と重ならない(前後10フレーム)
+				// 通常矢印と重ならない (前後10フレーム)
 				&& tmpArrowData[_key].find(_other => _arrow >= _other - scatterFrame && _arrow <= _other + scatterFrame) === undefined
 				// 直前の矢印と重ならない
 				&& tmpArrowData[_key].find(_other => prev2Num === _other) === undefined

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7707,10 +7707,8 @@ const applySRandom = (_keyNum, _shuffleGroup, _arrowHeader, _frzHeader) => {
 			if (g_stateObj.shuffle.startsWith(`Scatter`)) {
 				currentFreeSpaces = freeSpacesFlat.length > 0 ? freeSpacesFlat : currentFreeSpaces;
 			}
-
 			const random = Math.floor(Math.random() * currentFreeSpaces.length);
 			tmpArrowData[currentFreeSpaces[random]].push(_arrow);
-
 		})
 	});
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7666,7 +7666,7 @@ const applySRandom = (_keyNum, _shuffleGroup, _arrowHeader, _frzHeader) => {
 				currentFreeSpaces = freeSpacesFlat.length > 0 ? freeSpacesFlat : freeSpaces;
 			}
 			// ランダムに配置
-			const random = Math.floor(Math.random() * freeSpaces.length);
+			const random = Math.floor(Math.random() * currentFreeSpaces.length);
 			tmpFrzData[currentFreeSpaces[random]].push(_freeze);
 		});
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7676,6 +7676,7 @@ const applySRandom = (_keyNum, _shuffleGroup, _arrowHeader, _frzHeader) => {
 		let prev2Num = 0, prevNum = 0;
 		allArrows.forEach(_arrow => {
 
+			// 直前の矢印のフレーム数を取得
 			if (prev2Num !== _arrow) {
 				if (prevNum !== _arrow) {
 					prev2Num = prevNum;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -966,7 +966,7 @@ const g_settings = {
     scrolls: [],
     scrollNum: 0,
 
-    shuffles: [C_FLG_OFF, `Mirror`, `X-Mirror`, `Turning`, `Random`, `Random+`, `S-Random`, `S-Random+`],
+    shuffles: [C_FLG_OFF, `Mirror`, `X-Mirror`, `Turning`, `Random`, `Random+`, `S-Random`, `S-Random+`, `Scatter`, `Scatter+`],
     shuffleNum: 0,
     swapPattern: [4, 5, 6, 7],
 
@@ -1054,6 +1054,14 @@ const g_shuffleFunc = {
         applySRandom(keyNum, shuffleGroup, `dummyArrow`, `dummyFrz`);
     },
     'S-Random+': keyNum => {
+        applySRandom(keyNum, [[...Array(keyNum).keys()]], `arrow`, `frz`);
+        applySRandom(keyNum, [[...Array(keyNum).keys()]], `dummyArrow`, `dummyFrz`);
+    },
+    'Scatter': (keyNum, shuffleGroup) => {
+        applySRandom(keyNum, shuffleGroup, `arrow`, `frz`);
+        applySRandom(keyNum, shuffleGroup, `dummyArrow`, `dummyFrz`);
+    },
+    'Scatter+': keyNum => {
         applySRandom(keyNum, [[...Array(keyNum).keys()]], `arrow`, `frz`);
         applySRandom(keyNum, [[...Array(keyNum).keys()]], `dummyArrow`, `dummyFrz`);
     },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
### 1. Shuffleオプション「Scatter」「Scatter+」の追加
現行のShuffleオプションに、S-Random/S-Random+と同じく矢印個別にシャッフルするものの、
縦連打が発生しにくいオプションを追加しました。

散らばりの条件は現状次のようにしています。
- フリーズアローの始端/終端から前後10フレームは同じレーンの矢印・フリーズアローを配置しない
- 矢印の前後10フレームは同じレーンの矢印を配置しない
- 直前にいる矢印と同じレーンに矢印を配置しない
- 上記が破綻する場合は、S-Randomと同じルールで配置する

### 2. 通常存在しないパターンでのS-Randomロード中のエラー修正
全押し中にフリーズアローがいた場合、S-Randomロード中にエラーで止まる問題を修正しました。

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. キーによって運指が大きく異なるので、運指練習としてS-Randomを緩和したオプションが必要と感じたため。
2. 通常存在しえないですが、代替キーを想定した譜面やプレイングが実際にあるので、念のため対策しました。
通常のS-Randomでは、フリーズアロー位置と重ならないように矢印を配置しますが、
上記が発生した場合に限り、重なりを無視して配置します。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
