### PR TITLE
fix: [0822] ベンダープレフィックスの設定を元に戻す

### DIFF
--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -869,5 +869,6 @@ input[type="color"] {
 .result_Cleared,
 .result_Failed {
 	background-clip: text;
+	-webkit-background-clip: text;
 	color: rgba(255, 255, 255, 0.0);
 }

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1147,6 +1147,8 @@ const createColorObject2 = (_id,
 
 	style.maskImage = `url("${g_imgObj[charaStyle]}")`;
 	style.maskSize = `contain`;
+	style.webkitMaskImage = `url("${g_imgObj[charaStyle]}")`;
+	style.webkitMaskSize = `contain`;
 	Object.keys(rest).forEach(property => style[property] = rest[property]);
 	setAttrs(div, { color: rest.background ?? ``, type: charaStyle, cnt: 0, });
 
@@ -4163,6 +4165,7 @@ const titleInit = _ => {
 				font-family:${g_headerObj.titlefonts[0]};
 				background: ${titlegrds[0]};
 				background-clip: text;
+				-webkit-background-clip: text;
 				color: rgba(255,255,255,0.0);
 				${txtAnimations[0]}
 			" class="${g_headerObj.titleAnimationClass[0]}">
@@ -4175,6 +4178,7 @@ const titleInit = _ => {
 				font-family:${g_headerObj.titlefonts[1]};
 				background: ${titlegrds[1]};
 				background-clip: text;
+				-webkit-background-clip: text;
 				color: rgba(255,255,255,0.0);
 				${txtAnimations[1]}
 			" class="${g_headerObj.titleAnimationClass[1]}">


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. ベンダープレフィックスの設定（mask, background-clip）を元に戻す
- v36.1.0以降にベンダープレフィックスの設定（mask, background-clip）を外しましたが、
古いOSの場合、ブラウザの更新ができないことがあり、プレイに支障が出ることがありました。
 
## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 上述の通りです。PR #1641 の内容を元に戻します。
ただ、画像読込（preload）についてはFirefox 85以降（2021年1月）でも対応済みのためそのままとします。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
- v36以降で同様の修正が必要です。
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
