### PR TITLE
feat: [0862] addXY関数について設定を上書きする機能を追加

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1169,6 +1169,7 @@ const calcXY = (_id, _typeId) => {
  * @param {string} _typeId 
  * @param {number} _x 
  * @param {number} _y 
+ * @param {boolean} [_overwrite=false]
  */
 const addXY = (_id, _typeId, _x = 0, _y = 0, _overwrite = false) => {
     if (_overwrite) {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1170,7 +1170,10 @@ const calcXY = (_id, _typeId) => {
  * @param {number} _x 
  * @param {number} _y 
  */
-const addXY = (_id, _typeId, _x = 0, _y = 0) => {
+const addXY = (_id, _typeId, _x = 0, _y = 0, _overwrite = false) => {
+    if (_overwrite) {
+        delete g_posXYs?.[_id];
+    }
     if (g_posXYs[_id] === undefined) {
         g_posXYs[_id] = {};
     }


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. addXY関数について設定を上書きする機能を追加

- addXY関数にこれまでのid座標差分をリセットする引数 `_overwrite` を追加しました。
- デフォルトは`false`です。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. これまでの設定が差分積み上げで、上書きする方法がなかったため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
	- Enhanced positional data updates now offer an option to refresh existing coordinates. This improvement leads to more consistent and accurate information display when position data is updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->