### PR TITLE
improve: [0910] keyRetryX, keyTitleBackXの表示をkeyCtrlXのように表示を変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -540,8 +540,9 @@ const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {})
 					// scrollDirXのスクロール方向表示処理
 					return _value === 1 ? `1|<span style="color:#ff9999">↑</span>` : `-1|<span style="color:#66ff66">↓</span>`;
 
-				} else if (_rootKey.startsWith(`keyCtrl`) && !_rootKey.startsWith(`keyCtrlPtn`)) {
-					// keyCtrlXの対応キー表示処理
+				} else if (listMatching(_rootKey, [`keyCtrl`, `keyRetry`, `keyTitleBack`], { prefix: `^` })
+					&& !_rootKey.startsWith(`keyCtrlPtn`)) {
+					// keyCtrlX, keyRetryX, keyTitleBackX の対応キー表示処理
 					return (g_kCd[_value] && _value !== 0) ? `${_value}|<span style="color:#ffff66">${g_kCd[_value]}</span>` : `----`;
 				}
 			} else if (isObj(_value)) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -524,7 +524,9 @@ const formatObject = (_obj, _indent = 0, { colorFmt = true, rootKey = `` } = {})
 				// カラーコードの色付け処理
 				_value = escapeHtml(_value).replaceAll(`\n`, `<br>`);
 				const colorCodePattern = /(#|0x)(?:[A-Fa-f0-9]{6}(?:[A-Fa-f0-9]{2})?|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{3})/g;
-				if (colorCodePattern.test(_value)) {
+				if (_value === C_FLG_ON) {
+					return `<span style="color:#66ff66">&#x2714; ON</span>`;
+				} else if (colorCodePattern.test(_value)) {
 					return _value.replace(colorCodePattern, (match) =>
 						`<span style="color:${match.replace(`0x`, `#`)}">◆</span>${match.replace(`0x`, `#`)}`);
 				}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. keyRetryX, keyTitleBackXの表示をkeyCtrlXのように表示を変更
- Precondition画面の表示で、keyRetryX, keyTitleBackXの表示をkeyCtrlXのようにキー名が表示されるように変更しました。

### 2. 値が「ON」のとき、ブール値の表示のように表示を変更
- Precondition画面の表示で、「ON」のときの表示をブール値の表示のように変更しました。


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. ローカルのキーコード表示のままになっているため。
2. 意味合いが「true」と同じため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/90469394-2ad3-409d-8e61-34398408d510" width="60%">
<img src="https://github.com/user-attachments/assets/033a3f80-f0a4-4db5-b741-8610a224b5da" width="60%">


## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the display of key controls to support a wider range of inputs, resulting in more consistent visual cues during interaction.
  - On-screen prompts for keyboard actions are now rendered more accurately, delivering a more intuitive experience.
  - This update expands the recognized control options so users receive clear and predictable feedback when using keyboard commands.
  - Introduced a visual indicator for the "ON" state with a green checkmark for specific values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->