### PR TITLE
feat: [0883] Data Management画面で表示するローカルストレージ情報をキー名順にソートするよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -426,6 +426,16 @@ const parseStorageData = (_keyName, _default = {}) => {
 }
 
 /**
+ * オブジェクトをキー名でソート
+ * @param {Object} _obj 
+ * @returns {Object}
+ */
+const sortObjectByKeys = _obj => Object.keys(_obj).sort().reduce((acc, key) => {
+	acc[key] = _obj[key];
+	return acc;
+}, {});
+
+/**
  * 画面表示用インデント処理
  * @param {number} _level 
  * @returns {string}
@@ -4898,7 +4908,7 @@ const dataMgtInit = () => {
 		})
 	);
 
-	g_localStorageMgt = parseStorageData(g_localStorageUrl);
+	g_localStorageMgt = sortObjectByKeys(parseStorageData(g_localStorageUrl));
 
 	multiAppend(divRoot,
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1334,7 +1334,7 @@ const g_storageFunc = new Map([
 
     // キー別のストレージ情報
     ['keyStorage', (_key) => {
-        let keyStorage = parseStorageData(`danonicw-${_key}k`);
+        let keyStorage = sortObjectByKeys(parseStorageData(`danonicw-${_key}k`));
         if (Object.keys(keyStorage).length === 0) {
 
             // キー別の情報が見つからない場合は作品別の情報から検索


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. Data Management画面で表示するローカルストレージ情報をキー名順にソートするよう変更
- これまでは挿入順でしたが、キー名順にソートするように変更しました。
- 表示部分だけで、実際にローカルストレージに入る順序はこれまで通りです。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. キー毎の設定を比較する際に見やすくするため。


## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/a7e74f4b-9b6b-4296-8717-6574674b4e55" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the handling of stored data so that configurations are now automatically organized in a predictable order.
  
- **Refactor**
  - Updated the internal processing logic to ensure consistently ordered data, leading to more reliable and uniform behavior across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->