### PR TITLE
feat: [0879] ローカルストレージ情報のコピー機能を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -517,7 +517,11 @@ const formatObject = (_obj, _indent = 0, { seen = new WeakSet(), colorFmt = true
 			return `<br>${nestedIndent}"${key}": ${formattedValue}`;
 		}).join(`,`);
 
-	return `{${formattedEntries}<br>${baseIndent}}`;
+	let result = `{${formattedEntries}<br>${baseIndent}}`;
+	if (!colorFmt) {
+		result = result.replaceAll(`<br>`, `\r\n`).replaceAll(`&nbsp;`, ` `);
+	}
+	return result;
 }
 
 /**
@@ -4819,6 +4823,7 @@ const dataMgtInit = () => {
 	clearWindow(true);
 	const prevPage = g_currentPage;
 	g_currentPage = `dataMgt`;
+	let selectedKey = g_keyObj.currentKey;
 
 	multiAppend(divRoot,
 
@@ -4887,17 +4892,28 @@ const dataMgtInit = () => {
 		createMgtButton(`customKey`, 3.5, 0),
 		createMgtButton(`others`, 4.5, 0),
 		createMgtLabel(`keyData`, 6),
-		createDivCss2Label(`lblTargetKey`, `(${getKeyName(g_headerObj.keyLabels[0])})`, {
+		createDivCss2Label(`lblTargetKey`, `(${getKeyName(selectedKey)})`, {
 			x: 90, y: g_limitObj.setLblHeight * 6 + 40,
 			siz: g_limitObj.setLblSiz, align: C_ALIGN_LEFT,
 		})
 	);
 
 	g_localStorageMgt = parseStorageData(g_localStorageUrl);
+
 	multiAppend(divRoot,
+
+		// 保存データの表示
 		createDivCss2Label(`lblWorkDataView`,
 			viewKeyStorage(`workStorage`), g_lblPosObj.lblWorkDataView),
-		createDivCss2Label(`lblKeyDataView`, viewKeyStorage(`keyStorage`, g_headerObj.keyLabels[0]), g_lblPosObj.lblKeyDataView),
+		createDivCss2Label(`lblKeyDataView`, viewKeyStorage(`keyStorage`, selectedKey), g_lblPosObj.lblKeyDataView),
+
+		// 保存データの出力ボタン
+		createCss2Button(`btnWorkStorage`, g_lblNameObj.b_copyStorage, () =>
+			copyTextToClipboard(formatObject(g_storageFunc.get(`workStorage`)(), 0, { colorFmt: false }), g_msgInfoObj.I_0006),
+			g_lblPosObj.btnWorkStorage, g_cssObj.button_Default, g_cssObj.button_ON),
+		createCss2Button(`btnKeyStorage`, g_lblNameObj.b_copyStorage, () =>
+			copyTextToClipboard(formatObject(g_storageFunc.get(`keyStorage`)(selectedKey), 0, { colorFmt: false }), g_msgInfoObj.I_0006),
+			g_lblPosObj.btnKeyStorage, g_cssObj.button_Default, g_cssObj.button_ON),
 	);
 	setUserSelect($id(`lblWorkDataView`), `text`);
 	setUserSelect($id(`lblKeyDataView`), `text`);
@@ -4910,6 +4926,7 @@ const dataMgtInit = () => {
 		keyListSprite.appendChild(createMgtButton(key, j - 2, 0, {
 			w: Math.max(50, getStrWidth(getKeyName(key) + `    `, g_limitObj.setLblSiz, getBasicFont())),
 			func: () => {
+				selectedKey = key;
 				lblKeyDataView.innerHTML = viewKeyStorage(`keyStorage`, key);
 				lblTargetKey.innerHTML = `(${getKeyName(key)})`;
 			},

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -268,6 +268,12 @@ const updateWindowSiz = () => {
             overflow: C_DIS_AUTO, background: `#222222`, color: `#cccccc`,
             whiteSpace: `nowrap`,
         },
+        btnWorkStorage: {
+            x: g_btnX(1) - 140, y: 100, w: 70, h: 20, siz: 16,
+        },
+        btnKeyStorage: {
+            x: g_btnX(1) - 140, y: 100 + g_sHeight / 4 + 10, w: 70, h: 20, siz: 16,
+        },
 
         /** 設定画面 */
         btnBack: {
@@ -3390,6 +3396,7 @@ const g_lang_msgInfoObj = {
         I_0003: `各譜面の明細情報をクリップボードにコピーしました！`,
         I_0004: `musicUrlが設定されていないため、無音モードで再生します`,
         I_0005: `正規のミラー譜面で無いため、ハイスコアは保存されません`,
+        I_0006: `ローカルストレージ情報をクリップボードにコピーしました！`,
     },
     En: {
         W_0001: `Your browser is not guaranteed to work.<br>
@@ -3443,6 +3450,7 @@ const g_lang_msgInfoObj = {
         I_0003: `Charts information is copied to the clipboard!`,
         I_0004: `Play in silence mode because "musicUrl" is not set`,
         I_0005: `Highscore is not saved because not a regular mirrored chart.`,
+        I_0006: `Local storage information copied to clipboard!`,
     },
 };
 
@@ -3487,6 +3495,7 @@ const g_lblNameObj = {
     b_reset: `Reset Key`,
     b_safeMode: `Safe Mode -> `,
     b_undo: `Restore`,
+    b_copyStorage: `Copy`,
     b_settings: `To Settings`,
     b_copy: `CopyResult`,
     b_tweet: `Post X`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. ローカルストレージ情報のコピー機能を追加
- Data Management画面から、ローカルストレージ情報をコピーできる機能を追加しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. ローカルストレージ情報を加工して表示するようになってしまったため、
オリジナルに近い出力を行う機能として作成しました。
このデータから復元する機能は実装していません。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/06444f3c-597c-4c6a-b567-c04520bd5a87" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- データ復元については現状考えていません。
JSONのチェックが煩雑になること、カスタム変数があった場合に検知できないこと、
使う場面はパソコン変更時になると思いますがAdjustmentやVolumeはパソコンによって異なること、等が理由です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced text formatting for cleaner data display.
  - Improved key selection handling for a smoother interactive experience.
  - Introduced new buttons for local storage management.
  - Added a "Copy" action with immediate feedback when local storage information is copied to the clipboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->