### PR TITLE
refactor: [0918] 不要プロパティの整理

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2081,7 +2081,7 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 		[spriteData[tmpFrame], dataCnts] =
 			checkDuplicatedObjects(spriteData[tmpFrame]);
 
-		const emptyPatterns = [``, `[loop]`, `[jump]`];
+		const emptyPatterns = [`[loop]`, `[jump]`];
 		const colorObjFlg = tmpSpriteData[2]?.startsWith(`[c]`) || false;
 		const spriteFrameData = spriteData[tmpFrame][dataCnts] = {
 			depth: tmpDepth,
@@ -2103,8 +2103,10 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 				spriteFrameData.colorObjInfo.animationFillMode = tmpObj.animationFillMode;
 			}
 
+		} else if (tmpObj.path === ``) {
+			spriteFrameData.command = ``;
 		} else if (emptyPatterns.includes(tmpObj.path)) {
-			// ループ、フレームジャンプ、空の場合の処理
+			// ループ、フレームジャンプの場合の処理
 			spriteFrameData.command = tmpObj.path;
 			spriteFrameData.jumpFrame = tmpObj.class;
 			spriteFrameData.maxLoop = tmpObj.left;
@@ -9144,6 +9146,7 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 	const mergeColorData = (_header = ``) => {
 		if (obj[`color${_header}Data`] === undefined) return [];
 		const tmpArr = obj[`color${_header}Data`].concat(obj[`acolor${_header}Data`]);
+		delete obj[`acolor${_header}Data`];
 		return tmpArr.sort((_a, _b) => _a[0] - _b[0]).flat();
 	};
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 不要プロパティの整理
- g_scoreObjの不要なプロパティを動的に削除するようにしました。
後でデバッグで確認したいプロパティは残しています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. デバッグでも不要なプロパティを保持しているため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
