### PR TITLE
fix: [0818] ReverseのときにwordRev_data時でも歌詞表示の自動反転が起きてしまう問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8047,11 +8047,12 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 
 		if (g_stateObj.reverse === C_FLG_ON) {
 			let wordTarget = ``;
-			makeDedupliArray(wordTargets).forEach(val => {
+			for (let val of makeDedupliArray(wordTargets)) {
 				if (getRefData(`word`, val) !== undefined) {
 					wordTarget = val;
+					break;
 				}
-			});
+			}
 
 			// wordRev_dataが指定されている場合はそのままの位置を採用
 			// word_dataのみ指定されている場合、下記ルールに従って設定


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. ReverseのときにwordRev_data時でも歌詞表示の自動反転が起きてしまう問題を修正
- ReverseのときにwordRev_data時でも歌詞表示の自動反転が起きてしまうようになっていました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. PR #1679 の考慮漏れです。
「パターンを優先度順に並べて最初にヒットした名前がリバース系の歌詞表示で無いこと」の条件部分においてループを途中で切る処理が抜けており、上記事象が発生しました。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
- この時点でv34の修正には反映済みです。
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
