### PR TITLE
feat: [0821] playbackRateの値に合わせてAdjustmentの設定幅を伸縮するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -11079,7 +11079,7 @@ const resultInit = _ => {
 		return result;
 	};
 	const bayesExVal = 6 * bayesFunc(0, diffLength) / (diffLength * (diffLength + 1) * (diffLength + 2));
-	const estimatedAdj = (diffLength <= 20 ? `` : Math.round((g_stateObj.adjustment - bayesExVal) * 10) / 10);
+	const estimatedAdj = (diffLength <= 20 ? `` : Math.round((g_stateObj.adjustment / g_headerObj.playbackRate - bayesExVal) * 10) / 10);
 
 	// 背景スプライトを作成
 	createMultipleSprite(`backResultSprite`, g_headerObj.backResultMaxDepth);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -11126,12 +11126,14 @@ const resultInit = _ => {
 	}
 
 	// 曲名・オプション描画
-	const musicTitle = g_headerObj.musicTitles[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.musicTitle;
+	const playbackView = (g_headerObj.playbackRate === 1 ? `` : ` [Rate:${g_headerObj.playbackRate}]`);
+	const musicTitle = (g_headerObj.musicTitles[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.musicTitle) + playbackView;
 
-	const mTitleForView = [g_headerObj.musicTitleForView[0], g_headerObj.musicTitleForView[1] || ``];
+	const mTitleForView = [g_headerObj.musicTitleForView[0], (g_headerObj.musicTitleForView[1] || ``) + playbackView];
 	if (g_headerObj.musicTitlesForView[g_headerObj.musicNos[g_stateObj.scoreId]] !== undefined) {
 		mTitleForView.forEach((mTitle, j) =>
-			mTitleForView[j] = g_headerObj.musicTitlesForView[g_headerObj.musicNos[g_stateObj.scoreId]][j]);
+			mTitleForView[j] = g_headerObj.musicTitlesForView[g_headerObj.musicNos[g_stateObj.scoreId]][j])
+			+ (j === 1 ? playbackView : ``);
 	}
 
 	const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5526,7 +5526,6 @@ const createOptionWindow = _sprite => {
 	// 縦位置: 5.5
 	createGeneralSetting(spriteList.shuffle, `shuffle`, g_settings.scoreDetails.length > 0 ? {
 		addRFunc: _ => makeHighScore(g_stateObj.scoreId),
-		addLFunc: _ => makeHighScore(g_stateObj.scoreId),
 	} : {});
 
 	// ---------------------------------------------------
@@ -5534,7 +5533,6 @@ const createOptionWindow = _sprite => {
 	// 縦位置: 6.5
 	createGeneralSetting(spriteList.autoPlay, `autoPlay`, g_settings.scoreDetails.length > 0 ? {
 		addRFunc: _ => makeHighScore(g_stateObj.scoreId),
-		addLFunc: _ => makeHighScore(g_stateObj.scoreId),
 	} : {});
 
 	// ---------------------------------------------------
@@ -5578,9 +5576,7 @@ const createOptionWindow = _sprite => {
 	// 縦位置: 10.5  短縮ショートカットあり
 	createGeneralSetting(spriteList.adjustment, `adjustment`, {
 		skipTerms: g_settings.adjustmentTerms, hiddenBtn: true, scLabel: g_lblNameObj.sc_adjustment, roundNum: 5,
-		unitName: g_lblNameObj.frame,
-		addRFunc: _ => viewAdjustment(),
-		addLFunc: _ => viewAdjustment(),
+		unitName: g_lblNameObj.frame, addRFunc: _ => viewAdjustment(),
 	});
 
 	const viewAdjustment = _ => {
@@ -5648,7 +5644,7 @@ const createOptionWindow = _sprite => {
  * @param {object} _options
  */
 const createGeneralSetting = (_obj, _settingName, { unitName = ``,
-	skipTerms = fillArray(3, 1), hiddenBtn = false, addRFunc = _ => { }, addLFunc = _ => { },
+	skipTerms = fillArray(3, 1), hiddenBtn = false, addRFunc = _ => { }, addLFunc = addRFunc,
 	settingLabel = _settingName, displayName = g_currentPage, scLabel = ``, roundNum = 0, adjY = 0 } = {}) => {
 
 	const settingUpper = toCapitalize(_settingName);
@@ -6265,7 +6261,6 @@ const createSettingsDisplayWindow = _sprite => {
 	// 縦位置: 7.4
 	createGeneralSetting(spriteList.appearance, `appearance`, {
 		addRFunc: _ => dispAppearanceSlider(),
-		addLFunc: _ => dispAppearanceSlider(),
 	});
 
 	// Hidden+/Sudden+初期値用スライダー、ロックボタン

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9416,7 +9416,8 @@ const mainInit = _ => {
 	}
 
 	// 曲名・アーティスト名、譜面名表示
-	const musicTitle = g_headerObj.musicTitles[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.musicTitle;
+	const playbackView = (g_headerObj.playbackRate === 1 ? `` : ` [Rate:${g_headerObj.playbackRate}]`);
+	const musicTitle = (g_headerObj.musicTitles[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.musicTitle) + playbackView;
 	const artistName = g_headerObj.artistNames[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.artistName;
 	const assistFlg = (g_autoPlaysBase.includes(g_stateObj.autoPlay) ? `` : `-${getStgDetailName(g_stateObj.autoPlay)}${getStgDetailName('less')}`);
 	const shuffleName = (g_stateObj.shuffle !== C_FLG_OFF ? `: ${getStgDetailName(g_stateObj.shuffle)}` : ``);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -11300,7 +11300,8 @@ const resultInit = _ => {
 		maxCombo: 0, fmaxCombo: 0, score: 0,
 	};
 
-	const highscoreCondition = (g_stateObj.autoAll === C_FLG_OFF && (g_stateObj.shuffle === C_FLG_OFF || (mirrorName !== `` && orgShuffleFlg)));
+	const highscoreCondition = (g_stateObj.autoAll === C_FLG_OFF && g_headerObj.playbackRate === 1 &&
+		(g_stateObj.shuffle === C_FLG_OFF || (mirrorName !== `` && orgShuffleFlg)));
 	if (highscoreCondition) {
 
 		// ハイスコア差分描画

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5587,7 +5587,7 @@ const createOptionWindow = _sprite => {
 		if (g_headerObj.playbackRate !== 1) {
 			document.getElementById(`lnkAdjustment`).innerHTML +=
 				`<br>(${(Math.round(g_stateObj.adjustment * 100 / g_headerObj.playbackRate) / 100).toFixed(2)}${g_lblNameObj.frame})`;
-			document.getElementById(`lnkAdjustment`).style.fontSize = `12px`;
+			document.getElementById(`lnkAdjustment`).style.fontSize = `${g_limitObj.adjustmentViewSiz}px`;
 		}
 	};
 	viewAdjustment();

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -43,6 +43,7 @@ const g_remoteFlg = g_rootPath.match(`^https://cwtickle.github.io/danoniplus/`) 
 const g_randTime = Date.now();
 const g_isFile = location.href.match(/^file/);
 const g_isLocal = location.href.match(/^file/) || location.href.indexOf(`localhost`) !== -1;
+const isLocalMusicFile = _scoreId => g_isFile && !listMatching(getMusicUrl(g_stateObj.scoreId), [`.js`, `.txt`], { suffix: `$` });
 
 window.onload = async () => {
 	g_loadObj.main = true;
@@ -5581,8 +5582,10 @@ const createOptionWindow = _sprite => {
 
 	const viewAdjustment = _ => {
 		if (g_headerObj.playbackRate !== 1) {
-			document.getElementById(`lnkAdjustment`).innerHTML =
-				`${(Math.round(g_stateObj.adjustment * 100 / g_headerObj.playbackRate) / 100).toFixed(1)}${g_lblNameObj.frame}`
+			const adjustmentVal = isLocalMusicFile(g_stateObj.scoreId) ?
+				Math.round(g_stateObj.adjustment / g_headerObj.playbackRate) :
+				(Math.round(g_stateObj.adjustment * 100 / g_headerObj.playbackRate) / 100).toFixed(1);
+			document.getElementById(`lnkAdjustment`).innerHTML = `${adjustmentVal}${g_lblNameObj.frame}`
 				+ `<span style="font-size:${g_limitObj.adjustmentViewOrgSiz}px"> (${g_stateObj.adjustment.toFixed(1)}${g_localStorage.adjustment === g_stateObj.adjustment ? '*' : ''})</span>`;
 			document.getElementById(`lnkAdjustment`).style.fontSize = `${g_limitObj.adjustmentViewSiz}px`;
 			document.getElementById(`lnkAdjustment`).style.lineHeight = `${g_limitObj.adjustmentLineHeight}px`;
@@ -7760,10 +7763,11 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	obj.dummyArrowData = [];
 	obj.dummyFrzData = [];
 
-	// realAdjustment: 全体, intAdjustment: 整数値のみ(切り捨て), decimalAdjustment: 小数値のみ
+	// realAdjustment: 全体, intAdjustment: 整数値のみ(切り捨て、ファイル時のみ四捨五入), decimalAdjustment: 小数値のみ
 	const headerAdjustment = parseFloat(g_headerObj.adjustment[g_stateObj.scoreId] || g_headerObj.adjustment[0]);
 	g_stateObj.realAdjustment = (parseFloat(g_stateObj.adjustment) + headerAdjustment) / g_headerObj.playbackRate + _preblankFrame;
-	g_stateObj.intAdjustment = Math.floor(g_stateObj.realAdjustment);
+	g_stateObj.intAdjustment = isLocalMusicFile(g_stateObj.scoreId) ?
+		Math.round(g_stateObj.realAdjustment) : Math.floor(g_stateObj.realAdjustment);
 	g_stateObj.decimalAdjustment = g_stateObj.realAdjustment - g_stateObj.intAdjustment;
 
 	const blankFrame = g_headerObj.blankFrame;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5579,7 +5579,18 @@ const createOptionWindow = _sprite => {
 	createGeneralSetting(spriteList.adjustment, `adjustment`, {
 		skipTerms: g_settings.adjustmentTerms, hiddenBtn: true, scLabel: g_lblNameObj.sc_adjustment, roundNum: 5,
 		unitName: g_lblNameObj.frame,
+		addRFunc: _ => viewAdjustment(),
+		addLFunc: _ => viewAdjustment(),
 	});
+
+	const viewAdjustment = _ => {
+		if (g_headerObj.playbackRate !== 1) {
+			document.getElementById(`lnkAdjustment`).innerHTML +=
+				`<br>(${(Math.round(g_stateObj.adjustment * 100 / g_headerObj.playbackRate) / 100).toFixed(2)}${g_lblNameObj.frame})`;
+			document.getElementById(`lnkAdjustment`).style.fontSize = `12px`;
+		}
+	};
+	viewAdjustment();
 
 	// ---------------------------------------------------
 	// フェードイン (Fadein)
@@ -5648,47 +5659,47 @@ const createGeneralSetting = (_obj, _settingName, { unitName = ``,
 		multiAppend(_obj,
 			makeSettingLblCssButton(linkId, `${initName}${g_localStorage[_settingName] === g_stateObj[_settingName] ? ' *' : ''}`, 0,
 				_ => {
-					setSetting(skipTerms[1], _settingName, unitName, roundNum);
-					addRFunc();
+					setSetting(skipTerms[1], _settingName, unitName, roundNum, { func: _ => addRFunc() });
 				}, {
 				cxtFunc: _ => {
-					setSetting(skipTerms[1] * (-1), _settingName, unitName, roundNum);
-					addLFunc();
+					setSetting(skipTerms[1] * (-1), _settingName, unitName, roundNum, { func: _ => addLFunc() });
 				}
 			}),
 
 			// 右回し・左回しボタン（外側）
-			makeMiniCssButton(linkId, `R`, 0, _ => {
-				setSetting(skipTerms[0], _settingName, unitName, roundNum);
-				addRFunc();
-			}),
-			makeMiniCssButton(linkId, `L`, 0, _ => {
-				setSetting(skipTerms[0] * (-1), _settingName, unitName, roundNum);
-				addLFunc();
-			}),
+			makeMiniCssButton(linkId, `R`, 0, _ =>
+				setSetting(skipTerms[0], _settingName, unitName, roundNum, { func: _ => addRFunc() })),
+			makeMiniCssButton(linkId, `L`, 0, _ =>
+				setSetting(skipTerms[0] * (-1), _settingName, unitName, roundNum, { func: _ => addLFunc() })),
 		);
 
 		// 右回し・左回しボタン（内側）
 		if (skipTerms[1] > 1) {
 			multiAppend(_obj,
-				makeMiniCssButton(linkId, `RR`, 0, _ => setSetting(skipTerms[1], _settingName, unitName, roundNum)),
-				makeMiniCssButton(linkId, `LL`, 0, _ => setSetting(skipTerms[1] * (-1), _settingName, unitName, roundNum)),
+				makeMiniCssButton(linkId, `RR`, 0, _ =>
+					setSetting(skipTerms[1], _settingName, unitName, roundNum, { func: _ => addRFunc() })),
+				makeMiniCssButton(linkId, `LL`, 0, _ =>
+					setSetting(skipTerms[1] * (-1), _settingName, unitName, roundNum, { func: _ => addLFunc() })),
 			);
 		}
 
 		// 右回し・左回しボタン（最内側）
 		if (skipTerms[2] > 1) {
 			multiAppend(_obj,
-				makeMiniCssButton(linkId, `RRR`, 0, _ => setSetting(skipTerms[2], _settingName, unitName, roundNum), { dw: -g_limitObj.setMiniWidth / 2 }),
-				makeMiniCssButton(linkId, `LLL`, 0, _ => setSetting(skipTerms[2] * (-1), _settingName, unitName, roundNum), { dw: -g_limitObj.setMiniWidth / 2 }),
+				makeMiniCssButton(linkId, `RRR`, 0, _ =>
+					setSetting(skipTerms[2], _settingName, unitName, roundNum, { func: _ => addRFunc() })
+					, { dw: -g_limitObj.setMiniWidth / 2 }),
+				makeMiniCssButton(linkId, `LLL`, 0, _ =>
+					setSetting(skipTerms[2] * (-1), _settingName, unitName, roundNum, { func: _ => addLFunc() })
+					, { dw: -g_limitObj.setMiniWidth / 2 }),
 			);
 		}
 
 		// 右回し・左回しボタン（不可視）
 		if (hiddenBtn) {
 			multiAppend(_obj,
-				makeMiniCssButton(linkId, `HR`, 0, _ => setSetting(1, _settingName, unitName, roundNum), { visibility: `hidden` }),
-				makeMiniCssButton(linkId, `HL`, 0, _ => setSetting(-1, _settingName, unitName, roundNum), { visibility: `hidden` }),
+				makeMiniCssButton(linkId, `HR`, 0, _ => setSetting(1, _settingName, unitName, roundNum, { func: _ => addRFunc() }), { visibility: `hidden` }),
+				makeMiniCssButton(linkId, `HL`, 0, _ => setSetting(-1, _settingName, unitName, roundNum, { func: _ => addLFunc() }), { visibility: `hidden` }),
 			);
 		}
 
@@ -5731,7 +5742,7 @@ const getStgDetailName = _name => {
  * @param {string} _unitName
  * @param {number} _roundNum
  */
-const setSetting = (_scrollNum, _settingName, _unitName = ``, _roundNum = 0) => {
+const setSetting = (_scrollNum, _settingName, _unitName = ``, _roundNum = 0, { func = _ => true } = {}) => {
 	let settingNum = g_settings[`${_settingName}Num`];
 	const settingList = g_settings[`${_settingName}s`];
 	const settingMax = settingList.length - 1;
@@ -5752,6 +5763,7 @@ const setSetting = (_scrollNum, _settingName, _unitName = ``, _roundNum = 0) => 
 	g_settings[`${_settingName}Num`] = settingNum;
 	document.getElementById(`lnk${toCapitalize(_settingName)}`).textContent =
 		`${getStgDetailName(g_stateObj[_settingName])}${_unitName}${g_localStorage[_settingName] === g_stateObj[_settingName] ? ' *' : ''}`;
+	func();
 };
 
 /**
@@ -7753,7 +7765,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 
 	// realAdjustment: 全体, intAdjustment: 整数値のみ(切り捨て), decimalAdjustment: 小数値のみ
 	const headerAdjustment = parseFloat(g_headerObj.adjustment[g_stateObj.scoreId] || g_headerObj.adjustment[0]);
-	g_stateObj.realAdjustment = parseFloat(g_stateObj.adjustment) + headerAdjustment + _preblankFrame;
+	g_stateObj.realAdjustment = (parseFloat(g_stateObj.adjustment) + headerAdjustment) / g_headerObj.playbackRate + _preblankFrame;
 	g_stateObj.intAdjustment = Math.floor(g_stateObj.realAdjustment);
 	g_stateObj.decimalAdjustment = g_stateObj.realAdjustment - g_stateObj.intAdjustment;
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -11133,8 +11133,7 @@ const resultInit = _ => {
 	const mTitleForView = [g_headerObj.musicTitleForView[0], (g_headerObj.musicTitleForView[1] || ``) + playbackView];
 	if (g_headerObj.musicTitlesForView[g_headerObj.musicNos[g_stateObj.scoreId]] !== undefined) {
 		mTitleForView.forEach((mTitle, j) =>
-			mTitleForView[j] = g_headerObj.musicTitlesForView[g_headerObj.musicNos[g_stateObj.scoreId]][j])
-			+ (j === 1 ? playbackView : ``);
+			mTitleForView[j] = g_headerObj.musicTitlesForView[g_headerObj.musicNos[g_stateObj.scoreId]][j] + (j === 1 ? playbackView : ``));
 	}
 
 	const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5585,9 +5585,11 @@ const createOptionWindow = _sprite => {
 
 	const viewAdjustment = _ => {
 		if (g_headerObj.playbackRate !== 1) {
-			document.getElementById(`lnkAdjustment`).innerHTML +=
-				`<br>(${(Math.round(g_stateObj.adjustment * 100 / g_headerObj.playbackRate) / 100).toFixed(2)}${g_lblNameObj.frame})`;
+			document.getElementById(`lnkAdjustment`).innerHTML =
+				`${(Math.round(g_stateObj.adjustment * 100 / g_headerObj.playbackRate) / 100).toFixed(1)}${g_lblNameObj.frame}`
+				+ `<span style="font-size:${g_limitObj.adjustmentViewOrgSiz}px"> (${g_stateObj.adjustment.toFixed(1)}${g_localStorage.adjustment === g_stateObj.adjustment ? '*' : ''})</span>`;
 			document.getElementById(`lnkAdjustment`).style.fontSize = `${g_limitObj.adjustmentViewSiz}px`;
+			document.getElementById(`lnkAdjustment`).style.lineHeight = `${g_limitObj.adjustmentLineHeight}px`;
 		}
 	};
 	viewAdjustment();

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5584,7 +5584,7 @@ const createOptionWindow = _sprite => {
 		if (g_headerObj.playbackRate !== 1) {
 			const adjustmentVal = isLocalMusicFile(g_stateObj.scoreId) ?
 				Math.round(g_stateObj.adjustment / g_headerObj.playbackRate) :
-				(Math.round(g_stateObj.adjustment * 100 / g_headerObj.playbackRate) / 100).toFixed(1);
+				(g_stateObj.adjustment / g_headerObj.playbackRate).toFixed(1);
 			document.getElementById(`lnkAdjustment`).innerHTML = `${adjustmentVal}${g_lblNameObj.frame}`
 				+ `<span style="font-size:${g_limitObj.adjustmentViewOrgSiz}px"> (${g_stateObj.adjustment.toFixed(1)}${g_localStorage.adjustment === g_stateObj.adjustment ? '*' : ''})</span>`;
 			document.getElementById(`lnkAdjustment`).style.fontSize = `${g_limitObj.adjustmentViewSiz}px`;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -29,7 +29,10 @@ const g_limitObj = {
     // Adjustment, HitPositionの設定幅
     adjustment: 30,
     hitPosition: 50,
-    adjustmentViewSiz: 12,
+
+    adjustmentViewSiz: 14,
+    adjustmentViewOrgSiz: 11,
+    adjustmentLineHeight: 12,
 
     // 譜面密度グラフの分割数、上位色付け数
     densityDivision: 16,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -30,6 +30,7 @@ const g_limitObj = {
     adjustment: 30,
     hitPosition: 50,
 
+    // playbackRate有効時のAdjustmentの設定値の文字サイズ、行幅
     adjustmentViewSiz: 14,
     adjustmentViewOrgSiz: 11,
     adjustmentLineHeight: 12,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -29,6 +29,7 @@ const g_limitObj = {
     // Adjustment, HitPositionの設定幅
     adjustment: 30,
     hitPosition: 50,
+    adjustmentViewSiz: 12,
 
     // 譜面密度グラフの分割数、上位色付け数
     densityDivision: 16,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. playbackRateの値に合わせてAdjustmentの設定幅を伸縮するよう変更
- playbackRateが1以上の場合はAdjustmentの間隔を狭く、未満の場合は広くなるように自動調整します。
- 調整後のAdjustmentはplaybackRate＝1以外の場合、画面上に表示されます。
- 小数Adjustmentが使えない環境の場合は、整数への丸め処理を行います。 

### 2. playbackRateの値を1以外にした場合、プレイ・結果画面に表示するよう変更
- 曲名の横に表示するように変更しています。

### 3. playbackRateの値を1以外にした場合、ハイスコアを保存しないよう変更
- 本来の内容とは別扱いのため、ハイスコアを保存しないようにしました。

### 4. 設定ボタン関数の引数拡張
- 設定ボタンの制御関数（setSetting）の引数にオブジェクト引数を追加し、
その中で後続関数を指定できるようにしました。
- 合わせて、`createGeneralSetting` の全てのボタンに対して拡張関数（addRFunc, addLFunc）を適用するよう変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 頻度はそれほど多くないですが、低速再生したいときにAdjustmentにズレがあると再生倍速ごとにAdjustmentを調整し直す必要がありました。
2. playbackRateの値が画面上のどこにも表示されないため。
設定の変更というより、楽曲が変わっているため楽曲のカスタマイズという扱いにしています。
3. 上述の通りです。
4. 同じ内容の繰り返し記述を避けるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/ff2b480f-c68e-4861-b8f5-1c3a52b7985f" width="50%"><img src="https://github.com/cwtickle/danoniplus/assets/44026291/079f99d6-e4fc-4b9b-8a90-9dd831443a04" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
