### PR TITLE
feat: [0888] 前提条件表示用画面へのボタンを設定画面にも追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5126,6 +5126,7 @@ const preconditionInit = () => {
 				document.getElementById(`btnPrecond${k}`).classList.replace(g_cssObj.button_Reset, g_cssObj.button_Default);
 			}
 			lblPrecondView.innerHTML = viewKeyStorage(g_settings.preconditions[g_settings.preconditionNum * numOfPrecs + j]);
+			lblPrecondView.scrollTop = 0;
 			evt.target.classList.replace(g_cssObj.button_Default, g_cssObj.button_Reset);
 		}, {
 			x: g_btnX() + g_btnWidth((j % (numOfPrecs / 2)) / (numOfPrecs / 2 + 1)),

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5087,6 +5087,7 @@ const dataMgtInit = () => {
 
 const preconditionInit = () => {
 	clearWindow(true);
+	const prevPage = g_currentPage;
 	g_currentPage = `precondition`;
 
 	multiAppend(divRoot,
@@ -5148,7 +5149,7 @@ const preconditionInit = () => {
 			Object.assign(g_lblPosObj.btnPrecond, {
 				resetFunc: () => {
 					viewKeyStorage.cache = new Map();
-					dataMgtInit();
+					prevPage === `dataMgt` ? dataMgtInit() : g_moveSettingWindow(false);
 				},
 			}), g_cssObj.button_Back),
 	);
@@ -5210,6 +5211,12 @@ const commonSettingBtn = _labelName => {
 		createCss2Button(`btnReset`, g_lblNameObj.dataReset, () => {
 			dataMgtInit();
 		}, g_lblPosObj.btnReset, g_cssObj.button_Reset),
+
+		// 前提条件表示用画面へ移動（debug=trueの場合のみ）
+		createCss2Button(`btnPrecond`, g_lblNameObj.b_precond, () => true,
+			Object.assign(g_lblPosObj.btnPrecond, {
+				resetFunc: () => preconditionInit(),
+			}), g_cssObj.button_Setting),
 	);
 };
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 前提条件表示用画面へのボタンを設定画面にも追加
- 設定画面（Settings / Display / Ex-Settings）から前提条件表示（Precondition）へ直接移動できるボタンを追加しました。
- 表示条件はURLクエリに`debug=true`をつけた場合のみです。

### 2. 前提表示画面の対象切り替え時、スクロール位置がリセットされるよう変更
- 同じエリアの上書きだったため、スクロールがそのままになっていました。
- 今回の変更で都度リセットするように変えています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 利便性向上のため。
2. 利便性向上のため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/84faa5d2-1a41-42bc-a0fe-de5026a6f497" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- 特定時のみしか使わせない機能のため、ショートカットは実装しません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new control button in the settings area that triggers a refined reset process.
  - Enhanced navigation behavior so the app now adapts its response based on your previous page, ensuring a smoother and more context-sensitive experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->