### PR TITLE
fix: [0851] 加算するモーションフレーム数の計算方法の誤りを修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8961,7 +8961,7 @@ const pushArrows = (_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 				g_workObj.initY[tmpFrame] = g_workObj.initY[frmPrev];
 				g_workObj.arrivalFrame[tmpFrame] = g_workObj.arrivalFrame[frmPrev];
 				g_workObj.motionFrame[tmpFrame] = g_workObj.motionFrame[frmPrev];
-				g_workObj.initBoostY[tmpFrame] = calcInitBoostY(frmPrev);
+				g_workObj.initBoostY[tmpFrame] = calcInitBoostY(tmpFrame);
 
 			} else {
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8809,7 +8809,7 @@ const getBrakeTrace = _frms => {
 const getFountainTrace = (_frms, _spd) => {
 	const minj = C_MOTION_STD_POS + 1;
 	const maxj = C_MOTION_STD_POS + Math.ceil(400 / _spd) + 1;
-	const maxMotionFrm = Math.max(maxj, C_MOTION_STD_POS + 200);
+	const maxMotionFrm = Math.max(maxj, C_MOTION_STD_POS + g_sHeight / 2);
 	const diff = 50 / (maxj - minj);
 	const factor = 0.5 + _spd / 40;
 
@@ -8931,7 +8931,7 @@ const pushArrows = (_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 		g_workObj.initY[frmPrev] = tmpObj.startY;
 		g_workObj.arrivalFrame[frmPrev] = tmpObj.arrivalFrm;
 		g_workObj.motionFrame[frmPrev] = tmpObj.motionFrm;
-		g_workObj.initBoostY[frmPrev] = sumData(g_workObj.motionOnFrames.filter((val, j) => j < g_workObj.motionFrame[frmPrev]));
+		g_workObj.initBoostY[frmPrev] = sumData(g_workObj.motionOnFrames.filter((val, j) => j <= g_workObj.motionFrame[frmPrev]));
 
 		if (_frzFlg) {
 			g_workObj[`mk${camelHeader}Length`][_j] = [];
@@ -8960,7 +8960,7 @@ const pushArrows = (_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 				g_workObj.initY[tmpFrame] = g_workObj.initY[frmPrev];
 				g_workObj.arrivalFrame[tmpFrame] = g_workObj.arrivalFrame[frmPrev];
 				g_workObj.motionFrame[tmpFrame] = g_workObj.motionFrame[frmPrev];
-				g_workObj.initBoostY[tmpFrame] = sumData(g_workObj.motionOnFrames.filter((val, j) => j < g_workObj.motionFrame[frmPrev]));
+				g_workObj.initBoostY[tmpFrame] = sumData(g_workObj.motionOnFrames.filter((val, j) => j <= g_workObj.motionFrame[frmPrev]));
 
 			} else {
 
@@ -8977,7 +8977,7 @@ const pushArrows = (_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 				g_workObj.initY[frmPrev] = tmpObj.startY;
 				g_workObj.arrivalFrame[frmPrev] = tmpObj.arrivalFrm;
 				g_workObj.motionFrame[frmPrev] = tmpObj.motionFrm;
-				g_workObj.initBoostY[frmPrev] = sumData(g_workObj.motionOnFrames.filter((val, j) => j < g_workObj.motionFrame[frmPrev]));
+				g_workObj.initBoostY[frmPrev] = sumData(g_workObj.motionOnFrames.filter((val, j) => j <= g_workObj.motionFrame[frmPrev]));
 			}
 
 			// 出現タイミングを保存

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8910,6 +8910,7 @@ const pushArrows = (_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 			return;
 		}
 
+		const calcInitBoostY = _frm => sumData(g_workObj.motionOnFrames.filter((val, j) => j <= g_workObj.motionFrame[_frm]));
 		const camelHeader = toCapitalize(_header);
 		const setcnt = (_frzFlg ? 2 : 1);
 		if (_frzFlg && _data.length % 2 !== 0) {
@@ -8931,7 +8932,7 @@ const pushArrows = (_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 		g_workObj.initY[frmPrev] = tmpObj.startY;
 		g_workObj.arrivalFrame[frmPrev] = tmpObj.arrivalFrm;
 		g_workObj.motionFrame[frmPrev] = tmpObj.motionFrm;
-		g_workObj.initBoostY[frmPrev] = sumData(g_workObj.motionOnFrames.filter((val, j) => j <= g_workObj.motionFrame[frmPrev]));
+		g_workObj.initBoostY[frmPrev] = calcInitBoostY(frmPrev);
 
 		if (_frzFlg) {
 			g_workObj[`mk${camelHeader}Length`][_j] = [];
@@ -8960,7 +8961,7 @@ const pushArrows = (_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 				g_workObj.initY[tmpFrame] = g_workObj.initY[frmPrev];
 				g_workObj.arrivalFrame[tmpFrame] = g_workObj.arrivalFrame[frmPrev];
 				g_workObj.motionFrame[tmpFrame] = g_workObj.motionFrame[frmPrev];
-				g_workObj.initBoostY[tmpFrame] = sumData(g_workObj.motionOnFrames.filter((val, j) => j <= g_workObj.motionFrame[frmPrev]));
+				g_workObj.initBoostY[tmpFrame] = calcInitBoostY(frmPrev);
 
 			} else {
 
@@ -8977,7 +8978,7 @@ const pushArrows = (_dataObj, _speedOnFrame, _motionOnFrame, _firstArrivalFrame)
 				g_workObj.initY[frmPrev] = tmpObj.startY;
 				g_workObj.arrivalFrame[frmPrev] = tmpObj.arrivalFrm;
 				g_workObj.motionFrame[frmPrev] = tmpObj.motionFrm;
-				g_workObj.initBoostY[frmPrev] = sumData(g_workObj.motionOnFrames.filter((val, j) => j <= g_workObj.motionFrame[frmPrev]));
+				g_workObj.initBoostY[frmPrev] = calcInitBoostY(frmPrev);
 			}
 
 			// 出現タイミングを保存


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
### 1. 加算するモーションフレーム数の計算方法の誤りを修正

- 加算するモーションフレーム数の計算方法に誤りがあり、1フレーム分が反映されていませんでした。
- Boost、Brakeについてはモーション適用範囲が狭かったため影響はほぼありませんでしたが、
最近追加したFountainについては直近の変更 #1732 により、出現部分ギリギリまでフレーム加算があるため問題が表面化しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. PR #1732 の考慮漏れです。
過去バージョンにFountainオプションは存在しないため影響はないと思いますが、
同じ処理を使っているため一応修正は必要と考えます。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
