### PR TITLE
refactor: [0900] formatObject関数の処理を整理、速度変化・色変化の装飾追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -499,7 +499,6 @@ const viewKeyStorage = (_name, _key = ``, _colorFmt = true) => {
  * @param {Number} _indent 
  * @param {boolean} [colorFmt=true] フォーマット加工フラグ
  * @param {string} [rootKey=''] オブジェクトの最上位プロパティ名
- * @param {Object} [_parent=null]
  * @returns {string}
  */
 const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {}) => {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -503,7 +503,8 @@ const viewKeyStorage = (_name, _key = ``, _colorFmt = true) => {
  * @returns {string}
  */
 const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {}) => {
-	if (_obj === null || typeof _obj !== 'object') {
+	const isObj = _obj => typeof _obj === C_TYP_OBJECT && _obj !== null;
+	if (!isObj(_obj)) {
 		return JSON.stringify(_obj);
 	}
 	const baseIndent = getIndent(_indent);
@@ -542,7 +543,7 @@ const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {})
 					// keyCtrlXの対応キー表示処理
 					return (g_kCd[_value] && _value !== 0) ? `${_value}|<span style="color:#ffff66">${g_kCd[_value]}</span>` : `----`;
 				}
-			} else if (typeof _value === C_TYP_OBJECT && _value !== null) {
+			} else if (isObj(_value)) {
 				return formatObject(_value, _indent + 1, { colorFmt, rootKey: _rootKey });
 			}
 		}
