### PR TITLE
improve: [0810] シャッフルグループ数の上限を見直し、ミラー譜面のハイスコア保存条件を変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -11082,6 +11082,8 @@ const resultInit = _ => {
 
 	const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
 	const transKeyName = (hasVal(g_keyObj[`transKey${keyCtrlPtn}`]) ? `(${g_keyObj[`transKey${keyCtrlPtn}`]})` : ``);
+	const orgShuffleFlg = g_keyObj[`shuffle${keyCtrlPtn}`].filter((shuffleGr, j) => shuffleGr !== g_keyObj[`shuffle${keyCtrlPtn}_0d`][j]).length === 0;
+	const shuffleName = `${getStgDetailName(g_stateObj.shuffle)}${!orgShuffleFlg && !g_stateObj.shuffle.endsWith(`+`) ? getStgDetailName('(S)') : ''}`;
 
 	/**
 	 * プレイスタイルのカスタム有無
@@ -11096,7 +11098,7 @@ const resultInit = _ => {
 		`${getKeyName(g_headerObj.keyLabels[g_stateObj.scoreId])}${transKeyName} ${getStgDetailName('key')} / ${g_headerObj.difLabels[g_stateObj.scoreId]}`,
 		`${withOptions(g_autoPlaysBase.includes(g_stateObj.autoPlay), true, `-${getStgDetailName(g_stateObj.autoPlay)}${getStgDetailName('less')}`)}`,
 		`${withOptions(g_headerObj.makerView, false, `(${g_headerObj.creatorNames[g_stateObj.scoreId]})`)}`,
-		`${withOptions(g_stateObj.shuffle, C_FLG_OFF, `[${getStgDetailName(g_stateObj.shuffle)}]`)}`
+		`${withOptions(g_stateObj.shuffle, C_FLG_OFF, `[${shuffleName}]`)}`
 	];
 	let difData = difDatas.filter(value => value !== ``).join(` `);
 	const difDataForImage = difDatas.filter((value, j) => value !== `` && j !== 2).join(` `);
@@ -11231,8 +11233,7 @@ const resultInit = _ => {
 	// ハイスコア差分計算
 	const assistFlg = (g_autoPlaysBase.includes(g_stateObj.autoPlay) ? `` : `-${g_stateObj.autoPlay}less`);
 	const mirrorName = (g_stateObj.shuffle.indexOf(`Mirror`) !== -1 ? `-${g_stateObj.shuffle}` : ``);
-	const orgMirrorFlg = g_keyObj[`shuffle${keyCtrlPtn}`].filter((shuffleGr, j) => shuffleGr !== g_keyObj[`shuffle${keyCtrlPtn}_0d`][j]).length === 0;
-	if (mirrorName !== `` && !orgMirrorFlg) {
+	if (mirrorName !== `` && !orgShuffleFlg) {
 		makeInfoWindow(g_msgInfoObj.I_0005, `leftToRightFade`);
 	}
 	let scoreName = `${g_headerObj.keyLabels[g_stateObj.scoreId]}${transKeyName}${getStgDetailName('k-')}${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}${mirrorName}`;
@@ -11245,7 +11246,7 @@ const resultInit = _ => {
 		maxCombo: 0, fmaxCombo: 0, score: 0,
 	};
 
-	const highscoreCondition = (g_stateObj.autoAll === C_FLG_OFF && (g_stateObj.shuffle === C_FLG_OFF || (mirrorName !== `` && orgMirrorFlg)));
+	const highscoreCondition = (g_stateObj.autoAll === C_FLG_OFF && (g_stateObj.shuffle === C_FLG_OFF || (mirrorName !== `` && orgShuffleFlg)));
 	if (highscoreCondition) {
 
 		// ハイスコア差分描画
@@ -11352,7 +11353,7 @@ const resultInit = _ => {
 	const hashTag = (hasVal(g_headerObj.hashTag) ? ` ${g_headerObj.hashTag}` : ``);
 	let tweetDifData = `${getKeyName(g_headerObj.keyLabels[g_stateObj.scoreId])}${transKeyName}${getStgDetailName('k-')}${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}`;
 	if (g_stateObj.shuffle !== `OFF`) {
-		tweetDifData += `:${getStgDetailName(g_stateObj.shuffle)}`;
+		tweetDifData += `:${shuffleName}`;
 	}
 	const twiturl = new URL(g_localStorageUrl);
 	twiturl.searchParams.append(`scoreId`, g_stateObj.scoreId);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6453,7 +6453,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	 * @param {number} _scrollNum 
 	 */
 	const changeTmpShuffleNum = (_j, _scrollNum = 1) => {
-		const tmpShuffle = changeTmpData(`shuffle`, g_limitObj.kcShuffleNums, _j, _scrollNum);
+		const tmpShuffle = changeTmpData(`shuffle`, g_keyObj[`keyCtrl${keyCtrlPtn}`].length - 1, _j, _scrollNum);
 		document.getElementById(`sArrow${_j}`).textContent = tmpShuffle + 1;
 
 		changeShuffleConfigColor(keyCtrlPtn, g_keyObj[`shuffle${keyCtrlPtn}_${g_keycons.shuffleGroupNum}`][_j], _j);
@@ -11231,6 +11231,10 @@ const resultInit = _ => {
 	// ハイスコア差分計算
 	const assistFlg = (g_autoPlaysBase.includes(g_stateObj.autoPlay) ? `` : `-${g_stateObj.autoPlay}less`);
 	const mirrorName = (g_stateObj.shuffle.indexOf(`Mirror`) !== -1 ? `-${g_stateObj.shuffle}` : ``);
+	const orgMirrorFlg = g_keyObj[`shuffle${keyCtrlPtn}`].filter((shuffleGr, j) => shuffleGr !== g_keyObj[`shuffle${keyCtrlPtn}_0d`][j]).length === 0;
+	if (mirrorName !== `` && !orgMirrorFlg) {
+		makeInfoWindow(g_msgInfoObj.I_0005, `leftToRightFade`);
+	}
 	let scoreName = `${g_headerObj.keyLabels[g_stateObj.scoreId]}${transKeyName}${getStgDetailName('k-')}${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}${mirrorName}`;
 	if (g_headerObj.makerView) {
 		scoreName += `-${g_headerObj.creatorNames[g_stateObj.scoreId]}`;
@@ -11241,7 +11245,7 @@ const resultInit = _ => {
 		maxCombo: 0, fmaxCombo: 0, score: 0,
 	};
 
-	const highscoreCondition = (g_stateObj.autoAll === C_FLG_OFF && (g_stateObj.shuffle === C_FLG_OFF || mirrorName !== ``));
+	const highscoreCondition = (g_stateObj.autoAll === C_FLG_OFF && (g_stateObj.shuffle === C_FLG_OFF || (mirrorName !== `` && orgMirrorFlg)));
 	if (highscoreCondition) {
 
 		// ハイスコア差分描画

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9543,8 +9543,17 @@ const mainInit = _ => {
 		);
 	}
 
+	const msg = [];
 	if (getMusicUrl(g_stateObj.scoreId) === `nosound.mp3`) {
-		makeInfoWindow(g_msgInfoObj.I_0004, `leftToRightFade`, { _x: g_workObj.playingX, _y: g_headerObj.playingY });
+		msg.push(g_msgInfoObj.I_0004);
+	}
+	if (g_stateObj.shuffle.indexOf(`Mirror`) !== -1 &&
+		g_stateObj.dataSaveFlg && g_stateObj.autoAll === C_FLG_OFF &&
+		g_keyObj[`shuffle${keyCtrlPtn}`].filter((shuffleGr, j) => shuffleGr !== g_keyObj[`shuffle${keyCtrlPtn}_0d`][j]).length > 0) {
+		msg.push(g_msgInfoObj.I_0005);
+	}
+	if (msg.length > 0) {
+		makeInfoWindow(msg.join(`<br>`), `leftToRightFade`, { _x: g_workObj.playingX, _y: g_headerObj.playingY });
 	}
 
 	// ユーザカスタムイベント(初期)
@@ -11233,9 +11242,6 @@ const resultInit = _ => {
 	// ハイスコア差分計算
 	const assistFlg = (g_autoPlaysBase.includes(g_stateObj.autoPlay) ? `` : `-${g_stateObj.autoPlay}less`);
 	const mirrorName = (g_stateObj.shuffle.indexOf(`Mirror`) !== -1 ? `-${g_stateObj.shuffle}` : ``);
-	if (mirrorName !== `` && !orgShuffleFlg) {
-		makeInfoWindow(g_msgInfoObj.I_0005, `leftToRightFade`);
-	}
 	let scoreName = `${g_headerObj.keyLabels[g_stateObj.scoreId]}${transKeyName}${getStgDetailName('k-')}${g_headerObj.difLabels[g_stateObj.scoreId]}${assistFlg}${mirrorName}`;
 	if (g_headerObj.makerView) {
 		scoreName += `-${g_headerObj.creatorNames[g_stateObj.scoreId]}`;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3041,6 +3041,7 @@ const g_lblNameObj = {
     'u_Random+': `Random+`,
     'u_S-Random': `S-Random`,
     'u_S-Random+': `S-Random+`,
+    'u_(S)': `(S)`,
 
     'u_ALL': `ALL`,
     'u_Onigiri': `Onigiri`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -122,9 +122,6 @@ const g_limitObj = {
 
     // キーコンフィグで表示するカラーピッカー数
     kcColorPickerNum: 5,
-
-    // キーコンフィグで設定できるシャッフルグループ上限数
-    kcShuffleNums: 20,
 };
 
 /** 設定項目の位置 */
@@ -2856,6 +2853,7 @@ const g_lang_msgInfoObj = {
         I_0002: `入力したキーは割り当てできません。他のキーを指定してください。`,
         I_0003: `各譜面の明細情報をクリップボードにコピーしました！`,
         I_0004: `musicUrlが設定されていないため、無音モードで再生します`,
+        I_0005: `正規のミラー譜面で無いため、ハイスコアは保存されません`,
     },
     En: {
         W_0001: `Your browser is not guaranteed to work.<br>
@@ -2905,6 +2903,7 @@ const g_lang_msgInfoObj = {
         I_0002: `The specified key cannot be assigned. Please specify another key.`,
         I_0003: `Charts information is copied to the clipboard!`,
         I_0004: `Play in silence mode because "musicUrl" is not set`,
+        I_0005: `Highscore is not saved because not a regular mirrored chart.`,
     },
 };
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
### 1. シャッフルグループ数の上限変更
- シャッフルグループ数の上限を`（対応キー - 1）`になるように修正しました。
- 7keyであれば6、12keyであれば11が上限となります。

### 2. Mirror/X-Mirrorのハイスコア保存条件の変更
- キーコンフィグ画面右上の `ShuffleGr: 1` と同じシャッフルグループで無い場合、
Mirror/X-Mirrorのハイスコアを更新しないよう変更しました。
- 更新条件に合致しない Mirror / X-Mirror 譜面の場合、プレイ開始時にメッセージが表示されるようになります。

### 3. シャッフル利用時の譜面名の表記変更
- キーコンフィグ画面右上の `ShuffleGr: 1` と同じシャッフルグループで無い場合、
譜面名のシャッフル名に`(S)`を付加するようにしました。
OFF/Random+/S-Random+/Scatter+のようにグループに関係のないシャッフルの場合は付加されません。

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitLab Issues, Twitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 対応キー数を超えて設定を可能にすると、正規と同じ譜面をミラーとしてプレイ可能となってしまうため。
最低でも1組は2キー以上属するように変更しています。
※対応キーの半分まで、といった閾値も考えましたが多様性を考慮して正規と合致しない上限としました。
2. 1.関連ですが、これを許してしまうと何の譜面に対するハイスコアかが特定できなくなるため。
3. 2.関連の修正です。これを適用すると`ShuffleGr: 2, 3`の場合も`(S)`が表示されますが、
あえて区別する必要性が薄いため今回は一律同じ記号にしました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/a1dac5e7-8de8-4f3a-b190-dead881e2c4a" width="50%"><img src="https://github.com/cwtickle/danoniplus/assets/44026291/2d2c8d33-c255-4379-8880-0f48c3c89a73" width="50%">


## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- (S) は (Self) の略名です。