### PR TITLE
fix: [0890] g_keyObjの自動削除処理でdivMax, keyGroupOrderが消えてしまう問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2496,9 +2496,7 @@ const initialControl = async () => {
 		const type = keyProp.find(prop => key.startsWith(prop)) || ``;
 		if (type !== ``) {
 			const keyName = String(key.split(`_`)[0].slice(type.length));
-			if (!g_headerObj.keyLists.includes(keyName) &&
-				keyName !== `` && keyName !== `Default` &&
-				!keyName.startsWith(`Max`) && !keyName.startsWith(`Order`)) {
+			if (!g_headerObj.keyLists.includes(keyName) && keyName !== `` && keyName !== `Default`) {
 				delete g_keyObj[key];
 			}
 		}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2497,7 +2497,8 @@ const initialControl = async () => {
 		if (type !== ``) {
 			const keyName = String(key.split(`_`)[0].slice(type.length));
 			if (!g_headerObj.keyLists.includes(keyName) &&
-				keyName !== `` && keyName !== `Default` && !keyName.startsWith(`Max`)) {
+				keyName !== `` && keyName !== `Default` &&
+				!keyName.startsWith(`Max`) && !keyName.startsWith(`Order`)) {
 				delete g_keyObj[key];
 			}
 		}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2496,7 +2496,8 @@ const initialControl = async () => {
 		const type = keyProp.find(prop => key.startsWith(prop)) || ``;
 		if (type !== ``) {
 			const keyName = String(key.split(`_`)[0].slice(type.length));
-			if (!g_headerObj.keyLists.includes(keyName) && keyName !== `` && keyName !== `Default`) {
+			if (!g_headerObj.keyLists.includes(keyName) &&
+				keyName !== `` && keyName !== `Default` && !keyName.startsWith(`Max`)) {
 				delete g_keyObj[key];
 			}
 		}

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3148,10 +3148,11 @@ g_keycons.groups.forEach(type => {
 });
 
 // 特殊キーのコピー種 (simple: 代入、multiple: 配列ごと代入)
+// 後でプロパティ削除に影響するため、先頭文字が全く同じ場合は長い方を先に定義する (例: divMax, div)
 const g_keyCopyLists = {
     simpleDef: [`blank`, `scale`],
-    simple: [`div`, `divMax`, `blank`, `scale`, `keyRetry`, `keyTitleBack`, `transKey`, `scrollDir`, `assistPos`, `flatMode`],
-    multiple: [`chara`, `color`, `stepRtn`, `pos`, `shuffle`, `keyGroup`, `keyGroupOrder`, `layerGroup`, `layerTrans`],
+    simple: [`divMax`, `div`, `blank`, `scale`, `keyRetry`, `keyTitleBack`, `transKey`, `scrollDir`, `assistPos`, `flatMode`],
+    multiple: [`chara`, `color`, `stepRtn`, `pos`, `shuffle`, `keyGroupOrder`, `keyGroup`, `layerGroup`, `layerTrans`],
 };
 
 // タイトル画面関連のリスト群


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. g_keyObjの自動削除処理でdivMax, keyGroupOrderが消えてしまう問題を修正
- PR #1792 にて g_keyObj の未使用プロパティを削除しましたが、
divX_Yの削除処理中にdivMaxX_Yが紛れてしまい、必要なものも含めて削除されるようになっていました。
元の配列定義の順序を変えることで対処しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 必要なプロパティも含めて削除されてしまうため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Reordered internal configuration elements to enhance clarity and consistency.
- **Documentation**
  - Added inline explanations that outline the ordering priorities for improved maintainability.

These internal enhancements ensure a more robust foundation for future updates while keeping the user interface unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->