### PR TITLE
fix: [0898] キー名が英小文字から始まる場合にData Management画面で止まる問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5009,10 +5009,12 @@ const dataMgtInit = () => {
 		g_stateObj[`dm_${key}`] = C_FLG_OFF;
 		g_settings.dataMgtNum[key] = 0;
 
+		const keyWidth = Math.min(Math.max(50, getStrWidth(getKeyName(key), g_limitObj.setLblSiz, getBasicFont())), 80);
 		keyListSprite.appendChild(createMgtButton(key, j - 2, 0, {
-			w: Math.max(50, getStrWidth(getKeyName(key) + `    `, g_limitObj.setLblSiz, getBasicFont())),
+			w: keyWidth,
+			siz: getFontSize(getKeyName(key), keyWidth, getBasicFont(), g_limitObj.setLblSiz, 10),
 		}));
-		document.getElementById(`btn${key}`).innerHTML = getKeyName(key);
+		document.getElementById(`btn${toCapitalize(key)}`).innerHTML = getKeyName(key);
 
 		keyListSprite.appendChild(createCss2Button(`btnView${key}`, ``, evt => {
 			keyList.forEach(keyx => {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. キー名が英小文字から始まる場合にData Management画面で止まる問題を修正
- キー名のボタンを動的に作っているため、ボタンidの値上書き時にエラーが発生していました。
- 合わせて、キー名が長すぎる場合に文字サイズを調整する機能も追加しています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 一部のキーのときに画面が止まってしまうため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/f677e09a-c8cf-4059-8ed9-c9719fc17131" width="80%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- ver39.5.0以降で発生する問題です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced button appearance with consistent sizing and refined label capitalization for improved clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->