### PR TITLE
fix: [0837] 色変化（ncolor_data）で矢印種類を省略したときに色変化対象が正しく反映されない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -514,8 +514,8 @@ const fuzzyListMatching = (_str, _headerList, _footerList) =>
  * @returns {string} 置換後文字列
  */
 const replaceStr = (_str, _pairs) => {
-	let tmpStr = _str || ``;
-	_pairs.forEach(pair => tmpStr = tmpStr.split(pair[0]).join(pair[1]));
+	let tmpStr = _str;
+	_pairs.forEach(pair => tmpStr = tmpStr?.split(pair[0]).join(pair[1]));
 	return tmpStr;
 };
 
@@ -8251,8 +8251,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 				const pos = tmpColorData[1]?.indexOf(`:`);
 				const patternStr = pos > 0 ? [trimStr(tmpColorData[1].substring(0, pos)), trimStr(tmpColorData[1].substring(pos + 1))]
 					: [tmpColorData[1]];
-				const patterns = patternStr[1] !== undefined ?
-					replaceStr(trimStr(patternStr[1]), g_escapeStr.colorPatternName)?.split(`/`) : [`Arrow`];
+				const patterns = replaceStr(trimStr(patternStr[1]), g_escapeStr.colorPatternName)?.split(`/`) || [`Arrow`];
 
 				// 矢印番号の組み立て
 				const colorVals = [];

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8251,7 +8251,8 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 				const pos = tmpColorData[1]?.indexOf(`:`);
 				const patternStr = pos > 0 ? [trimStr(tmpColorData[1].substring(0, pos)), trimStr(tmpColorData[1].substring(pos + 1))]
 					: [tmpColorData[1]];
-				const patterns = replaceStr(trimStr(patternStr[1]), g_escapeStr.colorPatternName)?.split(`/`) || [`Arrow`];
+				const patterns = patternStr[1] !== undefined ?
+					replaceStr(trimStr(patternStr[1]), g_escapeStr.colorPatternName)?.split(`/`) : [`Arrow`];
 
 				// 矢印番号の組み立て
 				const colorVals = [];


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 色変化（ncolor_data）で矢印種類を省略したときに色変化対象が正しく反映されない問題を修正
- 色変化で矢印種類を省略した場合、`Arrow`（矢印）になるように作っていましたが、そうなっていなかったため修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. PR #1697 の修正が起因です。replaceStr関数について、undefinedを``(空文字)に変換するようにしていたため、想定しない動きになっていました。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- ver37のみが対象です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for external DOS data and encoded music files.
	- Added enhancements to the title, settings, key configuration, loading, and result screens.
- **Improvements**
	- Optimized game logic for better handling of arrows, freeze arrows, timing, and scoring.
	- Implemented UI improvements for a better user experience.
- **Bug Fixes**
	- Resolved various issues related to the initialization and loading process, including localization and settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->