### PR TITLE
refactor: [0894] キーコンフィグ保存時にコピーする元の配列が未定義の場合、それがコピーされないよう見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6878,7 +6878,8 @@ const getKeyCtrl = (_localStorage, _extraKeyName = ``) => {
 		const isUpdate = prevPtn !== -1 && g_keyObj.prevKey !== g_keyObj.currentKey;
 		g_keyCopyLists.multiple.filter(header => g_keyObj[`${header}${basePtn}`] !== undefined && isUpdate)
 			.forEach(header => g_keyObj[`${header}${copyPtn}`] = structuredClone(g_keyObj[`${header}${basePtn}`]));
-		g_keyCopyLists.simple.forEach(header => g_keyObj[`${header}${copyPtn}`] = g_keyObj[`${header}${basePtn}`]);
+		g_keyCopyLists.simple.filter(header => g_keyObj[`${header}${basePtn}`] !== undefined && isUpdate)
+			.forEach(header => g_keyObj[`${header}${copyPtn}`] = g_keyObj[`${header}${basePtn}`]);
 
 		g_keycons.groups.forEach(type => {
 			let maxPtn = 0;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. キーコンフィグ保存時にコピーする元の配列が未定義の場合、それがコピーされないよう見直し
- キーコンフィグ保存時にコピーする元の配列が未定義の場合、コピーされないようにしました。
- undefinedがコピーされても影響はありませんが、意図しない問題を避けるため対応しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 他の処理との処理整合のため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
