### PR TITLE
feat: [0899] エディターのカスタムキー定義を自動生成する機能を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2544,19 +2544,6 @@ const initialControl = async () => {
 	const customKeyList = g_headerObj.keyLists.filter(val =>
 		g_keyObj.defaultKeyList.findIndex(key => key === val) < 0);
 
-	const arrowMaps = new Map([
-		[`ArrowLeft`, `KeyU`],
-		[`ArrowDown`, `KeyI`],
-		[`ArrowUp`, `Digit8`],
-		[`ArrowRight`, `KeyO`],
-		[`Space`, `KeyG`],
-		[`KeyB`, `KeyH`],
-		[`Enter`, `BackSlash`],
-		[`ShiftLeft`, `KeyZ`],
-		[`ShiftRight`, `Slash`],
-		[`Tab`, `KeyQ`],
-	]);
-
 	customKeyList.forEach(key => {
 		const keyBase = `${key}_0`;
 		const keyCtrlPtn = `${g_keyObj.defaultProp}${keyBase}`;
@@ -2577,8 +2564,8 @@ const initialControl = async () => {
 			g_editorTmp[keyN].id = orgKeyNum * 100 + baseX + j;
 			g_editorTmp[keyN].num = keyNum;
 			g_editorTmp[keyN].chars = keyCtrlList.map(val => g_kCd[val[0]]);
-			g_editorTmp[keyN].keys = keyCtrlList.map(val => g_kCdN[val[0]]).map(val => arrowMaps.get(val) || val);
-			g_editorTmp[keyN].alternativeKeys = keyCtrlList.map(val => val[1] === 0 ? `` : g_kCdN[val[1]]).map(val => arrowMaps.get(val) || val);
+			g_editorTmp[keyN].keys = keyCtrlList.map(val => g_kCdN[val[0]]).map(val => replaceStr(val, g_escapeStr.editorKey));
+			g_editorTmp[keyN].alternativeKeys = keyCtrlList.map(val => val[1] === 0 ? `` : g_kCdN[val[1]]).map(val => replaceStr(val, g_escapeStr.editorKey));
 			g_editorTmp[keyN].noteNames = charaList.map(val => `${val}_data`);
 			g_editorTmp[keyN].freezeNames = charaList.map(val => {
 				let frzName = replaceStr(val, g_escapeStr.frzName);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2551,6 +2551,10 @@ const initialControl = async () => {
 		[`ArrowRight`, `KeyO`],
 		[`Space`, `KeyG`],
 		[`KeyB`, `KeyH`],
+		[`Enter`, `BackSlash`],
+		[`ShiftLeft`, `KeyZ`],
+		[`ShiftRight`, `Slash`],
+		[`Tab`, `KeyQ`],
 	]);
 
 	customKeyList.forEach(key => {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -788,6 +788,18 @@ const g_escapeStr = {
         [`all[]`, `sumData(g_detailObj.arrowCnt[{0}]) + sumData(g_detailObj.frzCnt[{0}])`],
         [`maxlife[]`, `g_headerObj.maxLifeVal`],
     ],
+    editorKey: [
+        [`ArrowLeft`, `KeyU`],
+        [`ArrowDown`, `KeyI`],
+        [`ArrowUp`, `Digit8`],
+        [`ArrowRight`, `KeyO`],
+        [`Space`, `KeyG`],
+        [`KeyB`, `KeyH`],
+        [`Enter`, `BackSlash`],
+        [`ShiftLeft`, `KeyZ`],
+        [`ShiftRight`, `Slash`],
+        [`Tab`, `KeyQ`],
+    ]
 };
 
 /** 設定・オプション画面用共通 */

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -283,6 +283,9 @@ const updateWindowSiz = () => {
         btnKeyStorage: {
             x: g_btnX(1) - 140, y: 100 + g_sHeight / 4 + 10, w: 70, h: 20, siz: 16,
         },
+        btnPrecondView: {
+            x: g_btnX(1) - 90, y: 110, w: 70, h: 20, siz: 16,
+        },
 
         /** 設定画面 */
         btnBack: {
@@ -1156,8 +1159,9 @@ const g_settings = {
     settingWindowNum: 0,
 
     preconditions: [`g_rootObj`, `g_headerObj`, `g_keyObj`, `g_scoreObj`, `g_workObj`,
-        `g_detailObj`, `g_stateObj`, `g_attrObj`],
+        `g_detailObj`, `g_stateObj`, `g_attrObj`, `g_editorTmp`],
     preconditionNum: 0,
+    preconditionNumSub: 0,
 };
 
 g_settings.volumeNum = g_settings.volumes.length - 1;
@@ -2487,6 +2491,7 @@ const g_keyObj = {
     dfPtnNum: 0,
 
     minKeyCtrlNum: 2,
+    defaultKeyList: [],
 
     // キー別ヘッダー
     // - 譜面データ中に出てくる矢印(ノーツ)の種類と順番(ステップゾーン表示順)を管理する
@@ -3023,6 +3028,11 @@ const g_keyObj = {
 // g_keyObj.defaultProp の上書きを禁止
 Object.defineProperty(g_keyObj, `defaultProp`, { writable: false });
 
+// 既定のキー定義リストを動的に作成
+Object.keys(g_keyObj)
+    .filter(key => key.startsWith(g_keyObj.defaultProp) && key.endsWith(`_0`))
+    .forEach(key => g_keyObj.defaultKeyList.push(key.split(`_`)[0].slice(g_keyObj.defaultProp.length)));
+
 // キーパターンのコピーリスト
 // ・コピー先：コピー元の順に指定する
 // ・上から順に処理する
@@ -3156,6 +3166,8 @@ g_keycons.groups.forEach(type => {
     const tmpName = Object.keys(g_keyObj).filter(val => val.startsWith(type) && val.endsWith(`_0`));
     tmpName.forEach(property => g_keyObj[`${property.slice(0, -2)}`] = g_keyObj[property].concat());
 });
+
+const g_editorTmp = {};
 
 // 特殊キーのコピー種 (simple: 代入、multiple: 配列ごと代入)
 // 後でプロパティ削除に影響するため、先頭文字が全く同じ場合は長い方を先に定義する (例: divMax, div)
@@ -3447,6 +3459,7 @@ const g_lang_msgInfoObj = {
         I_0004: `musicUrlが設定されていないため、無音モードで再生します`,
         I_0005: `正規のミラー譜面で無いため、ハイスコアは保存されません`,
         I_0006: `ローカルストレージ情報をクリップボードにコピーしました！`,
+        I_0007: `オブジェクト情報をクリップボードにコピーしました！`,
     },
     En: {
         W_0001: `Your browser is not guaranteed to work.<br>
@@ -3501,6 +3514,7 @@ const g_lang_msgInfoObj = {
         I_0004: `Play in silence mode because "musicUrl" is not set`,
         I_0005: `Highscore is not saved because not a regular mirrored chart.`,
         I_0006: `Local storage information copied to clipboard!`,
+        I_0007: `Object information copied to clipboard!`,
     },
 };
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. エディターのカスタムキー定義を自動生成する機能を追加

- Dancing☆Onigiri エディター (CW Edition対応)のフォーマットに合わせて、
既定で用意されていないキー種が指定されたときに
エディター用のカスタムキー定義を自動生成する機能を追加しました。
- 前提条件画面の「g_editorTmp」より確認が可能です。

#### 仕様

- エディター上、上下左右及び「B」「Space」は予約されているため、他のキーで代替します。
- 代替先に同じものがいるかどうかは見ません。その場合は個別に調整してください。
- idの値については、`keyCtrlXのリスト数×100 + (0～99までの乱数)`で定義しています。
こちらも既存のエディターのid値と同じかは確認できないので、必要に応じて変更してください。

|元のキー|代替先|
|----|----|
|ArrowLeft|KeyU|
|ArrowDown|KeyI|
|ArrowUp|Digit8|
|ArrowRight|KeyO|
|Space|KeyG|
|KeyB|KeyH|
|Enter|BackSlash|
|ShiftLeft|KeyZ|
|ShiftRight|Slash|
|Tab|KeyQ|

- keyGroupXの定義がある場合、keyGroupの種類別にカスタムキー定義を分離して表示します。
（スクリーンショット参照）

### 2. 前提条件画面のオブジェクトに対してクリップボードへコピーする機能を追加

- データ管理画面と同様に、オブジェクトをコピーする機能を追加しました。
- g_rootObjについては仕様上エスケープされます。あくまでおまけとしての使用を想定しています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. Wikiにも記述はあるが、独自のカスタムキーやトランスキーを定義した場合、1から作るのが手間のため。
2. 画面上のものは装飾が入っており、直接データとして参照したい場合の方法が必要と考えたため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/4a5dee6e-1355-4af1-879e-15c108dbd5ab" width="70%">
<img src="https://github.com/user-attachments/assets/aa54bcac-9e17-4eb5-9e73-cb4b1e28b57a" width="70%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- あくまで参考用です。加工して使うことを想定しています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced formatting options for data display and clipboard copying, ensuring consistent results.
  - Added an interactive button for streamlined access to additional view details.
  - Expanded keyboard shortcut support within the editor, improving navigation and overall interaction.
  - Updated notifications to inform users when information is successfully copied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->