### PR TITLE
fix: [0853] 色変化(ncolor_data)でキーパターンを変えると適用する矢印グループが想定と異なる問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9207,6 +9207,9 @@ const getFrzLength = (_speedOnFrame, _startFrame, _endFrame) => {
 
 /**
  * キーパターン(デフォルト)に対応する矢印番号を格納
+ * - 色変化(旧仕様)、矢印・フリーズアローモーション、スクロール変化で
+ *   矢印グループをキーパターンごとに切り替える際に使用
+ * - 色変化(ncolor_data)ではsetColor2Dataにて同様の処理を行っているため使用しない
  */
 const convertReplaceNums = () => {
 	const tkObj = getKeyInfo();
@@ -9284,7 +9287,7 @@ const pushColors = (_header, _frame, _val, _colorCd, _allFlg, _pattern = ``) => 
 			allUseTypes.push(`Frz`);
 		}
 		// 色変化情報の格納
-		baseHeaders.forEach(baseHeader => pushColor(baseHeader, g_workObj.replaceNums[_val] + addAll));
+		baseHeaders.forEach(baseHeader => pushColor(baseHeader, _val + addAll));
 	};
 
 	/**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9208,7 +9208,8 @@ const getFrzLength = (_speedOnFrame, _startFrame, _endFrame) => {
 /**
  * キーパターン(デフォルト)に対応する矢印番号を格納
  * - 色変化、矢印・フリーズアローモーション、スクロール変化で
- *   矢印グループをキーパターンごとに切り替える際に使用
+ *   矢印レーンの番号を実際のキーパターンに対応する番号に置き換える際に使用
+ * - 例: [0, 1, 2, 3, 4] -> [4, 0, 1, 2, 3]
  */
 const convertReplaceNums = () => {
 	const tkObj = getKeyInfo();

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9207,9 +9207,8 @@ const getFrzLength = (_speedOnFrame, _startFrame, _endFrame) => {
 
 /**
  * キーパターン(デフォルト)に対応する矢印番号を格納
- * - 色変化(旧仕様)、矢印・フリーズアローモーション、スクロール変化で
+ * - 色変化、矢印・フリーズアローモーション、スクロール変化で
  *   矢印グループをキーパターンごとに切り替える際に使用
- * - 色変化(ncolor_data)ではsetColor2Dataにて同様の処理を行っているため使用しない
  */
 const convertReplaceNums = () => {
 	const tkObj = getKeyInfo();

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8278,7 +8278,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 						// g付きの場合は矢印グループから対象の矢印番号を検索
 						const groupVal = setIntVal(val.slice(1));
 						for (let j = 0; j < keyNum; j++) {
-							if (g_keyObj[`color${_keyCtrlPtn}`][j] === groupVal) {
+							if (g_keyObj[`color${g_keyObj.currentKey}_0`][j] === groupVal) {
 								colorVals.push(j);
 							}
 						}
@@ -9287,7 +9287,7 @@ const pushColors = (_header, _frame, _val, _colorCd, _allFlg, _pattern = ``) => 
 			allUseTypes.push(`Frz`);
 		}
 		// 色変化情報の格納
-		baseHeaders.forEach(baseHeader => pushColor(baseHeader, _val + addAll));
+		baseHeaders.forEach(baseHeader => pushColor(baseHeader, g_workObj.replaceNums[_val] + addAll));
 	};
 
 	/**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 色変化(ncolor_data)でキーパターンを変えると適用する矢印グループが想定と異なる問題を修正
- 従来の色変化(color_data / acolor_data)では、キーパターンごとに同じ矢印でも矢印番号が異なるため、convertReplaceNums関数を使って割当先のコンバートを行っていました。
- 従来の色変化では矢印単発と矢印グループで処理分岐しており、矢印グループ時はconvertReplaceNums関数で生成した g_workObj.replaceNums によりコンバートが行われないように処理されていましたが、色変化(ncolor_data)では矢印単発・グループに関係なくコンバートが掛かるようになっていたため、矢印グループ時に想定しない色変化になっていました。
- setColor2Dataで行っていた箇所を、convertReplaceNums関数を通しても問題が無いように修正することで解消しています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. Discordでの指摘より。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
- ver36以降で発生していると思われます。
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
