### PR TITLE
feat: [0852] Scatterオプションのシャッフル方法を一部見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8065,25 +8065,21 @@ const applySRandom = (_keyNum, _shuffleGroup, _arrowHeader, _frzHeader) => {
 				sameFlg = false;
 			}
 
+			const getFreeSpaces = ({ scatterFrame = 0, frzFlg = false, prevFlg = false } = {}) =>
+				_group.filter(_key =>
+					// 通常矢印と重ならない
+					tmpArrowData[_key].find(_other => _arrow >= _other - scatterFrame && _arrow <= _other + scatterFrame) === undefined
+					// フリーズと重ならない
+					&& (!frzFlg || (frzFlg && tmpFrzData[_key].find(_freeze => _arrow >= _freeze.begin - scatterFrame && _arrow <= _freeze.end + scatterFrame) === undefined))
+					// 直前の矢印と重ならない
+					&& (!prevFlg || (prevFlg && tmpArrowData[_key].find(_other => prev2Num === _other) === undefined))
+				);
+
 			// 置ける場所を検索
-			const freeSpacesFlat = _group.filter(_key =>
-				// フリーズと重ならない (前後10フレーム)
-				tmpFrzData[_key].find(_freeze => _arrow >= _freeze.begin - scatterFrame && _arrow <= _freeze.end + scatterFrame) === undefined
-				// 通常矢印と重ならない (前後10フレーム)
-				&& tmpArrowData[_key].find(_other => _arrow >= _other - scatterFrame && _arrow <= _other + scatterFrame) === undefined
-				// 直前の矢印と重ならない
-				&& tmpArrowData[_key].find(_other => prev2Num === _other) === undefined
-			);
-			const freeSpaces = _group.filter(_key =>
-				// フリーズと重ならない
-				tmpFrzData[_key].find(_freeze => _arrow >= _freeze.begin && _arrow <= _freeze.end) === undefined
-				// 通常矢印と重ならない
-				&& tmpArrowData[_key].find(_other => _arrow === _other) === undefined
-			);
-			const freeSpacesAlt = _group.filter(_key =>
-				// 通常矢印と重ならない
-				tmpArrowData[_key].find(_other => _arrow === _other) === undefined
-			);
+			const freeSpacesFlat = getFreeSpaces({ scatterFrame, frzFlg: true, prevFlg: true });
+			const freeSpaces = getFreeSpaces({ frzFlg: true });
+			const freeSpacesAlt = getFreeSpaces();
+
 			// ランダムに配置
 			let currentFreeSpaces = freeSpaces.length > 0 ? freeSpaces : freeSpacesAlt;
 			if (g_stateObj.shuffle.startsWith(`Scatter`)) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8070,9 +8070,9 @@ const applySRandom = (_keyNum, _shuffleGroup, _arrowHeader, _frzHeader) => {
 					// 通常矢印と重ならない
 					tmpArrowData[_key].find(_other => _arrow >= _other - scatterFrame && _arrow <= _other + scatterFrame) === undefined
 					// フリーズと重ならない
-					&& (!frzFlg || (frzFlg && tmpFrzData[_key].find(_freeze => _arrow >= _freeze.begin - scatterFrame && _arrow <= _freeze.end + scatterFrame) === undefined))
+					&& (!frzFlg || tmpFrzData[_key].find(_freeze => _arrow >= _freeze.begin - scatterFrame && _arrow <= _freeze.end + scatterFrame) === undefined)
 					// 直前の矢印と重ならない
-					&& (!prevFlg || (prevFlg && tmpArrowData[_key].find(_other => prev2Num === _other) === undefined))
+					&& (!prevFlg || tmpArrowData[_key].find(_other => prev2Num === _other) === undefined)
 				);
 
 			// 置ける場所を検索

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8068,14 +8068,13 @@ const applySRandom = (_keyNum, _shuffleGroup, _arrowHeader, _frzHeader) => {
 			}
 
 			// 置ける場所を検索
