### PR TITLE
fix: [0842] フェードインで矢印が足りない場合でもクリアランプの点灯条件を通過してしまう問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -11876,7 +11876,7 @@ const resultInit = () => {
 			if (![``, `failed`, `cleared`].includes(g_resultObj.spState)) {
 				g_localStorage.highscores[scoreName][g_resultObj.spState] = true;
 			}
-			if (!g_gameOverFlg && g_finishFlg && g_workObj.requiredAccuracy !== `----`) {
+			if (!g_gameOverFlg && g_finishFlg && g_workObj.requiredAccuracy !== `----` && playingArrows === g_fullArrows) {
 				if (g_localStorage.highscores[scoreName].clearLamps === undefined) {
 					g_localStorage.highscores[scoreName].clearLamps = [];
 				}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
### 1. フェードインで矢印が足りない場合でもクリアランプの点灯条件を通過してしまう問題を修正
- クリアランプ条件に総矢印数を判定させているという条件が抜けており、
フェードインでも対象のif文を通過するようになっていました。
- これにより、未プレイでフェードイン開始して最後まで行った場合に
ハイスコアの条件は満たしてもクリアランプの条件は満たすという状態が発生します。
ただ、クリアランプを点けるときにはハイスコアオブジェクトが定義されていることを前提としていたためリファレンスエラーが発生していました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. クリアランプ条件の間違いにより、意図しないランプがついてしまうのを防ぐため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
