### PR TITLE
feat: [0892] 特定ドメインのみ常時デバッグモードにするよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -48,6 +48,12 @@ const getQueryParamVal = _name => {
 	return param !== null ? decodeURIComponent(param.replace(/\+/g, ` `)) : null;
 };
 
+const g_reservedDomains = [
+	`danonicw.skr.jp/`,
+	`tickle.cloudfree.jp/`
+];
+Object.freeze(g_reservedDomains);
+
 const g_rootPath = current().match(/(^.*\/)/)[0];
 const g_workPath = new URL(location.href).href.match(/(^.*\/)/)[0];
 const g_remoteFlg = g_rootPath.match(`^https://cwtickle.github.io/danoniplus/`) !== null ||
@@ -55,7 +61,9 @@ const g_remoteFlg = g_rootPath.match(`^https://cwtickle.github.io/danoniplus/`) 
 const g_randTime = Date.now();
 const g_isFile = location.href.match(/^file/);
 const g_isLocal = location.href.match(/^file/) || location.href.indexOf(`localhost`) !== -1;
-const g_isDebug = g_isLocal || getQueryParamVal(`debug`) === `true`;
+const g_isDebug = g_isLocal ||
+	g_reservedDomains.some(domain => location.href.match(`^https://${domain}`) !== null) ||
+	getQueryParamVal(`debug`) === `true`;
 const isLocalMusicFile = _scoreId => g_isFile && !listMatching(getMusicUrl(_scoreId), [`.js`, `.txt`], { suffix: `$` });
 
 window.onload = async () => {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -48,16 +48,24 @@ const getQueryParamVal = _name => {
 	return param !== null ? decodeURIComponent(param.replace(/\+/g, ` `)) : null;
 };
 
+// 常時デバッグを許可するドメイン
 const g_reservedDomains = [
 	`danonicw.skr.jp`,
 	`tickle.cloudfree.jp`,
 ];
 Object.freeze(g_reservedDomains);
 
+// 外部参照を許可するドメイン
+const g_referenceDomains = [
+	`cwtickle.github.io/danoniplus`,
+	`support-v\\d+--danoniplus.netlify.app`,
+];
+Object.freeze(g_referenceDomains);
+
 const g_rootPath = current().match(/(^.*\/)/)[0];
 const g_workPath = new URL(location.href).href.match(/(^.*\/)/)[0];
-const g_remoteFlg = g_rootPath.match(`^https://cwtickle.github.io/danoniplus/`) !== null ||
-	g_rootPath.match(/danoniplus.netlify.app/) !== null;
+const g_remoteFlg = g_referenceDomains.some(domain => g_rootPath.match(`^https://${domain}/`) !== null);
+
 const g_randTime = Date.now();
 const g_isFile = location.href.match(/^file/);
 const g_isLocal = location.href.match(/^file/) || location.href.indexOf(`localhost`) !== -1;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -49,8 +49,8 @@ const getQueryParamVal = _name => {
 };
 
 const g_reservedDomains = [
-	`danonicw.skr.jp/`,
-	`tickle.cloudfree.jp/`
+	`danonicw.skr.jp`,
+	`tickle.cloudfree.jp`,
 ];
 Object.freeze(g_reservedDomains);
 
@@ -62,7 +62,7 @@ const g_randTime = Date.now();
 const g_isFile = location.href.match(/^file/);
 const g_isLocal = location.href.match(/^file/) || location.href.indexOf(`localhost`) !== -1;
 const g_isDebug = g_isLocal ||
-	g_reservedDomains.some(domain => location.href.match(`^https://${domain}`) !== null) ||
+	g_reservedDomains.some(domain => location.href.match(`^https://${domain}/`) !== null) ||
 	getQueryParamVal(`debug`) === `true`;
 const isLocalMusicFile = _scoreId => g_isFile && !listMatching(getMusicUrl(_scoreId), [`.js`, `.txt`], { suffix: `$` });
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 特定ドメインのみ常時デバッグモードにするよう変更
- ファイル、localhostに加えてプレビューサイトドメインについて、常時デバッグモードにするよう変更しました。

### 2. 外部参照を許可するドメインをリスト化、コードの整理
- リスト化することで対象を明確にするようにしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. サイト側で個別のカスタムが必要な状況だったため、本体側で制御することで特殊な制御を無くします。
2. コードの見やすさのため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- netlifyドメインはCORSに引っかかるため実質ローカルしか使えませんが、今後のために残しておきます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Optimized our environment detection so that debug settings now activate only when accessed from specific trusted domains.
	- Introduced a new constant for reserved domains to enhance security measures.
	- Added a new constant for reference domains to improve domain validation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->