### PR TITLE
fix: [0846] 色変化（ncolor_data）で矢印種類を省略したときに色変化対象が正しく反映されない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8264,7 +8264,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 				const pos = tmpColorData[1]?.indexOf(`:`);
 				const patternStr = pos > 0 ? [trimStr(tmpColorData[1].substring(0, pos)), trimStr(tmpColorData[1].substring(pos + 1))]
 					: [tmpColorData[1]];
-				const patterns = replaceStr(trimStr(patternStr[1]), g_escapeStr.colorPatternName)?.split(`/`) || [`Arrow`];
+				const patterns = replaceStr(trimStr(patternStr[1] || `Arrow`), g_escapeStr.colorPatternName).split(`/`);
 
 				// 矢印番号の組み立て
 				const colorVals = [];

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -516,6 +516,9 @@ const fuzzyListMatching = (_str, _headerList, _footerList) =>
  * @returns {string} 置換後文字列
  */
 const replaceStr = (_str, _pairs) => {
+	if (_str === undefined) {
+		return _str;
+	}
 	let tmpStr = _str;
 	_pairs.forEach(pair => tmpStr = String(tmpStr)?.split(pair[0]).join(pair[1]));
 	return tmpStr;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 色変化（ncolor_data）で矢印種類を省略したときに色変化対象が正しく反映されない問題を修正
- 以前、PR #1714 で修正して直しましたが、同じ条件で問題が発生したため再度修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. replaceStr関数を PR #1717 で修正しましたが、文字列をStringに変換していたためundefinedが文字列化され想定外の動きになっていました。undefined時はそのままの値を戻すよう変更しています。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
