### PR TITLE
fix: [0817] ダミーフリーズアロー生成時に画面が止まってしまう問題を修正　他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10636,7 +10636,7 @@ const changeHitFrz = (_j, _k, _name, _difFrame = 0) => {
 	styfrzBar.background = getColor(`HitBar`);
 	styfrzBtm.top = wUnit(currentFrz.btmY);
 	styfrzBtm.background = tmpHitColor;
-	styfrzTop.top = wUnit(parseFloat(styfrzTop.top) - hitPos);
+	styfrzTop.top = wUnit(- hitPos);
 	styfrzTopShadow.top = styfrzTop.top;
 	styfrzBtmShadow.top = styfrzBtm.top;
 	if (_name === `frz`) {
@@ -10662,17 +10662,11 @@ const changeFailedFrz = (_j, _k) => {
 	$id(`frzHit${_j}`).opacity = 0;
 	$id(`frzTop${frzNo}`).display = C_DIS_INHERIT;
 	$id(`frzTop${frzNo}`).background = `#cccccc`;
-	$id(`frzTopShadow${frzNo}`).opacity = 1;
 	$id(`frzTopShadow${frzNo}`).background = `#333333`;
 	$id(`frzBtmShadow${frzNo}`).background = `#333333`;
 	$id(`frzBar${frzNo}`).background = `#999999`;
 	$id(`frzBar${frzNo}`).opacity = 1;
 	$id(`frzBtm${frzNo}`).background = `#cccccc`;
-
-	// 判定位置調整分の補正
-	const hitPos = g_workObj.hitPosition * g_workObj.scrollDir[_j];
-	$id(`frzTop${frzNo}`).top = wUnit(- hitPos);
-	$id(`frzTopShadow${frzNo}`).top = wUnit(- hitPos);
 };
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9030,7 +9030,8 @@ const getArrowSettings = _ => {
 
 			g_typeLists.frzColor.forEach((frzType, k) => {
 				g_workObj[`frz${frzType}Colors${type}`][j] = g_headerObj.frzColor[colorj][k] || ``;
-				g_workObj[`dummyFrz${frzType}Colors${type}`][j] = g_headerObj.setDummyColor[colorj];
+				g_workObj[`dummyFrz${frzType}Colors${type}`][j] =
+					frzType.includes(`Shadow`) ? `` : g_headerObj.setDummyColor[colorj] || ``;
 			});
 			g_workObj[`frzNormalShadowColors${type}`][j] = g_headerObj.frzShadowColor[colorj][0] || ``;
 			g_workObj[`frzHitShadowColors${type}`][j] = g_headerObj.frzShadowColor[colorj][1] || ``;
@@ -10290,7 +10291,7 @@ const mainInit = _ => {
 		// ダミーフリーズアロー生成
 		g_workObj.mkDummyFrzArrow[currentFrame]?.forEach(data =>
 			makeFrzArrow(data, ++dummyFrzCnts[data], `dummyFrz`, g_workObj.dummyFrzNormalColors[data],
-				_workObj.dummyFrzNormalBarColors[data], g_workObj.dummyFrzNormalShadowColors[data]));
+				g_workObj.dummyFrzNormalBarColors[data], g_workObj.dummyFrzNormalShadowColors[data]));
 
 		// フリーズアロー生成
 		g_workObj.mkFrzArrow[currentFrame]?.forEach(data =>
@@ -10598,6 +10599,7 @@ const changeHitFrz = (_j, _k, _name, _difFrame = 0) => {
 
 	const styfrzBar = $id(`${_name}Bar${frzNo}`);
 	const styfrzBtm = $id(`${_name}Btm${frzNo}`);
+	const styfrzTop = $id(`${_name}Top${frzNo}`);
 	const styfrzTopShadow = $id(`${_name}TopShadow${frzNo}`);
 	const styfrzBtmShadow = $id(`${_name}BtmShadow${frzNo}`);
 
@@ -10634,7 +10636,8 @@ const changeHitFrz = (_j, _k, _name, _difFrame = 0) => {
 	styfrzBar.background = getColor(`HitBar`);
 	styfrzBtm.top = wUnit(currentFrz.btmY);
 	styfrzBtm.background = tmpHitColor;
-	styfrzTopShadow.opacity = 0;
+	styfrzTop.top = wUnit(parseFloat(styfrzTop.top) - hitPos);
+	styfrzTopShadow.top = styfrzTop.top;
 	styfrzBtmShadow.top = styfrzBtm.top;
 	if (_name === `frz`) {
 		const tmpShadowColor = getColor(`HitShadow`);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. ダミーフリーズアロー生成時に画面が止まってしまう問題を修正
- ダミーフリーズアロー生成時に、フリーズアローの通常色の値が指定できずにエラーが発生していました。この問題を修正しています。
```
|difData=9A,Normal|frzLeft_data=200,300|
```

### 2. ダミーフリーズアローヒット時に、開始矢印の塗りつぶし色が消えてしまう問題を修正
- ダミーフリーズアローでは開始矢印の塗りつぶし部分を表示したままにしますが、それが消えてしまっていました。

### 3. スキンがデフォルトのとき、ダミーフリーズアローの矢印の塗りつぶし色が矢印の枠色と同じになってしまう問題を修正
- スキンがデフォルトのとき、ダミーフリーズアローでは矢印の塗りつぶし色は黒ですが、矢印の枠色と同じ灰色が適用されていました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. Discordでの指摘より。
https://discord.com/channels/698460971231870977/944491021918683196/1252996678634438686
PR #1638 (ver36.0.0) でのコード間違いによるものです。
2. PR #1438 (ver31.0.0) にてHitPosition実装時に開始位置を補正する処理を省略してopacity=0を掛けたことが原因です。また位置補正はフリーズアロー失敗時しか考慮できていなかったため、成功時も考慮するように変更しました。
3. PR #1638 (ver36.0.0) にてフリーズアローの塗りつぶし色のデフォルト値に矢印の枠色と同じデフォルト色を与えてしまったことが原因です。塗りつぶし色の場合は未指定（空）を与えるように変更しています。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
