### PR TITLE
feat: [0838] 古い関数・定数を条件付きで復活

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2169,6 +2169,9 @@ const initialControl = async () => {
 	loadLegacySettingFunc();
 	deleteDiv(divRoot, `lblLoading`);
 
+	// 古い関数の読込 (ファイルがある場合のみ)
+	await loadScript2(`${g_rootPath}../js/lib/legacy_functions.js?${g_randTime}`, false);
+
 	// クエリで譜面番号が指定されていればセット
 	g_stateObj.scoreId = setIntVal(getQueryParamVal(`scoreId`));
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -56,6 +56,7 @@ window.onload = async () => {
 	// ロード直後に定数・初期化ファイル、旧バージョン定義関数を読込
 	await loadScript2(`${g_rootPath}../js/lib/danoni_localbinary.js?${g_randTime}`, false);
 	await loadScript2(`${g_rootPath}../js/lib/danoni_constants.js?${g_randTime}`);
+	await loadScript2(`${g_rootPath}../js/lib/legacy_functions.js?${g_randTime}`, false);
 	initialControl();
 };
 
@@ -2168,9 +2169,6 @@ const initialControl = async () => {
 	await loadScript2(`${settingRoot}danoni_setting${settingType}.js?${g_randTime}`, false);
 	loadLegacySettingFunc();
 	deleteDiv(divRoot, `lblLoading`);
-
-	// 古い関数の読込 (ファイルがある場合のみ)
-	await loadScript2(`${g_rootPath}../js/lib/legacy_functions.js?${g_randTime}`, false);
 
 	// クエリで譜面番号が指定されていればセット
 	g_stateObj.scoreId = setIntVal(getQueryParamVal(`scoreId`));

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3442,16 +3442,6 @@ const g_skinJsObj = {
     result: [],
 };
 
-/** 過去関数の互換 */
-const convertreplaceNums = () => {
-    console.warn('convertreplaceNums is deprecated. Use convertReplaceNums instead.');
-    convertReplaceNums();
-};
-const MainInit = () => {
-    console.warn('MainInit is deprecated. Use mainInit instead.');
-    mainInit();
-};
-
 /**
  * 従来のカスタム関数をg_customJsObj, g_skinJsObjへ追加
  * - customjsファイルを読み込んだ直後にこの関数を呼び出している

--- a/js/lib/legacy_functions.js
+++ b/js/lib/legacy_functions.js
@@ -99,6 +99,11 @@ let C_CLR_SETTING = `#999900`;
 let C_CLR_RESET = `#009900`;
 let C_CLR_TWEET = `#009999`;
 
+let C_CLR_TEXT = `#ffffff`;
+let C_CLR_TITLE = `#cccccc`;
+let C_CLR_LOADING_BAR = `#eeeeee`;
+let C_CLR_LNK = `#111111`;
+
 const C_CLR_II = `#66ffff`;
 const C_CLR_SHAKIN = `#99ff99`;
 const C_CLR_MATARI = `#ff9966`;

--- a/js/lib/legacy_functions.js
+++ b/js/lib/legacy_functions.js
@@ -1,0 +1,151 @@
+'use strict';
+/**
+ * Dancing☆Onigiri (CW Edition)
+ * 旧関数のラップ関数群
+ *
+ * Source by tickle
+ * Created : 2024/10/29 
+ * Revised : ----/--/--
+ *
+ * https://github.com/cwtickle/danoniplus
+ */
+
+const createSprite = (_parentObjName, _newObjName, x, y, w, h, _options = {}) =>
+    createEmptySprite(document.getElementById(_parentObjName), _newObjName, { x, y, w, h, title: _options?.description });
+
+const createDivLabel = (_id, x, y, w, h, siz, color, _text) =>
+    createDivCss2Label(_id, _text, { x, y, w, h, siz, color });
+
+const createDivCustomLabel = (_id, x, y, w, h, siz, color, _text, _font) =>
+    createDivCss2Label(_id, _text, { x, y, w, h, siz, color, fontFamily: _font });
+
+const createDivCssLabel = (_id, x, y, w, h, siz, _text, _class = g_cssObj.title_base) =>
+    createDivCss2Label(_id, _text, { x, y, w, h, siz }, _class);
+
+const createArrowEffect = (_id, color, x, y, siz, rotate) =>
+    createColorObject2(_id, { x, y, w: siz, h: siz, rotate, background: color });
+
+const createColorObject = (_id, color, x, y, w, h, rotate = ``, styleName = ``) =>
+    createColorObject2(_id, { x, y, w, h, rotate, styleName, background: color });
+
+const createButton = (_obj, _func) => {
+    const div = createCss2Button(_obj.id, _obj.name, _func, {
+        x: _obj.x, y: _obj.y, w: _obj.w, h: _obj.h,
+        siz: _obj?.fontsize, align: _obj?.align, animationName: _obj?.animationName,
+        backgroundColor: _obj?.normalColor,
+    });
+    div.onmouseover = () => div.style.backgroundColor = _obj?.hoverColor;
+    div.onmouseout = () => div.style.backgroundColor = _obj?.normalColor;
+    return div;
+};
+
+const createCssButton = (_obj, _func) =>
+    createCss2Button(_obj.id, _obj.name, _func, {
+        x: _obj?.x, y: _obj?.y, w: _obj?.w, h: _obj?.h,
+        siz: _obj?.fontsize, align: _obj?.align, animationName: _obj?.animationName
+    }, _obj?.class);
+
+const makeSettingLblButton = (_id, _name, _heightPos, _func) =>
+    makeSettingLblCssButton(_id, _name, _heightPos, _func);
+
+const makeDifLblButton = (_id, _name, _heightPos, _func) =>
+    makeDifLblCssButton(_id, _name, _heightPos, _func);
+
+const makeMiniButton = (_id, _directionFlg, _heightPos, _func) =>
+    makeMiniCssButton(_id, _directionFlg, _heightPos, _func);
+
+const makeResultPlayData = (_id, _x, _color, _heightPos, _text, _align) => {
+    const div = makeCssResultPlayData(_id, _x, ``, _heightPos, _text, _align);
+    div.style.color = _color;
+    return div;
+};
+
+const makeResultSymbol = (_id, _x, _color, _heightPos, _text, _align) => {
+    const div = makeCssResultSymbol(_id, _x, ``, _heightPos, _text, _align);
+    div.style.color = _color;
+    return div;
+}
+
+const checkArrayVal = (_checkArray, _type, _minLength) => {
+    const checkFlg = hasArrayList(_data, _minLength);
+    if (_type === C_TYP_FLOAT) {
+        if (isNaN(parseFloat(_checkArray[0]))) {
+            return false;
+        }
+    } else if (_type === C_TYP_NUMBER) {
+        if (isNaN(parseInt(_checkArray[0]))) {
+            return false;
+        }
+    }
+    return checkFlg;
+};
+
+const paddingLeft = (_str, _length, _chr) => String(_str)?.padStart(_length, _chr);
+
+const convertreplaceNums = () => {
+    console.warn('convertreplaceNums is deprecated. Use convertReplaceNums instead.');
+    convertReplaceNums();
+};
+const MainInit = () => {
+    console.warn('MainInit is deprecated. Use mainInit instead.');
+    mainInit();
+};
+
+let C_CLR_DEFAULT = `#333333`;
+let C_CLR_DEFHOVER = `#666666`;
+let C_CLR_BACK = `#000099`;
+let C_CLR_NEXT = `#990000`;
+let C_CLR_SETTING = `#999900`;
+let C_CLR_RESET = `#009900`;
+let C_CLR_TWEET = `#009999`;
+
+const C_CLR_II = `#66ffff`;
+const C_CLR_SHAKIN = `#99ff99`;
+const C_CLR_MATARI = `#ff9966`;
+const C_CLR_UWAN = `#ff9999`;
+const C_CLR_SHOBON = `#ccccff`;
+const C_CLR_KITA = `#ffff99`;
+const C_CLR_IKNAI = `#99ff66`;
+
+let C_CLR_MAXLIFE = `#444400`;
+let C_CLR_CLEARLIFE = `#004444`;
+let C_CLR_DEFAULTLIFE = `#444444`;
+let C_CLR_BACKLIFE = `#222222`;
+
+const C_LBL_TITLESIZE = 32;
+const C_LBL_BTNSIZE = 28;
+const C_LBL_LNKSIZE = 16;
+
+const C_BTN_HEIGHT = 50;
+const C_LNK_HEIGHT = 30;
+const C_LEN_SETLBL_LEFT = 160;
+const C_LEN_SETLBL_WIDTH = 210;
+const C_LEN_DIFSELECTOR_WIDTH = 250;
+const C_LEN_DIFCOVER_WIDTH = 110;
+const C_LEN_SETLBL_HEIGHT = 22;
+const C_SIZ_SETLBL = 17;
+const C_LEN_SETDIFLBL_HEIGHT = 25;
+const C_SIZ_SETDIFLBL = 17;
+const C_LEN_SETMINI_WIDTH = 40;
+const C_SIZ_SETMINI = 18;
+const C_SIZ_DIFSELECTOR = 14;
+const C_SIZ_MAIN = 14;
+const C_SIZ_MUSIC_TITLE = 13;
+
+const C_LEN_JDGCHARA_WIDTH = 200;
+const C_LEN_JDGCHARA_HEIGHT = 20;
+const C_SIZ_JDGCHARA = 20;
+
+const C_LEN_JDGCNTS_WIDTH = 100;
+const C_LEN_JDGCNTS_HEIGHT = 20;
+const C_SIZ_JDGCNTS = 16;
+
+const C_LEN_GRAPH_WIDTH = 286;
+const C_LEN_GRAPH_HEIGHT = 226;
+const C_CLR_SPEEDGRAPH_SPEED = `#cc3333`;
+const C_CLR_SPEEDGRAPH_BOOST = `#999900`;
+const C_CLR_DENSITY_MAX = `#990000cc`;
+const C_CLR_DENSITY_DEFAULT = `#999999cc`;
+const C_LEN_DENSITY_DIVISION = 16;
+
+const C_MAX_ADJUSTMENT = 30;

--- a/js/lib/legacy_functions.js
+++ b/js/lib/legacy_functions.js
@@ -67,13 +67,13 @@ const makeResultSymbol = (_id, _x, _color, _heightPos, _text, _align) => {
 }
 
 const checkArrayVal = (_checkArray, _type, _minLength) => {
-    const checkFlg = hasArrayList(_data, _minLength);
+    const checkFlg = hasArrayList(_checkArray, _minLength);
     if (_type === C_TYP_FLOAT) {
-        if (isNaN(parseFloat(_checkArray[0]))) {
+        if (Number.isNaN(parseFloat(_checkArray[0]))) {
             return false;
         }
     } else if (_type === C_TYP_NUMBER) {
-        if (isNaN(parseInt(_checkArray[0]))) {
+        if (Number.isNaN(parseInt(_checkArray[0]))) {
             return false;
         }
     }

--- a/js/lib/legacy_functions.js
+++ b/js/lib/legacy_functions.js
@@ -73,7 +73,7 @@ const checkArrayVal = (_checkArray, _type, _minLength) => {
             return false;
         }
     } else if (_type === C_TYP_NUMBER) {
-        if (Number.isNaN(parseInt(_checkArray[0]))) {
+        if (Number.isNaN(parseInt(_checkArray[0], 10))) {
             return false;
         }
     }

--- a/js/lib/legacy_functions.js
+++ b/js/lib/legacy_functions.js
@@ -64,7 +64,7 @@ const makeResultSymbol = (_id, _x, _color, _heightPos, _text, _align) => {
     const div = makeCssResultSymbol(_id, _x, ``, _heightPos, _text, _align);
     div.style.color = _color;
     return div;
-}
+};
 
 const checkArrayVal = (_checkArray, _type, _minLength) => {
     const checkFlg = hasArrayList(_checkArray, _minLength);

--- a/js/lib/legacy_functions.js
+++ b/js/lib/legacy_functions.js
@@ -10,24 +10,31 @@
  * https://github.com/cwtickle/danoniplus
  */
 
+/** @deprecated */
 const createSprite = (_parentObjName, _newObjName, x, y, w, h, _options = {}) =>
     createEmptySprite(document.getElementById(_parentObjName), _newObjName, { x, y, w, h, title: _options?.description });
 
+/** @deprecated */
 const createDivLabel = (_id, x, y, w, h, siz, color, _text) =>
     createDivCss2Label(_id, _text, { x, y, w, h, siz, color });
 
+/** @deprecated */
 const createDivCustomLabel = (_id, x, y, w, h, siz, color, _text, _font) =>
     createDivCss2Label(_id, _text, { x, y, w, h, siz, color, fontFamily: _font });
 
+/** @deprecated */
 const createDivCssLabel = (_id, x, y, w, h, siz, _text, _class = g_cssObj.title_base) =>
     createDivCss2Label(_id, _text, { x, y, w, h, siz }, _class);
 
+/** @deprecated */
 const createArrowEffect = (_id, color, x, y, siz, rotate) =>
     createColorObject2(_id, { x, y, w: siz, h: siz, rotate, background: color });
 
+/** @deprecated */
 const createColorObject = (_id, color, x, y, w, h, rotate = ``, styleName = ``) =>
     createColorObject2(_id, { x, y, w, h, rotate, styleName, background: color });
 
+/** @deprecated */
 const createButton = (_obj, _func) => {
     const div = createCss2Button(_obj.id, _obj.name, _func, {
         x: _obj.x, y: _obj.y, w: _obj.w, h: _obj.h,
@@ -38,34 +45,38 @@ const createButton = (_obj, _func) => {
     div.onmouseout = () => div.style.backgroundColor = _obj?.normalColor;
     return div;
 };
-
+/** @deprecated */
 const createCssButton = (_obj, _func) =>
     createCss2Button(_obj.id, _obj.name, _func, {
         x: _obj?.x, y: _obj?.y, w: _obj?.w, h: _obj?.h,
         siz: _obj?.fontsize, align: _obj?.align, animationName: _obj?.animationName
     }, _obj?.class);
 
+/** @deprecated */
 const makeSettingLblButton = (_id, _name, _heightPos, _func) =>
     makeSettingLblCssButton(_id, _name, _heightPos, _func);
 
+/** @deprecated */
 const makeDifLblButton = (_id, _name, _heightPos, _func) =>
     makeDifLblCssButton(_id, _name, _heightPos, _func);
 
+/** @deprecated */
 const makeMiniButton = (_id, _directionFlg, _heightPos, _func) =>
     makeMiniCssButton(_id, _directionFlg, _heightPos, _func);
 
+/** @deprecated */
 const makeResultPlayData = (_id, _x, _color, _heightPos, _text, _align) => {
     const div = makeCssResultPlayData(_id, _x, ``, _heightPos, _text, _align);
     div.style.color = _color;
     return div;
 };
-
+/** @deprecated */
 const makeResultSymbol = (_id, _x, _color, _heightPos, _text, _align) => {
     const div = makeCssResultSymbol(_id, _x, ``, _heightPos, _text, _align);
     div.style.color = _color;
     return div;
 };
-
+/** @deprecated */
 const checkArrayVal = (_checkArray, _type, _minLength) => {
     const checkFlg = hasArrayList(_checkArray, _minLength);
     if (_type === C_TYP_FLOAT) {
@@ -79,78 +90,124 @@ const checkArrayVal = (_checkArray, _type, _minLength) => {
     }
     return checkFlg;
 };
-
+/** @deprecated */
 const paddingLeft = (_str, _length, _chr) => String(_str)?.padStart(_length, _chr);
 
+/** @deprecated */
 const convertreplaceNums = () => {
     console.warn('convertreplaceNums is deprecated. Use convertReplaceNums instead.');
     convertReplaceNums();
 };
+/** @deprecated */
 const MainInit = () => {
     console.warn('MainInit is deprecated. Use mainInit instead.');
     mainInit();
 };
-
+/** @deprecated */
 let C_CLR_DEFAULT = `#333333`;
+/** @deprecated */
 let C_CLR_DEFHOVER = `#666666`;
+/** @deprecated */
 let C_CLR_BACK = `#000099`;
+/** @deprecated */
 let C_CLR_NEXT = `#990000`;
+/** @deprecated */
 let C_CLR_SETTING = `#999900`;
+/** @deprecated */
 let C_CLR_RESET = `#009900`;
+/** @deprecated */
 let C_CLR_TWEET = `#009999`;
-
+/** @deprecated */
 let C_CLR_TEXT = `#ffffff`;
+/** @deprecated */
 let C_CLR_TITLE = `#cccccc`;
+/** @deprecated */
 let C_CLR_LOADING_BAR = `#eeeeee`;
+/** @deprecated */
 let C_CLR_LNK = `#111111`;
-
+/** @deprecated */
 const C_CLR_II = `#66ffff`;
+/** @deprecated */
 const C_CLR_SHAKIN = `#99ff99`;
+/** @deprecated */
 const C_CLR_MATARI = `#ff9966`;
+/** @deprecated */
 const C_CLR_UWAN = `#ff9999`;
+/** @deprecated */
 const C_CLR_SHOBON = `#ccccff`;
+/** @deprecated */
 const C_CLR_KITA = `#ffff99`;
+/** @deprecated */
 const C_CLR_IKNAI = `#99ff66`;
-
+/** @deprecated */
 let C_CLR_MAXLIFE = `#444400`;
+/** @deprecated */
 let C_CLR_CLEARLIFE = `#004444`;
+/** @deprecated */
 let C_CLR_DEFAULTLIFE = `#444444`;
+/** @deprecated */
 let C_CLR_BACKLIFE = `#222222`;
-
+/** @deprecated */
 const C_LBL_TITLESIZE = 32;
+/** @deprecated */
 const C_LBL_BTNSIZE = 28;
+/** @deprecated */
 const C_LBL_LNKSIZE = 16;
-
+/** @deprecated */
 const C_BTN_HEIGHT = 50;
+/** @deprecated */
 const C_LNK_HEIGHT = 30;
+/** @deprecated */
 const C_LEN_SETLBL_LEFT = 160;
+/** @deprecated */
 const C_LEN_SETLBL_WIDTH = 210;
+/** @deprecated */
 const C_LEN_DIFSELECTOR_WIDTH = 250;
+/** @deprecated */
 const C_LEN_DIFCOVER_WIDTH = 110;
+/** @deprecated */
 const C_LEN_SETLBL_HEIGHT = 22;
+/** @deprecated */
 const C_SIZ_SETLBL = 17;
+/** @deprecated */
 const C_LEN_SETDIFLBL_HEIGHT = 25;
+/** @deprecated */
 const C_SIZ_SETDIFLBL = 17;
+/** @deprecated */
 const C_LEN_SETMINI_WIDTH = 40;
+/** @deprecated */
 const C_SIZ_SETMINI = 18;
+/** @deprecated */
 const C_SIZ_DIFSELECTOR = 14;
+/** @deprecated */
 const C_SIZ_MAIN = 14;
+/** @deprecated */
 const C_SIZ_MUSIC_TITLE = 13;
-
+/** @deprecated */
 const C_LEN_JDGCHARA_WIDTH = 200;
+/** @deprecated */
 const C_LEN_JDGCHARA_HEIGHT = 20;
+/** @deprecated */
 const C_SIZ_JDGCHARA = 20;
-
+/** @deprecated */
 const C_LEN_JDGCNTS_WIDTH = 100;
+/** @deprecated */
 const C_LEN_JDGCNTS_HEIGHT = 20;
+/** @deprecated */
 const C_SIZ_JDGCNTS = 16;
-
+/** @deprecated */
 const C_LEN_GRAPH_WIDTH = 286;
+/** @deprecated */
 const C_LEN_GRAPH_HEIGHT = 226;
+/** @deprecated */
 const C_CLR_SPEEDGRAPH_SPEED = `#cc3333`;
+/** @deprecated */
 const C_CLR_SPEEDGRAPH_BOOST = `#999900`;
+/** @deprecated */
 const C_CLR_DENSITY_MAX = `#990000cc`;
+/** @deprecated */
 const C_CLR_DENSITY_DEFAULT = `#999999cc`;
+/** @deprecated */
 const C_LEN_DENSITY_DIVISION = 16;
-
+/** @deprecated */
 const C_MAX_ADJUSTMENT = 30;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
### 1. 古い関数・定数を条件付きで復活
- 以前、「danoni_legacy_function.js」で退避していた古い関数及び定数群を、
「legacy_functions.js」として復活させました。
- 古い関数を新しい関数でラップするようにコードを変えています。
- 読込必須ではないので、これまで通りファイルを置かなければ読み込まれることはありません。

### 復活対象外の関数・定数
- 使用頻度の低いもの、もしくは今の仕組み上使えない関数は除外しています。
対象と理由は次の通りです。

#### createLabel
- Canvas直書きであることと、他の機能により機能不全となる可能性が高いため。
現関数で置き換えができないことも理由の一つです。

#### getStrLength
- 代替関数が存在しないため。元々はフォントサイズに合わせた横幅を調べるのに使っていましたが、
現在は`getStrWidth`により横幅がわかるため不要となりました。
なお、`getStrWidth`ではフォントとサイズの情報が追加引数として必要となるため、
`getStrLength`では情報が足りません。

#### loadScript / importCssFile / loadMultipleFiles
- いずれもコールバック関数を引数に持つ関数です。
- 後継としてloadScript2 / importCssFile2 / loadMultipleFiles2 がありそちらの方が便利なのと、
意図的にファイルを追加読込することが考えにくいため、対象外としました。

#### C_CLR_DEFAULTA～E, C_CLR_SFSF
-  利用頻度が限られるため対象外としました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. ラベル・ボタン関数やその周辺の定数は利用頻度が高く、置き換えに時間を要するため。
新関数でラップすることでメンテナンス上の課題がある程度解消できたため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
- 旧関数は互換のために残しているものです。
関数の拡張はしませんので、基本は現行の関数を使ってください。
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new JavaScript file for legacy functions to enhance the graphical interface.
	- Added URI decoding functionality and support for custom CSS properties in the game header.
	- Implemented automatic resizing of the game window based on layout.
	- Enabled custom font settings and result screen customization for song title and artist information.
	- Enhanced organization of custom JavaScript functions for better usability.

- **Bug Fixes**
	- Deprecated certain functions with warnings to guide users towards updated alternatives, ensuring a smoother transition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->