### PR TITLE
fix: [0870] フェードイン、Appearanceのフィルター位置が動作しない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1166,7 +1166,7 @@ const setUserSelect = (_style, _value = C_DIS_NONE) => {
  * @returns {HTMLDivElement}
  */
 const createDivCss2Label = (_id, _text, { x = 0, y = 0, w = g_limitObj.setLblWidth, h = g_limitObj.setLblHeight,
-	siz = g_limitObj.setLblSiz, align = C_ALIGN_CENTER, ...rest } = {}, ..._classes) => {
+	siz = g_limitObj.setLblSiz, align = C_ALIGN_CENTER, type = `text`, ...rest } = {}, ..._classes) => {
 	const div = createDiv(_id, x, y, w, h, [g_cssObj.title_base, ..._classes]);
 
 	const style = div.style;
@@ -1174,7 +1174,7 @@ const createDivCss2Label = (_id, _text, { x = 0, y = 0, w = g_limitObj.setLblWid
 	style.fontFamily = getBasicFont();
 	style.textAlign = `${align}`;
 	style.pointerEvents = C_DIS_NONE;
-	if (rest?.overflow === C_DIS_AUTO) {
+	if (rest?.overflow === C_DIS_AUTO || type === `range`) {
 		style.pointerEvents = C_DIS_AUTO;
 	}
 	div.innerHTML = _text;
@@ -4804,26 +4804,15 @@ const setSpriteList = _settingList => {
 };
 
 /**
- * スライダー共通処理 (Fadein)
+ * スライダー共通処理 (Fadein, Appearance)
  * @param {HTMLInputElement} _slider 
  * @param {HTMLDivElement} _link 
+ * @param {string} _type 
  * @returns {string}
  */
-const inputSlider = (_slider, _link) => {
+const inputSlider = (_slider, _link, _type) => {
 	const value = parseInt(_slider.value);
-	_link.textContent = `${value}${g_lblNameObj.percent}`;
-	return value;
-};
-
-/**
- * スライダー共通処理 (Appearance)
- * @param {HTMLInputElement} _slider 
- * @param {HTMLDivElement} _link 
- * @returns {string}
- */
-const inputSliderAppearance = (_slider, _link) => {
-	const value = parseInt(_slider.value);
-	_link.textContent = `${g_hidSudObj.distH[g_stateObj.appearance](value)}`;
+	_link.textContent = g_sliderView.get(_type)(value);
 	return value;
 };
 
@@ -5929,7 +5918,7 @@ const createOptionWindow = _sprite => {
 
 	const fadeinSlider = document.getElementById(`fadeinSlider`);
 	fadeinSlider.addEventListener(`input`, () =>
-		g_stateObj.fadein = inputSlider(fadeinSlider, lnkFadein), false);
+		g_stateObj.fadein = inputSlider(fadeinSlider, lnkFadein, `fadein`), false);
 
 	// ---------------------------------------------------
 	// ボリューム (Volume) 
@@ -6636,12 +6625,12 @@ const createSettingsDisplayWindow = _sprite => {
 
 	const appearanceSlider = document.getElementById(`appearanceSlider`);
 	appearanceSlider.addEventListener(`input`, () =>
-		g_hidSudObj.filterPos = inputSliderAppearance(appearanceSlider, lblAppearancePos), false);
+		g_hidSudObj.filterPos = inputSlider(appearanceSlider, lblAppearancePos, `appearance`), false);
 
 	const dispAppearanceSlider = () => {
 		[`lblAppearanceBar`, `lnkLockBtn`, `lnkfilterLine`].forEach(obj =>
 			$id(obj).visibility = g_appearanceRanges.includes(g_stateObj.appearance) ? `Visible` : `Hidden`);
-		inputSliderAppearance(appearanceSlider, lblAppearancePos);
+		inputSlider(appearanceSlider, lblAppearancePos, `appearance`);
 	};
 	dispAppearanceSlider();
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -274,7 +274,7 @@ const updateWindowSiz = () => {
             x: g_limitObj.setLblLeft, y: 0,
         },
         lblFadeinBar: {
-            x: g_limitObj.setLblLeft, y: 0,
+            x: g_limitObj.setLblLeft, y: 0, type: `range`,
         },
 
         /** 設定: 譜面明細子画面 */
@@ -327,7 +327,7 @@ const updateWindowSiz = () => {
             x: g_limitObj.setLblLeft, y: 20, siz: 12, align: C_ALIGN_CENTER,
         },
         lblAppearanceBar: {
-            x: g_limitObj.setLblLeft, y: 15,
+            x: g_limitObj.setLblLeft, y: 15, type: `range`,
         },
         lnkLockBtn: {
             x: g_limitObj.setLblLeft + g_limitObj.setLblWidth - 40, y: 0, w: 40, h: g_limitObj.setLblHeight, siz: 12,
@@ -1448,6 +1448,11 @@ const g_effectFunc = new Map([
     ['Storm', () => g_setEffect(`effects-storm`, `effects-storm`, ``)],
     ['Blinking', () => g_setEffect(`effects-blinking`, `effects-blinking`, ``)],
     ['Squids', () => g_setEffect(`effects-squids-arrow`, `effects-squids-frz`)],
+]);
+
+const g_sliderView = new Map([
+    ['fadein', _val => `${_val}${g_lblNameObj.percent}`],
+    ['appearance', _val => `${g_hidSudObj.distH[g_stateObj.appearance](_val)}`],
 ]);
 
 const g_keycons = {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. フェードイン、Appearanceのフィルター位置が動作しない問題を修正
- PR #1762 を修正した影響で、動作しなくなっていました。
- ラベル作成時に`type: 'range'`を指定することで、選択対象にするように変更しました。

### 2. スライダー処理を共通化
- 今後のために、フェードインとAppearanceのフィルター位置でバラバラだった関数を共通化しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 動作に影響するため。
2. 今後、スライダー処理が使われる可能性があるときに流用しやすくするため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- v39.4.0以降で発生する問題です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced slider controls that now support multiple types for more flexible interaction.
  - Improved display formatting for slider values, including percentage indicators for fade-in and tailored appearance settings.
  
- **Refactor**
  - Consolidated slider functionality for a more consistent and intuitive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->