### PR TITLE
[ver39.7.2] Data Management画面のJSON表示でカスタムキーの場合に色データが上下両方に出てしまう問題を修正

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@
 
 | Version      | Supported          | Latest Version                                                                 | Logs                                                                   | First Release | End of Support   |
 | ------------ | ------------------ | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------- | ------------- | ---------------- |
-| v39 :anchor: | :heavy_check_mark: | [v39.7.1](https://github.com/cwtickle/danoniplus/releases/tag/v39.7.1)         | [:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-latest) | 2025-02-01    | (At Release v48) |
+| v39 :anchor: | :heavy_check_mark: | [v39.7.2](https://github.com/cwtickle/danoniplus/releases/tag/v39.7.2)         | [:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-latest) | 2025-02-01    | (At Release v48) |
 | v38          | :heavy_check_mark: | [v38.3.3](https://github.com/cwtickle/danoniplus/releases/tag/v38.3.3)         | [:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-latest) | 2024-11-04    | (At Release v41) |
 | v37          | :warning:          | [v37.8.8](https://github.com/cwtickle/danoniplus/releases/tag/v37.8.8)         | [:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v37)    | 2024-06-15    | (At Release v40) |
 | v36          | :x:                | [v36.6.11 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v36.6.11)         | [:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v36)    | 2024-04-15    | 2025-02-01 |

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8,7 +8,7 @@
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 39.7.1`;
+const g_version = `Ver 39.7.2`;
 const g_revisedDate = `2025/02/20`;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -5,7 +5,7 @@
  *
  * Source by tickle
  * Created : 2019/11/19
- * Revised : 2025/02/20 (v39.7.0)
+ * Revised : 2025/02/20 (v39.7.2)
  *
  * https://github.com/cwtickle/danoniplus
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danoniplus",
-  "version": "39.7.1",
+  "version": "39.7.2",
   "description": "Dancing☆Onigiri (CW Edition) - Web-based Rhythm Game",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- #1779 

## 補足
- リリースが詰まっているので、ver39.7.1とマージします。
#1777 もご覧ください。