### PR TITLE
feat: [0896] boolean型の値についてformatObjectで色を付けるよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -523,6 +523,8 @@ const formatObject = (_obj, _indent = 0, { seen = new WeakSet(), colorFmt = true
 					return _value.replace(colorCodePattern, (match) =>
 						`<span style="color:${match.replace(`0x`, `#`)}">◆</span>${match.replace(`0x`, `#`)}`);
 				}
+			} else if (typeof _value === 'boolean') {
+				return _value ? `<span style="color:#66ff66">true</span>` : `<span style="color:#ff9999">false</span>`;
 			}
 			if (Array.isArray(_value)) {
 				let formattedArray = _value.map(item => formatValue(item, _value));

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -524,7 +524,7 @@ const formatObject = (_obj, _indent = 0, { seen = new WeakSet(), colorFmt = true
 						`<span style="color:${match.replace(`0x`, `#`)}">◆</span>${match.replace(`0x`, `#`)}`);
 				}
 			} else if (typeof _value === C_TYP_BOOLEAN) {
-				return _value ? `<span style="color:#66ff66">true</span>` : `<span style="color:#ff9999">false</span>`;
+				return _value ? `<span style="color:#66ff66">&#x2714; true</span>` : `<span style="color:#ff9999">&#x274c; false</span>`;
 			} else if (rootKey.startsWith(`scrollDir`) && typeof _value === C_TYP_NUMBER) {
 				return _value === 1 ? `1|<span style="color:#ff9999">↑</span>` : `-1|<span style="color:#66ff66">↓</span>`;
 			}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -537,7 +537,7 @@ const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {})
 
 				} else if (rootKey.startsWith(`keyCtrl`)) {
 					// keyCtrlXの対応キー表示処理
-					return (g_kCd[_value] && _value !== 0) ? `${_value}|<span style="color:#ffff66">${g_kCd[_value]}</span>` : undefined;
+					return (g_kCd[_value] && _value !== 0) ? `${_value}|<span style="color:#ffff66">${g_kCd[_value]}</span>` : `----`;
 				}
 			} else if (typeof _value === C_TYP_OBJECT && _value !== null) {
 				return formatObject(_value, _indent + 1, { colorFmt, rootKey });
@@ -569,7 +569,7 @@ const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {})
 					: isNestedObject
 						? formatObject(value, _indent + 1, { colorFmt, rootKey })
 						: formatValue(value, _obj)
-			}).filter(val => val !== undefined).join(isArrayOfArrays ? `,<br>` : `, `);
+			}).filter(val => !hasVal(val) || val !== `----`).join(isArrayOfArrays ? `,<br>` : `, `);
 
 		return `[${isArrayOfArrays ? `<br>` : ``}${formattedArray}${isArrayOfArrays ? `<br>${baseIndent}` : ''}]`;
 	}
@@ -582,7 +582,7 @@ const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {})
 				? formatObject(value, _indent + 1, { colorFmt, rootKey: rootKey === `` ? key : rootKey }, _obj)
 				: formatValue(value, _obj);
 			return `<br>${nestedIndent}"${key}": ${formattedValue}`;
