### PR TITLE
improve: [0826] 曲名や制作者名で実体参照記述をしているときに、CopyResultで元の文字になるよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -476,7 +476,7 @@ const fuzzyListMatching = (_str, _headerList, _footerList) =>
  */
 const replaceStr = (_str, _pairs) => {
 	let tmpStr = _str;
-	_pairs.forEach(pair => tmpStr = tmpStr?.replaceAll(pair[0], pair[1]));
+	_pairs.forEach(pair => tmpStr = tmpStr?.replaceAll(String(pair[0]), String(pair[1]).replaceAll(`$&`, `$ &`)));
 	return tmpStr;
 };
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -494,10 +494,16 @@ const escapeHtml = (_str, _escapeList = g_escapeStr.escape) => escapeHtmlForEnab
 const escapeHtmlForEnabledTag = _str => replaceStr(_str, g_escapeStr.escapeTag);
 
 /**
+ * HTML Entityから元の文字に戻す
+ * @param {string} _str 
+ */
+const unEscapeEmoji = _str => _str?.replace(/&#(.*?);/g, (_, p1) => String.fromCodePoint(`0${p1}`));
+
+/**
  * エスケープ文字を元の文字に戻す
  * @param {string} _str 
  */
-const unEscapeHtml = _str => replaceStr(_str, g_escapeStr.unEscapeTag);
+const unEscapeHtml = _str => unEscapeEmoji(replaceStr(_str, g_escapeStr.unEscapeTag));
 
 /**
  * 配列の中身を全てエスケープ処理

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -476,7 +476,7 @@ const fuzzyListMatching = (_str, _headerList, _footerList) =>
  */
 const replaceStr = (_str, _pairs) => {
 	let tmpStr = _str;
-	_pairs.forEach(pair => tmpStr = tmpStr?.replaceAll(String(pair[0]), String(pair[1]).replaceAll(`$&`, `$ &`)));
+	_pairs.forEach(pair => tmpStr = tmpStr?.replaceAll(pair[0], String(pair[1]).replaceAll(`$&`, `$ &`)));
 	return tmpStr;
 };
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 曲名や制作者名で実体参照記述をしているときに、CopyResultで元の文字になるよう変更
- `&#9803;`のように実体参照をしている場合、画面に表示する際には問題はありませんが、CopyResultでクリップボードに表示する場合には元の文字に変換する必要がありました。
- 変換する関数（unEscapeEmoji）を追加して、元の文字に戻るようにしました。
呼び出し元は`unEscapeHtml`関数なので、`unEscapeHtml`関数を呼び出せば今回追加した関数も自動実行されることになります。

### 2. 特定文字（`$&`）への置換で結果が想定外となる問題を修正
- 文字列置換の過程で、`$&`という文字への置換が行われない問題を修正しました。
- 文字列置換では`String.replaceAll(searchString, replacement)`を指定しているのですが、
第二引数(replacement)に`$&`という文字が含まれた場合、変換前の第一引数に置き換わってしまう問題が見つかっています。（Chrome 127にて確認）
- この問題を解消するため、暫定的に置換後の文字列に`$&`が含まれている場合に
`$ &`と半角スペースを間に入れることで対処しました。
```js
const str = `[format]`;
console.log(str.replaceAll(`[format]`, `テスト$&#39;`);
// 想定される値："テスト$&#39;"
// 実際の値　　："テスト[format]#39;"
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 本体はUTF-8なので絵文字を直接指定しても影響は無いですが、こういった記述を実体参照で行った場合に本体側で自動変換する仕組みがありませんでした。
2. レアケースだと思いますが、該当処理を入れても影響は限定的と思われるため今回実装しました。
実装当初は発生していなかったと思われ、いつからこの仕様になったかは不明です。

## :camera: スクリーンショット / Screenshot
<img src="https://github.com/user-attachments/assets/c68c9ee8-692f-4bf7-bae7-94745c4c96b7" width="60%">

<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Enhanced text processing capabilities to accurately handle both emoji and standard HTML entities.
    - Introduced a new function to convert HTML entities back to their original Unicode characters, improving the robustness of HTML content handling. 

- **Bug Fixes**
    - Resolved issues related to the incorrect display of emojis in HTML content by integrating new processing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->