### PR TITLE
feat: [0889] 未使用プロパティの削除、データ管理・前提条件画面のレイアウト調整

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2491,7 +2491,7 @@ const initialControl = async () => {
 
 	// 未使用のg_keyObjプロパティを削除
 	const keyProp = g_keyCopyLists.simple.concat(g_keyCopyLists.multiple, `keyCtrl`, `keyName`, `minWidth`, `ptchara`);
-	const delKeyPropList = [`ptchara7`, `keyTransPattern`];
+	const delKeyPropList = [`ptchara7`, `keyTransPattern`, `dfPtnNum`, `minKeyCtrlNum`, `minPatterns`];
 	Object.keys(g_keyObj).forEach(key => {
 		const type = keyProp.find(prop => key.startsWith(prop)) || ``;
 		if (type !== ``) {
@@ -2500,7 +2500,7 @@ const initialControl = async () => {
 				delete g_keyObj[key];
 			}
 		}
-		if (key.match(/^chara7_[a-z]/) || delKeyPropList.includes(key)) {
+		if (key.match(/^chara7_[a-z]/) || delKeyPropList.includes(key) || g_keyObj[key] === undefined) {
 			delete g_keyObj[key];
 		}
 	});
@@ -4974,16 +4974,30 @@ const dataMgtInit = () => {
 	keyList.forEach((key, j) => {
 		g_stateObj[`dm_${key}`] = C_FLG_OFF;
 		g_settings.dataMgtNum[key] = 0;
+
 		keyListSprite.appendChild(createMgtButton(key, j - 2, 0, {
 			w: Math.max(50, getStrWidth(getKeyName(key) + `    `, g_limitObj.setLblSiz, getBasicFont())),
-			func: () => {
-				selectedKey = key;
-				lblKeyDataView.innerHTML = viewKeyStorage(`keyStorage`, key);
-				lblTargetKey.innerHTML = `(${getKeyName(key)})`;
-			},
 		}));
 		document.getElementById(`btn${key}`).innerHTML = getKeyName(key);
+
+		keyListSprite.appendChild(createCss2Button(`btnView${key}`, ``, evt => {
+			keyList.forEach(keyx => {
+				document.getElementById(`btnView${keyx}`).classList.replace(g_cssObj.button_Next, g_cssObj.button_Default);
+				document.getElementById(`btnView${keyx}`).classList.replace(g_cssObj.button_ON, g_cssObj.button_OFF);
+				document.getElementById(`btnView${keyx}`).textContent = ``;
+			});
+			document.getElementById(`btnView${key}`).classList.replace(g_cssObj.button_Default, g_cssObj.button_Next);
+			document.getElementById(`btnView${key}`).classList.replace(g_cssObj.button_OFF, g_cssObj.button_ON);
+			selectedKey = key;
+			evt.target.textContent = `x`;
+			lblKeyDataView.innerHTML = viewKeyStorage(`keyStorage`, key);
+			lblKeyDataView.scrollTop = 0;
+			lblTargetKey.innerHTML = `(${getKeyName(key)})`;
+		}, {
+			x: 0, y: g_limitObj.setLblHeight * (j - 2) + 40, w: 16, h: 20, siz: 12, borderStyle: `solid`
+		}, g_cssObj.button_Default, g_cssObj.button_OFF));
 	});
+	document.getElementById(`btnView${selectedKey}`).click();
 
 	// ユーザカスタムイベント(初期)
 	g_customJsObj.dataMgt.forEach(func => func());
@@ -5131,7 +5145,7 @@ const preconditionInit = () => {
 		}, {
 			x: g_btnX() + g_btnWidth((j % (numOfPrecs / 2)) / (numOfPrecs / 2 + 1)),
 			y: 70 + Number(j >= numOfPrecs / 2) * 20, w: g_btnWidth(1 / (numOfPrecs / 2 + 1)), h: 20, siz: 12,
-		}, g_cssObj.button_Default, g_cssObj.button_ON));
+		}, g_cssObj.button_Default));
 	}
 	btnPrecond0.classList.replace(g_cssObj.button_Default, g_cssObj.button_Reset);
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. `g_keyObj`の未使用プロパティの削除対象追加
- `dfPtnNum`, `minKeyCtrlNum`, `minPatterns`と、undefinedプロパティを動的削除の対象としました。

### 2. データ管理画面のキー別ストレージ表示と削除対象ボタンの分離
- わかりづらいレイアウトのため、ボタンを分離しました。従来のボタンが削除対象を選ぶボタン、
新規に作成したボタンがキー別ストレージ表示を切り替えるボタンです。
また前提条件画面同様に、スクロール位置をリセットするようにしました。

### 3. 前提条件画面のボタンの不要なCSSクラスを除去
- 対象を選ぶボタンで定義不要なクラスがあったため、除去しました。


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. いずれもカスタムキー作成部分以外の利用がないため。
2. 削除対象でもないのにボタンをクリックしないと切り替わらないのが煩わしいため。
3. コード流用時の間違い防止のため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/8dce6f2f-7698-42b9-8f07-c81ff8f9b4d0" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a dynamic button that auto-activates on launch, ensuring the correct view is immediately updated for a smoother user experience.

- **Refactor**
  - Refined key management processes to enhance overall responsiveness and streamline user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->