### PR TITLE
feat: [0912] ダンおに譜面作成エディタ ver3フォーマットの自動生成機能を実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2619,8 +2619,10 @@ const initialControl = async () => {
 			const keyCtrlList = g_keyObj[keyCtrlPtn].filter((val, j) => filterCond(j));
 			const charaList = g_keyObj[`chara${keyBase}`].filter((val, j) => filterCond(j));
 			const colorList = g_keyObj[`color${keyBase}_0`].filter((val, j) => filterCond(j));
+			const stepRtnList = g_keyObj[`stepRtn${keyBase}_0`].filter((val, j) => filterCond(j));
 			const keyNum = g_keyObj[keyCtrlPtn].filter((val, j) => filterCond(j)).length;
 
+			// Dancing☆Onigiri (CW Edition対応)のフォーマット
 			g_editorTmp[keyN] = {};
 			g_editorTmp[keyN].id = orgKeyNum * 100 + baseX + j;
 			g_editorTmp[keyN].num = keyNum;
@@ -2636,6 +2638,62 @@ const initialControl = async () => {
 				return `${frzName}_data`;
 			});
 			g_editorTmp[keyN].colorGroup = colorList.map(val => val % 3);
+
+			// ダンおに譜面作成エディタ ver3フォーマット
+			g_editorTmp2 += `<br>`;
+			g_editorTmp2 += `\$key=${keyN}<br>`;
+			g_editorTmp2 += `\$map=${colorList.map(val => val < 3 ? (val + 1) % 3 : val % 7).join(',')}<br>`;
+			g_editorTmp2 += `\$pos=${fillArray(keyNum).map((val, j) =>
+				isNaN(parseFloat(stepRtnList[j])) ? 28 : 24)}<br>`;
+			g_editorTmp2 += `\$txt=${g_editorTmp[keyN].chars.map(val => val.replace(`, `, ``)).join(`,`)}<br>`;
+
+			let k = 0, n = 0;
+			let prevMirrorList = [];
+			while (g_keyObj[`shuffle${keyBase}_${k}`] !== undefined) {
+				// 既存のシャッフルグループからミラー配列を自動生成
+				const orgTmpList = []
+				const mirrorTmpList = [];
+				const mirrorList = [];
+				g_keyObj[`shuffle${keyBase}_${k}`].filter((val, m) => filterCond(m))
+					.forEach((_val, _i) => orgTmpList[_val]?.push(_i) || (orgTmpList[_val] = [_i]));
+				orgTmpList.forEach((list, idx) => mirrorTmpList[idx] = list.toReversed());
+				orgTmpList?.forEach((list, a) => list?.forEach((val, b) => mirrorList[orgTmpList[a][b]] = mirrorTmpList[a][b]));
+				if (!mirrorList.every((val, p) => val === prevMirrorList[p])) {
+					g_editorTmp2 += `\$conv${n + 1}=Mirror${n + 1},${mirrorList.join(',')}<br>`;
+					prevMirrorList = mirrorList.concat();
+					n++;
+				}
+				k++;
+			}
+			g_editorTmp2 += `<br>`;
+
+			g_editorTmp2 += `\$dosformat=<br>function externalDosInit() {[E]<br>`;
+			g_editorTmp2 += `[E]<br>`;
+			g_editorTmp2 += `&nbsp;&nbsp;g_externalDos = \`[E]<br>`;
+			g_editorTmp2 += `[E]<br>`;
+			g_editorTmp2 += `[header][E]<br>`;
+			g_editorTmp2 += `[E]<br>`;
+
+			g_editorTmp2 += `[notestart]<br>`;
+			g_editorTmp[keyN].noteNames.forEach((val, j) =>
+				g_editorTmp2 += `|${val.slice(0, -(`_data`.length))}[i]_data=[a${String(j).padStart(2, `0`)}]|[E]<br>`);
+			g_editorTmp2 += `<br>`;
+
+			g_editorTmp[keyN].freezeNames.forEach((val, j) =>
+				g_editorTmp2 += `|${val.slice(0, -(`_data`.length))}[i]_data=[f${String(j).padStart(2, `0`)}]|[E]<br>`);
+			g_editorTmp2 += `<br>`;
+
+			g_editorTmp2 += `|speed[i]_data=[speed]|[E]<br>`;
+			g_editorTmp2 += `|boost[i]_data=[boost]|[E]<br>`;
+			g_editorTmp2 += `[datatext][E]<br>`;
+			g_editorTmp2 += `|edit[i]_info=[edit]|[E][E]<br>`;
+			g_editorTmp2 += `[noteend]<br>`;
+			g_editorTmp2 += `<br>`;
+
+			g_editorTmp2 += `[footer]<br>`;
+			g_editorTmp2 += `&nbsp;&nbsp;\`;[E]<br>`;
+			g_editorTmp2 += `}<br>`;
+			g_editorTmp2 += `<br>`;
 		});
 	});
 };
