### PR TITLE
fix: [0878] 横幅が長いときにData Management画面のボタンが余計に左に表示される問題を修正

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -193,7 +193,7 @@ const getScMsg = {
 const updateWindowSiz = () => {
     Object.assign(g_windowObj, {
         optionSprite: { x: (g_sWidth - 450) / 2, y: 65, w: 450, h: 325 },
-        dataSprite: { x: (g_sWidth - Math.max(g_sWidth - 100, 450)) / 2, y: 65, w: Math.max(g_sWidth - 100, 450), h: 325 },
+        dataSprite: { x: g_btnX() + (g_sWidth - Math.max(g_sWidth - 100, 450)) / 2, y: 65, w: Math.max(g_sWidth - 100, 450), h: 325 },
         difList: { x: 165, y: 60, w: 280, h: 270 + g_sHeight - 500, overflow: C_DIS_AUTO, pointerEvents: C_DIS_AUTO },
         difCover: { x: 20, y: 60, w: 145, h: 270 + g_sHeight - 500, opacity: 0.95, pointerEvents: C_DIS_AUTO },
         difFilter: { x: 0, y: 66, w: 140, h: 204 + g_sHeight - 500, overflow: C_DIS_AUTO, pointerEvents: C_DIS_AUTO },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 横幅が長いときにData Management画面のボタンが余計に左に表示される問題を修正
- 横幅が長いとき、全体的に中央に寄るように調整されていますが
Data Management画面の一部ボタンのみ補正がされていませんでした。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. PR #1775 の考慮漏れです。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- レイアウトの問題なので、動作上の問題はありません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the layout by refining the horizontal placement of a key display element. This adjustment improves its alignment with neighboring interactive components, resulting in a more balanced and cohesive user interface. Users should experience a steadier and visually consistent arrangement that better integrates with adjacent controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->