### PR TITLE
feat: [0819] Appearance設定のLockボタンにショートカットキーを割り当て

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1589,6 +1589,7 @@ const g_shortcutObj = {
         ShiftLeft_KeyA: { id: `lnkAppearanceL` },
         ShiftRight_KeyA: { id: `lnkAppearanceL` },
         KeyA: { id: `lnkAppearanceR` },
+        KeyL: { id: `lnkLockBtn` },
         ShiftLeft_KeyO: { id: `lnkOpacityL` },
         ShiftRight_KeyO: { id: `lnkOpacityL` },
         KeyO: { id: `lnkOpacityR` },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1.  Appearance設定のLockボタンにショートカットキーを割り当て
- Hidden+/Sudden+/Hid&Sud+のときに表示される「Lock」ボタンにショートカットキー「L」を割り当てました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. Resolves #1683 

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
