### PR TITLE
feat: [0905] リモート接続時の画像ファイルについて、カスタム分は自サーバーから取得するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3146,7 +3146,7 @@ const preheaderConvert = _dosObj => {
 		const skinName = match[1] || match[2] || match[3];
 
 		// デフォルトセット以外はリモート先のデータを使用しない
-		return g_defaultSkinSet.findIndex(val => val === skinName) < 0 ?
+		return g_defaultSets.skinType.findIndex(val => val === skinName) < 0 ?
 			convLocalPath(file, `skin`) : file;
 	});
 	obj.defaultSkinFlg = tmpSkinTypes.includes(`default`) && setBoolVal(_dosObj.bgCanvasUse ?? g_presetObj.bgCanvasUse, true);
@@ -3907,6 +3907,14 @@ const updateImgType = (_imgType, _initFlg = false) => {
 	resetImgs(_imgType.name, _imgType.extension);
 	reloadImgObj();
 	Object.keys(g_imgObj).forEach(key => g_imgObj[key] = `${g_rootPath}${g_imgObj[key]}`);
+
+	// リモート時は作品ページ側にある画像を優先し、リモートに存在するもののみリモートから取得する
+	if (g_remoteFlg) {
+		Object.keys(g_imgObj).forEach(key => g_imgObj[key] = `${g_workPath}${g_imgObj[key]}`);
+		if (g_defaultSets.imgType.findIndex(val => val === _imgType.name) >= 0) {
+			Object.keys(g_defaultSets.imgList).forEach(key => g_imgObj[key] = `${g_rootPath}${g_imgObj[key]}`);
+		}
+	}
 	if (_imgType.extension === undefined && g_presetObj.overrideExtension !== undefined) {
 		Object.keys(g_imgObj).forEach(key => g_imgObj[key] = `${g_imgObj[key].slice(0, -3)}${g_presetObj.overrideExtension}`);
 	}

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -585,6 +585,13 @@ const C_DIR_SKIN = `../skin/`;
 // カレントディレクトリマーク
 const C_MRK_CURRENT_DIRECTORY = `(..)`;
 
+// デフォルトセット（リモート取得対象）
+const g_defaultSets = {
+    skinType: [`default`, `light`, `skyblue`],
+    imgType: [``, `classic`, `classic-thin`, `note`],
+    imgList: [],
+};
+
 /**
  * カスタム画像セットの設定（サーバ上の場合のみ有効）
  * 
@@ -679,6 +686,7 @@ const reloadImgObj = () => {
     g_imgObj.titleArrow = C_IMG_TITLE_ARROW;
 };
 reloadImgObj();
+Object.keys(g_imgObj).forEach(key => g_defaultSets.imgList.push(key));
 
 // g_imgObjのうち、初期読込するリスト
 const g_imgInitList = [
@@ -3201,9 +3209,6 @@ const g_titleLists = {
     animation: [`Name`, `Duration`, `Delay`, `TimingFunction`],
 
 };
-
-// デフォルトスキンセット（リモート取得対象）
-const g_defaultSkinSet = [`default`, `light`, `skyblue`];
 
 const g_animationData = [`back`, `mask`, `style`];
 const g_animationFunc = {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. リモート接続時の画像ファイルについて、カスタム分は自サーバーから取得するよう変更
- リモート（github, jsDelivr）のとき、画像ファイルはリモートから取るようになっていますが、
カスタム画像については自サーバーから取得するように変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 現状、リモートのときはカスタム画像が使用できないため。
なお、背景・マスクモーションの画像についてはデフォルトが作品フォルダ基準のため、こういった問題は発生しません。
⇒ 参考：https://github.com/cwtickle/danoniplus/wiki/dos-h0087-syncBackPath

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Prioritized remote image loading improves content display when remote sourcing is active.
  
- **Refactor**
  - Streamlined settings for visual themes and image types for a more consistent experience.
  - Enhanced image tracking to ensure current images are properly displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->