### PR TITLE
fix: [0904] リモート接続時、共通設定ファイルがデフォルトのときに自サーバーから参照できない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2431,7 +2431,7 @@ const initialControl = async () => {
 
 	// 共通設定ファイルの指定
 	let tmpSettingType = g_rootObj.settingType ?? ``;
-	if (g_remoteFlg && hasVal(tmpSettingType) && !tmpSettingType.includes(`(..)`)) {
+	if (g_remoteFlg && !tmpSettingType.includes(`(..)`)) {
 		tmpSettingType = `(..)../js/${tmpSettingType}`;
 	};
 	let [settingType, settingRoot] = getFilePath(tmpSettingType);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. リモート接続時、共通設定ファイルがデフォルトのときに自サーバーから参照できない問題を修正
- リモート接続時、共通設定ファイルがデフォルトのときはsettingTypeが空でした。
このときの条件文が間違っており、自サーバーのファイルを見に行かないようになっていました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. PR #1817 の対応漏れ。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
