### PR TITLE
refactor: [0868] CSSのpointer-events属性のデフォルト値を種別ごとに設定するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1284,7 +1284,7 @@ const createEmptySprite = (_parentObj, _newObjId, { x = 0, y = 0, w = g_sWidth, 
 	div.title = title;
 
 	const style = div.style;
-	style.pointerEvents = C_DIS_NONE;
+	style.pointerEvents = title === `` ? C_DIS_NONE : C_DIS_AUTO;
 	Object.keys(rest).forEach(property => style[property] = rest[property]);
 	_parentObj.appendChild(div);
 
@@ -6030,7 +6030,7 @@ const createGeneralSetting = (_obj, _settingName, { unitName = ``,
  */
 const createLblSetting = (_settingName, _adjY = 0, _settingLabel = _settingName) => {
 	const lbl = createDivCss2Label(`lbl${_settingName}`, g_lblNameObj[_settingLabel], {
-		x: -5, y: _adjY, w: 110,
+		x: -5, y: _adjY, w: 110, pointerEvents: C_DIS_AUTO,
 	}, `settings_${_settingName}`);
 	lbl.title = g_msgObj[`${_settingName.charAt(0).toLowerCase()}${_settingName.slice(1)}`];
 	return lbl;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -89,6 +89,7 @@ const C_FLG_ON = `ON`;
 const C_FLG_OFF = `OFF`;
 const C_FLG_ALL = `ALL`;
 const C_DIS_NONE = `none`;
+const C_DIS_AUTO = `auto`;
 const C_DIS_INHERIT = `inherit`;
 
 // 初期化フラグ（ボタンアニメーション制御）
@@ -663,7 +664,7 @@ const createScText = (_obj, _settingLabel, { displayName = `option`, dfLabel = `
 		multiAppend(_obj,
 			createDivCss2Label(`sc${_settingLabel}`,
 				g_scViewObj.format.split(`{0}`).join(dfLabel || (`${g_kCd[g_kCdN.findIndex(kCd => kCd === scKey[0])] ?? ''}`)), {
-				x, y, w, siz, fontWeight: `bold`, opacity: 0.75, pointerEvents: C_DIS_NONE,
+				x, y, w, siz, fontWeight: `bold`, opacity: 0.75,
 			})
 		);
 	}
@@ -1106,7 +1107,6 @@ const getFontSize = (_str, _maxWidth, _font = getBasicFont(), _maxFontsize = 64,
 const createDescDiv = (_id, _str, { altId = _id, siz = g_limitObj.mainSiz } = {}) =>
 	createDivCss2Label(_id, _str, Object.assign(g_lblPosObj[altId], {
 		siz: getFontSize(_str, g_lblPosObj[altId]?.w || g_sWidth, getBasicFont(), siz),
-		pointerEvents: C_DIS_NONE,
 	}));
 
 /*-----------------------------------------------------------*/
@@ -1173,6 +1173,7 @@ const createDivCss2Label = (_id, _text, { x = 0, y = 0, w = g_limitObj.setLblWid
 	style.fontSize = wUnit(siz);
 	style.fontFamily = getBasicFont();
 	style.textAlign = `${align}`;
+	style.pointerEvents = C_DIS_NONE;
 	div.innerHTML = _text;
 	Object.keys(rest).forEach(property => style[property] = rest[property]);
 
@@ -1212,6 +1213,7 @@ const createColorPicker = (_parentObj, _id, _func, { x = 0, y = 0 } = {}) => {
 	picker.style.left = wUnit(x);
 	picker.style.top = wUnit(y);
 	picker.style.position = `absolute`;
+	picker.style.pointerEvents = C_DIS_AUTO;
 	picker.addEventListener(`change`, _func);
 	_parentObj.appendChild(picker);
 	return picker;
@@ -1252,6 +1254,7 @@ const createColorObject2 = (_id,
 	style.maskSize = `contain`;
 	style.webkitMaskImage = `url("${g_imgObj[charaStyle]}")`;
 	style.webkitMaskSize = `contain`;
+	style.pointerEvents = C_DIS_NONE;
 	Object.keys(rest).forEach(property => style[property] = rest[property]);
 	setAttrs(div, { color: rest.background ?? ``, type: charaStyle, cnt: 0, });
 
@@ -1281,6 +1284,7 @@ const createEmptySprite = (_parentObj, _newObjId, { x = 0, y = 0, w = g_sWidth, 
 	div.title = title;
 
 	const style = div.style;
+	style.pointerEvents = C_DIS_NONE;
 	Object.keys(rest).forEach(property => style[property] = rest[property]);
 	_parentObj.appendChild(div);
 
@@ -1404,6 +1408,7 @@ const createCss2Button = (_id, _text, _func = () => true, {
 	style.textAlign = align;
 	style.fontSize = wUnit(siz);
 	style.fontFamily = getBasicFont();
+	style.pointerEvents = C_DIS_AUTO;
 	if (rest.animationName !== undefined) {
 		style.animationDuration = `1s`;
 	}
@@ -1414,7 +1419,7 @@ const createCss2Button = (_id, _text, _func = () => true, {
 		if (g_initialFlg && g_btnWaitFrame[groupName].initial) {
 		} else {
 			style.pointerEvents = C_DIS_NONE;
-			setTimeout(() => style.pointerEvents = rest.pointerEvents ?? `auto`,
+			setTimeout(() => style.pointerEvents = rest.pointerEvents ?? C_DIS_AUTO,
 				g_btnWaitFrame[groupName].b_frame * 1000 / g_fps);
 		}
 	}
@@ -3102,7 +3107,7 @@ const headerConvert = _dosObj => {
 	g_settings.speedNum = roundZero(g_settings.speeds.findIndex(speed => speed === g_stateObj.speed));
 
 	// グラデーションのデフォルト中間色を設定
-	divRoot.appendChild(createDivCss2Label(`dummyLabel`, ``, { pointerEvents: C_DIS_NONE }));
+	divRoot.appendChild(createDivCss2Label(`dummyLabel`, ``));
 	obj.baseBrightFlg = setBoolVal(_dosObj.baseBright, checkLightOrDark(colorNameToCode(window.getComputedStyle(dummyLabel, ``).color)));
 	const intermediateColor = obj.baseBrightFlg ? `#111111` : `#eeeeee`;
 
@@ -3470,7 +3475,7 @@ const headerConvert = _dosObj => {
 	obj.commentExternal = setBoolVal(_dosObj.commentExternal);
 
 	// Reverse時の歌詞の自動反転制御
-	obj.wordAutoReverse = _dosObj.wordAutoReverse ?? g_presetObj.wordAutoReverse ?? `auto`;
+	obj.wordAutoReverse = _dosObj.wordAutoReverse ?? g_presetObj.wordAutoReverse ?? C_DIS_AUTO;
 
 	// プレイ中クレジットを表示しないエリアのサイズ(X方向)
 	obj.customViewWidth = setVal(_dosObj.customViewWidth ?? _dosObj.customCreditWidth, 0, C_TYP_FLOAT);
@@ -4567,10 +4572,7 @@ const titleInit = () => {
 	}
 
 	// マスクスプライトを作成
-	const maskTitleSprite = createMultipleSprite(`maskTitleSprite`, g_headerObj.maskTitleMaxDepth);
-	if (!g_headerObj.masktitleButton) {
-		maskTitleSprite.style.pointerEvents = C_DIS_NONE;
-	}
+	createMultipleSprite(`maskTitleSprite`, g_headerObj.maskTitleMaxDepth);
 
 	/**
 	 * タイトルのモーション設定
@@ -4678,10 +4680,10 @@ const setWindowStyle = (_text, _bkColor, _textColor, _align = C_ALIGN_LEFT, { _x
 	const lbl = createDivCss2Label(`lblWarning`, _text, {
 		x: _x, y: 70 + _y, w: _w, h: warnHeight, siz: g_limitObj.mainSiz, backgroundColor: _bkColor,
 		opacity: 0.9, lineHeight: wUnit(15), color: _textColor, align: _align, fontFamily: getBasicFont(),
-		whiteSpace: `normal`,
+		whiteSpace: `normal`, pointerEvents: C_DIS_AUTO,
 	});
 	if (warnHeight === 150) {
-		lbl.style.overflow = `auto`;
+		lbl.style.overflow = C_DIS_AUTO;
 	}
 
 	// 一時的な枠を削除
@@ -5387,7 +5389,7 @@ const makeHighScore = _scoreId => {
 			`${g_localStorage.highscores?.[scoreName]?.fullCombo ?? '' ? '<span class="result_FullCombo">◆</span>' : ''}` +
 			`${g_localStorage.highscores?.[scoreName]?.perfect ?? '' ? '<span class="result_Perfect">◆</span>' : ''}` +
 			`${g_localStorage.highscores?.[scoreName]?.allPerfect ?? '' ? '<span class="result_AllPerfect">◆</span>' : ''}`, { xPos: 1, dx: 20, yPos: 12, w: 100, align: C_ALIGN_CENTER }),
-		createScoreLabel(`lblHClearLamps`, `Cleared: ` + (g_localStorage.highscores?.[scoreName]?.clearLamps?.join(', ') ?? `---`), { yPos: 13, overflow: `auto`, w: g_sWidth / 2 + 40, h: 37 }),
+		createScoreLabel(`lblHClearLamps`, `Cleared: ` + (g_localStorage.highscores?.[scoreName]?.clearLamps?.join(', ') ?? `---`), { yPos: 13, overflow: C_DIS_AUTO, w: g_sWidth / 2 + 40, h: 37 }),
 
 		createScoreLabel(`lblHShuffle`, g_stateObj.shuffle.indexOf(`Mirror`) < 0 ? `` : `Shuffle: <span class="common_iknai">${g_stateObj.shuffle}</span>`, { yPos: 11.5, dx: -130 }),
 		createScoreLabel(`lblHAssist`, g_autoPlaysBase.includes(g_stateObj.autoPlay) ? `` : `Assist: <span class="common_kita">${g_stateObj.autoPlay}</span>`, { yPos: 12.5, dx: -130 }),
@@ -6921,18 +6923,18 @@ const keyConfigInit = (_kcType = g_kcType) => {
 			// 矢印の塗り部分
 			createColorObject2(`arrowShadow${j}`, {
 				x: keyconX, y: keyconY, background: hasVal(g_headerObj[`setShadowColor${g_colorType}`][colorPos]) ? getShadowColor(colorPos, arrowColor) : ``,
-				rotate: g_keyObj[`stepRtn${keyCtrlPtn}_${g_keycons.stepRtnGroupNum}`][j], styleName: `Shadow`, pointerEvents: `none`,
+				rotate: g_keyObj[`stepRtn${keyCtrlPtn}_${g_keycons.stepRtnGroupNum}`][j], styleName: `Shadow`,
 			}),
 			// 矢印本体
 			createColorObject2(`arrow${j}`, {
-				x: keyconX, y: keyconY, background: arrowColor, rotate: g_keyObj[`stepRtn${keyCtrlPtn}_${g_keycons.stepRtnGroupNum}`][j], pointerEvents: `none`,
+				x: keyconX, y: keyconY, background: arrowColor, rotate: g_keyObj[`stepRtn${keyCtrlPtn}_${g_keycons.stepRtnGroupNum}`][j],
 			}),
 		);
 		if (g_headerObj.shuffleUse && g_keyObj[`shuffle${keyCtrlPtn}`] !== undefined) {
 			keyconSprite.appendChild(
 				createCss2Button(`sArrow${j}`, ``, () => changeTmpShuffleNum(j), {
 					x: keyconX, y: keyconY - 12, w: C_ARW_WIDTH, h: 15, siz: 12, fontWeight: `bold`,
-					pointerEvents: (g_settings.shuffles.filter(val => val.endsWith(`+`)).length > 0 ? `auto` : `none`),
+					pointerEvents: (g_settings.shuffles.filter(val => val.endsWith(`+`)).length > 0 ? C_DIS_AUTO : C_DIS_NONE),
 					cxtFunc: () => changeTmpShuffleNum(j, -1),
 				}, g_cssObj.button_Default_NoColor, g_cssObj.title_base)
 			);
@@ -8609,7 +8611,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 			// word_dataのみ指定されている場合、下記ルールに従って設定
 			if (!wordTarget.includes(`Rev`) && g_stateObj.scroll === `---`) {
 				// Reverse時の歌詞の自動反転制御設定
-				if (g_headerObj.wordAutoReverse !== `auto`) {
+				if (g_headerObj.wordAutoReverse !== C_DIS_AUTO) {
 					wordReverseFlg = g_headerObj.wordAutoReverse === C_FLG_ON;
 				} else if (keyNum === divideCnt + 1) {
 					wordReverseFlg = true;
@@ -8633,7 +8635,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 		let wordReverseFlg = _reverseFlg;
 		const tmpArrayData = splitLF(_data);
 
-		if (g_headerObj.wordAutoReverse === `auto`) {
+		if (g_headerObj.wordAutoReverse === C_DIS_AUTO) {
 			tmpArrayData.filter(data => hasVal(data) && data?.indexOf(`<br>`) !== -1).forEach(() => wordReverseFlg = false);
 		}
 
@@ -12487,7 +12489,7 @@ const resultInit = () => {
 	 * @param {string} _msg 
 	 */
 	const copyResultImageData = _msg => {
-		const tmpDiv = createEmptySprite(divRoot, `tmpDiv`, { x: 0, y: 0, w: g_sWidth, h: g_sHeight });
+		const tmpDiv = createEmptySprite(divRoot, `tmpDiv`, { x: 0, y: 0, w: g_sWidth, h: g_sHeight, pointerEvents: C_DIS_AUTO });
 		tmpDiv.style.background = `#000000cc`;
 		const canvas = document.createElement(`canvas`);
 		const artistName = g_headerObj.artistNames[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.artistName;
@@ -12662,10 +12664,7 @@ const resultInit = () => {
 	);
 
 	// マスクスプライトを作成
-	const maskResultSprite = createMultipleSprite(`maskResultSprite`, g_headerObj.maskResultMaxDepth);
-	if (!g_headerObj.maskresultButton) {
-		maskResultSprite.style.pointerEvents = C_DIS_NONE;
-	}
+	createMultipleSprite(`maskResultSprite`, g_headerObj.maskResultMaxDepth);
 
 	// リザルトモーションの0フレーム対応
 	g_animationData.filter(sprite => g_scoreObj[`${sprite}ResultFrameNum`] === 0 && g_headerObj[`${sprite}ResultData`][0] !== undefined)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4572,7 +4572,8 @@ const titleInit = () => {
 	}
 
 	// マスクスプライトを作成
-	createMultipleSprite(`maskTitleSprite`, g_headerObj.maskTitleMaxDepth);
+	const maskTitleSprite = createMultipleSprite(`maskTitleSprite`, g_headerObj.maskTitleMaxDepth);
+	maskTitleSprite.style.pointerEvents = g_headerObj.masktitleButton ? C_DIS_AUTO : C_DIS_NONE;
 
 	/**
 	 * タイトルのモーション設定
@@ -12664,7 +12665,8 @@ const resultInit = () => {
 	);
 
 	// マスクスプライトを作成
-	createMultipleSprite(`maskResultSprite`, g_headerObj.maskResultMaxDepth);
+	const makeResultSprite = createMultipleSprite(`maskResultSprite`, g_headerObj.maskResultMaxDepth);
+	makeResultSprite.style.pointerEvents = g_headerObj.maskresultButton ? C_DIS_AUTO : C_DIS_NONE;
 
 	// リザルトモーションの0フレーム対応
 	g_animationData.filter(sprite => g_scoreObj[`${sprite}ResultFrameNum`] === 0 && g_headerObj[`${sprite}ResultData`][0] !== undefined)

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -156,14 +156,14 @@ let [g_sWidth, g_sHeight] = [
 ];
 $id(`canvas-frame`).width = `${Math.max(g_sWidth, 500)}px`;
 $id(`canvas-frame`).height = `${Math.max(g_sHeight, 500)}px`;
-$id(`canvas-frame`).margin = `auto`;
+$id(`canvas-frame`).margin = C_DIS_AUTO;
 
 const g_btnWidth = (_multi = 1) => Math.min(g_sWidth, g_limitObj.btnBaseWidth) * _multi;
 const g_btnX = (_multi = 0) => g_btnWidth(_multi) + Math.max((g_sWidth - g_limitObj.btnBaseWidth) / 2, 0);
 
 // 固定ウィンドウサイズ
 const g_windowObj = {
-    divRoot: { margin: `auto`, letterSpacing: `normal` },
+    divRoot: { margin: C_DIS_AUTO, letterSpacing: `normal`, pointerEvents: C_DIS_AUTO },
     divBack: { background: `linear-gradient(#000000, #222222)` },
 
     colorPickSprite: { x: 0, y: 90, w: 50, h: 280 },
@@ -191,13 +191,13 @@ const getScMsg = {
 const updateWindowSiz = () => {
     Object.assign(g_windowObj, {
         optionSprite: { x: (g_sWidth - 450) / 2, y: 65, w: 450, h: 325 },
-        difList: { x: 165, y: 60, w: 280, h: 270 + g_sHeight - 500, overflow: `auto` },
-        difCover: { x: 20, y: 60, w: 145, h: 270 + g_sHeight - 500, opacity: 0.95 },
-        difFilter: { x: 0, y: 66, w: 140, h: 204 + g_sHeight - 500, overflow: `auto` },
+        difList: { x: 165, y: 60, w: 280, h: 270 + g_sHeight - 500, overflow: C_DIS_AUTO, pointerEvents: C_DIS_AUTO },
+        difCover: { x: 20, y: 60, w: 145, h: 270 + g_sHeight - 500, opacity: 0.95, pointerEvents: C_DIS_AUTO },
+        difFilter: { x: 0, y: 66, w: 140, h: 204 + g_sHeight - 500, overflow: C_DIS_AUTO, pointerEvents: C_DIS_AUTO },
         displaySprite: { x: 25, y: 30, w: (g_sWidth - 450) / 2, h: g_limitObj.setLblHeight * 5 },
-        scoreDetail: { x: 20, y: 85, w: (g_sWidth - 500) / 2 + 420, h: 245, visibility: `hidden` },
+        scoreDetail: { x: 20, y: 85, w: (g_sWidth - 500) / 2 + 420, h: 245, visibility: `hidden`, pointerEvents: C_DIS_AUTO },
         detailObj: { w: (g_sWidth - 500) / 2 + 420, h: 230, visibility: `hidden` },
-        keyconSprite: { y: 105, h: g_sHeight - 105, overflow: `auto` },
+        keyconSprite: { y: 105, h: g_sHeight - 105, overflow: C_DIS_AUTO },
         loader: { y: g_sHeight - 10, h: 10, backgroundColor: `#333333` },
         playDataWindow: { x: g_sWidth / 2 - 225, y: 70, w: 450, h: 110 },
         resultWindow: { x: g_sWidth / 2 - 200, y: 185, w: 400, h: 210 },
@@ -232,7 +232,7 @@ const updateWindowSiz = () => {
         },
         lblComment: {
             x: g_btnX(), y: 70, w: g_btnWidth(), h: g_sHeight - 180, siz: g_limitObj.difSelectorSiz, align: C_ALIGN_LEFT,
-            overflow: `auto`, background: `#222222`, color: `#cccccc`, display: C_DIS_NONE,
+            overflow: C_DIS_AUTO, background: `#222222`, color: `#cccccc`, display: C_DIS_NONE,
             whiteSpace: `normal`,
         },
         btnComment: {
@@ -304,7 +304,7 @@ const updateWindowSiz = () => {
             x: 130, y: 70, w: 200, h: 90,
         },
         dataArrowInfo2: {
-            x: 140, y: 70, w: (g_sWidth - 500) / 2 + 275, h: 150, overflow: `auto`,
+            x: 140, y: 70, w: (g_sWidth - 500) / 2 + 275, h: 150, overflow: C_DIS_AUTO,
         },
         lnkDifInfo: {
             w: g_limitObj.difCoverWidth, h: 20, borderStyle: `solid`,
@@ -340,7 +340,6 @@ const updateWindowSiz = () => {
         },
         kcMsg: {
             x: g_btnX(), y: g_sHeight - 33, w: g_btnWidth(), h: 20, siz: g_limitObj.mainSiz,
-            pointerEvents: `none`,
         },
         kcDesc: {
             x: g_btnX() + 50, y: 68, w: g_btnWidth() - 100, h: 20,
@@ -434,7 +433,7 @@ const updateWindowSiz = () => {
         },
         lblWord: {
             x: 100, w: g_headerObj.playingWidth - 200, h: 50,
-            siz: g_limitObj.mainSiz, align: C_ALIGN_LEFT, display: `block`, margin: `auto`,
+            siz: g_limitObj.mainSiz, align: C_ALIGN_LEFT, display: `block`, margin: C_DIS_AUTO,
         },
         finishView: {
             x: g_headerObj.playingWidth / 2 - 150, y: g_headerObj.playingHeight / 2 - 50, w: 300, h: 20, siz: 50,
@@ -492,13 +491,13 @@ const updateWindowSiz = () => {
 const g_windowAlign = {
     left: () => {
         $id(`canvas-frame`).marginLeft = `0px`;
-        $id(`canvas-frame`).marginRight = `auto`;
+        $id(`canvas-frame`).marginRight = C_DIS_AUTO;
     },
     center: () => {
-        $id(`canvas-frame`).margin = `auto`;
+        $id(`canvas-frame`).margin = C_DIS_AUTO;
     },
     right: () => {
-        $id(`canvas-frame`).marginLeft = `auto`;
+        $id(`canvas-frame`).marginLeft = C_DIS_AUTO;
         $id(`canvas-frame`).marginRight = `0px`;
     },
 };


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. CSSのpointer-events属性のデフォルト値を種別ごとに設定するよう変更

- CSSのpointer-events属性（ポインターイベントの対象にするかどうかの属性）について、
作成する種別ごとにデフォルト値を設定し、原則その設定を継承するように変更しました。
- pointer-eventsについてはこちらのページを参照してください。
https://developer.mozilla.org/ja/docs/Web/CSS/pointer-events
- CW Editionにおける階層のページに、pointer-eventsについての補足があります。
https://github.com/cwtickle/danoniplus/wiki/tips-0021-object-layer

|関数|pointer-eventの既定値|種別|備考|
|----|----|----|----|
|createEmptySprite|**none (対象外)**|ベースオブジェクト|title属性がある場合は対象|
|createDivCss2Label|**none (対象外)**|ラベル||
|createColorObject2|**none (対象外)**|カラーオブジェクト<br>(矢印、フリーズアロー等)||
|createCss2Button|auto (対象)|ボタン||
|createColorPicker|auto (対象)|カラーピッカー||

- createLblSetting関数で作られる設定用のラベルについては対象です。
- 譜面明細子画面、譜面選択リスト、結果画面（画像コピー用）といった透過させると問題になるオブジェクトは例外的に対象としています。
- divRoot自体のpointer-event属性は対象（auto）となっています。デフォルトのコンテキスト制御をOFFにするといった制御を行っており、これが無効になると困るためです。
- 今回制御しているのはあくまで初期値です。pointerEvents変数を渡している場合はその値が優先されます。
- タイトル画面、結果画面におけるマスクの扱いは従来通りです。
masktitleButton / maskresultButton設定にて対象か対象外かを設定します。デフォルトは**対象**  (透過しない)です。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 現状はほとんどのラベル・ボタンが `pointer-events: auto`(対象)であるが、実際にポインターイベントの対象にする必要のあるラベルは限られているため。
また、本来押させたいボタンが背面にあるために押せない事象が発生しうるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- ほとんどの場合、有効にする必要があるのはボタンのため問題ないと思われる。
- 透過できない子画面などをカスタムしている場合は、注意が必要。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced UI interactivity by improving pointer event handling, resulting in more responsive color pickers, buttons, and labels.
- **Refactor**
  - Standardized layout margins and interaction settings to ensure consistent behavior across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->