### PR TITLE
feat: [0813] キー数変化で同時に複数のキーを共存させる機能を実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8218,13 +8218,24 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	// キー変化定義
 	obj.keychFrames = [];
 	obj.keychTarget = [];
+	obj.keychTargetAlpha = [];
 	if (hasVal(getRefData(`keych`, `${scoreIdHeader}_data`))) {
 		const keychdata = splitLF2(getRefData(`keych`, `${scoreIdHeader}_data`), `,`);
 		obj.keychFrames.push(...(keychdata.filter((val, j) => j % 2 === 0)).map(val => val === `0` ? 0 : calcFrame(val)));
-		obj.keychTarget.push(...keychdata.filter((val, j) => j % 2 === 1));
+
+		keychdata.filter((val, j) => j % 2 === 1)?.forEach(targets => {
+			const targetKeyList = [], targetKeyAlpha = [];
+			targets?.split(`/`).forEach(target => {
+				targetKeyList.push(target?.split(`:`)[0]);
+				targetKeyAlpha.push(target?.split(`:`)[1] || 1);
+			})
+			obj.keychTarget.push(targetKeyList);
+			obj.keychTargetAlpha.push(targetKeyAlpha);
+		});
 	}
 	obj.keychFrames.unshift(0);
-	obj.keychTarget.unshift(`0`);
+	obj.keychTarget.unshift([`0`]);
+	obj.keychTargetAlpha.unshift([1]);
 
 	return obj;
 };
@@ -10251,7 +10262,7 @@ const mainInit = _ => {
 		// キー変化
 		while (currentFrame >= g_scoreObj.keychFrames[keychCnts]) {
 			for (let j = 0; j < keyNum; j++) {
-				appearKeyTypes(j, g_scoreObj.keychTarget[keychCnts]);
+				appearKeyTypes(j, g_scoreObj.keychTarget[keychCnts], g_scoreObj.keychTargetAlpha[keychCnts]);
 			}
 			keychCnts++;
 		}
@@ -10482,18 +10493,23 @@ const makeCounterSymbol = (_id, _x, _class, _heightPos, _text, _display = C_DIS_
  * @param {number} _j
  * @param {string} _display 
  */
-const appearStepZone = (_j, _display) => $id(`stepRoot${_j}`).display = _display;
+const appearStepZone = (_j, _display, _alpha = 1) => {
+	$id(`stepRoot${_j}`).display = _display;
+	$id(`stepRoot${_j}`).opacity = _alpha;
+};
 
 /**
  * 部分キーのステップゾーン出現処理
  * @param {number} _j 
- * @param {string} _target 
+ * @param {array} _targets 
  */
-const appearKeyTypes = (_j, _target) => {
+const appearKeyTypes = (_j, _targets, _alphas = fillArray(_targets.length, 1)) => {
 	appearStepZone(_j, C_DIS_NONE);
-	if (g_workObj.keyGroupMaps[_j].includes(_target)) {
-		appearStepZone(_j, C_DIS_INHERIT);
-	}
+	_targets.forEach((target, k) => {
+		if (g_workObj.keyGroupMaps[_j].includes(target)) {
+			appearStepZone(_j, C_DIS_INHERIT, _alphas[k]);
+		}
+	});
 };
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8226,8 +8226,8 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 		keychdata.filter((val, j) => j % 2 === 1)?.forEach(targets => {
 			const targetKeyList = [], targetKeyAlpha = [];
 			targets?.split(`/`).forEach(target => {
-				targetKeyList.push(target?.split(`:`)[0]);
-				targetKeyAlpha.push(target?.split(`:`)[1] || 1);
+				targetKeyList.push(trimStr(target?.split(`:`)[0]));
+				targetKeyAlpha.push(trimStr(target?.split(`:`)[1]) || 1);
 			})
 			obj.keychTarget.push(targetKeyList);
 			obj.keychTargetAlpha.push(targetKeyAlpha);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. キー数変化 (keych_data) で同時に複数のキーを共存させる機能の実装
- キー数変化 (keych_data) を機能拡張し、スラッシュ区切りで
複数の部分キーを指定できるようにしました。
さらに、コロン(`:`)区切りでその部分キーの透明度（アルファ）が指定できるようになります。
透明度は０～１の間で指定し、１が完全に見える状態、０が全く見えない状態です。
```
|keych_data=
0,11L                            // 11Lkey: 100％
200,11:0.3/11L                   // 11key: 30%、11Lkey: 100％
3000,11/11L:0.3                  // 11key: 100%、11Lkey: 30％
|
```
- 後ろに指定した方が手前に来るので、アルファが小さいものを先に指定する必要があります。
- `keych_data`で指定する部分キー名は、カスタムキーの定義`keyGroupX`で指定する名前です。
difDataで指定するキー名と同じとは限りません。
- `keych_data`はステップゾーンの表示・非表示を切り替える機能です。
その部分キーを指定したからと言って、部分キー以外の矢印・フリーズアローが使えなくなるわけではありません。
```
|keyGroupX=11L/11,11L/11,...|
```

### 2. キー数変化の部分キー指定箇所においてタブ、半角空白をカットする機能を追加
- 部分キー指定箇所が複雑になるので、背景・マスクモーションと同じ仕様としました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. キー数変化演出で、アルファを徐々に掛けていく方法がこれまで無く、
背景・マスクモーションを駆使する必要があったため。
2. 上記で記述の通りです。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
- この例では5keyを透明度30%で表示させています。
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/91fc2d75-9317-411d-92ac-361873d2a58d" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
https://github.com/cwtickle/danoniplus/wiki/keys