### PR TITLE
fix: [0874] キーパターンが別キーモードで、デフォルトのショートカットが異なる場合にショートカットキーが変わらない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5808,14 +5808,8 @@ const setDifficulty = (_initFlg) => {
 			});
 
 		}
-
-		const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
-		if (g_headerObj.keyRetryDef === C_KEY_RETRY) {
-			g_headerObj.keyRetry = setIntVal(getKeyCtrlVal(g_keyObj[`keyRetry${keyCtrlPtn}`]), g_headerObj.keyRetryDef);
-		}
-		if (g_headerObj.keyTitleBackDef === C_KEY_TITLEBACK) {
-			g_headerObj.keyTitleBack = setIntVal(getKeyCtrlVal(g_keyObj[`keyTitleBack${keyCtrlPtn}`]), g_headerObj.keyTitleBackDef);
-		}
+		// 曲中ショートカットキーの切り替え
+		setPlayingShortcut();
 	}
 
 	// スクロール設定用の配列を入れ替え
@@ -7754,6 +7748,9 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		// カラーグループ、シャッフルグループの再設定
 		g_keycons.groups.forEach(type => resetGroupList(type, `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`));
 
+		// 曲中ショートカットキーの切り替え
+		setPlayingShortcut();
+
 		// キーコンフィグ画面を再呼び出し
 		keyConfigInit();
 
@@ -7937,6 +7934,20 @@ const getKeyInfo = () => {
 	return {
 		keyCtrlPtn, keyNum, posMax, divideCnt, keyGroupMaps, keyGroupList,
 	};
+};
+
+/**
+ * デフォルトの曲中ショートカットをキー数・キーパターンにより切り替え
+ * - キーコンフィグ画面で個別に変えていた場合は変更しない
+ */
+const setPlayingShortcut = () => {
+	const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
+	if (g_headerObj.keyRetryDef === C_KEY_RETRY) {
+		g_headerObj.keyRetry = setIntVal(getKeyCtrlVal(g_keyObj[`keyRetry${keyCtrlPtn}`]), g_headerObj.keyRetryDef);
+	}
+	if (g_headerObj.keyTitleBackDef === C_KEY_TITLEBACK) {
+		g_headerObj.keyTitleBack = setIntVal(getKeyCtrlVal(g_keyObj[`keyTitleBack${keyCtrlPtn}`]), g_headerObj.keyTitleBackDef);
+	}
 };
 
 /**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. キーパターンが別キーモードで、デフォルトの曲中ショートカットが異なる場合に曲中ショートカットキーが変わらない問題を修正
- キー数が変わったときにデフォルトのショートカットが異なる場合には変わるようになっていましたが、
別キーモードには対応していませんでした。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. Discordでの指摘より。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
- キーコンフィグ画面でタイトルバック、リトライキーを変えた場合は変更しません。
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the handling of key shortcut configurations for improved maintainability and consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->