### PR TITLE
improve: [0901] CDNとしてjsdelivrをリモート対象に追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3135,7 +3135,16 @@ const preheaderConvert = _dosObj => {
 
 	// 外部スキンファイルの指定
 	const tmpSkinType = _dosObj.skinType ?? g_presetObj.skinType ?? `default`;
-	const tmpSkinTypes = tmpSkinType.split(`,`);
+	const tmpSkinTypes = tmpSkinType.split(`,`).map(file => {
+
+		// スキンタイプを取得（ディレクトリパス、カレント指定(..)を除去）
+		const match = file.match(/.*\/(.+)|\(\.\.\)([^/]+)|(.+)/);
+		const skinName = match[1] || match[2] || match[3];
+
+		// デフォルトセット以外はリモート先のデータを使用しない
+		return g_defaultSkinSet.findIndex(val => val === skinName) < 0 ?
+			convLocalPath(file, `skin`) : file;
+	});
 	obj.defaultSkinFlg = tmpSkinTypes.includes(`default`) && setBoolVal(_dosObj.bgCanvasUse ?? g_presetObj.bgCanvasUse, true);
 	setJsFiles(tmpSkinTypes, C_DIR_SKIN, `skin`);
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -58,6 +58,7 @@ Object.freeze(g_reservedDomains);
 // 外部参照を許可するドメイン
 const g_referenceDomains = [
 	`cwtickle.github.io/danoniplus`,
+	`cdn.jsdelivr.net/npm`,
 	`support-v\\d+--danoniplus.netlify.app`,
 ];
 Object.freeze(g_referenceDomains);
@@ -1086,7 +1087,7 @@ const loadMultipleFiles2 = async (_fileData, _loadType) => {
 		if (_loadType === `js`) {
 			await loadScript2(filePath, false);
 		} else if (_loadType === `css`) {
-			const cssPath = filePath.split(`.js`).join(`.css`);
+			const cssPath = filePath.split(`.js?`).join(`.css?`);
 			await importCssFile2(cssPath);
 		}
 	}));

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3202,6 +3202,9 @@ const g_titleLists = {
 
 };
 
+// デフォルトスキンセット（リモート取得対象）
+const g_defaultSkinSet = [`default`, `light`, `skyblue`];
+
 const g_animationData = [`back`, `mask`, `style`];
 const g_animationFunc = {
     make: {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. CDNとしてjsdelivrをリモート対象に追加
- CDNサービスであるjsdelivrで公開されているdanoniplusリポジトリが使えるように、
リモート対象に追加しました。
- また、今のままだと処理の都合でskinファイルが利用できないため、コードを修正しています。

### jsdelivrのページ
https://www.jsdelivr.com/package/npm/danoniplus

### 2. リモート指定のとき、デフォルトのスキンファイル以外はリモートのファイルを取得しないよう変更

- デフォルトで用意されている、「default」「light」「skyblue」以外はリモート接続先から取得せず、
自サイトの公開サーバーのファイルを使用するように変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. CDN経由で利用することでサーバー上に一式揃えなくても作品が作れるため。
2. カスタムJS/CSSファイルと同様の仕様に揃えることでわかりやすくするため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded support for external resources by including an additional trusted asset provider.
  - Introduced a new default skin set for enhanced customization options.

- **Bug Fixes**
  - Improved the CSS asset URL generation to enhance handling of query parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->