### PR TITLE
feat: [0849] MotionオプションにCompressを追加

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -952,7 +952,7 @@ const g_settings = {
     speedNum: 0,
     speedTerms: [20, 5, 1],
 
-    motions: [C_FLG_OFF, `Boost`, `Hi-Boost`, `Brake`, `Fountain`],
+    motions: [C_FLG_OFF, `Boost`, `Hi-Boost`, `Brake`, `Compress`, `Fountain`],
     motionNum: 0,
 
     reverses: [C_FLG_OFF, C_FLG_ON],
@@ -1073,6 +1073,7 @@ const g_motionFunc = {
     'Boost': _frms => getBoostTrace(_frms, 3),
     'Hi-Boost': _frms => getBoostTrace(_frms, g_stateObj.speed * 2),
     'Brake': _frms => getBrakeTrace(_frms),
+    'Compress': _frms => getBoostTrace(_frms, g_stateObj.speed * 5 / 8, -1),
     'Fountain': _frms => getFountainTrace(_frms, g_stateObj.speed * 2),
 };
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
### 1. MotionオプションにCompressを追加
- 矢印が元の速度から徐々に減少しながらステップゾーンへ近づくオプション（Compress）を追加しました。
- 従来のBrakeは元の速度から加速した状態で進み、最終的に元の速度に戻るため意味が異なります。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. プレイの選択肢を増やすため。
以前、PRで出したことがありますが速度変化で0.5倍がかかると逆走する問題がありました。
逆走の幅を緩和したので、0.375倍までは逆走しないようになっています。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
- Fountainなど他のモーションと同様、矢印の出現時間は変わらないため途中から出現します。
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
