### PR TITLE
fix: [0854] 色変化(ncolor_data)で別キーモードにしか存在しないレーンを含む矢印グループ指定ができるよう修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8274,22 +8274,14 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 				// 矢印番号の組み立て
 				const colorVals = [];
 				replaceStr(patternStr[0], g_escapeStr.targetPatternName)?.split(`/`)?.forEach(val => {
-					if (val.startsWith('g')) {
-						// g付きの場合は矢印グループから対象の矢印番号を検索
-						const groupVal = setIntVal(val.slice(1));
-						for (let j = 0; j < keyNum; j++) {
-							if (g_keyObj[`color${g_keyObj.currentKey}_0`][j] === groupVal) {
-								colorVals.push(j);
-							}
-						}
-					} else if (val.indexOf(`...`) > 0) {
+					if (val.indexOf(`...`) > 0) {
 						// 範囲指定表記の補完 例. 0...3 -> 0/1/2/3
 						const [valMin, valMax] = [val.split(`...`)[0], val.split(`...`)[1]].map(val => setIntVal(val));
 						for (let k = valMin; k <= valMax; k++) {
-							colorVals.push(setIntVal(k));
+							colorVals.push(String(k));
 						}
 					} else {
-						colorVals.push(setIntVal(val));
+						colorVals.push(val);
 					}
 				});
 
@@ -9287,7 +9279,17 @@ const pushColors = (_header, _frame, _val, _colorCd, _allFlg, _pattern = ``) => 
 			allUseTypes.push(`Frz`);
 		}
 		// 色変化情報の格納
-		baseHeaders.forEach(baseHeader => pushColor(baseHeader, g_workObj.replaceNums[_val] + addAll));
+		if (_val.startsWith('g')) {
+			// g付きの場合は矢印グループから対象の矢印番号を検索
+			const groupVal = setIntVal(_val.slice(1));
+			for (let j = 0; j < tkObj.keyNum; j++) {
+				if (g_keyObj[`color${tkObj.keyCtrlPtn}`][j] === groupVal) {
+					baseHeaders.forEach(baseHeader => pushColor(baseHeader, j + addAll));
+				}
+			}
+		} else {
+			baseHeaders.forEach(baseHeader => pushColor(baseHeader, g_workObj.replaceNums[setIntVal(_val)] + addAll));
+		}
 	};
 
 	/**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 色変化(ncolor_data)で別キーモードにしか存在しないレーンを含む矢印グループ指定ができるよう修正

- PR #1738 にて当初の問題は修正しましたが、別キーモードにしか存在しないレーンに矢印がいた場合、
その矢印が属する矢印グループを適用した際に色が変わらない問題がありました。
- 従来関数同様、pushColors内で矢印グループを扱う方法に変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 直接的な問題ではないですが、従来の色変化では対応しているため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
- 過去バージョンに影響しますが、変更箇所が多いのでv36～37への適用は見送ります。
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
