### PR TITLE
fix: [0881] キーパターン違いで対象のキーアシストがいない場合、キーパターン変更時に止まることがある問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7160,6 +7160,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	const getKeyConfigColor = (_j, _colorPos) => {
 		let arrowColor = g_headerObj.setColor[_colorPos];
 		if (typeof g_keyObj[`assistPos${keyCtrlPtn}`] === C_TYP_OBJECT &&
+			g_keyObj[`assistPos${keyCtrlPtn}`][g_stateObj.autoPlay] !== undefined &&
 			!g_autoPlaysBase.includes(g_stateObj.autoPlay)) {
 			if (g_keyObj[`assistPos${keyCtrlPtn}`][g_stateObj.autoPlay][_j] === 1) {
 				arrowColor = g_headerObj.setDummyColor[_colorPos];


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. キーパターン違いで対象のキーアシストがいない場合、キーパターン変更時に止まることがある問題を修正
- 以下のようなキーパターンA～Cがあり、それぞれ以下のアシストリストを持っていた場合に
AutoPlayが「Left」のとき、キーパターンBに変えた時に止まる問題を修正しました。
※キーパターンAはリストにいるので問題なく、Cの場合はリストがないので問題ありませんでした。
   - キーパターンAのアシストリスト: [`Left`, `Right`]
   - キーパターンBのアシストリスト: [`AA`]
   - キーパターンCのアシストリスト: (未定義)

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. レアケースではあるが、回避すべき事象ではあるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling to prevent potential runtime issues by ensuring that necessary data is available before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->