### PR TITLE
refactor: [867] 自動拡張時、背景・マスクモーションの位置補正をcreateMultipleSpriteへ内包

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1297,7 +1297,8 @@ const createEmptySprite = (_parentObj, _newObjId, { x = 0, y = 0, w = g_sWidth, 
 const createMultipleSprite = (_baseName, _num, { x = 0 } = {}) => {
 	const sprite = createEmptySprite(divRoot, _baseName);
 	for (let j = 0; j <= _num; j++) {
-		createEmptySprite(sprite, `${_baseName}${j}`, { x });
+		createEmptySprite(sprite, `${_baseName}${j}`);
+		addX(`${_baseName}${j}`, `root`, x);
 	}
 	return sprite;
 };
@@ -9951,8 +9952,7 @@ const mainInit = () => {
 	const mainCommonPos = { w: g_headerObj.playingWidth, h: g_posObj.arrowHeight };
 
 	// 背景スプライトを作成
-	createMultipleSprite(`backSprite`, g_scoreObj.backMaxDepth);
-	addX(`backSprite`, `root`, g_workObj.backX);
+	createMultipleSprite(`backSprite`, g_scoreObj.backMaxDepth, { x: g_workObj.backX });
 
 	// ステップゾーン、矢印のメインスプライトを作成
 	const mainSprite = createEmptySprite(divRoot, `mainSprite`, mainCommonPos);
@@ -9971,8 +9971,7 @@ const mainInit = () => {
 	const [keyCtrlPtn, keyNum] = [tkObj.keyCtrlPtn, tkObj.keyNum];
 
 	// マスクスプライトを作成 (最上位)
-	createMultipleSprite(`maskSprite`, g_scoreObj.maskMaxDepth);
-	addX(`maskSprite`, `root`, g_workObj.backX);
+	createMultipleSprite(`maskSprite`, g_scoreObj.maskMaxDepth, { x: g_workObj.backX });
 
 	// カラー・モーションを適用するオブジェクトの種類
 	const objList = (g_stateObj.dummyId === `` ? [``] : [`dummy`, ``]);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1298,8 +1298,8 @@ const createMultipleSprite = (_baseName, _num, { x = 0 } = {}) => {
 	const sprite = createEmptySprite(divRoot, _baseName);
 	for (let j = 0; j <= _num; j++) {
 		createEmptySprite(sprite, `${_baseName}${j}`);
-		addX(`${_baseName}${j}`, `root`, x);
 	}
+	addX(_baseName, `root`, x);
 	return sprite;
 };
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 自動拡張時、背景・マスクモーションの位置補正をcreateMultipleSpriteへ内包

- 自動拡張時の背景・マスクモーションの位置補正をcreateMultipleSpriteへ内包しました。
- もともとX座標補正を行うことも含んでいたため、内部関数としてaddXを入れるようにしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. コードの見やすさのため。
addXの指定忘れがなくなり、差分管理もされるため後々の変更にも対応できる。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- ブランチがhotfixになっていますが、不具合対応ではありません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the creation and positioning of visual elements to ensure they display with consistent horizontal alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->