### PR TITLE
feat: [0859] Appearance用のフィルターを階層別に定義するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -11329,6 +11329,7 @@ const makeStepZone = (_j, _keyCtrlPtn) => {
 /**
  * アルファマスクの再描画 (Appearance: Hidden+, Sudden+ 用)
  * @param {number} _num 
+ * @param {boolean} _shiftFlg シフトキーを押したかどうかのフラグ
  */
 const changeAppearanceFilter = (_num = 10, _shiftFlg = keyIsShift()) => {
 	const MAX_FILTER_POS = 100;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9814,6 +9814,9 @@ const getArrowSettings = () => {
 	g_workObj.drunkXFlg = false;
 	g_workObj.drunkYFlg = false;
 
+	// AppearanceFilterの可視範囲設定
+	g_workObj.aprFilterCnt = 0;
+
 	if (g_stateObj.dataSaveFlg) {
 		// ローカルストレージへAdjustment, HitPosition, Volume設定を保存
 		g_storeSettings.forEach(setting => g_localStorage[setting] = g_stateObj[setting]);
@@ -10046,7 +10049,7 @@ const mainInit = () => {
 
 	// Appearanceのオプション適用時は一部描画を隠す
 	changeAppearanceFilter(g_appearanceRanges.includes(g_stateObj.appearance) ?
-		g_hidSudObj.filterPos : g_hidSudObj.filterPosDefault[g_stateObj.appearance]);
+		g_hidSudObj.filterPos : g_hidSudObj.filterPosDefault[g_stateObj.appearance], true);
 
 	// 現在の矢印・フリーズアローの速度、個別加算速度の初期化 (速度変化時に直す)
 	g_workObj.currentSpeed = 2;
@@ -11327,7 +11330,7 @@ const makeStepZone = (_j, _keyCtrlPtn) => {
  * アルファマスクの再描画 (Appearance: Hidden+, Sudden+ 用)
  * @param {number} _num 
  */
-const changeAppearanceFilter = (_num = 10) => {
+const changeAppearanceFilter = (_num = 10, _shiftFlg = keyIsShift()) => {
 	const MAX_FILTER_POS = 100;
 	const topNum = g_hidSudObj[g_stateObj.appearance];
 	const bottomNum = (g_hidSudObj[g_stateObj.appearance] + 1) % 2;
@@ -11351,6 +11354,21 @@ const changeAppearanceFilter = (_num = 10) => {
 			$id(`filterBar${bottomNum + j}_HS`).top = wUnit(parseFloat($id(`arrowSprite${j}`).top) + g_posObj.arrowHeight * appearPers[bottomNum] / MAX_FILTER_POS);
 			$id(`filterBar${topNum + j}_HS`).top = wUnit(parseFloat($id(`arrowSprite${j + 1}`).top) + g_posObj.arrowHeight * appearPers[topNum] / MAX_FILTER_POS);
 		}
+
+		// 階層が多い場合はShift+pgUp/pgDownで表示する階層グループを切り替え
+		if (_shiftFlg && g_stateObj.d_filterline === C_FLG_ON) {
+			[`${topNum + j}`, `${bottomNum + j}`].forEach(type => {
+				$id(`filterBar${type}`).display = (j === g_workObj.aprFilterCnt ? C_DIS_INHERIT : C_DIS_NONE);
+
+				if (![`Default`, `Halfway`].includes(g_stateObj.stepArea)) {
+					$id(`filterBar${type}_HS`).display = (j === g_workObj.aprFilterCnt ? C_DIS_INHERIT : C_DIS_NONE);
+				}
+			});
+		}
+	}
+
+	if (_shiftFlg) {
+		g_workObj.aprFilterCnt = nextPos(g_workObj.aprFilterCnt, 2, g_stateObj.layerNum);
 	}
 
 	if (g_appearanceRanges.includes(g_stateObj.appearance)) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9983,24 +9983,24 @@ const mainInit = () => {
 	// mainSprite配下に層別のスプライトを作成し、ステップゾーン・矢印本体・フリーズアローヒット部分に分ける
 	const mainSpriteN = [], stepSprite = [], arrowSprite = [], frzHitSprite = [];
 	const mainCommonPos = { w: g_headerObj.playingWidth, h: g_posObj.arrowHeight };
-	for (let j = 0; j < g_stateObj.layerNum; j++) {
-		const mainSpriteJ = createEmptySprite(mainSprite, `mainSprite${j}`, mainCommonPos);
-		mainSpriteN.push(mainSpriteJ);
-		addTransform(`mainSprite${j}`, `mainSprite${j}`,
-			g_keyObj[`layerTrans${keyCtrlPtn}`]?.[0]?.[Math.floor(j / 2) + (j + Number(g_stateObj.reverse === C_FLG_ON)) % 2]);
-		stepSprite.push(createEmptySprite(mainSpriteJ, `stepSprite${j}`, mainCommonPos));
-		arrowSprite.push(createEmptySprite(mainSpriteJ, `arrowSprite${j}`, Object.assign({ y: g_workObj.hitPosition * (j % 2 === 0 ? 1 : -1) }, mainCommonPos)));
-		frzHitSprite.push(createEmptySprite(mainSpriteJ, `frzHitSprite${j}`, mainCommonPos));
-	}
 
 	// Hidden+, Sudden+用のライン、パーセント表示
 	const filterCss = g_stateObj.filterLock === C_FLG_OFF ? g_cssObj.life_Failed : g_cssObj.life_Cleared;
 	const doubleFilterFlg = ![`Default`, `Halfway`].includes(g_stateObj.stepArea);
+
 	for (let j = 0; j < g_stateObj.layerNum; j++) {
-		document.getElementById(`mainSprite${j}`).appendChild(createColorObject2(`filterBar${j}`, g_lblPosObj.filterBar, filterCss));
+		const mainSpriteJ = createEmptySprite(mainSprite, `mainSprite${j}`, mainCommonPos);
+		mainSpriteN.push(mainSpriteJ);
+		mainSpriteJ.appendChild(createColorObject2(`filterBar${j}`, g_lblPosObj.filterBar, filterCss));
 		if (doubleFilterFlg) {
-			document.getElementById(`mainSprite${j % 2 == 0 ? j + 1 : j - 1}`).appendChild(createColorObject2(`filterBar${j}_HS`, g_lblPosObj.filterBar, filterCss));
+			mainSpriteJ.appendChild(createColorObject2(`filterBar${j % 2 == 0 ? j + 1 : j - 1}_HS`, g_lblPosObj.filterBar, filterCss));
 		}
+		addTransform(`mainSprite${j}`, `mainSprite${j}`,
+			g_keyObj[`layerTrans${keyCtrlPtn}`]?.[0]?.[Math.floor(j / 2) + (j + Number(g_stateObj.reverse === C_FLG_ON)) % 2]);
+
+		stepSprite.push(createEmptySprite(mainSpriteJ, `stepSprite${j}`, mainCommonPos));
+		arrowSprite.push(createEmptySprite(mainSpriteJ, `arrowSprite${j}`, Object.assign({ y: g_workObj.hitPosition * (j % 2 === 0 ? 1 : -1) }, mainCommonPos)));
+		frzHitSprite.push(createEmptySprite(mainSpriteJ, `frzHitSprite${j}`, mainCommonPos));
 	}
 
 	if (g_appearanceRanges.includes(g_stateObj.appearance)) {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1228,25 +1228,19 @@ const g_stepAreaFunc = {
         });
     },
     'Mismatched': () => {
-        [`mainSprite`].forEach(sprite => {
-            for (let j = 0; j < g_stateObj.layerNum; j++) {
-                addTransform(`${sprite}${j}`, `stepArea`, `rotate(${(j % 2 === 0 ? 1 : -1) * -15}deg)`);
-            }
-        });
+        for (let j = 0; j < g_stateObj.layerNum; j++) {
+            addTransform(`mainSprite${j}`, `stepArea`, `rotate(${(j % 2 === 0 ? 1 : -1) * -15}deg)`);
+        }
     },
     'R-Mismatched': () => {
-        [`mainSprite`].forEach(sprite => {
-            for (let j = 0; j < g_stateObj.layerNum; j++) {
-                addTransform(`${sprite}${j}`, `stepArea`, `rotate(${(j % 2 === 0 ? 1 : -1) * 15}deg)`);
-            }
-        });
+        for (let j = 0; j < g_stateObj.layerNum; j++) {
+            addTransform(`mainSprite${j}`, `stepArea`, `rotate(${(j % 2 === 0 ? 1 : -1) * 15}deg)`);
+        }
     },
     'X-Flower': () => {
-        [`mainSprite`].forEach(sprite => {
-            for (let j = 0; j < Math.min(g_stateObj.layerNum, 4); j++) {
-                addTransform(`${sprite}${j}`, `stepArea`, `rotate(${(j % 2 === 0 ? 1 : -1) * (j % 4 < 2 ? 1 : -1) * -15}deg)`);
-            }
-        });
+        for (let j = 0; j < Math.min(g_stateObj.layerNum, 4); j++) {
+            addTransform(`mainSprite${j}`, `stepArea`, `rotate(${(j % 2 === 0 ? 1 : -1) * (j % 4 < 2 ? 1 : -1) * -15}deg)`);
+        }
     },
 };
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1228,21 +1228,21 @@ const g_stepAreaFunc = {
         });
     },
     'Mismatched': () => {
-        [`stepSprite`, `arrowSprite`, `frzHitSprite`].forEach(sprite => {
+        [`mainSprite`].forEach(sprite => {
             for (let j = 0; j < g_stateObj.layerNum; j++) {
                 addTransform(`${sprite}${j}`, `stepArea`, `rotate(${(j % 2 === 0 ? 1 : -1) * -15}deg)`);
             }
         });
     },
     'R-Mismatched': () => {
-        [`stepSprite`, `arrowSprite`, `frzHitSprite`].forEach(sprite => {
+        [`mainSprite`].forEach(sprite => {
             for (let j = 0; j < g_stateObj.layerNum; j++) {
                 addTransform(`${sprite}${j}`, `stepArea`, `rotate(${(j % 2 === 0 ? 1 : -1) * 15}deg)`);
             }
         });
     },
     'X-Flower': () => {
-        [`stepSprite`, `arrowSprite`, `frzHitSprite`].forEach(sprite => {
+        [`mainSprite`].forEach(sprite => {
             for (let j = 0; j < Math.min(g_stateObj.layerNum, 4); j++) {
                 addTransform(`${sprite}${j}`, `stepArea`, `rotate(${(j % 2 === 0 ? 1 : -1) * (j % 4 < 2 ? 1 : -1) * -15}deg)`);
             }


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. Appearance用のフィルターを階層別に定義するよう変更

- Appearance用のフィルターを階層別に定義し、StepAreaなど変則的な設定の場合でもAppearance用のフィルターが機能するように変更しました。
- この変更に合わせ、StepAreaの「Mismatched」「R-Mismatched」「X-Flower」について回転軸を「mainSprite*N*」に変更しています。
- 多層にまたがる場合はフィルターの線が多く出てしまうため、最大4個表示するようにして、
「Shift」+「PgUp/PgDown」にてフィルター表示の線を切り替えるようにしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 従来はAppearance用のフィルターがmainSprite上にあり、個々の階層が変化したときに追従できていませんでした。

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->

- StepAreaの設定が「Default」「Halfway」以外のとき、余計なAppearance用のフィルターが表示される場合がありますが、仕様です。
- 未使用の階層グループがあった場合に余計なフィルターが出る可能性がある
⇒ 階層が多い場合、「Shift」を押しながら「PgUp/PgDown」で切り替えできるようにしました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced appearance filter controls for a more interactive and responsive display. The filter bars now adjust dynamically based on user inputs, providing a clearer visual experience.
- **Refactor**
	- Streamlined logic for sprite transformations, focusing on a single sprite type for improved clarity and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->