### PR TITLE
feat: [0863] transform, XY座標管理用の関数の見直し

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1166,8 +1166,12 @@ const addXY = (_id, _typeId, _x = 0, _y = 0, _overwrite = false) => {
     }
     g_posXs[_id].set(_typeId, _x);
     g_posYs[_id].set(_typeId, _y);
-    $id(_id).left = `${sumData(Array.from(g_posXs[_id].values()))}px`;
-    $id(_id).top = `${sumData(Array.from(g_posYs[_id].values()))}px`;
+    if (_x !== 0) {
+        $id(_id).left = `${sumData(Array.from(g_posXs[_id].values()))}px`;
+    }
+    if (_y !== 0) {
+        $id(_id).top = `${sumData(Array.from(g_posYs[_id].values()))}px`;
+    }
 };
 
 /**

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1113,7 +1113,8 @@ const g_moveSettingWindow = (_changePageFlg = true, _direction = 1) => {
  * transform, 座標管理
  */
 const g_transforms = {};
-const g_posXYs = {};
+const g_posXs = {};
+const g_posYs = {};
 
 /**
  * idごとのtransformを追加・変更
@@ -1124,12 +1125,10 @@ const g_posXYs = {};
  */
 const addTransform = (_id, _transformId, _transform) => {
     if (g_transforms[_id] === undefined) {
-        g_transforms[_id] = {};
+        g_transforms[_id] = new Map();
     }
-    g_transforms[_id][_transformId] = _transform;
-    const _transforms = [];
-    Object.keys(g_transforms[_id]).forEach(transformId => _transforms.push(g_transforms[_id][transformId]));
-    $id(_id).transform = _transforms.join(` `);
+    g_transforms[_id].set(_transformId, _transform);
+    $id(_id).transform = Array.from(g_transforms[_id].values()).join(` `);
 };
 
 /**
@@ -1145,22 +1144,7 @@ const addTempTransform = (_id, _transform) => {
  * transformの初期化
  */
 const resetTransform = () => {
-    Object.keys(g_transforms).forEach(_id => g_transforms[_id] = {});
-};
-
-/**
- * 座標計算
- * @param {string} _id 
- * @param {string} _typeId 
- */
-const calcXY = (_id, _typeId) => {
-    const _posXs = [], _posYs = [];
-    Object.keys(g_posXYs[_id]).forEach(typeId => {
-        _posXs.push(g_posXYs[_id][typeId][0]);
-        _posYs.push(g_posXYs[_id][typeId][1]);
-    });
-    $id(_id).left = `${sumData(_posXs)}px`;
-    $id(_id).top = `${sumData(_posYs)}px`;
+    Object.keys(g_transforms).forEach(_id => delete g_transforms[_id]);
 };
 
 /**
@@ -1173,13 +1157,17 @@ const calcXY = (_id, _typeId) => {
  */
 const addXY = (_id, _typeId, _x = 0, _y = 0, _overwrite = false) => {
     if (_overwrite) {
-        delete g_posXYs?.[_id];
+        delete g_posXs?.[_id];
+        delete g_posYs?.[_id];
     }
-    if (g_posXYs[_id] === undefined) {
-        g_posXYs[_id] = {};
+    if (g_posXs[_id] === undefined) {
+        g_posXs[_id] = new Map();
+        g_posYs[_id] = new Map();
     }
-    g_posXYs[_id][_typeId] = [_x, _y];
-    calcXY(_id, _typeId);
+    g_posXs[_id].set(_typeId, _x);
+    g_posYs[_id].set(_typeId, _y);
+    $id(_id).left = `${sumData(Array.from(g_posXs[_id].values()))}px`;
+    $id(_id).top = `${sumData(Array.from(g_posYs[_id].values()))}px`;
 };
 
 /**
@@ -1188,15 +1176,18 @@ const addXY = (_id, _typeId, _x = 0, _y = 0, _overwrite = false) => {
  * @param {string} _typeId 
  */
 const delXY = (_id, _typeId) => {
-    delete g_posXYs[_id][_typeId];
-    calcXY(_id, _typeId);
+    g_posXs[_id]?.delete(_typeId);
+    g_posYs[_id]?.delete(_typeId);
+    $id(_id).left = `${sumData(Array.from(g_posXs[_id].values()))}px`;
+    $id(_id).top = `${sumData(Array.from(g_posYs[_id].values()))}px`;
 };
 
 /**
  * 座標位置情報の初期化
  */
 const resetXY = () => {
-    Object.keys(g_posXYs).forEach(_id => delete g_posXYs[_id]);
+    Object.keys(g_posXs).forEach(_id => delete g_posXs[_id]);
+    Object.keys(g_posYs).forEach(_id => delete g_posYs[_id]);
 };
 
 /**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. transform, XY座標管理用の関数の見直し

- transform, XY座標管理用の関数の内部処理を見直し、id単位の管理をObjectからMapに変更しました。
- id管理まではObject管理です。
- id管理別のtransform、X, Y座標を管理する箇所をMapに変えているという意味です。
- 関数の呼び出し方法は変わりません。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. Objectの場合、順序性が保証されず（挿入順になるとは限らない）、
順序によって表現が変わってしまうTransform属性とは相性が悪いと考えたため。
X, Y座標についてもObjectよりMapの方が情報量が少なく軽量のため合わせて置き換えています。

参考：[JavaScript] オブジェクト/Mapのキーの列挙順は保証されるのか
https://qiita.com/anqooqie/items/ab3fed5d269d278cdd2b

参考：【JavaScript】Mapを正しく使うためにまとめた情報
https://qiita.com/takahiro-kato/items/e41a2c0ec14f50eac441

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the underlying management of element positioning and transformations to improve data efficiency and responsiveness. 
	- Streamlined the handling of position data with the introduction of distinct variables for x and y coordinates. 
	- Updated transformation management to utilize a more structured approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->