### PR TITLE
refactor: [0866] PlayWindow, EffectをカスタムJSの前に移動、コード整理

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10067,6 +10067,12 @@ const mainInit = () => {
 	// StepArea処理
 	g_stepAreaFunc.get(g_stateObj.stepArea)();
 
+	// mainSpriteのtransform追加処理
+	addTransform(`mainSprite`, `playWindow`, g_playWindowFunc.get(g_stateObj.playWindow)());
+
+	// EffectのArrowEffect追加処理
+	g_effectFunc.get(g_stateObj.effect)();
+
 	// Appearanceのオプション適用時は一部描画を隠す
 	changeAppearanceFilter(g_appearanceRanges.includes(g_stateObj.appearance) ?
 		g_hidSudObj.filterPos : g_hidSudObj.filterPosDefault[g_stateObj.appearance], true);
@@ -10333,12 +10339,6 @@ const mainInit = () => {
 
 	// ユーザカスタムイベント(初期)
 	g_customJsObj.main.forEach(func => func());
-
-	// mainSpriteのtransform追加処理
-	addTransform(`mainSprite`, `playWindow`, g_playWindowFunc.get(g_stateObj.playWindow)());
-
-	// EffectのArrowEffect追加処理
-	g_effectFunc.get(g_stateObj.effect)();
 
 	/**
 	 * キーを押したときの処理
@@ -11369,25 +11369,29 @@ const changeAppearanceFilter = (_num = 10, _shiftFlg = keyIsShift()) => {
 	const bottomShape = `inset(${numPlus}% 0% ${_num}% 0%)`;
 	const appearPers = [_num, MAX_FILTER_POS - _num];
 
+	const topDist = g_posObj.arrowHeight * appearPers[topNum] / MAX_FILTER_POS;
+	const bottomDist = g_posObj.arrowHeight * appearPers[bottomNum] / MAX_FILTER_POS;
+
 	for (let j = 0; j < g_stateObj.layerNum; j += 2) {
 		$id(`arrowSprite${topNum + j}`).clipPath = topShape;
 		$id(`arrowSprite${bottomNum + j}`).clipPath = bottomShape;
 
-		$id(`filterBar${topNum + j}`).top = wUnit(parseFloat($id(`arrowSprite${j}`).top) + g_posObj.arrowHeight * appearPers[topNum] / MAX_FILTER_POS);
-		$id(`filterBar${bottomNum + j}`).top = wUnit(parseFloat($id(`arrowSprite${j + 1}`).top) + g_posObj.arrowHeight * appearPers[bottomNum] / MAX_FILTER_POS);
+		$id(`filterBar${topNum + j}`).top = wUnit(parseFloat($id(`arrowSprite${j}`).top) + topDist);
+		$id(`filterBar${bottomNum + j}`).top = wUnit(parseFloat($id(`arrowSprite${j + 1}`).top) + bottomDist);
 
 		if (![`Default`, `Halfway`].includes(g_stateObj.stepArea)) {
-			$id(`filterBar${bottomNum + j}_HS`).top = wUnit(parseFloat($id(`arrowSprite${j}`).top) + g_posObj.arrowHeight * appearPers[bottomNum] / MAX_FILTER_POS);
-			$id(`filterBar${topNum + j}_HS`).top = wUnit(parseFloat($id(`arrowSprite${j + 1}`).top) + g_posObj.arrowHeight * appearPers[topNum] / MAX_FILTER_POS);
+			$id(`filterBar${bottomNum + j}_HS`).top = wUnit(parseFloat($id(`arrowSprite${j}`).top) + bottomDist);
+			$id(`filterBar${topNum + j}_HS`).top = wUnit(parseFloat($id(`arrowSprite${j + 1}`).top) + topDist);
 		}
 
 		// 階層が多い場合はShift+pgUp/pgDownで表示する階層グループを切り替え
 		if (_shiftFlg && g_stateObj.d_filterline === C_FLG_ON) {
 			[`${topNum + j}`, `${bottomNum + j}`].forEach(type => {
-				$id(`filterBar${type}`).display = (j === g_workObj.aprFilterCnt ? C_DIS_INHERIT : C_DIS_NONE);
+				const displayState = (j === g_workObj.aprFilterCnt ? C_DIS_INHERIT : C_DIS_NONE);
+				$id(`filterBar${type}`).display = displayState;
 
 				if (![`Default`, `Halfway`].includes(g_stateObj.stepArea)) {
-					$id(`filterBar${type}_HS`).display = (j === g_workObj.aprFilterCnt ? C_DIS_INHERIT : C_DIS_NONE);
+					$id(`filterBar${type}_HS`).display = displayState;
 				}
 			});
 		}
@@ -11586,7 +11590,6 @@ const changeHitFrz = (_j, _k, _name, _difFrame = 0) => {
 	const styfrzBtmRoot = $id(`${_name}BtmRoot${frzNo}`);
 	const styfrzBtm = $id(`${_name}Btm${frzNo}`);
 	const styfrzTopRoot = $id(`${_name}TopRoot${frzNo}`);
-	const styfrzTop = $id(`${_name}Top${frzNo}`);
 	const styfrzBtmShadow = $id(`${_name}BtmShadow${frzNo}`);
 
 	// フリーズアロー位置の修正（ステップゾーン上に来るように）

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -11364,11 +11364,13 @@ const changeAppearanceFilter = (_num = 10, _shiftFlg = keyIsShift()) => {
 		_num = MAX_FILTER_POS / 2;
 	}
 
+	// アルファマスクの位置設定
 	const numPlus = (g_stateObj.appearance === `Hid&Sud+` ? _num : 0);
 	const topShape = `inset(${_num}% 0% ${numPlus}% 0%)`;
 	const bottomShape = `inset(${numPlus}% 0% ${_num}% 0%)`;
-	const appearPers = [_num, MAX_FILTER_POS - _num];
 
+	// フィルターバーの位置設定
+	const appearPers = [_num, MAX_FILTER_POS - _num];
 	const topDist = g_posObj.arrowHeight * appearPers[topNum] / MAX_FILTER_POS;
 	const bottomDist = g_posObj.arrowHeight * appearPers[bottomNum] / MAX_FILTER_POS;
 
@@ -11406,6 +11408,7 @@ const changeAppearanceFilter = (_num = 10, _shiftFlg = keyIsShift()) => {
 			$id(`filterBar${(g_hidSudObj.std[g_stateObj.appearance][g_stateObj.reverse]) % 2}`).top;
 		filterView.textContent = `${_num}%`;
 
+		// スクロールが1種類でHidden+/Sudden+の場合、対面のフィルターバーは不要なため非表示にする
 		if (g_stateObj.appearance !== `Hid&Sud+` && g_workObj.dividePos.every(v => v === g_workObj.dividePos[0])) {
 			$id(`filterBar${(g_hidSudObj.std[g_stateObj.appearance][g_stateObj.reverse] + 1) % 2}`).display = C_DIS_NONE;
 		}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -11485,10 +11485,14 @@ const changeReturn = (_rad, _axis) => {
 
 /**
  * AutoRetryの設定
- * @param {number} _retryNum AutoRetryの設定位置（g_settings.autoRetryNum）
+ * @param {string} _retryCondition リトライ基準となるAutoRetry名
  */
-const quickRetry = (_retryNum) => {
-	if (g_settings.autoRetryNum >= _retryNum && !g_workObj.autoRetryFlg) {
+const quickRetry = (_retryCondition) => {
+	const retryNum = g_settings.autoRetrys.findIndex(val => val === _retryCondition);
+	if (retryNum < 0) {
+		return;
+	}
+	if (g_settings.autoRetryNum >= retryNum && !g_workObj.autoRetryFlg) {
 		g_workObj.autoRetryFlg = true;
 		setTimeout(() => {
 			g_audio.pause();
@@ -11790,11 +11794,11 @@ const displayDiff = (_difFrame, _fjdg = ``, _justFrames = g_headerObj.justFrames
 	} else if (_difFrame > _justFrames) {
 		diffJDisp = `<span class="common_diffFast">Fast ${difCnt} Frames</span>`;
 		g_resultObj.fast++;
-		quickRetry(4);
+		quickRetry(`Fast/Slow`);
 	} else if (_difFrame < _justFrames * (-1)) {
 		diffJDisp = `<span class="common_diffSlow">Slow ${difCnt} Frames</span>`;
 		g_resultObj.slow++;
-		quickRetry(4);
+		quickRetry(`Fast/Slow`);
 	}
 	document.getElementById(`diff${_fjdg}J`).innerHTML = diffJDisp;
 };
@@ -11840,7 +11844,7 @@ const lifeRecovery = () => {
  */
 const lifeDamage = (_excessive = false) => {
 	g_workObj.lifeVal -= g_workObj.lifeDmg * (_excessive ? 0.25 : 1);
-	quickRetry(1);
+	quickRetry(`Miss`);
 
 	if (g_workObj.lifeVal <= 0) {
 		g_workObj.lifeVal = 0;
@@ -11892,7 +11896,7 @@ const judgeRecovery = (_name, _difFrame) => {
 		}
 	}
 	if (_name === `shakin`) {
-		quickRetry(3);
+		quickRetry(`Shakin(Great)`);
 	}
 	g_customJsObj[`judg_${_name}`].forEach(func => func(_difFrame));
 };
@@ -11931,7 +11935,7 @@ const judgeMatari = _difFrame => {
 	changeJudgeCharacter(`matari`, g_lblNameObj.j_matari);
 	comboJ.textContent = ``;
 	finishViewing();
-	quickRetry(2);
+	quickRetry(`Matari(Good)`);
 
 	g_customJsObj.judg_matari.forEach(func => func(_difFrame));
 };

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1151,7 +1151,7 @@ const resetTransform = () => {
  * id, transformIdに合致するtransform情報の取得
  * @param {string} _id 
  * @param {string} _transformId 
- * @returns 
+ * @returns {string}
  */
 const getTransform = (_id, _transformId) => {
     return g_transforms[_id]?.[_transformId] || ``;
@@ -1387,7 +1387,7 @@ const g_shakingFunc = new Map([
 
 /**
  * ランダムな軸を返す補助関数
- * @returns 軸
+ * @returns {string} 軸
  */
 const g_getRandomAxis = () => {
     const axes = [`X`, `Y`, `Z`];
@@ -1397,7 +1397,7 @@ const g_getRandomAxis = () => {
 /**
  * 最初に選んだ軸を除く、次の軸を返す補助関数
  * @param {string} _primaryAxis 
- * @returns 軸
+ * @returns {string} 軸
  */
 const g_getSecondaryAxis = (_primaryAxis) => {
     const remainingAxes = [`X`, `Y`, `Z`, undefined].filter(val => val !== _primaryAxis);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. プレイ画面のPlayWindow, Effect処理をカスタムJSの前に移動
- プレイ画面のPlayWindow, Effect処理をカスタムJSの前に移動しました。

### 2. AutoRetryを行う関数の引数を数字から設定名に変更
- quickRetryの引数を変更しました。
設定名指定になり、設定箇所が変更されても追従されるようになりました。

### 3. コードの整理
- 重複している箇所を変数に格納して共用するようにしました。


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. カスタムJSの後にいると、割り込み処理での修正が難しくなるため。
2. 引数が数字で指定されており、わかる人でないと判別できないため。
3. コードの見やすさのため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**  
  - Updated visual transformation processes for smoother, more consistent animation effects.  
  - Streamlined filtering logic for a cleaner and more organized display of elements.

These behind-the-scenes enhancements improve performance and maintainability while preserving the familiar user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->