### PR TITLE
feat: [0880] Data Management画面における表示エリア・ボタンの高さ可変対応

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -168,7 +168,6 @@ const g_windowObj = {
     divBack: { background: `linear-gradient(#000000, #222222)` },
 
     colorPickSprite: { x: 0, y: 90, w: 50, h: 280 },
-    keyListSprite: { x: 0, y: g_limitObj.setLblHeight * 7.5 + 40, w: 150, h: 120, overflow: C_DIS_AUTO },
 };
 
 const g_lblPosObj = {};
@@ -194,6 +193,7 @@ const updateWindowSiz = () => {
     Object.assign(g_windowObj, {
         optionSprite: { x: (g_sWidth - 450) / 2, y: 65, w: 450, h: 325 },
         dataSprite: { x: g_btnX() + (g_sWidth - Math.max(g_sWidth - 100, 450)) / 2, y: 65, w: Math.max(g_sWidth - 100, 450), h: 325 },
+        keyListSprite: { x: 0, y: g_limitObj.setLblHeight * 7.5 + 40, w: 150, h: g_sHeight - 380, overflow: C_DIS_AUTO },
         difList: { x: 165, y: 60, w: 280, h: 270 + g_sHeight - 500, overflow: C_DIS_AUTO, pointerEvents: C_DIS_AUTO },
         difCover: { x: 20, y: 60, w: 145, h: 270 + g_sHeight - 500, opacity: 0.95, pointerEvents: C_DIS_AUTO },
         difFilter: { x: 0, y: 66, w: 140, h: 204 + g_sHeight - 500, overflow: C_DIS_AUTO, pointerEvents: C_DIS_AUTO },
@@ -264,7 +264,7 @@ const updateWindowSiz = () => {
             whiteSpace: `nowrap`,
         },
         lblKeyDataView: {
-            x: g_btnX(1 / 3) + 10, y: 100 + g_sHeight / 4 + 10, w: g_btnWidth(7 / 12), h: g_sHeight / 3 - 10, siz: 12, align: C_ALIGN_LEFT,
+            x: g_btnX(1 / 3) + 10, y: 100 + g_sHeight / 4 + 10, w: g_btnWidth(7 / 12), h: g_sHeight * 3 / 4 - 215, siz: 12, align: C_ALIGN_LEFT,
             overflow: C_DIS_AUTO, background: `#222222`, color: `#cccccc`,
             whiteSpace: `nowrap`,
         },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. Data Management画面における表示エリア・ボタンの高さ可変対応
- Data Management画面において、キー別の表示エリアとボタンについて
高さが変更になった場合でも補正されるように対応しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1.  動作上の問題はないが、高さが可変になったときに余白ができてしまうため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/1bc61512-cd19-498d-a23c-650886fecdb9" width="70%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced dynamic layout responsiveness: UI elements now adjust in size according to the window dimensions for an optimized viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->