### PR TITLE
fix: [0856] フリーズアロー判定に関する不具合を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10770,7 +10770,7 @@ const mainInit = () => {
 			judgeMotionFunc[`${_name}NG`](_j, _k, frzName, currentFrz.cnt);
 
 		} else {
-			currentFrz.frzBarLength -= movY;
+			currentFrz.frzBarLength -= movY * currentFrz.dir;
 			if (currentFrz.frzBarLength > 0) {
 				currentFrz.y -= movY;
 				$id(frzName).top = wUnit(currentFrz.y);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10426,6 +10426,10 @@ const mainInit = () => {
 
 		arrowOFF: (_j, _k, _cnt) => {
 
+			// 直前のフリーズアローが未判定で、自身の判定範囲がキター(O.K.)の範囲内のとき
+			// 本来はシャキン(Great)としたいところだが、実装が複雑になるため上記条件とする
+			judgeNextFunc.frzOFF(_j, g_workObj.judgFrzCnt[_j] + 1, _cnt);
+
 			if (g_workObj.judgArrowCnt[_j] === _k - 1 && _cnt <= g_judgObj.arrowJ[g_judgPosObj.shakin]) {
 				const prevArrowName = `arrow${_j}_${g_workObj.judgArrowCnt[_j]}`;
 				const prevArrow = g_attrObj[prevArrowName];
@@ -10453,7 +10457,7 @@ const mainInit = () => {
 				const prevFrz = g_attrObj[prevFrzName];
 
 				// 自身より前のフリーズアローが移動中かつキター(O.K.)の領域外のとき
-				if (prevFrz.isMoving && prevFrz.cnt < (-1) * g_judgObj.frzJ[g_judgPosObj.kita]) {
+				if (prevFrz && prevFrz.isMoving && prevFrz.cnt < (-1) * g_judgObj.frzJ[g_judgPosObj.kita]) {
 
 					// 自身より前のフリーズアローが未判定の場合、強制的に枠外判定を行う
 					if (prevFrz.cnt >= (-1) * g_judgObj.frzJ[g_judgPosObj.iknai] && !prevFrz.judgEndFlg) {
@@ -10766,7 +10770,7 @@ const mainInit = () => {
 			judgeMotionFunc[`${_name}NG`](_j, _k, frzName, currentFrz.cnt);
 
 		} else {
-			currentFrz.frzBarLength -= g_workObj.currentSpeed;
+			currentFrz.frzBarLength -= movY;
 			if (currentFrz.frzBarLength > 0) {
 				currentFrz.y -= movY;
 				$id(frzName).top = wUnit(currentFrz.y);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10426,8 +10426,8 @@ const mainInit = () => {
 
 		arrowOFF: (_j, _k, _cnt) => {
 
-			// 直前のフリーズアローが未判定で、自身の判定範囲がキター(O.K.)の範囲内のとき
-			// 本来はシャキン(Great)としたいところだが、実装が複雑になるため上記条件とする
+			// 直前のフリーズアローが未判定で、自身の判定範囲がキター(O.K.)の範囲内のとき判定対象を矢印側へ移す
+			// 本来はシャキン(Great)の範囲内としたいところだが、実装が複雑になるため上記条件とする
 			judgeNextFunc.frzOFF(_j, g_workObj.judgFrzCnt[_j] + 1, _cnt);
 
 			if (g_workObj.judgArrowCnt[_j] === _k - 1 && _cnt <= g_judgObj.arrowJ[g_judgPosObj.shakin]) {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. フリーズアロー移動中のフリーズアロー長の計算誤りを修正
- フリーズアロー長の計算誤りにより、個別加速（boost_data）分だけ
その後の判定がずれる問題が発生していました。

### 2. フリーズアローの末尾付近に矢印がいる場合の判定不具合を修正
- フリーズアローの末尾付近に矢印がいる場合、
フリーズアローを見逃すと直後の矢印の判定が起こらない問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1, 2. Discordでの指摘より。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- 2.については実装が複雑になるため、フリーズアローの既存処理を使うようにしています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced loading process with support for external CSS and JavaScript files
  - Improved title screen with comment display area
  - Added advanced settings for color and image types
  - Expanded result screen functionality with high score display and result image creation

- **Bug Fixes**
  - Various improvements to game mechanics and screen handling

- **Refactor**
  - Code optimizations and structural improvements throughout the game

<!-- end of auto-generated comment: release notes by coderabbit.ai -->