### PR TITLE
fix: [0901] リモート接続時、値が空の場合に不要なファイル参照が発生してしまう問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3131,7 +3131,7 @@ const preheaderConvert = _dosObj => {
 		});
 
 	const convLocalPath = (_file, _type) =>
-		g_remoteFlg && !_file.includes(`(..)`) ? `(..)../${_type}/${_file}` : _file;
+		g_remoteFlg && hasVal(_file) && !_file.includes(`(..)`) ? `(..)../${_type}/${_file}` : _file;
 
 	// 外部スキンファイルの指定
 	const tmpSkinType = _dosObj.skinType ?? g_presetObj.skinType ?? `default`;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. リモート接続時、値が空の場合に不要なファイル参照が発生してしまう問題を修正
- preheaderConvert関数内にいる、convLocalPath関数にて空の値が渡った場合に
不要なファイル参照が発生する問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. danoni_main.jsとしてリモート（github, jsdelivr）のパスを指定している場合のみ発生します。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- 過去バージョンから発生している問題ではありますが、
githubは最新版、jsdelivrはver40.4.0以降しか機能していないため過去バージョンには影響しません。
このため、最新盤のみの修正とします。