### PR TITLE
feat: [0848] MotionオプションにFountainを追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -16,13 +16,13 @@ let g_localVersion = ``;
 let g_localVersion2 = ``;
 
 // ショートカット用文字列(↓の文字列を検索することで対象箇所へジャンプできます)
-//  共通:water　初期化:peach　タイトル:melon  設定:lime　ディスプレイ:lemon  キーコンフィグ:orange  譜面読込:strawberry  メイン:banana  結果:grape
+//  共通:water 初期化:peach タイトル:melon 設定:lime ディスプレイ:lemon キーコンフィグ:orange 譜面読込:strawberry メイン:banana 結果:grape
 //  シーンジャンプ:Scene
 
 /**
  * ▽ 画面の構成
  *  [タイトル]-[設定]-[ディスプレイ]-[キーコンフィグ]-[譜面読込]-[メイン]-[リザルト]
- *  ⇒　各画面に Init がついたものが画面の基本構成(ルート)を表す。
+ *  ⇒ 各画面に Init がついたものが画面の基本構成(ルート)を表す。
  * 
  * ▽ スプライトの親子関係
  *  基本的にdiv要素で管理。最下層を[divRoot]とし、createEmptySprite()でdiv子要素を作成。
@@ -44,7 +44,7 @@ const g_remoteFlg = g_rootPath.match(`^https://cwtickle.github.io/danoniplus/`) 
 const g_randTime = Date.now();
 const g_isFile = location.href.match(/^file/);
 const g_isLocal = location.href.match(/^file/) || location.href.indexOf(`localhost`) !== -1;
-const isLocalMusicFile = _scoreId => g_isFile && !listMatching(getMusicUrl(g_stateObj.scoreId), [`.js`, `.txt`], { suffix: `$` });
+const isLocalMusicFile = _scoreId => g_isFile && !listMatching(getMusicUrl(_scoreId), [`.js`, `.txt`], { suffix: `$` });
 
 window.onload = async () => {
 	g_loadObj.main = true;
@@ -1009,7 +1009,7 @@ const makeColorGradation = (_colorStr, { _defaultColorgrd = g_headerObj.defaultC
 	}
 
 	// 矢印の塗りつぶしの場合：透明度を50%にする
-	// 背景矢印の場合　　　　：透明度を25%にする
+	// 背景矢印の場合       ：透明度を25%にする
 	const alphaVal = (_shadowFlg && _objType !== `frz`) ? `80` : (_objType === `titleArrow` ? `40` : ``);
 
 	let convertColorStr = ``;
@@ -5455,7 +5455,7 @@ const setDifficulty = (_initFlg) => {
 
 		if (!g_stateObj.extraKeyFlg) {
 
-			// キー別のローカルストレージの初期設定　※特殊キーは除く
+			// キー別のローカルストレージの初期設定 ※特殊キーは除く
 			g_localKeyStorage = hasKeyStorage ? JSON.parse(hasKeyStorage) : {
 				reverse: C_FLG_OFF,
 				keyCtrl: [[]],
@@ -5809,7 +5809,7 @@ const createOptionWindow = _sprite => {
 	// 縦位置: 7.5
 	spriteList.gauge.appendChild(createLblSetting(`Gauge`));
 
-	// ゲージ設定詳細　縦位置: ゲージ設定+1
+	// ゲージ設定詳細 縦位置: ゲージ設定+1
 	spriteList.gauge.appendChild(createDivCss2Label(`lblGauge2`, ``, g_lblPosObj.lblGauge2));
 
 	if (g_headerObj.gaugeUse) {
@@ -8287,7 +8287,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 							}
 						}
 					} else if (val.indexOf(`...`) > 0) {
-						// 範囲指定表記の補完　例. 0...3 -> 0/1/2/3
+						// 範囲指定表記の補完 例. 0...3 -> 0/1/2/3
 						const [valMin, valMax] = [val.split(`...`)[0], val.split(`...`)[1]].map(val => setIntVal(val));
 						for (let k = valMin; k <= valMax; k++) {
 							colorVals.push(setIntVal(k));

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8800,6 +8800,25 @@ const getBrakeTrace = _frms => {
 };
 
 /**
+ * Fountain用の適用関数
+ * - 反対側から出現し、画面中央付近で折り返す。タイミングは初期速度により変化。
+ * @param {number[]} _frms 
+ * @param {number} _spd
+ * @returns {number[]}
+ */
+const getFountainTrace = (_frms, _spd) => {
+	const minj = C_MOTION_STD_POS + 1;
+	const maxj = C_MOTION_STD_POS + Math.ceil(400 / _spd) + 1;
+	const diff = 50 / (maxj - minj);
+	const factor = 0.5 + _spd / 40;
+
+	for (let j = minj; j < maxj; j++) {
+		_frms[j] = Math.floor((10 - (j - C_MOTION_STD_POS - 1) * diff) * factor);
+	}
+	return _frms;
+}
+
+/**
  * 最初のフレームで出現する矢印が、ステップゾーンに到達するまでのフレーム数を取得
  * @param {number} _startFrame 
  * @param {object} _speedOnFrame 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -952,7 +952,7 @@ const g_settings = {
     speedNum: 0,
     speedTerms: [20, 5, 1],
 
-    motions: [C_FLG_OFF, `Boost`, `Hi-Boost`, `Brake`],
+    motions: [C_FLG_OFF, `Boost`, `Hi-Boost`, `Brake`, `Fountain`],
     motionNum: 0,
 
     reverses: [C_FLG_OFF, C_FLG_ON],
@@ -1073,6 +1073,7 @@ const g_motionFunc = {
     'Boost': _frms => getBoostTrace(_frms, 3),
     'Hi-Boost': _frms => getBoostTrace(_frms, g_stateObj.speed * 2),
     'Brake': _frms => getBrakeTrace(_frms),
+    'Fountain': _frms => getFountainTrace(_frms, g_stateObj.speed * 2),
 };
 
 const g_keycons = {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
### 1. MotionオプションにFountainを追加
- 矢印・フリーズアローが流れる反対側から出現し、画面中央で折り返してステップゾーンへ向かうモーションオプション（Fountain）を追加しました。
- 速度により矢印・フリーズアローが表示するフレーム数が異なるため、折り返しするフレームを動的に買えるようにしています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 矢印・フリーズアローモーションでは実現しにくいオプションとしてプレイの選択肢を増やすため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
- 速度変化による影響は少ないと考えています。
- 数式については改良の余地があるかもしれません。
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
