### PR TITLE
fix: [0877] Data Management画面のJSON表示でカスタムキーの場合に色データが上下両方に出てしまう問題を修正

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1033,6 +1033,7 @@ const g_settings = {
     },
     environments: [`adjustment`, `volume`, `colorType`, `appearance`, `opacity`, `hitPosition`],
     keyStorages: [`reverse`, `keyCtrl`, `keyCtrlPtn`, `shuffle`, `color`, `stepRtn`],
+    colorStorages: [`setColor`, `setShadowColor`, `frzColor`, `frzShadowColor`],
 
     speeds: makeSpeedList(C_MIN_SPEED, C_MAX_SPEED),
     speedNum: 0,
@@ -1302,11 +1303,11 @@ const g_resetFunc = new Map([
     }],
     ['environment', () => g_settings.environments.forEach(key => delete g_localStorageMgt[key])],
     [`customKey`, () => Object.keys(g_localStorageMgt)
-        .filter(key => listMatching(key, g_settings.keyStorages.concat(`setColor`), { prefix: `^` }))
+        .filter(key => listMatching(key, g_settings.keyStorages.concat(g_settings.colorStorages), { prefix: `^` }))
         .forEach(key => delete g_localStorageMgt[key])],
     [`others`, () => Object.keys(g_localStorageMgt)
         .filter(key => !g_settings.environments.includes(key) && key !== `highscores` &&
-            !listMatching(key, g_settings.keyStorages.concat(`setColor`), { prefix: `^` }))
+            !listMatching(key, g_settings.keyStorages.concat(g_settings.colorStorages), { prefix: `^` }))
         .forEach(key => delete g_localStorageMgt[key])],
 ]);
 
@@ -1320,7 +1321,7 @@ const g_storageFunc = new Map([
         const settingStorage = {};
 
         // カスタムキー定義のストレージデータを表示から除去
-        Object.keys(g_localStorageMgt).filter(val => !listMatching(val, g_settings.keyStorages.concat(`setColor`), { prefix: `^` }))
+        Object.keys(g_localStorageMgt).filter(val => !listMatching(val, g_settings.keyStorages.concat(g_settings.colorStorages), { prefix: `^` }))
             .forEach(val => settingStorage[val] = g_localStorageMgt[val]);
         return settingStorage;
     }],


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. Data Management画面のJSON表示でカスタムキーの場合に色データが上下両方に出てしまう問題を修正
- カスタムキーの色データを作品別の情報から除去できておらず、中途半端な表示になっていました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. PR #1771 の対応漏れ。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the application's handling of color settings, providing a more dynamic and consistent experience for visual customizations.

- **Refactor**
  - Streamlined the processes for saving and resetting color configurations, ensuring that changes persist reliably during usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->