-			const scatterFrame2 = scatterFrame * (sameFlg ? 0 : 1);
 			const freeSpacesFlat = _group.filter(_key =>
 				// フリーズと重ならない (前後10フレーム)
-				tmpFrzData[_key].find(_freeze => _arrow >= _freeze.begin - scatterFrame2 && _arrow <= _freeze.end + scatterFrame2) === undefined
+				tmpFrzData[_key].find(_freeze => _arrow >= _freeze.begin - scatterFrame && _arrow <= _freeze.end + scatterFrame) === undefined
 				// 通常矢印と重ならない (前後10フレーム)
-				&& tmpArrowData[_key].find(_other => _arrow >= _other - scatterFrame2 && _arrow <= _other + scatterFrame2) === undefined
+				&& tmpArrowData[_key].find(_other => _arrow >= _other - scatterFrame && _arrow <= _other + scatterFrame) === undefined
 				// 直前の矢印と重ならない
-				&& (sameFlg || (!sameFlg && tmpArrowData[_key].find(_other => prev2Num === _other) === undefined))
+				&& tmpArrowData[_key].find(_other => prev2Num === _other) === undefined
 			);
 			const freeSpaces = _group.filter(_key =>
 				// フリーズと重ならない
@@ -8090,7 +8089,7 @@ const applySRandom = (_keyNum, _shuffleGroup, _arrowHeader, _frzHeader) => {
 			// ランダムに配置
 			let currentFreeSpaces = freeSpaces.length > 0 ? freeSpaces : freeSpacesAlt;
 			if (g_stateObj.shuffle.startsWith(`Scatter`)) {
-				currentFreeSpaces = freeSpacesFlat.length > 0 ? freeSpacesFlat : currentFreeSpaces;
+				currentFreeSpaces = freeSpacesFlat.length > 0 && !sameFlg ? freeSpacesFlat : currentFreeSpaces;
 			}
 			const random = Math.floor(Math.random() * currentFreeSpaces.length);
 			tmpArrowData[currentFreeSpaces[random]].push(_arrow);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8059,12 +8059,10 @@ const applySRandom = (_keyNum, _shuffleGroup, _arrowHeader, _frzHeader) => {
 
 			// 直前の矢印のフレーム数を取得
 			sameFlg = true;
-			if (prev2Num !== _arrow) {
-				if (prevNum !== _arrow) {
-					prev2Num = prevNum;
-					prevNum = _arrow;
-					sameFlg = false;
-				}
+			if (prev2Num !== _arrow && prevNum !== _arrow) {
+				prev2Num = prevNum;
+				prevNum = _arrow;
+				sameFlg = false;
 			}
 
 			// 置ける場所を検索

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8054,25 +8054,28 @@ const applySRandom = (_keyNum, _shuffleGroup, _arrowHeader, _frzHeader) => {
 		// 通常矢印の配置
 		const allArrows = _group.map(_key => g_scoreObj[`${_arrowHeader}Data`][_key]).flat();
 		allArrows.sort((_a, _b) => _a - _b);
-		let prev2Num = 0, prevNum = 0;
+		let prev2Num = 0, prevNum = 0, sameFlg = true;
 		allArrows.forEach(_arrow => {
 
 			// 直前の矢印のフレーム数を取得
+			sameFlg = true;
 			if (prev2Num !== _arrow) {
 				if (prevNum !== _arrow) {
 					prev2Num = prevNum;
 					prevNum = _arrow;
+					sameFlg = false;
 				}
 			}
 
 			// 置ける場所を検索
+			const scatterFrame2 = scatterFrame * (sameFlg ? 0 : 1);
 			const freeSpacesFlat = _group.filter(_key =>
 				// フリーズと重ならない (前後10フレーム)
-				tmpFrzData[_key].find(_freeze => _arrow >= _freeze.begin - scatterFrame && _arrow <= _freeze.end + scatterFrame) === undefined
+				tmpFrzData[_key].find(_freeze => _arrow >= _freeze.begin - scatterFrame2 && _arrow <= _freeze.end + scatterFrame2) === undefined
 				// 通常矢印と重ならない (前後10フレーム)
-				&& tmpArrowData[_key].find(_other => _arrow >= _other - scatterFrame && _arrow <= _other + scatterFrame) === undefined
+				&& tmpArrowData[_key].find(_other => _arrow >= _other - scatterFrame2 && _arrow <= _other + scatterFrame2) === undefined
 				// 直前の矢印と重ならない
-				&& tmpArrowData[_key].find(_other => prev2Num === _other) === undefined
+				&& (sameFlg || (!sameFlg && tmpArrowData[_key].find(_other => prev2Num === _other) === undefined))
 			);
 			const freeSpaces = _group.filter(_key =>
 				// フリーズと重ならない


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. Scatterオプションのシャッフル方法を一部見直し
- Shuffleオプションの1つである、「Scatter」「Scatter+」について、
同時押しが続いた時の矢印のシャッフル方法を見直しました。
- 具体的には、直前の矢印が重ならないように配置するのはフレームが変わった最初の矢印だけで、
同時押しの対の矢印については従来のS-Randomと同じ処理にしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 4keyを従来の「Scatter」でシャッフルした場合、同時押しが連続すると単調な配置になってしまうため。
また、本来の目的としては単発矢印に対して散らばっていれば良いため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
