### PR TITLE
improve: [0909] 外部参照を許可するドメインを変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -58,7 +58,7 @@ Object.freeze(g_reservedDomains);
 // 外部参照を許可するドメイン
 const g_referenceDomains = [
 	`cwtickle.github.io/danoniplus`,
-	`cdn.jsdelivr.net/npm`,
+	`cdn.jsdelivr.net`,
 	`unpkg.com`,
 	`support-v\\d+--danoniplus.netlify.app`,
 ];


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 外部参照を許可するドメインを変更
- 外部参照を許可している jsdelivr のドメインを変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1.  jsdelivrについて、npm以外にgithubから取得できる場合があるため。

参考：https://www.jsdelivr.com/package/gh/cwtickle/kirizma-cw

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the external asset reference domain to broaden resource coverage. This change ensures that assets are now loaded from a wider host range, which may improve overall resource availability and performance for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->