### PR TITLE
fix: [0827] 一部文字列の置換処理がおかしくなる問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -475,8 +475,8 @@ const fuzzyListMatching = (_str, _headerList, _footerList) =>
  * @param {array} _pairs 
  */
 const replaceStr = (_str, _pairs) => {
-	let tmpStr = _str;
-	_pairs.forEach(pair => tmpStr = tmpStr?.split(pair[0]).join(pair[1]));
+	let tmpStr = _str || ``;
+	_pairs.forEach(pair => tmpStr = tmpStr.split(pair[0]).join(pair[1]));
 	return tmpStr;
 };
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -476,7 +476,7 @@ const fuzzyListMatching = (_str, _headerList, _footerList) =>
  */
 const replaceStr = (_str, _pairs) => {
 	let tmpStr = _str;
-	_pairs.forEach(pair => tmpStr = tmpStr?.replaceAll(pair[0], String(pair[1]).replaceAll(`$&`, `$ &`)));
+	_pairs.forEach(pair => tmpStr = tmpStr?.split(pair[0]).join(pair[1]));
 	return tmpStr;
 };
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
### 1. 一部文字列の置換処理がおかしくなる問題を修正
- 文字列置換の過程で、`$&`という文字への置換が行われない問題を解消しました。
- v26以前で実装した方法に戻しています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. PR #1696 で対応しましたが、完全に直せていないため、元の方法に戻します。
ver27.0.0にてsplit -> joinからreplaceAllに変更したことが原因です。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Simplified string replacement logic, improving the accuracy of substring replacements.

- **Chores**
	- Refined the implementation to enhance performance and maintainability without altering public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->