### PR TITLE
feat: [0855] プレイ中ショートカットの変更に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5517,9 +5517,11 @@ const setDifficulty = (_initFlg) => {
 		const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
 		if (g_headerObj.keyRetryDef === C_KEY_RETRY) {
 			g_headerObj.keyRetry = setIntVal(getKeyCtrlVal(g_keyObj[`keyRetry${keyCtrlPtn}`]), g_headerObj.keyRetryDef);
+			g_headerObj.keyRetryDef2 = g_headerObj.keyRetry;
 		}
 		if (g_headerObj.keyTitleBackDef === C_KEY_TITLEBACK) {
 			g_headerObj.keyTitleBack = setIntVal(getKeyCtrlVal(g_keyObj[`keyTitleBack${keyCtrlPtn}`]), g_headerObj.keyTitleBackDef);
+			g_headerObj.keyTitleBackDef2 = g_headerObj.keyTitleBack;
 		}
 	}
 
@@ -7014,9 +7016,11 @@ const keyConfigInit = (_kcType = g_kcType) => {
 
 		// タイトルバックのショートカットキー変更
 		createCss2Button(`scTitleBack`, getScMsg.TitleBack(), () => {
-			cursor.style.left = wUnit(g_btnX(1 / 4) - kcSubX);
-			cursor.style.top = wUnit(g_sHeight - 160 + kcSubY);
-			selectedKc = `TitleBack`;
+			if (!g_isMac) {
+				cursor.style.left = wUnit(g_btnX(1 / 4) - kcSubX);
+				cursor.style.top = wUnit(g_sHeight - 160 + kcSubY);
+				selectedKc = `TitleBack`;
+			}
 		}, g_lblPosObj.scTitleBack, g_cssObj.button_Default_NoColor,
 			g_headerObj.keyTitleBack === g_headerObj.keyTitleBackDef2 ?
 				g_cssObj.title_base : g_cssObj.keyconfig_Changekey),
@@ -7486,6 +7490,10 @@ const keyConfigInit = (_kcType = g_kcType) => {
 			g_headerObj[`key${selectedKc}Def`] = setKey;
 			document.getElementById(`sc${selectedKc}`).textContent = getScMsg[selectedKc]();
 			document.getElementById(`sc${selectedKc}`).style.fontSize = `${getFontSize(getScMsg[selectedKc](), g_btnWidth(5 / 12) - 40, getBasicFont(), 13)}px`;
+			if (g_isMac) {
+				scTitleBack.textContent = getScMsg.TitleBack();
+				scTitleBack.style.fontSize = `${getFontSize(getScMsg.TitleBack(), g_btnWidth(5 / 12) - 40, getBasicFont(), 13)}px`;
+			}
 			changeConfigColor(document.getElementById(`sc${selectedKc}`),
 				g_headerObj[`key${selectedKc}`] === g_headerObj[`key${selectedKc}Def2`] ?
 					g_cssObj.title_base : g_cssObj.keyconfig_Changekey);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9571,7 +9571,7 @@ const getArrowSettings = () => {
 	g_gameOverFlg = false;
 	g_finishFlg = true;
 	g_workObj.nonDefaultSc = g_headerObj.keyRetry !== C_KEY_RETRY || g_headerObj.keyTitleBack !== C_KEY_TITLEBACK;
-	if (g_headerObj.scArea === 0 && (g_headerObj.keyRetry !== g_headerObj.keyRetryDef2 || g_headerObj.keyTitleBack !== g_headerObj.keyTitleBackDef2)) {
+	if (g_headerObj.scAreaWidth === 0 && (g_headerObj.keyRetry !== g_headerObj.keyRetryDef2 || g_headerObj.keyTitleBack !== g_headerObj.keyTitleBackDef2)) {
 		g_workObj.nonDefaultSc = false;
 	}
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7006,15 +7006,18 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	const kcSub = parseFloat(keyconSprite.style.height) / ((1 + g_keyObj.scale) / 2) - parseFloat(keyconSprite.style.height);
 	multiAppend(divRoot,
 
+		// ショートカットキーメッセージ
+		createDescDiv(`scMsg`, g_lblNameObj.kcShortcutDesc, { altId: `scKcMsg` }),
+
 		// タイトルバックのショートカットキー変更
-		createCss2Button(`scTitleBack`, getScMsg1(), () => {
-			cursor.style.left = wUnit(g_btnX());
+		createCss2Button(`scTitleBack`, getScMsg.TitleBack(), () => {
+			cursor.style.left = wUnit(g_btnX(1 / 4));
 			cursor.style.top = wUnit(g_sHeight - 160 + kcSub);
 			selectedKc = `TitleBack`;
 		}, g_lblPosObj.scTitleBack, g_cssObj.button_Default_NoColor, g_cssObj.title_base),
 
 		// リトライのショートカットキー変更
-		createCss2Button(`scRetry`, getScMsg2(), () => {
+		createCss2Button(`scRetry`, getScMsg.Retry(), () => {
 			cursor.style.left = wUnit(g_btnX(5 / 8));
 			cursor.style.top = wUnit(g_sHeight - 160 + kcSub);
 			selectedKc = `Retry`;
@@ -7465,21 +7468,26 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		// 全角切替、BackSpace、Deleteキー、Escキーは割り当て禁止
 		// また、直前と同じキーを押した場合(BackSpaceを除く)はキー操作を無効にする
 		const disabledKeys = [240, 242, 243, 244, 91, 29, 28, 27, 259, g_prevKey];
+
+		if (selectedKc === `TitleBack` || selectedKc === `Retry`) {
+			// プレイ中ショートカットキー変更
+			if (disabledKeys.includes(setKey) || g_kCdN[setKey] === undefined) {
+				makeInfoWindow(g_msgInfoObj.I_0002, `fadeOut0`);
+				return;
+			}
+			g_headerObj[`key${selectedKc}`] = setKey;
+			g_headerObj[`key${selectedKc}Def`] = setKey;
+			document.getElementById(`sc${selectedKc}`).textContent = getScMsg[selectedKc]();
+			document.getElementById(`sc${selectedKc}`).style.fontSize = `${getFontSize(getScMsg[selectedKc](), g_btnWidth(5 / 12) - 40, getBasicFont(), 13)}px`;
+			return;
+		}
+
 		if (g_localeObj.val === `Ja`) {
 			disabledKeys.unshift(229);
 		}
 		if (disabledKeys.includes(setKey) || g_kCdN[setKey] === undefined) {
 			makeInfoWindow(g_msgInfoObj.I_0002, `fadeOut0`);
 			return;
-
-		} else if (selectedKc === `TitleBack` || selectedKc === `Retry`) {
-			// プレイ中ショートカットキー変更
-			g_headerObj[`key${selectedKc}`] = setKey;
-			g_headerObj[`key${selectedKc}Def`] = setKey;
-			scTitleBack.textContent = getScMsg1();
-			scRetry.textContent = getScMsg2();
-			return;
-
 		} else if ((setKey === C_KEY_TITLEBACK && g_currentk === 0) ||
 			((keyIsDown(g_kCdNameObj.metaLKey) || keyIsDown(g_kCdNameObj.metaRKey)) && keyIsShift())) {
 			return;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7017,14 +7017,18 @@ const keyConfigInit = (_kcType = g_kcType) => {
 			cursor.style.left = wUnit(g_btnX(1 / 4) - kcSubX);
 			cursor.style.top = wUnit(g_sHeight - 160 + kcSubY);
 			selectedKc = `TitleBack`;
-		}, g_lblPosObj.scTitleBack, g_cssObj.button_Default_NoColor, g_cssObj.title_base),
+		}, g_lblPosObj.scTitleBack, g_cssObj.button_Default_NoColor,
+			g_headerObj.keyTitleBack === g_headerObj.keyTitleBackDef2 ?
+				g_cssObj.title_base : g_cssObj.keyconfig_Changekey),
 
 		// リトライのショートカットキー変更
 		createCss2Button(`scRetry`, getScMsg.Retry(), () => {
 			cursor.style.left = wUnit(g_btnX(5 / 8) + kcSubX);
 			cursor.style.top = wUnit(g_sHeight - 160 + kcSubY);
 			selectedKc = `Retry`;
-		}, g_lblPosObj.scRetry, g_cssObj.button_Default_NoColor, g_cssObj.title_base),
+		}, g_lblPosObj.scRetry, g_cssObj.button_Default_NoColor,
+			g_headerObj.keyRetry === g_headerObj.keyRetryDef2 ?
+				g_cssObj.title_base : g_cssObj.keyconfig_Changekey),
 
 		// 別キーモード警告メッセージ
 		createDivCss2Label(
@@ -7482,6 +7486,9 @@ const keyConfigInit = (_kcType = g_kcType) => {
 			g_headerObj[`key${selectedKc}Def`] = setKey;
 			document.getElementById(`sc${selectedKc}`).textContent = getScMsg[selectedKc]();
 			document.getElementById(`sc${selectedKc}`).style.fontSize = `${getFontSize(getScMsg[selectedKc](), g_btnWidth(5 / 12) - 40, getBasicFont(), 13)}px`;
+			changeConfigColor(document.getElementById(`sc${selectedKc}`),
+				g_headerObj[`key${selectedKc}`] === g_headerObj[`key${selectedKc}Def2`] ?
+					g_cssObj.title_base : g_cssObj.keyconfig_Changekey);
 			return;
 		}
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7003,7 +7003,8 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		viewGroup(_type);
 	};
 
-	const kcSub = parseFloat(keyconSprite.style.height) / ((1 + g_keyObj.scale) / 2) - parseFloat(keyconSprite.style.height);
+	const kcSubX = parseFloat(keyconSprite.style.width) * ((1 - g_keyObj.scale) / 4);
+	const kcSubY = parseFloat(keyconSprite.style.height) / ((1 + g_keyObj.scale) / 2) - parseFloat(keyconSprite.style.height);
 	multiAppend(divRoot,
 
 		// ショートカットキーメッセージ
@@ -7011,15 +7012,15 @@ const keyConfigInit = (_kcType = g_kcType) => {
 
 		// タイトルバックのショートカットキー変更
 		createCss2Button(`scTitleBack`, getScMsg.TitleBack(), () => {
-			cursor.style.left = wUnit(g_btnX(1 / 4));
-			cursor.style.top = wUnit(g_sHeight - 160 + kcSub);
+			cursor.style.left = wUnit(g_btnX(1 / 4) - kcSubX);
+			cursor.style.top = wUnit(g_sHeight - 160 + kcSubY);
 			selectedKc = `TitleBack`;
 		}, g_lblPosObj.scTitleBack, g_cssObj.button_Default_NoColor, g_cssObj.title_base),
 
 		// リトライのショートカットキー変更
 		createCss2Button(`scRetry`, getScMsg.Retry(), () => {
-			cursor.style.left = wUnit(g_btnX(5 / 8));
-			cursor.style.top = wUnit(g_sHeight - 160 + kcSub);
+			cursor.style.left = wUnit(g_btnX(5 / 8) + kcSubX);
+			cursor.style.top = wUnit(g_sHeight - 160 + kcSubY);
 			selectedKc = `Retry`;
 		}, g_lblPosObj.scRetry, g_cssObj.button_Default_NoColor, g_cssObj.title_base),
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5517,11 +5517,9 @@ const setDifficulty = (_initFlg) => {
 		const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
 		if (g_headerObj.keyRetryDef === C_KEY_RETRY) {
 			g_headerObj.keyRetry = setIntVal(getKeyCtrlVal(g_keyObj[`keyRetry${keyCtrlPtn}`]), g_headerObj.keyRetryDef);
-			g_headerObj.keyRetryDef2 = g_headerObj.keyRetry;
 		}
 		if (g_headerObj.keyTitleBackDef === C_KEY_TITLEBACK) {
 			g_headerObj.keyTitleBack = setIntVal(getKeyCtrlVal(g_keyObj[`keyTitleBack${keyCtrlPtn}`]), g_headerObj.keyTitleBackDef);
-			g_headerObj.keyTitleBackDef2 = g_headerObj.keyTitleBack;
 		}
 	}
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2989,8 +2989,10 @@ const headerConvert = _dosObj => {
 	// プレイ中のショートカットキー
 	obj.keyRetry = setIntVal(getKeyCtrlVal(_dosObj.keyRetry), C_KEY_RETRY);
 	obj.keyRetryDef = obj.keyRetry;
+	obj.keyRetryDef2 = obj.keyRetry;
 	obj.keyTitleBack = setIntVal(getKeyCtrlVal(_dosObj.keyTitleBack), C_KEY_TITLEBACK);
 	obj.keyTitleBackDef = obj.keyTitleBack;
+	obj.keyTitleBackDef2 = obj.keyTitleBack;
 
 	// フリーズアローの許容フレーム数設定
 	obj.frzAttempt = setIntVal(_dosObj.frzAttempt, C_FRM_FRZATTEMPT);
@@ -9562,6 +9564,10 @@ const getArrowSettings = () => {
 	g_gameOverFlg = false;
 	g_finishFlg = true;
 	g_workObj.nonDefaultSc = g_headerObj.keyRetry !== C_KEY_RETRY || g_headerObj.keyTitleBack !== C_KEY_TITLEBACK;
+	if (g_headerObj.scArea === 0 && (g_headerObj.keyRetry !== g_headerObj.keyRetryDef2 || g_headerObj.keyTitleBack !== g_headerObj.keyTitleBackDef2)) {
+		g_workObj.nonDefaultSc = false;
+	}
+
 	g_workObj.backX = (g_workObj.nonDefaultSc && g_headerObj.playingLayout ? g_headerObj.scAreaWidth : 0);
 	g_workObj.playingX = g_headerObj.playingX + g_workObj.backX;
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1107,6 +1107,7 @@ const getFontSize = (_str, _maxWidth, _font = getBasicFont(), _maxFontsize = 64,
 const createDescDiv = (_id, _str, { altId = _id, siz = g_limitObj.mainSiz } = {}) =>
 	createDivCss2Label(_id, _str, Object.assign(g_lblPosObj[altId], {
 		siz: getFontSize(_str, g_lblPosObj[altId]?.w || g_sWidth, getBasicFont(), siz),
+		pointerEvents: C_DIS_NONE,
 	}));
 
 /*-----------------------------------------------------------*/
@@ -6680,6 +6681,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	const divRoot = document.getElementById(`divRoot`);
 	g_kcType = _kcType;
 	g_currentPage = `keyConfig`;
+	let selectedKc = `Default`;
 
 	// 譜面初期情報ロード許可フラグ
 	g_canLoadDifInfoFlg = false;
@@ -6845,6 +6847,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 					g_currentj = j;
 					g_currentk = k;
 					g_prevKey = -1;
+					selectedKc = `Default`;
 					g_keycons.cursorNum = g_keycons.cursorNumList.findIndex(val => val === g_currentj);
 					setKeyConfigCursor();
 				}, {
@@ -7000,12 +7003,22 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		viewGroup(_type);
 	};
 
+	const kcSub = parseFloat(keyconSprite.style.height) / ((1 + g_keyObj.scale) / 2) - parseFloat(keyconSprite.style.height);
 	multiAppend(divRoot,
 
-		// ショートカットキーメッセージ
-		createDescDiv(`scMsg`, g_lblNameObj.kcShortcutDesc.split(`{0}`)
-			.join(g_isMac ? `Shift+${g_kCd[g_headerObj.keyRetry]}` : g_kCd[g_headerObj.keyTitleBack])
-			.split(`{1}`).join(g_kCd[g_headerObj.keyRetry]), { altId: `scKcMsg` }),
+		// タイトルバックのショートカットキー変更
+		createCss2Button(`scTitleBack`, getScMsg1(), () => {
+			cursor.style.left = wUnit(g_btnX());
+			cursor.style.top = wUnit(g_sHeight - 160 + kcSub);
+			selectedKc = `TitleBack`;
+		}, g_lblPosObj.scTitleBack, g_cssObj.button_Default_NoColor, g_cssObj.title_base),
+
+		// リトライのショートカットキー変更
+		createCss2Button(`scRetry`, getScMsg2(), () => {
+			cursor.style.left = wUnit(g_btnX(5 / 8));
+			cursor.style.top = wUnit(g_sHeight - 160 + kcSub);
+			selectedKc = `Retry`;
+		}, g_lblPosObj.scRetry, g_cssObj.button_Default_NoColor, g_cssObj.title_base),
 
 		// 別キーモード警告メッセージ
 		createDivCss2Label(
@@ -7458,6 +7471,15 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		if (disabledKeys.includes(setKey) || g_kCdN[setKey] === undefined) {
 			makeInfoWindow(g_msgInfoObj.I_0002, `fadeOut0`);
 			return;
+
+		} else if (selectedKc === `TitleBack` || selectedKc === `Retry`) {
+			// プレイ中ショートカットキー変更
+			g_headerObj[`key${selectedKc}`] = setKey;
+			g_headerObj[`key${selectedKc}Def`] = setKey;
+			scTitleBack.textContent = getScMsg1();
+			scRetry.textContent = getScMsg2();
+			return;
+
 		} else if ((setKey === C_KEY_TITLEBACK && g_currentk === 0) ||
 			((keyIsDown(g_kCdNameObj.metaLKey) || keyIsDown(g_kCdNameObj.metaRKey)) && keyIsShift())) {
 			return;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -159,8 +159,10 @@ const g_windowObj = {
 };
 
 const g_lblPosObj = {};
-const getScMsg1 = () => g_lblNameObj.kcShortcutDesc1.split(`{0}`).join(g_isMac ? `Shift+${g_kCd[g_headerObj.keyRetry]}` : g_kCd[g_headerObj.keyTitleBack]);
-const getScMsg2 = () => g_lblNameObj.kcShortcutDesc2.split(`{1}`).join(g_kCd[g_headerObj.keyRetry]);
+const getScMsg = {
+    TitleBack: () => g_lblNameObj.kcShortcutDesc1.split(`{0}`).join(g_isMac ? `Shift+${g_kCd[g_headerObj.keyRetry]}` : g_kCd[g_headerObj.keyTitleBack]),
+    Retry: () => g_lblNameObj.kcShortcutDesc2.split(`{1}`).join(g_kCd[g_headerObj.keyRetry]),
+};
 
 /**
  * 可変部分のウィンドウサイズを更新
@@ -323,7 +325,7 @@ const updateWindowSiz = () => {
 
         /** キーコンフィグ画面 */
         scKcMsg: {
-            x: g_btnX(), y: g_sHeight - 50, w: g_btnWidth(), h: 20,
+            x: g_btnX(), y: g_sHeight - 50, w: g_btnWidth(1 / 4), h: 20,
         },
         kcMsg: {
             x: g_btnX(), y: g_sHeight - 33, w: g_btnWidth(), h: 20, siz: g_limitObj.mainSiz,
@@ -383,12 +385,12 @@ const updateWindowSiz = () => {
             title: g_msgObj.kcReset,
         },
         scTitleBack: {
-            x: g_btnX() + 20, y: g_sHeight - 50, align: C_ALIGN_RIGHT,
-            w: g_btnWidth(5 / 8) - 40, h: C_KYC_REPHEIGHT, siz: getFontSize(getScMsg1(), g_btnWidth(1 / 2) - 20, getBasicFont(), 13),
+            x: g_btnX(1 / 4) + 20, y: g_sHeight - 50, align: C_ALIGN_LEFT,
+            w: g_btnWidth(5 / 12) - 40, h: C_KYC_REPHEIGHT, siz: getFontSize(getScMsg.TitleBack(), g_btnWidth(5 / 12) - 40, getBasicFont(), 13),
         },
         scRetry: {
             x: g_btnX(5 / 8) + 20, y: g_sHeight - 50, align: C_ALIGN_LEFT,
-            w: g_btnWidth(3 / 8) - 40, h: C_KYC_REPHEIGHT, siz: getFontSize(getScMsg2(), g_btnWidth(1 / 2) - 20, getBasicFont(), 13),
+            w: g_btnWidth(5 / 12) - 40, h: C_KYC_REPHEIGHT, siz: getFontSize(getScMsg.Retry(), g_btnWidth(5 / 12) - 40, getBasicFont(), 13),
         },
 
         /** メイン画面 */
@@ -3168,8 +3170,9 @@ const g_lang_lblNameObj = {
         kcShuffleDesc: `番号をクリックでシャッフルグループ、矢印をクリックでカラーグループを変更`,
         kcNoShuffleDesc: `矢印をクリックでカラーグループを変更`,
         sdDesc: `[クリックでON/OFFを切替、灰色でOFF]`,
-        kcShortcutDesc1: `プレイ中ショートカット：「{0}」タイトルバック /`,
-        kcShortcutDesc2: `「{1}」リトライ`,
+        kcShortcutDesc: `プレイ中ショートカット：`,
+        kcShortcutDesc1: `タイトルバック: {0}`,
+        kcShortcutDesc2: `リトライ: {1}`,
         transKeyDesc: `別キーモードではキーコンフィグ、ColorType等は保存されません`,
         sdShortcutDesc: `Hid+/Sud+時ショートカット：「pageUp」カバーを上へ / 「pageDown」下へ`,
         resultImageDesc: `画像を右クリックしてコピーできます`,
@@ -3208,8 +3211,9 @@ const g_lang_lblNameObj = {
         kcShuffleDesc: `Click the number to change the shuffle group, and click the arrow to change the color.`,
         kcNoShuffleDesc: `Click the arrow to change the color group.`,
         sdDesc: `[Click to switch, gray to OFF]`,
-        kcShortcutDesc1: `Shortcut during play: "{0}" Return to title /`,
-        kcShortcutDesc2: `"{1}" Retry the game`,
+        kcShortcutDesc: `Shortcut during play:`,
+        kcShortcutDesc1: `Return to title: {0}`,
+        kcShortcutDesc2: `Retry the game: {1}`,
         transKeyDesc: `Key config, Color type, etc. are not saved in another key mode`,
         sdShortcutDesc: `When "Hidden+" or "Sudden+" select, "pageUp" cover up / "pageDown" cover down`,
         resultImageDesc: `You can copy the image by right-clicking on it.`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -159,6 +159,8 @@ const g_windowObj = {
 };
 
 const g_lblPosObj = {};
+const getScMsg1 = () => g_lblNameObj.kcShortcutDesc1.split(`{0}`).join(g_isMac ? `Shift+${g_kCd[g_headerObj.keyRetry]}` : g_kCd[g_headerObj.keyTitleBack]);
+const getScMsg2 = () => g_lblNameObj.kcShortcutDesc2.split(`{1}`).join(g_kCd[g_headerObj.keyRetry]);
 
 /**
  * 可変部分のウィンドウサイズを更新
@@ -379,6 +381,14 @@ const updateWindowSiz = () => {
             x: g_btnX(), y: g_sHeight - 75,
             w: g_btnWidth(1 / 3), h: g_limitObj.btnHeight / 2, siz: g_limitObj.btnSiz * 2 / 3,
             title: g_msgObj.kcReset,
+        },
+        scTitleBack: {
+            x: g_btnX() + 20, y: g_sHeight - 50, align: C_ALIGN_RIGHT,
+            w: g_btnWidth(5 / 8) - 40, h: C_KYC_REPHEIGHT, siz: getFontSize(getScMsg1(), g_btnWidth(1 / 2) - 20, getBasicFont(), 13),
+        },
+        scRetry: {
+            x: g_btnX(5 / 8) + 20, y: g_sHeight - 50, align: C_ALIGN_LEFT,
+            w: g_btnWidth(3 / 8) - 40, h: C_KYC_REPHEIGHT, siz: getFontSize(getScMsg2(), g_btnWidth(1 / 2) - 20, getBasicFont(), 13),
         },
 
         /** メイン画面 */
@@ -3158,7 +3168,8 @@ const g_lang_lblNameObj = {
         kcShuffleDesc: `番号をクリックでシャッフルグループ、矢印をクリックでカラーグループを変更`,
         kcNoShuffleDesc: `矢印をクリックでカラーグループを変更`,
         sdDesc: `[クリックでON/OFFを切替、灰色でOFF]`,
-        kcShortcutDesc: `プレイ中ショートカット：「{0}」タイトルバック / 「{1}」リトライ`,
+        kcShortcutDesc1: `プレイ中ショートカット：「{0}」タイトルバック /`,
+        kcShortcutDesc2: `「{1}」リトライ`,
         transKeyDesc: `別キーモードではキーコンフィグ、ColorType等は保存されません`,
         sdShortcutDesc: `Hid+/Sud+時ショートカット：「pageUp」カバーを上へ / 「pageDown」下へ`,
         resultImageDesc: `画像を右クリックしてコピーできます`,
@@ -3197,7 +3208,8 @@ const g_lang_lblNameObj = {
         kcShuffleDesc: `Click the number to change the shuffle group, and click the arrow to change the color.`,
         kcNoShuffleDesc: `Click the arrow to change the color group.`,
         sdDesc: `[Click to switch, gray to OFF]`,
-        kcShortcutDesc: `Shortcut during play: "{0}" Return to title / "{1}" Retry the game`,
+        kcShortcutDesc1: `Shortcut during play: "{0}" Return to title /`,
+        kcShortcutDesc2: `"{1}" Retry the game`,
         transKeyDesc: `Key config, Color type, etc. are not saved in another key mode`,
         sdShortcutDesc: `When "Hidden+" or "Sudden+" select, "pageUp" cover up / "pageDown" cover down`,
         resultImageDesc: `You can copy the image by right-clicking on it.`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. プレイ中ショートカットの変更に対応
- キーコンフィグ画面より、プレイ中ショートカットキーの変更をできるようにしました。
プレイ中ショートカットキーが表示されているエリアがボタンに代わり、そこをクリックしてから
キーを押すことで割り当てキーを変えることができます。
- ローカルストレージには未対応です。
- キーブロックの関係でEscapeキーが実質無効になっているため、例外的に「IME」（全角/半角）を設定可能にしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 作品により、プレイ中ショートカットを変えたい場合があるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/eaa4ece8-0afa-41e2-9b11-f58d02f3db8e" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- 現状、ショートカットキーを変更すると右下にショートカットキーを表示する機能があり、それが動いてしまっています。カスタムJSによりスコア等を表示しているため、どう対応するか考える必要があります。
⇒ danoni_setting.js の scAreaWidth, playingLayoutの設定で可能だがデフォルトは未設定。
⇒ scAreaWidth、scAreaの両方が未指定の時は、プレイ側が割当を変えてもプレイ画面には反映しないようにしました。
- カーソルがキーコンフィグのオブジェクト上にいるため、スクロールが発生する場合カーソルも合わせて移動してしまいますが、それを実際の位置に合わせて追従させるのは容易ではないため、この実装は見送る方向にします。
- Mac環境の場合はリトライとタイトルバックがセットになっているため、
変更できるのはリトライキーに限定されます（リトライキーに応じて、タイトルバックキーも変わります）。