### PR TITLE
fix: [0906] リモート接続時の画像パスが間違っているのを修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3906,13 +3906,14 @@ const updateImgType = (_imgType, _initFlg = false) => {
 	}
 	resetImgs(_imgType.name, _imgType.extension);
 	reloadImgObj();
-	Object.keys(g_imgObj).forEach(key => g_imgObj[key] = `${g_rootPath}${g_imgObj[key]}`);
+	const orgImgObj = structuredClone(g_imgObj);
+	Object.keys(g_imgObj).forEach(key => g_imgObj[key] = `${g_rootPath}${orgImgObj[key]}`);
 
 	// リモート時は作品ページ側にある画像を優先し、リモートに存在するもののみリモートから取得する
 	if (g_remoteFlg) {
-		Object.keys(g_imgObj).forEach(key => g_imgObj[key] = `${g_workPath}${g_imgObj[key]}`);
+		Object.keys(g_imgObj).forEach(key => g_imgObj[key] = `${g_workPath}${orgImgObj[key]}`);
 		if (g_defaultSets.imgType.findIndex(val => val === _imgType.name) >= 0) {
-			Object.keys(g_defaultSets.imgList).forEach(key => g_imgObj[key] = `${g_rootPath}${g_imgObj[key]}`);
+			g_defaultSets.imgList.forEach(key => g_imgObj[key] = `${g_rootPath}${orgImgObj[key]}`);
 		}
 	}
 	if (_imgType.extension === undefined && g_presetObj.overrideExtension !== undefined) {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. リモート接続時の画像パスが間違っているのを修正
- PR #1821 で対応しましたが、パスの渡し方に問題があり、表示できていませんでした。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 上記の問題のため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