@@ -602,10 +603,9 @@ const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {})
 	const formatCollection = () => {
 		const isArray = Array.isArray(_obj);
 		const isArrayOfArrays = isArray && _obj.every(item => Array.isArray(item));
-		const getNextObject = (_item, _rootKey) =>
-			typeof _item === C_TYP_OBJECT && _item !== null
-				? formatObject(_item, _indent + 1, { colorFmt, rootKey: _rootKey })
-				: formatValue(_item, _rootKey);
+		const getNextObject = (_item, _rootKey) => isObj(_item)
+			? formatObject(_item, _indent + 1, { colorFmt, rootKey: _rootKey })
+			: formatValue(_item, _rootKey);
 
 		if (isArray) {
 			let result = formatArrayValue(_obj);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -600,9 +600,10 @@ const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {})
 	 * @returns {string}
 	 */
 	const formatCollection = () => {
-		const isArrayOfArrays = Array.isArray(_obj) && _obj.every(item => Array.isArray(item));
+		const isArray = Array.isArray(_obj);
+		const isArrayOfArrays = isArray && _obj.every(item => Array.isArray(item));
 
-		if (Array.isArray(_obj)) {
+		if (isArray) {
 			let result = formatArrayValue(_obj);
 			if (result !== ``) {
 				return result;
@@ -610,25 +611,25 @@ const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {})
 		}
 
 		// 配列またはオブジェクトの各要素をフォーマット
-		const formattedEntries = (Array.isArray(_obj)
+		const formattedEntries = (isArray
 			? _obj.map(item => {
 				const formattedValue = isArrayOfArrays
 					? `<br>${nestedIndent}${formatValue(item, rootKey)}`
-					: typeof item === 'object' && item !== null
+					: typeof item === C_TYP_OBJECT && item !== null
 						? formatObject(item, _indent + 1, { colorFmt, rootKey })
 						: formatValue(item, rootKey);
 				return formattedValue;
 			})
 			: Object.entries(_obj).map(([key, value]) => {
 				const baseKey = rootKey === `` ? key : rootKey;
-				const formattedValue = typeof value === 'object' && value !== null
+				const formattedValue = typeof value === C_TYP_OBJECT && value !== null
 					? formatObject(value, _indent + 1, { colorFmt, rootKey: baseKey })
-					: formatValue(value, key);
+					: formatValue(value, baseKey);
 				return `<br>${nestedIndent}"${key}": ${formattedValue}`;
 			})).filter(val => !hasVal(val) || val !== `----`);
 
 		// 配列なら[]で囲む、オブジェクトなら{}で囲む
-		if (Array.isArray(_obj)) {
+		if (isArray) {
 			return _obj.length === 0
 				? '[]'
 				: `[${formattedEntries.join(', ')}${isArrayOfArrays ? `<br>${baseIndent}` : ''}]`;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -552,20 +552,19 @@ const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {})
 	/**
 	 * 配列の装飾処理
 	 * @param {number[]|string[]} _obj 
-	 * @param {string} _rootKey 
 	 * @returns {string}
 	 */
-	const formatArrayValue = (_obj, _rootKey) => {
+	const formatArrayValue = (_obj) => {
 
 		const formatSetArray = (_list, _numOfSet = 2) => {
-			if (_list.findIndex(val => val === _rootKey) >= 0) {
+			if (_list.findIndex(val => val === rootKey) >= 0) {
 				let result = `[`;
 				for (let j = 0; j < _obj.length; j += _numOfSet) {
 					result += `<br>${nestedIndent}${_obj[j]}: ${_obj[j + 1]}`;
 					for (let k = 0; k < _numOfSet - 2; k++) {
 						const idx = j + k + 2;
 						if (idx < _obj.length) {
-							result += `, ${formatValue(_obj[idx], _rootKey)}`;
+							result += `, ${formatValue(_obj[idx], rootKey)}`;
 						}
 					}
 				}
@@ -604,7 +603,7 @@ const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {})
 		const isArrayOfArrays = Array.isArray(_obj) && _obj.every(item => Array.isArray(item));
 
 		if (Array.isArray(_obj)) {
-			let result = formatArrayValue(_obj, rootKey);
+			let result = formatArrayValue(_obj);
 			if (result !== ``) {
 				return result;
 			}
@@ -638,7 +637,7 @@ const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {})
 		}
 	};
 
-	let result = formatCollection(_obj, _indent, { colorFmt, rootKey });
+	let result = formatCollection();
 	if (!colorFmt) {
 		result = result.replaceAll(`<br>`, `\r\n`).replaceAll(`&nbsp;`, ` `);
 	}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -576,9 +576,9 @@ const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {})
 		};
 		if (colorFmt) {
 			if (typeof _obj[0] === C_TYP_NUMBER) {
-				let result = formatSetArray([`speedData`, `boostData`], 2) ||
-					formatSetArray([`colorData`, `acolorData`], 4) ||
-					formatSetArray([`ncolorData`], 5);
+				let result;
+				Object.keys(g_dataSetObj).forEach(key =>
+					result ||= formatSetArray(g_dataSetObj[key], Number(key)));
 				if (result !== ``) {
 					return result;
 				}
@@ -598,27 +598,21 @@ const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {})
 
 	/**
 	 * 配列・オブジェクトのネスト整形処理
-	 * @param {any} _correction 
-	 * @param {number} _indent 
-	 * @param {boolean} colorFmt
-	 * @param {string} rootKey 
 	 * @returns {string}
 	 */
-	const formatCollection = (_correction, _indent, { colorFmt, rootKey }) => {
-		const baseIndent = getIndent(_indent);
-		const nestedIndent = getIndent(_indent + 1);
-		const isArrayOfArrays = Array.isArray(_correction) && _correction.every(item => Array.isArray(item));
+	const formatCollection = () => {
+		const isArrayOfArrays = Array.isArray(_obj) && _obj.every(item => Array.isArray(item));
 
-		if (Array.isArray(_correction)) {
-			let result = formatArrayValue(_correction, rootKey);
+		if (Array.isArray(_obj)) {
+			let result = formatArrayValue(_obj, rootKey);
 			if (result !== ``) {
 				return result;
 			}
 		}
 
 		// 配列またはオブジェクトの各要素をフォーマット
-		const formattedEntries = (Array.isArray(_correction)
-			? _correction.map(item => {
+		const formattedEntries = (Array.isArray(_obj)
+			? _obj.map(item => {
 				const formattedValue = isArrayOfArrays
 					? `<br>${nestedIndent}${formatValue(item, rootKey)}`
 					: typeof item === 'object' && item !== null
@@ -626,7 +620,7 @@ const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {})
 						: formatValue(item, rootKey);
 				return formattedValue;
 			})
-			: Object.entries(_correction).map(([key, value]) => {
+			: Object.entries(_obj).map(([key, value]) => {
 				const baseKey = rootKey === `` ? key : rootKey;
 				const formattedValue = typeof value === 'object' && value !== null
 					? formatObject(value, _indent + 1, { colorFmt, rootKey: baseKey })
@@ -635,8 +629,8 @@ const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {})
 			})).filter(val => !hasVal(val) || val !== `----`);
 
 		// 配列なら[]で囲む、オブジェクトなら{}で囲む
-		if (Array.isArray(_correction)) {
-			return _correction.length === 0
+		if (Array.isArray(_obj)) {
+			return _obj.length === 0
 				? '[]'
 				: `[${formattedEntries.join(', ')}${isArrayOfArrays ? `<br>${baseIndent}` : ''}]`;
 		} else {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -563,7 +563,10 @@ const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {})
 				for (let j = 0; j < _obj.length; j += _numOfSet) {
 					result += `<br>${nestedIndent}${_obj[j]}: ${_obj[j + 1]}`;
 					for (let k = 0; k < _numOfSet - 2; k++) {
-						result += `, ${formatValue(_obj[j + k + 2], _rootKey)}`;
+						const idx = j + k + 2;
+						if (idx < _obj.length) {
+							result += `, ${formatValue(_obj[idx], _rootKey)}`;
+						}
 					}
 				}
 				result += (_obj.length === 0 ? `` : `<br>${baseIndent}`) + `]`;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -602,6 +602,10 @@ const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {})
 	const formatCollection = () => {
 		const isArray = Array.isArray(_obj);
 		const isArrayOfArrays = isArray && _obj.every(item => Array.isArray(item));
+		const getNextObject = (_item, _rootKey) =>
+			typeof _item === C_TYP_OBJECT && _item !== null
+				? formatObject(_item, _indent + 1, { colorFmt, rootKey: _rootKey })
+				: formatValue(_item, _rootKey);
 
 		if (isArray) {
 			let result = formatArrayValue(_obj);
@@ -615,16 +619,11 @@ const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {})
 			? _obj.map(item => {
 				const formattedValue = isArrayOfArrays
 					? `<br>${nestedIndent}${formatValue(item, rootKey)}`
-					: typeof item === C_TYP_OBJECT && item !== null
-						? formatObject(item, _indent + 1, { colorFmt, rootKey })
-						: formatValue(item, rootKey);
+					: getNextObject(item, rootKey);
 				return formattedValue;
 			})
 			: Object.entries(_obj).map(([key, value]) => {
-				const baseKey = rootKey === `` ? key : rootKey;
-				const formattedValue = typeof value === C_TYP_OBJECT && value !== null
-					? formatObject(value, _indent + 1, { colorFmt, rootKey: baseKey })
-					: formatValue(value, baseKey);
+				const formattedValue = getNextObject(value, rootKey === `` ? key : rootKey);
 				return `<br>${nestedIndent}"${key}": ${formattedValue}`;
 			})).filter(val => !hasVal(val) || val !== `----`);
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3265,8 +3265,7 @@ const g_dataMinObj = {
  */
 const g_dataSetObj = {
     2: [`speedData`, `boostData`],
-    4: [`colorData`, `acolorData`,
-        `arrowCssMotionData`, `frzCssMotionData`,
+    4: [`colorData`, `arrowCssMotionData`, `frzCssMotionData`,
         `dummyArrowCssMotionData`, `dummyFrzCssMotionData`],
     5: [`ncolorData`, `scrollchData`],
 }

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3259,6 +3259,18 @@ const g_dataMinObj = {
     style: 1,
 };
 
+/**
+ * データフォーマット管理用
+ * - セット数: 対象の配列名の組で記述
+ */
+const g_dataSetObj = {
+    2: [`speedData`, `boostData`],
+    4: [`colorData`, `acolorData`,
+        `arrowCssMotionData`, `frzCssMotionData`,
+        `dummyArrowCssMotionData`, `dummyFrzCssMotionData`],
+    5: [`ncolorData`, `scrollchData`],
+}
+
 const g_dfColorObj = {
 
     // 矢印初期色情報


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. formatObject関数の処理を整理、速度変化・色変化の装飾追加
- formatObject関数の処理を整理しました。
- 速度変化、色変化について装飾処理を拡張し、セット配列について見やすくなるようにしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. データとコードの見やすさのため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/3be48c2d-87aa-4e00-933c-4896cfe9b31b" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a unified formatting method for both arrays and objects.
  - Added a new constant for managing data formats, providing clear associations between data sets and their identifiers.

- **Refactor**
  - Enhanced readability and maintainability of data formatting logic by encapsulating array handling and validation into dedicated functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->