### PR TITLE
improve: [0915] 初期ロード方法をwindow.onloadからreadyStateをチェックする方法に変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -77,7 +77,19 @@ const g_isDebug = g_isLocal ||
 	getQueryParamVal(`debug`) === `true`;
 const isLocalMusicFile = _scoreId => g_isFile && !listMatching(getMusicUrl(_scoreId), [`.js`, `.txt`], { suffix: `$` });
 
-window.onload = async () => {
+// 50msごとにdocument.readyStateをチェックしてcompleteになったらresolve
+const waitUntilLoaded = () => {
+	return new Promise(resolve => {
+		const checkReadyState = setInterval(() => {
+			if (document.readyState === 'complete') {
+				clearInterval(checkReadyState);
+				resolve();
+			}
+		}, 50);
+	});
+};
+(async () => {
+	await waitUntilLoaded();
 	g_loadObj.main = true;
 	g_currentPage = `initial`;
 	const links = document.querySelectorAll(`link`);
@@ -90,7 +102,7 @@ window.onload = async () => {
 	await loadScript2(`${g_rootPath}../js/lib/danoni_constants.js?${g_randTime}`);
 	await loadScript2(`${g_rootPath}../js/lib/legacy_functions.js?${g_randTime}`, false);
 	initialControl();
-};
+})();
 
 /*-----------------------------------------------------------*/
 /* Scene : COMMON [water] */


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 初期ロード方法をwindow.onloadからreadyStateをチェックする方法に変更
- 初期ロードを確認する方法として、`window.onload`ではなく
`readyState`が`complate`になるのを監視する方法に切り替えました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. CDNを利用する場合にロードが早すぎてwindow.onloadが動かないことがあるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
参考：https://qiita.com/fujishiro380/items/12e39ec85f162ce6b3c8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved page load handling to ensure that initialization and subsequent operations occur only after the page is fully loaded, leading to a more stable and consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->