### PR TITLE
fix: [0876] カスタムキーでData Management画面の実際の割り当てキーが表示されない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -482,7 +482,7 @@ const formatObject = (_obj, _indent = 0, { seen = new WeakSet(), colorFmt = true
 			}
 			if (Array.isArray(_value)) {
 				let formattedArray = _value.map(item => formatValue(item));
-				if (key === `keyCtrl`) {
+				if (key.startsWith(`keyCtrl`)) {
 					formattedArray = formattedArray.filter(item => item !== `0`)
 						.map(item => g_kCd[item] ? `${item}|<span style="color:#ffff66">${g_kCd[item]}</span>` : item);
 				}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. Data Management画面の実際の割り当てキーがカスタムキーの場合に表示されない問題を修正
- カスタムキーの場合に`keyCtrlX`の値に対して実際の割り当てキーが表示されない問題を修正しました。


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. PR #1775 の対応漏れ。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/2b851fc9-6d21-46cd-9951-7e3542788784" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced key recognition by broadening the matching criteria, ensuring a more consistent formatting behavior for control key inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->