### PR TITLE
feat: [0843] ライフ最大値を簡略変数化するよう変更

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -715,6 +715,7 @@ const g_escapeStr = {
         [`arrow[]`, `sumData(g_detailObj.arrowCnt[{0}])`],
         [`frz[]`, `sumData(g_detailObj.frzCnt[{0}])`],
         [`all[]`, `sumData(g_detailObj.arrowCnt[{0}]) + sumData(g_detailObj.frzCnt[{0}])`],
+        [`maxlife[]`, `g_headerObj.maxLifeVal`],
     ],
 };
 

--- a/js/template/danoni_setting.js
+++ b/js/template/danoni_setting.js
@@ -98,7 +98,7 @@ g_presetObj.gaugeCustom = {
 	SuddenDeath: {
 		Border: `x`,
 		Recovery: 0,
-		Damage: setVal(g_rootObj.maxLifeVal, C_VAL_MAXLIFE, C_TYP_FLOAT),
+		Damage: `{maxlife[]}`,
 		Init: 100,
 	},
 	Practice: {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. ライフ最大値を簡略変数化するよう変更
- ゲージの設定で使用する簡略変数として`maxlife[]`を追加しました。
ゲージ設定の中に`{maxlife[]}`として使うことで、
`g_headerObj.maxLifeVal`(ライフ最大値)に置き換えます。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. よく使う変数だが簡易的に使う手段が無く、
SuddenDeathの設定でもg_rootObjを参照する方法になっていたため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new escape pattern for gauge parameters, allowing dynamic referencing of maximum life values.
	- Updated the SuddenDeath gauge configuration to utilize the new maximum life reference.

- **Bug Fixes**
	- Improved gauge-related calculations by ensuring they correctly reference the maximum life value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->