### PR TITLE
fix: [0816] Reverseのときに歌詞表示の自動反転が効かない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8004,6 +8004,13 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 		getRefData(_header, `${_type}_data`)
 	];
 
+	const getPriorityListVal = (_type, _scoreNo) => [
+		`${_type}${g_localeObj.val}${_scoreNo}_data`,
+		`${_type}${g_localeObj.val}_data`,
+		`${_type}${_scoreNo}_data`,
+		`${_type}_data`
+	];
+
 	/**
 	 * 歌詞表示、背景・マスクデータの優先順取得 
 	 */
@@ -8039,16 +8046,18 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 */
 	const makeWordData = _scoreNo => {
 		const wordDataList = [];
+		const wordTargets = [];
 		let wordReverseFlg = false;
 		const divideCnt = getKeyInfo().divideCnt;
-		const addDataList = (_type = ``) => wordDataList.push(...getPriorityList(`word`, _type, _scoreNo));
+		const addDataList = (_type = ``) => wordTargets.push(...getPriorityListVal(_type, _scoreNo));
 		getPriorityHeader().forEach(val => addDataList(val));
+		makeDedupliArray(wordTargets).forEach(val => wordDataList.push(getRefData(`word`, val)));
 
 		if (g_stateObj.reverse === C_FLG_ON) {
 
 			// wordRev_dataが指定されている場合はそのままの位置を採用
 			// word_dataのみ指定されている場合、下記ルールに従って設定
-			if (wordDataList.find((v) => v !== undefined) === undefined) {
+			if (wordDataList.slice(0, -1).find((v) => v !== undefined) === undefined) {
 				// Reverse時の歌詞の自動反転制御設定
 				if (g_headerObj.wordAutoReverse !== `auto`) {
 					wordReverseFlg = g_headerObj.wordAutoReverse === C_FLG_ON;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8055,7 +8055,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 
 			// wordRev_dataが指定されている場合はそのままの位置を採用
 			// word_dataのみ指定されている場合、下記ルールに従って設定
-			if (!wordTarget.includes(`Rev`) && !wordTarget.includes(g_stateObj.scroll)) {
+			if (!wordTarget.includes(`Rev`) && g_stateObj.scroll === `---`) {
 				// Reverse時の歌詞の自動反転制御設定
 				if (g_headerObj.wordAutoReverse !== `auto`) {
 					wordReverseFlg = g_headerObj.wordAutoReverse === C_FLG_ON;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7992,19 +7992,11 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	}
 
 	/**
-	 * 譜面データの優先順配列の取得
-	 * @param {string} _header 
+	 * 譜面データの優先順配列パターンの取得
 	 * @param {string} _type 
 	 * @param {number} _scoreNo 
 	 */
-	const getPriorityList = (_header, _type, _scoreNo) => [
-		getRefData(_header, `${_type}${g_localeObj.val}${_scoreNo}_data`),
-		getRefData(_header, `${_type}${g_localeObj.val}_data`),
-		getRefData(_header, `${_type}${_scoreNo}_data`),
-		getRefData(_header, `${_type}_data`)
-	];
-
-	const getPriorityListVal = (_type, _scoreNo) => [
+	const getPriorityVal = (_type, _scoreNo) => [
 		`${_type}${g_localeObj.val}${_scoreNo}_data`,
 		`${_type}${g_localeObj.val}_data`,
 		`${_type}${_scoreNo}_data`,
@@ -8049,15 +8041,21 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 		const wordTargets = [];
 		let wordReverseFlg = false;
 		const divideCnt = getKeyInfo().divideCnt;
-		const addDataList = (_type = ``) => wordTargets.push(...getPriorityListVal(_type, _scoreNo));
+		const addDataList = (_type = ``) => wordTargets.push(...getPriorityVal(_type, _scoreNo));
 		getPriorityHeader().forEach(val => addDataList(val));
 		makeDedupliArray(wordTargets).forEach(val => wordDataList.push(getRefData(`word`, val)));
 
 		if (g_stateObj.reverse === C_FLG_ON) {
+			let wordTarget = ``;
+			makeDedupliArray(wordTargets).forEach(val => {
+				if (getRefData(`word`, val) !== undefined) {
+					wordTarget = val;
+				}
+			});
 
 			// wordRev_dataが指定されている場合はそのままの位置を採用
 			// word_dataのみ指定されている場合、下記ルールに従って設定
-			if (wordDataList.slice(0, -1).find((v) => v !== undefined) === undefined) {
+			if (!wordTarget.includes(`Rev`) && !wordTarget.includes(g_stateObj.scroll)) {
 				// Reverse時の歌詞の自動反転制御設定
 				if (g_headerObj.wordAutoReverse !== `auto`) {
 					wordReverseFlg = g_headerObj.wordAutoReverse === C_FLG_ON;
@@ -8138,9 +8136,11 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	 */
 	const makeBackgroundData = (_header, _scoreNo, { resultTypes = [] } = {}) => {
 		const dataList = [];
+		const animationTargets = [];
 		const calcFrameFunc = resultTypes.length > 0 ? undefined : calcFrame;
-		const addDataList = (_type = ``) => dataList.push(...getPriorityList(_header, _type, _scoreNo));
+		const addDataList = (_type = ``) => animationTargets.push(...getPriorityVal(_type, _scoreNo));
 		getPriorityHeader(resultTypes).forEach(val => addDataList(val));
+		makeDedupliArray(animationTargets).forEach(val => dataList.push(getRefData(_header, val)));
 
 		const data = dataList.find((v) => v !== undefined);
 		return (data !== undefined ? g_animationFunc.make[_header](data, calcFrameFunc) : [[], -1]);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. Reverseのときに歌詞表示の自動反転が効かない問題の修正
- 歌詞表示ではリバース有効時、改行が無い場合に限りword_dataを記載すれば自動反転する機能がありました。
- しかし、ver30以降のコード整理により、それが機能していませんでした。その問題を修正しています。
- 具体的には、下記の条件で判断します。
  - 歌詞表示に改行などが含まれていないこと
  - 11keyのような上下スクロールがデフォルトのキーで無いこと
  - 拡張スクロールがデフォルトであること　※追加
  - パターンを優先度順に並べて最初にヒットした名前がリバース系の歌詞表示で無いこと　※追加

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. Discordでの指摘より。
https://discord.com/channels/698460971231870977/944491021918683196/1252669246207557652
起因となるPRは #1393 (ver30.0.0)です。
元々はwordRev_dataがいればその値を優先し、word_dataのみであれば自動反転するという処理でしたが、機能拡張してコード整理した結果、機能しなくなっていました。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/5f5d73ac-f1c5-4ae0-a17b-dc2d0bc899b3" width="30%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- word2_dataなども同様に自動反転の対象とする必要があるので、追加で修正予定です。
⇒修正しました。検索して最初にヒットした対象がリバース系（wordRev_data）では無かった場合に限り適用するように変更しました。
- 今回の問題に直接影響はないものの、背景・マスクでも同様の処理があるので後で見直しをする予定です。