### PR TITLE
fix: [0850] Fountainで全体変速が1倍未満、個別加速が1倍以上のときにモーションが見づらくなる問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8809,10 +8809,11 @@ const getBrakeTrace = _frms => {
 const getFountainTrace = (_frms, _spd) => {
 	const minj = C_MOTION_STD_POS + 1;
 	const maxj = C_MOTION_STD_POS + Math.ceil(400 / _spd) + 1;
+	const maxMotionFrm = Math.max(maxj, C_MOTION_STD_POS + 200);
 	const diff = 50 / (maxj - minj);
 	const factor = 0.5 + _spd / 40;
 
-	for (let j = minj; j < maxj; j++) {
+	for (let j = minj; j < maxMotionFrm; j++) {
 		_frms[j] = Math.floor((10 - (j - C_MOTION_STD_POS - 1) * diff) * factor);
 	}
 	return _frms;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. Fountainオプション適用時、全体変速が1倍未満・個別加速が1倍以上のときにモーションが見づらくなる問題を修正
- Fountainオプション適用時、全体変速が1倍未満・個別加速が1倍以上が掛かっているとき、
モーションの適用範囲が全体変速１倍を基準としているため個別加速で矢印表示範囲が引き延ばされると
余計な部分が見えてしまい、視認性が悪くなることがありました。これを改善しています。
- 具体的には、200フレーム分のモーションを固定で設定するように変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 上述の通りです。PR #1729 関連。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