@@ -5275,9 +5333,14 @@ const preconditionInit = () => {
 
 		createDivCss2Label(`lblPrecondView`, viewKeyStorage(`g_rootObj`), g_lblPosObj.lblPrecondView),
 		createCss2Button(`btnPrecondView`, g_lblNameObj.b_copyStorage, () =>
-			copyTextToClipboard(
-				viewKeyStorage(g_settings.preconditions[g_settings.preconditionNum * numOfPrecs + g_settings.preconditionNumSub], ``, false),
-				g_msgInfoObj.I_0007),
+			copyTextToClipboard((() => {
+				const key = g_settings.preconditions[g_settings.preconditionNum * numOfPrecs + g_settings.preconditionNumSub];
+				if (key === `g_editorTmp2`) {
+					return g_editorTmp2.replaceAll(`<br>`, `\r\n`).replaceAll(`&nbsp;`, ` `);
+				} else {
+					return viewKeyStorage(key, ``, false);
+				}
+			})(), g_msgInfoObj.I_0007),
 			g_lblPosObj.btnPrecondView, g_cssObj.button_Default, g_cssObj.button_ON),
 	);
 	setUserSelect($id(`lblPrecondView`), `text`);

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1179,7 +1179,7 @@ const g_settings = {
     settingWindowNum: 0,
 
     preconditions: [`g_rootObj`, `g_headerObj`, `g_keyObj`, `g_scoreObj`, `g_workObj`,
-        `g_detailObj`, `g_stateObj`, `g_attrObj`, `g_editorTmp`],
+        `g_detailObj`, `g_stateObj`, `g_attrObj`, `g_editorTmp`, `g_editorTmp2`],
     preconditionNum: 0,
     preconditionNumSub: 0,
 };
@@ -3188,6 +3188,7 @@ g_keycons.groups.forEach(type => {
 });
 
 const g_editorTmp = {};
+let g_editorTmp2 = ``;
 
 // 特殊キーのコピー種 (simple: 代入、multiple: 配列ごと代入)
 // 後でプロパティ削除に影響するため、先頭文字が全く同じ場合は長い方を先に定義する (例: divMax, div)


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. ダンおに譜面作成エディタ ver3フォーマットの自動生成機能を実装

- ダンおに譜面作成エディタ ver3フォーマットに合わせて、
既定で用意されていないキー種が指定されたときに
エディター用のカスタムキー定義を自動生成する機能を追加しました。
- 前提条件画面の「g_editorTmp2」より確認が可能です。

#### 仕様補足

- 基本的に #1809 のときと同じです。
- カスタムキーが複数ある場合は複数分出力されるので、切り取って使うことを想定しています。
- 出力時の文字コードはUTF-8です。エディターのテンプレートファイルがANSI（SHIFT-JIS）のため、ファイル保存時はANSI（SHIFT-JIS）に変換して保存してください。

|項目|自動生成仕様|
|----|----|
|\$key|カスタムキー定義のキー数。keyNameXで設定している名前ではありません。|
|\$map|レーンごとの色。最大7つまで指定可能なため、7つを超えた場合は0から振り直します。<br>また、CW Editionと異なりおにぎりが0相当（CW Editonは2）のため、<br>0～2に限り1, 2, 0の順に割り当てます。|
|\$pos|列の幅。デフォルトは24で、矢印以外が指定された場合に28に設定します。<br>※stepRtnXの値を参照して決定しています。|
|\$txt|列の上部に表示するテキスト。割り当てキー名を表示します。<br>1つのキーに対して複数ある場合でも表示は1種類のみです。<br>また、区切り文字の関係でカンマが使えないためカンマは除去します。|
|\$conv1|範囲内のノート位置変換を行うルーチン。ミラー配置のみ自動生成します。<br>既存のシャッフルグループを使って、シャッフルグループ間でミラーになるように設定します。<br>複数あれば、複数分自動生成されます。|

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 独自のカスタムキーやトランスキーを定義した場合、1から作るのが手間のため。
また、Dancing☆Onigiri エディター (CW Edition対応)と異なり
個々のカスタムキー定義が用意されておらず、自動生成があった方がより便利のため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/a2d92a93-e04a-4305-b4b0-5a44d4a1f99f" width="70%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced output formatting that supports additional editor formats including Dancing☆Onigiri (CW Edition) and ダンおに譜面作成エディタ ver3.
	- Improved clipboard functionality by standardizing text formatting for better readability.
	- Extended configuration settings with additional processing options to support the new output and copy operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->