### PR TITLE
feat: [0847] リモート参照時のみ、カレントパス指定なしで作品URLの相対パスとしてファイル参照するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2809,19 +2809,24 @@ const preheaderConvert = _dosObj => {
 			obj.jsData.push([_type === `skin` ? `danoni_skin_${jsFile}.js` : jsFile, jsDir]);
 		});
 
+	const convLocalPath = (_file, _type) =>
+		g_remoteFlg && !_file.includes(`(..)`) ? `(..)../${_type}/${_file}` : _file;
+
 	// 外部スキンファイルの指定
 	const tmpSkinType = _dosObj.skinType ?? g_presetObj.skinType ?? `default`;
 	const tmpSkinTypes = tmpSkinType.split(`,`);
 	obj.defaultSkinFlg = tmpSkinTypes.includes(`default`) && setBoolVal(_dosObj.bgCanvasUse ?? g_presetObj.bgCanvasUse, true);
-	setJsFiles(tmpSkinTypes, C_DIR_SKIN, `skin`);
+	setJsFiles(tmpSkinTypes.map(file => convLocalPath(file, `skin`)), C_DIR_SKIN, `skin`);
 
 	// 外部jsファイルの指定
 	const tmpCustomjs = getHeader(_dosObj, ...getHname(`customJs`)) ?? g_presetObj.customJs ?? C_JSF_CUSTOM;
-	setJsFiles(tmpCustomjs.replaceAll(`*`, g_presetObj.customJs).split(`,`), C_DIR_JS);
+	setJsFiles(tmpCustomjs.replaceAll(`*`, g_presetObj.customJs).split(`,`)
+		.map(file => convLocalPath(file, `js`)), C_DIR_JS);
 
 	// 外部cssファイルの指定
 	const tmpCustomcss = getHeader(_dosObj, ...getHname(`customCss`)) ?? g_presetObj.customCss ?? ``;
-	setJsFiles(tmpCustomcss.replaceAll(`*`, g_presetObj.customCss).split(`,`), C_DIR_CSS);
+	setJsFiles(tmpCustomcss.replaceAll(`*`, g_presetObj.customCss).split(`,`)
+		.map(file => convLocalPath(file, `css`)), C_DIR_CSS);
 
 	// デフォルト曲名表示、背景、Ready表示の利用有無
 	g_titleLists.init.forEach(objName => {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2816,7 +2816,7 @@ const preheaderConvert = _dosObj => {
 	const tmpSkinType = _dosObj.skinType ?? g_presetObj.skinType ?? `default`;
 	const tmpSkinTypes = tmpSkinType.split(`,`);
 	obj.defaultSkinFlg = tmpSkinTypes.includes(`default`) && setBoolVal(_dosObj.bgCanvasUse ?? g_presetObj.bgCanvasUse, true);
-	setJsFiles(tmpSkinTypes.map(file => convLocalPath(file, `skin`)), C_DIR_SKIN, `skin`);
+	setJsFiles(tmpSkinTypes, C_DIR_SKIN, `skin`);
 
 	// 外部jsファイルの指定
 	const tmpCustomjs = getHeader(_dosObj, ...getHname(`customJs`)) ?? g_presetObj.customJs ?? C_JSF_CUSTOM;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. リモート参照時のみ、カレントパス指定なしで作品URLの相対パスとしてファイル参照するよう変更
- cwtickle.github.ioのjsファイルを読み込んでいるとき、カスタムJS/カスタムCSSについてカレントパス指定`(..)`なしであたかもjs/cssフォルダがあるかのような動きになるように変更しました。
（musicフォルダについては、元から上記の設定になっています）

### 例
```html
<script src="https://cwtickle.github.io/danoniplus/js/danoni_main.js" charset="UTF-8">
```
- 上記のようにjsファイルをcwtickle.github.ioのものにしていたとき：
```
|customjs=custom123.js|
```
- 上記記述は次のように書き換えられます。
なお、元からカレントパス指定`(..)`が存在する場合は変更しません。
```
|customjs=(..)../js/custom123.js|
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. cwtickle.github.ioのjsファイルを参照している場合で、cwtickle.github.io上にいるカスタムjsやカスタムcssを使用することは考えにくいため。また、わざわざカレントパス指定が必要なのが煩わしいため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
- cwtickle.github.ioのjsファイルを参照している場合にのみ適用される内容です。
それ以外の場合は何も変更しません。