-		}).filter(val => val !== undefined).join(`,`);
+		}).filter(val => !hasVal(val) || val !== `----`).join(`,`);
 
 	let result = `{${formattedEntries}<br>${baseIndent}}`;
 	if (!colorFmt) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -518,7 +518,7 @@ const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {})
 			if (typeof _value === C_TYP_STRING) {
 
 				// カラーコードの色付け処理
-				_value = escapeHtml(_value);
+				_value = escapeHtml(_value).replaceAll(`\n`, `<br>`);
 				const colorCodePattern = /(#|0x)(?:[A-Fa-f0-9]{6}(?:[A-Fa-f0-9]{2})?|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{3})/g;
 				if (colorCodePattern.test(_value)) {
 					return _value.replace(colorCodePattern, (match) =>

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -496,27 +496,28 @@ const viewKeyStorage = (_name, _key = ``) => {
  * オブジェクトのネスト表示処理
  * @param {Object} _obj 
  * @param {Number} _indent 
- * @param {WeakSet} [seen=new WeakSet()] 
  * @param {boolean} [colorFmt=true] フォーマット加工フラグ
  * @param {string} [rootKey=''] オブジェクトの最上位プロパティ名
  * @param {Object} [_parent=null]
  * @returns {string}
  */
-const formatObject = (_obj, _indent = 0, { seen = new WeakSet(), colorFmt = true, rootKey = `` } = {}, _parent = null) => {
+const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {}) => {
 	if (_obj === null || typeof _obj !== 'object') {
 		return JSON.stringify(_obj);
 	}
-	if (seen.has(_obj)) {
-		return '[Circular]';
-	}
-	seen.add(_obj);
 	const baseIndent = getIndent(_indent);
 	const nestedIndent = getIndent(_indent + 1);
 
-	// カラーコード、対応キーの色付け処理
-	const formatValue = (_value, _parent) => {
+	/**
+	 * データの装飾処理
+	 * @param {string|boolean|number|Object} _value 
+	 * @returns {string}
+	 */
+	const formatValue = (_value) => {
 		if (colorFmt) {
 			if (typeof _value === C_TYP_STRING) {
+
+				// カラーコードの色付け処理
 				_value = escapeHtml(_value);
 				const colorCodePattern = /(#|0x)(?:[A-Fa-f0-9]{6}(?:[A-Fa-f0-9]{2})?|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{3})/g;
 				if (colorCodePattern.test(_value)) {
@@ -524,21 +525,22 @@ const formatObject = (_obj, _indent = 0, { seen = new WeakSet(), colorFmt = true
 						`<span style="color:${match.replace(`0x`, `#`)}">◆</span>${match.replace(`0x`, `#`)}`);
 				}
 			} else if (typeof _value === C_TYP_BOOLEAN) {
-				return _value ? `<span style="color:#66ff66">&#x2714; true</span>` : `<span style="color:#ff9999">&#x274c; false</span>`;
-			} else if (rootKey.startsWith(`scrollDir`) && typeof _value === C_TYP_NUMBER) {
-				return _value === 1 ? `1|<span style="color:#ff9999">↑</span>` : `-1|<span style="color:#66ff66">↓</span>`;
-			}
 
-			if (Array.isArray(_value)) {
-				let formattedArray = _value.map(item => formatValue(item, _value));
-				if (rootKey.startsWith(`keyCtrl`)) {
-					formattedArray = formattedArray.filter(item => item !== `0`)
-						.map(item => g_kCd[item] ? `${item}|<span style="color:#ffff66">${g_kCd[item]}</span>` : item);
+				// boolean値の色付け処理
+				return _value ? `<span style="color:#66ff66">&#x2714; true</span>` : `<span style="color:#ff9999">&#x274c; false</span>`;
+
+			} else if (typeof _value === C_TYP_NUMBER) {
+
+				if (rootKey.startsWith(`scrollDir`)) {
+					// scrollDirXのスクロール方向表示処理
+					return _value === 1 ? `1|<span style="color:#ff9999">↑</span>` : `-1|<span style="color:#66ff66">↓</span>`;
+
+				} else if (rootKey.startsWith(`keyCtrl`)) {
+					// keyCtrlXの対応キー表示処理
+					return (g_kCd[_value] && _value !== 0) ? `${_value}|<span style="color:#ffff66">${g_kCd[_value]}</span>` : undefined;
 				}
-				return `[${formattedArray.join(`, `)}]`;
-			}
-			if (typeof _value === C_TYP_OBJECT && _value !== null) {
-				return formatObject(_value, _indent + 1, { seen, colorFmt, rootKey }, _parent);
+			} else if (typeof _value === C_TYP_OBJECT && _value !== null) {
+				return formatObject(_value, _indent + 1, { colorFmt, rootKey });
 			}
 		}
 		return JSON.stringify(_value);
@@ -565,9 +567,9 @@ const formatObject = (_obj, _indent = 0, { seen = new WeakSet(), colorFmt = true
 				return isArrayOfArrays
 					? `${nestedIndent}${formatValue(value, _obj)}`
 					: isNestedObject
-						? formatObject(value, _indent + 1, { seen, colorFmt, rootKey }, _obj)
+						? formatObject(value, _indent + 1, { colorFmt, rootKey })
 						: formatValue(value, _obj)
-			}).join(isArrayOfArrays ? `,<br>` : `, `);
+			}).filter(val => val !== undefined).join(isArrayOfArrays ? `,<br>` : `, `);
 
 		return `[${isArrayOfArrays ? `<br>` : ``}${formattedArray}${isArrayOfArrays ? `<br>${baseIndent}` : ''}]`;
 	}
@@ -576,12 +578,11 @@ const formatObject = (_obj, _indent = 0, { seen = new WeakSet(), colorFmt = true
 	const formattedEntries = Object.entries(_obj)
 		.map(([key, value]) => {
 			const isNestedObject = typeof value === 'object' && value !== null;
-			const seenNew = _parent ? seen : new WeakSet();
 			const formattedValue = isNestedObject
-				? formatObject(value, _indent + 1, { seen: seenNew, colorFmt, rootKey: rootKey === `` ? key : rootKey }, _obj)
+				? formatObject(value, _indent + 1, { colorFmt, rootKey: rootKey === `` ? key : rootKey }, _obj)
 				: formatValue(value, _obj);
 			return `<br>${nestedIndent}"${key}": ${formattedValue}`;
-		}).join(`,`);
+		}).filter(val => val !== undefined).join(`,`);
 
 	let result = `{${formattedEntries}<br>${baseIndent}}`;
 	if (!colorFmt) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -496,13 +496,13 @@ const viewKeyStorage = (_name, _key = ``) => {
  * オブジェクトのネスト表示処理
  * @param {Object} _obj 
  * @param {Number} _indent 
- * @param {WeakSet} [seen=new WeakSet()]
- * @param {boolean} [colorFmt=true]
- * @param {string} [key='']
+ * @param {WeakSet} [seen=new WeakSet()] 
+ * @param {boolean} [colorFmt=true] フォーマット加工フラグ
+ * @param {string} [rootKey=''] オブジェクトの最上位プロパティ名
  * @param {Object} [_parent=null]
  * @returns {string}
  */
-const formatObject = (_obj, _indent = 0, { seen = new WeakSet(), colorFmt = true, baseKey = ``, rootKey = `` } = {}, _parent = null) => {
+const formatObject = (_obj, _indent = 0, { seen = new WeakSet(), colorFmt = true, rootKey = `` } = {}, _parent = null) => {
 	if (_obj === null || typeof _obj !== 'object') {
 		return JSON.stringify(_obj);
 	}
@@ -531,14 +531,14 @@ const formatObject = (_obj, _indent = 0, { seen = new WeakSet(), colorFmt = true
 
 			if (Array.isArray(_value)) {
 				let formattedArray = _value.map(item => formatValue(item, _value));
-				if (baseKey.startsWith(`keyCtrl`)) {
+				if (rootKey.startsWith(`keyCtrl`)) {
 					formattedArray = formattedArray.filter(item => item !== `0`)
 						.map(item => g_kCd[item] ? `${item}|<span style="color:#ffff66">${g_kCd[item]}</span>` : item);
 				}
 				return `[${formattedArray.join(`, `)}]`;
 			}
 			if (typeof _value === 'object' && _value !== null) {
-				return formatObject(_value, _indent + 1, { seen, colorFmt, baseKey, rootKey }, _parent);
+				return formatObject(_value, _indent + 1, { seen, colorFmt, rootKey }, _parent);
 			}
 		}
 		return JSON.stringify(_value);
@@ -578,7 +578,7 @@ const formatObject = (_obj, _indent = 0, { seen = new WeakSet(), colorFmt = true
 			const isNestedObject = typeof value === 'object' && value !== null;
 			const seenNew = _parent ? seen : new WeakSet();
 			const formattedValue = isNestedObject
-				? formatObject(value, _indent + 1, { seen: seenNew, colorFmt, baseKey: key, rootKey: rootKey === `` ? baseKey : rootKey }, _obj)
+				? formatObject(value, _indent + 1, { seen: seenNew, colorFmt, rootKey: rootKey === `` ? key : rootKey }, _obj)
 				: formatValue(value, _obj);
 			return `<br>${nestedIndent}"${key}": ${formattedValue}`;
 		}).join(`,`);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -514,11 +514,11 @@ const formatObject = (_obj, _indent = 0, { seen = new WeakSet(), colorFmt = true
 	const nestedIndent = getIndent(_indent + 1);
 
 	// カラーコード、対応キーの色付け処理
-	const colorCodePattern = /(#|0x)(?:[A-Fa-f0-9]{6}(?:[A-Fa-f0-9]{2})?|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{3})/g;
 	const formatValue = (_value, _parent) => {
 		if (colorFmt) {
-			if (typeof _value === 'string') {
+			if (typeof _value === C_TYP_STRING) {
 				_value = escapeHtml(_value);
+				const colorCodePattern = /(#|0x)(?:[A-Fa-f0-9]{6}(?:[A-Fa-f0-9]{2})?|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{3})/g;
 				if (colorCodePattern.test(_value)) {
 					return _value.replace(colorCodePattern, (match) =>
 						`<span style="color:${match.replace(`0x`, `#`)}">◆</span>${match.replace(`0x`, `#`)}`);
@@ -537,7 +537,7 @@ const formatObject = (_obj, _indent = 0, { seen = new WeakSet(), colorFmt = true
 				}
 				return `[${formattedArray.join(`, `)}]`;
 			}
-			if (typeof _value === 'object' && _value !== null) {
+			if (typeof _value === C_TYP_OBJECT && _value !== null) {
 				return formatObject(_value, _indent + 1, { seen, colorFmt, rootKey }, _parent);
 			}
 		}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. boolean型の値についてformatObjectで色を付けるよう変更
- 前提条件画面で表示されるboolean型の値について色を付けるよう変更しました。

### 2. scrollDirの値についてformatObjectでスクロール方向を付けるよう変更
- 前提条件画面で表示されるscrollDirの値についてスクロール方向を付けるよう変更しました。

### 3. formatObject関数のループ対策用変数を削除
- ループ対策用変数である`seen`及び`_parent`を削除し、シンプルにしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 視覚的な見やすさのため。
2. 同上
3. ループの誤検知が発生しやすく、処理が複雑になりすぎるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/cb3fded4-23d3-415c-861a-cd5e46c89cae" width="60%">
<img src="https://github.com/user-attachments/assets/fbb0aa92-2b16-4d38-b9e3-08a6644ddb59" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the visual presentation of boolean values: now, "true" is displayed in green and "false" in red to provide clear, color-coded cues for improved readability.
  - Improved handling of complex key relationships in object formatting for better data representation.
  - Simplified function state management by removing unnecessary parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->