### PR TITLE
feat: [0913] CW Edition対応エディターについてカスタムキー定義のorderGroupsの自動生成に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2660,8 +2660,9 @@ const initialControl = async () => {
 
 				// 上下を入れ替えてグループ間でソート
 				const upDownIdxs = addNewOrderGroup(orgPosList, (a, b) => {
-					if (a.value >= divPos && b.value < divPos) return -1;
-					if (a.value < divPos && b.value >= divPos) return 1;
+					const aAbove = a.value < divPos;
+					const bAbove = b.value < divPos;
+					if (aAbove !== bAbove) return Number(aAbove) - Number(bAbove);
 					return a.value - b.value;
 				});
 				if (upDownIdxs !== undefined) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2605,6 +2605,10 @@ const initialControl = async () => {
 	const customKeyList = g_headerObj.keyLists.filter(val =>
 		g_keyObj.defaultKeyList.findIndex(key => key === val) < 0);
 
+	if (customKeyList.length === 0) {
+		g_settings.preconditions = g_settings.preconditions.filter(val => !val.includes(`g_editorTmp`));
+	}
+
 	const addNewOrderGroup = (_orgList, _sortRule) => {
 		// インデックスを保持した配列を作成、ルールに従ってソート
 		const indexedList = _orgList.map((value, idx) => ({ value, idx }));


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. CW Edition対応エディターについてカスタムキー定義のorderGroupsの自動生成に対応
- Dancing☆Onigiri エディター(CW Edition対応)について
カスタムキー定義の自動生成対象にorderGroupsを追加しました。
- 上下スクロールがある場合に入れ替えたパターンと、posXの小さい順に並べたパターンを追加しています。
- 前者については入れ替えたうえでその中身を小さい順にソートしています。

### 2. カスタムキーが存在しないときに、g_editorTmp/g_editorTmp2を非表示化

- 使用しないことが多いため、非表示化するようにしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. そのままの形では使いにくいことがあるため。
なお、posX順は画面の見た目になるので、見た目に反した配置の場合、意図通りにならないことがあります。
2. 動的に増えることが考えにくいため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/edc8cf12-8e64-4a1a-bf56-6342a92cf3b9" width="70%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced ordering system that dynamically organizes displayed items based on customizable sorting criteria for a more consistent presentation.
  - Added a new method for processing and sorting order groups to improve item organization.

- **Refactor**
  - Improved the grouping mechanism to automatically clear out unnecessary data, ensuring that only relevant groupings remain visible to provide a cleaner user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->