### PR TITLE
improve: [0824] フリーズアローの終端がいない場合に末尾のフリーズアロー始端を自動除去する仕様に変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2406,7 +2406,7 @@ const storeBaseData = (_scoreId, _scoreObj, _keyCtrlPtn) => {
 	g_detailObj.maxDensity[_scoreId] = getMaxValIdxs(densityData, g_limitObj.densityMaxVals).flat();
 
 	g_detailObj.arrowCnt[_scoreId] = noteCnt.arrow.concat();
-	g_detailObj.frzCnt[_scoreId] = noteCnt.frz.concat();
+	g_detailObj.frzCnt[_scoreId] = noteCnt.frz.map((val, k) => _scoreObj.frzData[k].length % 2 === 0 ? val : val - 1);
 	g_detailObj.startFrame[_scoreId] = startFrame;
 	g_detailObj.playingFrame[_scoreId] = playingFrame;
 	g_detailObj.playingFrameWithBlank[_scoreId] = lastFrame - startFrame;
@@ -8496,6 +8496,9 @@ const pushArrows = (_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 
 		const camelHeader = toCapitalize(_header);
 		const setcnt = (_frzFlg ? 2 : 1);
+		if (_frzFlg && _data.length % 2 !== 0) {
+			_data.pop();
+		}
 
 		const startPoint = [];
 		let spdNext = Infinity;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2406,7 +2406,7 @@ const storeBaseData = (_scoreId, _scoreObj, _keyCtrlPtn) => {
 	g_detailObj.maxDensity[_scoreId] = getMaxValIdxs(densityData, g_limitObj.densityMaxVals).flat();
 
 	g_detailObj.arrowCnt[_scoreId] = noteCnt.arrow.concat();
-	g_detailObj.frzCnt[_scoreId] = noteCnt.frz.map((val, k) => _scoreObj.frzData[k].length % 2 === 0 ? val : val - 1);
+	g_detailObj.frzCnt[_scoreId] = noteCnt.frz.map((val, k) => _scoreObj.frzData[k].length % 2 === 0 ? val : val - 0.5);
 	g_detailObj.startFrame[_scoreId] = startFrame;
 	g_detailObj.playingFrame[_scoreId] = playingFrame;
 	g_detailObj.playingFrameWithBlank[_scoreId] = lastFrame - startFrame;
@@ -4977,7 +4977,7 @@ const makeDifInfoLabels = _scoreId => {
 const makeDifInfo = _scoreId => {
 
 	const arrowCnts = sumData(g_detailObj.arrowCnt[_scoreId]);
-	const frzCnts = sumData(g_detailObj.frzCnt[_scoreId]);
+	const frzCnts = sumData(g_detailObj.frzCnt[_scoreId].map(val => Math.floor(val)));
 	const push3CntStr = (g_detailObj.toolDif[_scoreId].push3.length === 0 ? `None` : `(${g_detailObj.toolDif[_scoreId].push3.join(', ')})`);
 
 	if (document.getElementById(`lblTooldif`) === null) {
@@ -5010,6 +5010,9 @@ const makeDifInfo = _scoreId => {
 				if (maxVal !== minVal) {
 					array[j] = (val === minVal ? `<span class="settings_minArrowCnts">${val}</span>` :
 						(val === maxVal ? `<span class="settings_maxArrowCnts common_bold">${val}</span>` : val));
+				}
+				if (val - Math.floor(val) > 0) {
+					array[j] = `<span class="keyconfig_warning">${val}</span>`;
 				}
 			});
 			cntlistStr += array.join(`, `) + ` ]`;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7516,7 +7516,7 @@ const loadingScoreInit = async () => {
 	g_allArrow = 0;
 	g_allFrz = 0;
 	g_scoreObj.arrowData.forEach(data => g_allArrow += data.length);
-	g_scoreObj.frzData.forEach(data => g_allFrz += data.length);
+	g_scoreObj.frzData.forEach(data => g_allFrz += Math.floor(data.length / 2) * 2);
 
 	// ライフ回復・ダメージ量の計算
 	// フリーズ始点でも通常判定させる場合は総矢印数を水増しする


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. フリーズアローの終端がいない場合に末尾のフリーズアロー始端を自動除去する仕様に変更
- フリーズアローは本来2つ1セットのため、データ数が奇数の場合は譜面が成立しませんが、
対になっていない最終のフリーズアロー始端を除去することでプレイに支障が出ないようにしました。
- 単純に最後のデータを無効化します。途中に矢印が存在するかどうかは見ません。

### 2. 難易度表示（DifLevel）に表示しているフリーズアロー数について無効化分を含めないよう対応
- 無効化したフリーズアローはカウントしないように修正しました。
- レーン別フリーズアロー数は対が無いかどうかがわかるように、小数まで表示し色付けしました。
- なお、ツール値については元から対が無いフリーズアローは対象にしていない仕様になっています。

### 3. レーン別フリーズアロー数が小数のとき、AP時でもAP表示がされない問題を修正
- フリーズアロー数が小数のため、AP時でも数が合わずAP表示がされない状況でした。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. Discordでの話題より派生。
https://discord.com/channels/698460971231870977/1195445736851124254/1259339629220466698
2. 従来の表示方法では無効化分も含まれており、紛らわしいため。
3. 1.を対応することで新たに生じた問題のため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/cwtickle/danoniplus/assets/44026291/3059b58a-b2e6-4ca7-94c6-8e12cbaeaeb6" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
