### PR TITLE
fix: [0845] 旧関数のボタン作成処理の引数間違いを修正

### DIFF
--- a/js/lib/legacy_functions.js
+++ b/js/lib/legacy_functions.js
@@ -37,7 +37,7 @@ const createColorObject = (_id, color, x, y, w, h, rotate = ``, styleName = ``) 
 /** @deprecated */
 const createButton = (_obj, _func) => {
     const div = createCss2Button(_obj.id, _obj.name, _func, {
-        x: _obj.x, y: _obj.y, w: _obj.w, h: _obj.h,
+        x: _obj.x, y: _obj.y, w: _obj.width, h: _obj.height,
         siz: _obj?.fontsize, align: _obj?.align, animationName: _obj?.animationName,
         backgroundColor: _obj?.normalColor,
     });
@@ -48,7 +48,7 @@ const createButton = (_obj, _func) => {
 /** @deprecated */
 const createCssButton = (_obj, _func) =>
     createCss2Button(_obj.id, _obj.name, _func, {
-        x: _obj?.x, y: _obj?.y, w: _obj?.w, h: _obj?.h,
+        x: _obj?.x, y: _obj?.y, w: _obj?.width, h: _obj?.height,
         siz: _obj?.fontsize, align: _obj?.align, animationName: _obj?.animationName
     }, _obj?.class);
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 旧関数のボタン作成処理の引数間違いを修正
- createButton / createCssButton関数の引数（幅、高さ）について
_obj.width, _obj.heightを渡さなければいけないところ、_obj.w, _obj.hを渡していたため
ボタンの横幅、高さが想定と違うようになっていました。


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 上述の通りです。旧関数の修正のため、danoni_main.jsの変更はありません。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
- ver37.8.0に対して修正が必要です。
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Marked a series of legacy functions and constants as deprecated, indicating a transition to newer implementations.
	- Updated parameter handling for `createButton` and `createCssButton` functions to improve clarity.

- **Bug Fixes**
	- No specific bug fixes were noted, but the deprecation may prevent future issues related to outdated functions.

- **Documentation**
	- Deprecated annotations added to guide developers on transitioning away from legacy functions and constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->