### PR TITLE
fix: [0861] X, Y座標の関連処理の抜けを修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1538,6 +1538,7 @@ const makeBgCanvas = (_ctx, { w = g_sWidth, h = g_sHeight } = {}) => {
 const clearWindow = (_redrawFlg = false, _customDisplayName = ``) => {
 	resetKeyControl();
 	resetTransform();
+	resetXY();
 
 	// ボタン、オブジェクトをクリア (divRoot配下のもの)
 	deleteChildspriteAll(`divRoot`);

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1189,6 +1189,13 @@ const delXY = (_id, _typeId) => {
 };
 
 /**
+ * 座標位置情報の初期化
+ */
+const resetXY = () => {
+    Object.keys(g_posXYs).forEach(_id => delete g_posXYs[_id]);
+};
+
+/**
  * id, transformIdに合致するtransform情報の取得
  * @param {string} _id 
  * @param {string} _transformId 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. X, Y座標の補正値を画面切り替え時に消去する関数を追加

- X, Y座標の補正値を、g_transformsのように消去する関数を追加しました。
- clearWindow関数に内包しています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. X, Y座標の補正値が次のプレイ時に影響するのを防ぐため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
	- Enhanced the reset process when clearing the display, ensuring that all coordinate positions are refreshed for smoother visual transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->