### PR TITLE
fix: [0833] ImgTypeで拡張子の指定がないときに、強制的に他の拡張子に変更する機能の問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3447,7 +3447,7 @@ const updateImgType = (_imgType, _initFlg = false) => {
 	resetImgs(_imgType.name, _imgType.extension);
 	reloadImgObj();
 	Object.keys(g_imgObj).forEach(key => g_imgObj[key] = `${g_rootPath}${g_imgObj[key]}`);
-	if (_imgType[1] === undefined && g_presetObj.overrideExtension !== undefined) {
+	if (_imgType.extension === undefined && g_presetObj.overrideExtension !== undefined) {
 		Object.keys(g_imgObj).forEach(key => g_imgObj[key] = `${g_imgObj[key].slice(0, -3)}${g_presetObj.overrideExtension}`);
 	}
 	if (!g_isFile) {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. ImgTypeで拡張子の指定がないときに、強制的に他の拡張子に変更する機能の問題を修正
- 共通設定ファイル(danoni_setting.js)で`g_presetObj.overrideExtension`という設定があり、
これは本来デフォルト画像セットに対する設定でしたが、コードの不具合により、
`g_presetObj.overrideExtension`の設定があれば常時適用されるようになっていました。

```javascript
/**
  デフォルト画像セット (C_IMG_XXXX, 厳密にはg_imgObj) に対して拡張子の上書きを行うか設定
  文字列の後ろ3文字をカットして、下記の値を適用する。コメントアウトした場合は、上書きを行わない。
	`svg`: デフォルト(svg形式)、`png`: 従来画像(png形式)
*/
g_presetObj.overrideExtension = `png`;
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 本来の機能を果たしていないため。ただ、ImgTypeを複数セット用意していてかつ、`g_presetObj.overrideExtension`を設定していることが条件となるため、影響は局所的。
起因となったPRは #1108 (ver23.1.0) です。updateImgType関数が受ける引数「_imgType」が配列からオブジェクトに変わりましたが、一部コードが配列のままになっていました。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- 元々はデフォルト画像セットをpngで置き換えることがあるので実装した機能です。