### PR TITLE
improve: [0895] 前提条件画面からDataManagementへのリンクを追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5185,6 +5185,12 @@ const preconditionInit = () => {
 	g_customJsObj.precondition.forEach(func => func());
 
 	multiAppend(divRoot,
+
+		// データ管理画面へ移動
+		createCss2Button(`btnReset`, g_lblNameObj.dataReset, () => {
+			dataMgtInit();
+		}, g_lblPosObj.btnReset, g_cssObj.button_Reset),
+
 		createCss2Button(`btnBack`, g_lblNameObj.b_back, () => true,
 			Object.assign(g_lblPosObj.btnPrecond, {
 				resetFunc: () => {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5030,7 +5030,7 @@ const dataMgtInit = () => {
 	multiAppend(divRoot,
 		createCss2Button(`btnBack`, g_lblNameObj.b_back, () => true,
 			Object.assign(g_lblPosObj.btnResetBack, {
-				resetFunc: () => prevPage === `title` ? titleInit() : g_moveSettingWindow(false),
+				resetFunc: () => [`title`, `precondition`].includes(prevPage) ? titleInit() : g_moveSettingWindow(false),
 			}), g_cssObj.button_Back),
 
 		createCss2Button(`btnPrecond`, g_lblNameObj.b_precond, () => true,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 前提条件画面からDataManagementへのリンクを追加
- 他の画面と同様、Data Management画面へ移動できるようにしました。


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 他のレイアウトとの整合のため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/6419f3aa-15cd-45f4-a410-fc5878071419" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new "Reset" button in the user interface, allowing users to quickly reinitialize data management processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->