### PR TITLE
refactor: [0864] X, Y座標の管理関数を分離

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1315,7 +1315,7 @@ const g_stepAreaFunc = {
     'Halfway': () => {
         g_arrowGroupSprite.forEach(sprite => {
             for (let j = 0; j < g_stateObj.layerNum; j++) {
-                addXY(`${sprite}${j}`, `stepArea`, 0, (j % 2 === 0 ? 1 : -1) * (g_headerObj.playingHeight / 2 - g_posObj.stepY + (g_posObj.stepYR - C_ARW_WIDTH) / 2));
+                addY(`${sprite}${j}`, `stepArea`, (j % 2 === 0 ? 1 : -1) * (g_headerObj.playingHeight / 2 - g_posObj.stepY + (g_posObj.stepYR - C_ARW_WIDTH) / 2));
             }
         });
     },
@@ -1326,7 +1326,7 @@ const g_stepAreaFunc = {
         if (g_workObj.orgFlatFlg) {
             g_arrowGroupSprite.forEach(sprite => {
                 for (let j = 2; j < Math.min(g_stateObj.layerNum, 4); j++) {
-                    addXY(`${sprite}${j}`, `stepArea`, 0, (j % 2 === 0 ? 1 : -1) * (g_headerObj.playingHeight / 2 - g_posObj.stepY + (g_posObj.stepYR - C_ARW_WIDTH) / 2));
+                    addY(`${sprite}${j}`, `stepArea`, (j % 2 === 0 ? 1 : -1) * (g_headerObj.playingHeight / 2 - g_posObj.stepY + (g_posObj.stepYR - C_ARW_WIDTH) / 2));
                 }
             });
         }
@@ -1338,7 +1338,7 @@ const g_stepAreaFunc = {
         if (g_workObj.orgFlatFlg) {
             g_arrowGroupSprite.forEach(sprite => {
                 for (let j = 0; j < Math.min(g_stateObj.layerNum, 2); j++) {
-                    addXY(`${sprite}${j}`, `stepArea`, 0, (j % 2 === 0 ? 1 : -1) * (g_headerObj.playingHeight / 2 - g_posObj.stepY + (g_posObj.stepYR - C_ARW_WIDTH) / 2));
+                    addY(`${sprite}${j}`, `stepArea`, (j % 2 === 0 ? 1 : -1) * (g_headerObj.playingHeight / 2 - g_posObj.stepY + (g_posObj.stepYR - C_ARW_WIDTH) / 2));
                 }
             });
         }
@@ -1346,7 +1346,7 @@ const g_stepAreaFunc = {
     '2Step': () => {
         g_arrowGroupSprite.forEach(sprite => {
             for (let j = Math.min(g_stateObj.layerNum, 4) / 2; j < Math.min(g_stateObj.layerNum, 4); j++) {
-                addXY(`${sprite}${j}`, `stepArea`, 0, (j % 2 === 0 ? 1 : -1) * (g_headerObj.playingHeight / 2 - g_posObj.stepY + (g_posObj.stepYR - C_ARW_WIDTH) / 2));
+                addY(`${sprite}${j}`, `stepArea`, (j % 2 === 0 ? 1 : -1) * (g_headerObj.playingHeight / 2 - g_posObj.stepY + (g_posObj.stepYR - C_ARW_WIDTH) / 2));
             }
         });
     },

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1148,6 +1148,76 @@ const resetTransform = () => {
 };
 
 /**
+ * id, transformIdに合致するtransform情報の取得
+ * @param {string} _id 
+ * @param {string} _transformId 
+ * @returns 
+ */
+const getTransform = (_id, _transformId) => {
+    return g_transforms[_id]?.[_transformId] || ``;
+};
+
+/**
+ * 座標加算処理 (X座標)
+ * @param {string} _id 
+ * @param {string} _typeId 
+ * @param {number} [_x=0] 
+ * @param {boolean} [_overwrite=false] 
+ */
+const addX = (_id, _typeId, _x = 0, _overwrite = false) => {
+    if (_overwrite) {
+        delete g_posXs?.[_id];
+    }
+    if (g_posXs[_id] === undefined) {
+        g_posXs[_id] = new Map();
+    }
+    if (g_posXs[_id].get(_typeId) !== _x) {
+        g_posXs[_id].set(_typeId, _x);
+        $id(_id).left = `${sumData(Array.from(g_posXs[_id].values()))}px`;
+    }
+};
+
+/**
+ * 座標加算処理 (Y座標)
+ * @param {string} _id 
+ * @param {string} _typeId 
+ * @param {number} [_y=0] 
+ * @param {boolean} [_overwrite=false] 
+ */
+const addY = (_id, _typeId, _y = 0, _overwrite = false) => {
+    if (_overwrite) {
+        delete g_posYs?.[_id];
+    }
+    if (g_posYs[_id] === undefined) {
+        g_posYs[_id] = new Map();
+    }
+    if (g_posYs[_id].get(_typeId) !== _y) {
+        g_posYs[_id].set(_typeId, _y);
+        $id(_id).top = `${sumData(Array.from(g_posYs[_id].values()))}px`;
+    }
+};
+
+/**
+ * 座標リセット処理（X座標）
+ * @param {string} _id 
+ * @param {string} _typeId 
+ */
+const delX = (_id, _typeId) => {
+    g_posXs[_id]?.delete(_typeId);
+    $id(_id).left = `${sumData(Array.from(g_posXs[_id].values()))}px`;
+};
+
+/**
+ * 座標リセット処理（Y座標）
+ * @param {string} _id 
+ * @param {string} _typeId 
+ */
+const delY = (_id, _typeId) => {
+    g_posYs[_id]?.delete(_typeId);
+    $id(_id).top = `${sumData(Array.from(g_posYs[_id].values()))}px`;
+};
+
+/**
  * 座標加算処理
  * @param {string} _id 
  * @param {string} _typeId 
@@ -1156,22 +1226,8 @@ const resetTransform = () => {
  * @param {boolean} [_overwrite=false]
  */
 const addXY = (_id, _typeId, _x = 0, _y = 0, _overwrite = false) => {
-    if (_overwrite) {
-        delete g_posXs?.[_id];
-        delete g_posYs?.[_id];
-    }
-    if (g_posXs[_id] === undefined) {
-        g_posXs[_id] = new Map();
-        g_posYs[_id] = new Map();
-    }
-    g_posXs[_id].set(_typeId, _x);
-    g_posYs[_id].set(_typeId, _y);
-    if (_x !== 0) {
-        $id(_id).left = `${sumData(Array.from(g_posXs[_id].values()))}px`;
-    }
-    if (_y !== 0) {
-        $id(_id).top = `${sumData(Array.from(g_posYs[_id].values()))}px`;
-    }
+    addX(_id, _typeId, _x, _overwrite);
+    addY(_id, _typeId, _y, _overwrite);
 };
 
 /**
@@ -1180,10 +1236,8 @@ const addXY = (_id, _typeId, _x = 0, _y = 0, _overwrite = false) => {
  * @param {string} _typeId 
  */
 const delXY = (_id, _typeId) => {
-    g_posXs[_id]?.delete(_typeId);
-    g_posYs[_id]?.delete(_typeId);
-    $id(_id).left = `${sumData(Array.from(g_posXs[_id].values()))}px`;
-    $id(_id).top = `${sumData(Array.from(g_posYs[_id].values()))}px`;
+    delX(_id, _typeId);
+    delY(_id, _typeId);
 };
 
 /**
@@ -1192,16 +1246,6 @@ const delXY = (_id, _typeId) => {
 const resetXY = () => {
     Object.keys(g_posXs).forEach(_id => delete g_posXs[_id]);
     Object.keys(g_posYs).forEach(_id => delete g_posYs[_id]);
-};
-
-/**
- * id, transformIdに合致するtransform情報の取得
- * @param {string} _id 
- * @param {string} _transformId 
- * @returns 
- */
-const getTransform = (_id, _transformId) => {
-    return g_transforms[_id]?.[_transformId] || ``;
 };
 
 /**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. X, Y座標の管理関数を分離
- X, Y座標の管理関数を分離しました。
- 従来の addXY, delXY 関数はそのまま残し、内部関数としてaddX/addY, delX, delYを追加しています。
- また、前回と同じ値であれば座標を更新しないようにしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. #1756 にて見直しを行ったが、XY軸がセットのため融通が利かないことがあるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a method for retrieving transformation details using user-provided identifiers.

- **Refactor**
  - Streamlined coordinate management by separating horizontal and vertical updates, ensuring changes are applied only when necessary.
  - Enhanced default settings for coordinate updates to boost flexibility and consistency.

- **Documentation**
  - Updated user-facing guides to clarify the revised coordinate handling and transformation retrieval improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->