### PR TITLE
feat: [0820] 速度変化グラフにおいて最低/最高変化量を表記するように変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4743,26 +4743,29 @@ const drawSpeedGraph = _scoreId => {
 
 	const avgX = [0, 0];
 	const avgSubX = [1, 1];
-	const lineX = [125, 210];
+	const lineX = [0, 150], lineY = 208;
 	Object.keys(speedObj).forEach((speedType, j) => {
+		const frame = speedObj[speedType].frame;
+		const speed = speedObj[speedType].speed;
+
 		context.beginPath();
 		let preY;
 		let avgSubFrame = playingFrame;
 
-		for (let i = 0; i < speedObj[speedType].frame.length; i++) {
-			const x = speedObj[speedType].frame[i] * (g_limitObj.graphWidth - 30) / playingFrame + 30;
-			const y = (speedObj[speedType].speed[i] - 1) * -90 + 105;
+		for (let i = 0; i < frame.length; i++) {
+			const x = frame[i] * (g_limitObj.graphWidth - 30) / playingFrame + 30;
+			const y = (speed[i] - 1) * -90 + 105;
 
 			context.lineTo(x, preY);
 			context.lineTo(x, y);
 			preY = y;
 
-			const deltaFrame = speedObj[speedType].frame[i] - (speedObj[speedType].frame[i - 1] ?? startFrame);
-			avgX[j] += deltaFrame * (speedObj[speedType].speed[i - 1] ?? 1);
-			if ((speedObj[speedType].speed[i - 1] ?? 1) === 1) {
+			const deltaFrame = frame[i] - (frame[i - 1] ?? startFrame);
+			avgX[j] += deltaFrame * (speed[i - 1] ?? 1);
+			if ((speed[i - 1] ?? 1) === 1) {
 				avgSubFrame -= deltaFrame;
 			} else {
-				avgSubX[j] += deltaFrame * (speedObj[speedType].speed[i - 1]);
+				avgSubX[j] += deltaFrame * (speed[i - 1]);
 			}
 		}
 		avgX[j] /= playingFrame;
@@ -4773,11 +4776,16 @@ const drawSpeedGraph = _scoreId => {
 		context.stroke();
 
 		context.beginPath();
-		context.moveTo(lineX[j], 215);
-		context.lineTo(lineX[j] + 25, 215);
+		context.moveTo(lineX[j], lineY);
+		context.lineTo(lineX[j] + 25, lineY);
 		context.stroke();
-		context.font = `${wUnit(g_limitObj.difSelectorSiz)} ${getBasicFont()}`;
-		context.fillText(g_lblNameObj[`s_${speedType}`], lineX[j] + 30, 218);
+		context.font = `${wUnit(g_limitObj.graphMiniSiz)} ${getBasicFont()}`;
+		context.fillText(g_lblNameObj[`s_${speedType}`], lineX[j] + 30, lineY + 3);
+
+		const maxSpeed = Math.max(...speed);
+		const minSpeed = Math.min(...speed);
+
+		context.fillText(`(${minSpeed.toFixed(2)}x` + (minSpeed === maxSpeed ? `` : ` -- ${Math.max(...speed).toFixed(2)}x`) + `)`, lineX[j] + 30, lineY + 16);
 
 		updateScoreDetailLabel(`Speed`, `${speedType}S`, speedObj[speedType].cnt, j, g_lblNameObj[`s_${speedType}`]);
 		updateScoreDetailLabel(`Speed`, `avgD${speedType}`, avgSubX[j] === 1 ? `----` : `${(avgSubX[j]).toFixed(2)}x`, j + 4, g_lblNameObj[`s_avgD${speedType}`]);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 速度変化グラフにおいて最低/最高変化量を表記するように変更
- 凡例部分の下に実際の最低/最高変化量を表記するようにしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. ほとんどの場合問題とはならないが、
枠外に出たときに最低・最高がどの程度かがグラフではわからないため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/6032fda0-8f7f-429f-b439-321737f5776a" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
