### PR TITLE
feat: [0829] リバース設定を制限する機能を実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5797,7 +5797,7 @@ const makeDisabledLabel = (_id, _heightPos, _defaultStr) =>
  * @param {string} _extraKeyName 特殊キー名(通常キーは省略)
  */
 const getKeyReverse = (_localStorage, _extraKeyName = ``) => {
-	if (_localStorage[`reverse${_extraKeyName}`] !== undefined) {
+	if (_localStorage[`reverse${_extraKeyName}`] !== undefined && g_headerObj.reverseUse) {
 		g_stateObj.reverse = _localStorage[`reverse${_extraKeyName}`] ?? C_FLG_OFF;
 		g_settings.reverseNum = roundZero(g_settings.reverses.findIndex(reverse => reverse === g_stateObj.reverse));
 	} else {
@@ -5814,7 +5814,7 @@ const setReverseDefault = _ => {
 };
 
 const setReverse = _btn => {
-	if (!g_settings.scrolls.includes(`Reverse`)) {
+	if (!g_settings.scrolls.includes(`Reverse`) && g_headerObj.reverseUse) {
 		g_settings.reverseNum = (g_settings.reverseNum + 1) % 2;
 		g_stateObj.reverse = g_settings.reverses[g_settings.reverseNum];
 		setReverseView(_btn);
@@ -5824,7 +5824,7 @@ const setReverse = _btn => {
 const setReverseView = _btn => {
 	_btn.classList.replace(g_cssObj[`button_Rev${g_settings.reverses[(g_settings.reverseNum + 1) % 2]}`],
 		g_cssObj[`button_Rev${g_settings.reverses[g_settings.reverseNum]}`]);
-	if (!g_settings.scrolls.includes(`Reverse`)) {
+	if (!g_settings.scrolls.includes(`Reverse`) && g_headerObj.reverseUse) {
 		_btn.textContent = `${g_lblNameObj.Reverse}:${getStgDetailName(g_stateObj.reverse)}`;
 	} else {
 		_btn.textContent = `X`;
@@ -9141,7 +9141,9 @@ const getArrowSettings = _ => {
 			storageObj = g_localStorage;
 			addKey = g_keyObj.currentKey;
 		}
-		storageObj[`reverse${addKey}`] = g_stateObj.reverse;
+		if (g_headerObj.reverseUse) {
+			storageObj[`reverse${addKey}`] = g_stateObj.reverse;
+		}
 		storageObj[`keyCtrl${addKey}`] = setKeyCtrl(g_localKeyStorage, keyNum, keyCtrlPtn);
 		if (g_keyObj.currentPtn !== -1) {
 			storageObj[`keyCtrlPtn${addKey}`] = g_keyObj.currentPtn;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1084,7 +1084,7 @@ let g_storeSettings = [`adjustment`, `volume`, `appearance`, `opacity`, `hitPosi
 let g_storeSettingsEx = [`d_stepzone`, `d_judgment`, `d_fastslow`, `d_lifegauge`,
     `d_score`, `d_musicinfo`, `d_filterline`];
 
-let g_canDisabledSettings = [`motion`, `scroll`, `shuffle`, `autoPlay`, `gauge`, `excessive`, `appearance`];
+let g_canDisabledSettings = [`motion`, `scroll`, `reverse`, `shuffle`, `autoPlay`, `gauge`, `excessive`, `appearance`];
 
 const g_hidSudFunc = {
     filterPos: _filterPos => `${_filterPos}${g_lblNameObj.percent}`,

--- a/js/template/danoni_setting.js
+++ b/js/template/danoni_setting.js
@@ -226,6 +226,7 @@ g_presetObj.customDesignUse = {
 g_presetObj.settingUse = {
 	motion: `true`,
 	scroll: `true`,
+	// reverse: `true`,
 	shuffle: `true`,
 	autoPlay: `true`,
 	gauge: `true`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. リバース設定を制限する機能 (reverseUse) を実装
- リバース設定（Reverse）を制限する譜面ヘッダー「reverseUse」を実装しました。
- |reverseUse=false| で無効化できます。
- ローカルストレージでリバースが「ON」になっているときは、
|reverseUse=false|となっている作品に限り強制的に「OFF」にします。
ただし、|reverseUse=false|となっている作品についてはローカルストレージのリバース設定を上書きしないようにすることで、他の作品に影響しないようにしています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. リバース設定についてはこれまで、ローカルストレージにも保存する設定であることから
リバースプレイヤーとの公平性の観点で、制限する設定を入れていませんでした。
特定の作品についてやむを得ずリバースを止める必要がある作品が出てきたため、
例外的な措置として対応できるように、機能追加しました。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

### Scrollのみ無効化した場合
<img src="https://github.com/user-attachments/assets/0041fb90-6ef5-4b3a-b2cf-338a81380307" width="50%">

### Reverseのみ無効化した場合<br>（もしくはScrollに「Reverse」という名前の設定がいる場合）
<img src="https://github.com/user-attachments/assets/a51e3596-8aa6-41a1-b6bd-4664b5fdf12d" width="50%">

### Scroll, Reverseの両方を無効化した場合
<img src="https://github.com/user-attachments/assets/63af0670-8336-4e0d-b482-b42e5989465c" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced control over reverse settings, allowing users to toggle this feature on or off.
	- Added a new configuration option for the reverse functionality, improving user customization.

- **Bug Fixes**
	- Improved logic for retrieving and storing reverse settings, ensuring accurate state management based on user preferences.

- **Documentation**
	- Updated settings documentation to reflect the new reverse functionality and its toggle capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->