### PR TITLE
feat: [0919] 選曲機能を実装

### DIFF
--- a/danoni/danoni0.html
+++ b/danoni/danoni0.html
@@ -37,7 +37,7 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 <body>
 <table><tr><td>
 <p style="text-align:center;">
-	<span style="font-size:32px;">Preview</span>
+	<span id="webMusicTitle">Preview</span>
 </p>
 <hr>
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4957,19 +4957,19 @@ const titleInit = (_initFlg = false) => {
 
 			let spriteOpacity = 1;
 			let fadeOpacity = null;
-			const fadeStartOpacity = setInterval(() => {
-				clearInterval(fadeStartOpacity);
+			const fadeStartOpacity = setTimeout(() => {
+				clearTimeout(fadeStartOpacity);
 				setOpacity(spriteOpacity);
 			}, 2000);
 
 			const setOpacity = (_opacity) => {
 				if (_opacity <= 0) {
-					clearInterval(fadeOpacity);
+					clearTimeout(fadeOpacity);
 					mSelectTitleSprite.style.display = C_DIS_NONE;
 				} else {
 					mSelectTitleSprite.style.opacity = _opacity;
-					fadeOpacity = setInterval(() => {
-						spriteOpacity -= 0.1;
+					fadeOpacity = setTimeout(() => {
+						spriteOpacity -= 0.25;
 						setOpacity(spriteOpacity);
 					}, 50);
 				}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3941,7 +3941,7 @@ const headerConvert = _dosObj => {
 	obj.commentVal = tmpComment.split(`\n`).join(newlineTag);
 
 	const maxMusicNo = Math.max(...obj.musicNos);
-	for (let j = 1; j <= maxMusicNo + 1; j++) {
+	for (let j = 0; j <= maxMusicNo; j++) {
 		obj[`commentVal${j}`] = (_dosObj[`commentVal${j}`] || ``).split(`\n`).join(`<br>`).replace(`<br>`, ``);
 	}
 
@@ -5056,7 +5056,7 @@ const titleInit = (_initFlg = false) => {
 			viewKeyStorage.cache = new Map();
 
 			// コメント文の加工
-			lblComment.innerHTML = convertStrToVal(g_headerObj[`commentVal${g_settings.musicIdxNum + 1}`]);
+			lblComment.innerHTML = convertStrToVal(g_headerObj[`commentVal${g_settings.musicIdxNum}`]);
 
 			// 選曲変更時のカスタム関数実行
 			g_customJsObj.musicSelect.forEach(func => func(g_settings.musicIdxNum));

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2758,13 +2758,18 @@ const initialControl = async () => {
  * @param {string} _musicId 楽曲ID
  */
 const loadLocalStorage = (_musicId = ``) => {
-	// URLからscoreId, h(高さ), debugを削除
+
+	// 作品別ローカルストレージのキー(URL)取得のため、
+	// scoreId, h, debug, musicIdを削除
+	// 選択中の楽曲ID(_musicId)がある場合は、キーとして区別するため追加
 	const url = new URL(location.href);
 	url.searchParams.delete(`scoreId`);
 	url.searchParams.delete(`h`);
 	url.searchParams.delete(`debug`);
 	url.searchParams.delete(`musicId`);
 	g_localStorageUrl = url.toString();
+
+	// リザルト表示用のURL組み立てのため、_musicIdのないURLを保存
 	g_localStorageUrlOrg = g_localStorageUrl;
 
 	if (_musicId !== ``) {
@@ -3429,19 +3434,21 @@ const headerConvert = _dosObj => {
 				obj.artistUrls[j] = musics[2] || obj.artistUrls[0] || ``;
 				obj.bpms[j] = musics[4] || obj.bpms[0] || `----`;
 			}
-		}
-		const musics = splitComma(musicData[0]);
-		obj.musicTitle = obj.musicTitles[0];
-		obj.musicTitleForView = obj.musicTitlesForView[0];
-		obj.artistName = obj.artistNames[0] ?? ``;
-		if (obj.artistName === ``) {
-			makeWarningWindow(g_msgInfoObj.E_0011);
-			obj.artistName = `artistName`;
-		}
-		obj.artistUrl = musics[2] ?? ``;
-		if (hasVal(musics[3])) {
-			obj.musicTitles[0] = escapeHtml(getMusicNameSimple(musics[3]));
-			obj.musicTitlesForView[0] = escapeHtmlForArray(getMusicNameMultiLine(musics[3]));
+
+			if (j === 0) {
+				obj.musicTitle = obj.musicTitles[0];
+				obj.musicTitleForView = obj.musicTitlesForView[0];
+				obj.artistName = obj.artistNames[0];
+				if (obj.artistName === ``) {
+					makeWarningWindow(g_msgInfoObj.E_0011);
+					obj.artistName = `artistName`;
+				}
+				obj.artistUrl = obj.artistUrls[0];
+				if (hasVal(musics[3])) {
+					obj.musicTitles[0] = escapeHtml(getMusicNameSimple(musics[3]));
+					obj.musicTitlesForView[0] = escapeHtmlForArray(getMusicNameMultiLine(musics[3]));
+				}
+			}
 		}
 
 	} else {
@@ -3944,13 +3951,6 @@ const headerConvert = _dosObj => {
 	const maxMusicNo = Math.max(...obj.musicNos);
 	for (let j = 0; j <= maxMusicNo; j++) {
 		obj[`commentVal${j}`] = (_dosObj[`commentVal${j}`] || ``).split(`\n`).join(`<br>`).replace(`<br>`, ``);
-	}
-
-	// クレジット表示
-	if (document.getElementById(`webMusicTitle`) !== null) {
-		webMusicTitle.innerHTML =
-			`<span style="font-size:${wUnit(32)}">${obj.musicTitleForView.join(`<br>`)}</span><br>
-			<span style="font-size:${wUnit(16)}">(Artist: <a href="${obj.artistUrl}" target="_blank">${obj.artistName}</a>)</span>`;
 	}
 
 	// コメントの外部化設定
@@ -4980,6 +4980,9 @@ const titleInit = (_initFlg = false) => {
 			g_headerObj.musicSelectUse ? g_headerObj.viewLists[0] + 1 : ``))
 	}
 
+	// クレジット表示
+	externalWebTitle();
+
 	if (g_errMsgObj.title !== ``) {
 		makeWarningWindow();
 	}
@@ -5128,6 +5131,17 @@ const titleInit = (_initFlg = false) => {
 	divRoot.oncontextmenu = () => false;
 
 	g_skinJsObj.title.forEach(func => func());
+};
+
+/**
+ * 外部のタイトル表示
+ */
+const externalWebTitle = () => {
+	if (document.getElementById(`webMusicTitle`) !== null) {
+		webMusicTitle.innerHTML =
+			`<span style="font-size:${wUnit(32)}">${g_headerObj.musicTitlesForView[g_settings.musicIdxNum].join(`<br>`)}</span><br>
+			<span style="font-size:${wUnit(16)}">(Artist: <a href="${g_headerObj.artistUrls[g_settings.musicIdxNum]}" target="_blank">${g_headerObj.artistNames[g_settings.musicIdxNum]}</a>)</span>`;
+	}
 };
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5055,6 +5055,12 @@ const titleInit = (_initFlg = false) => {
 			loadLocalStorage(g_settings.musicIdxNum);
 			viewKeyStorage.cache = new Map();
 
+			// 初期化もしくは楽曲変更時に速度を初期化
+			if (_initFlg || _num !== 0) {
+				g_stateObj.speed = g_headerObj.initSpeeds[g_headerObj.viewLists[0]];
+				g_settings.speedNum = getCurrentNo(g_settings.speeds, g_stateObj.speed);
+			}
+
 			// コメント文の加工
 			lblComment.innerHTML = convertStrToVal(g_headerObj[`commentVal${g_settings.musicIdxNum}`]);
 
@@ -5104,7 +5110,7 @@ const titleInit = (_initFlg = false) => {
 		});
 
 		// 初期表示用 (2秒後に選曲画面を表示)
-		if (_initFlg && !g_headerObj.customTitleArrowUse) {
+		if (_initFlg && !g_headerObj.customTitleUse) {
 			const mSelectTitleSprite = createEmptySprite(divRoot, `mSelectTitleSprite`,
 				g_windowObj.mSelectTitleSprite, g_cssObj.settings_DifSelector);
 			multiAppend(mSelectTitleSprite,

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2599,10 +2599,8 @@ const initialControl = async () => {
 		}
 	}
 	g_customJsObj.preTitle.forEach(func => func());
-	g_settings.musicIdxNum = roundZero(
-		(getQueryParamVal(`musicId`) !== null ? [Number(getQueryParamVal(`musicId`))] :
-			g_headerObj.musicNos).find((val, j) => j === g_stateObj.scoreId)
-	);
+	g_settings.musicIdxNum = getQueryParamVal(`musicId`) !== null ? Number(getQueryParamVal(`musicId`)) :
+		g_headerObj.musicNos[g_stateObj.scoreId] || g_headerObj.musicNos[0];
 	titleInit(true);
 
 	// 未使用のg_keyObjプロパティを削除
@@ -3952,7 +3950,8 @@ const headerConvert = _dosObj => {
 
 	const maxMusicNo = Math.max(...obj.musicNos);
 	for (let j = 0; j <= maxMusicNo; j++) {
-		obj[`commentVal${j}`] = (_dosObj[`commentVal${j}`] || ``).split(`\n`).join(`<br>`).replace(`<br>`, ``);
+		obj[`commentVal${j}`] = (_dosObj[`commentVal${j}`] || ``).split(`\n`)
+			.filter((val, k) => k !== 0 || val !== ``).join(`<br>`);
 	}
 
 	// コメントの外部化設定
@@ -5016,6 +5015,7 @@ const titleInit = (_initFlg = false) => {
 			Object.assign(g_lblPosObj[_id], { siz: getLinkSiz(_text), whiteSpace: `normal`, resetFunc: () => openLink(_url) }), g_cssObj.button_Default);
 
 	if (g_headerObj.musicSelectUse && getQueryParamVal(`scoreId`) === null) {
+		// 選曲モードではクレジット表示は別で行われているため表示しない
 	} else {
 		if (tmpCreatorList.length === 0) {
 			tmpCreatorList.push(g_headerObj.creatorNames[0]);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3435,6 +3435,7 @@ const headerConvert = _dosObj => {
 				obj.bpms[j] = musics[4] || obj.bpms[0] || `----`;
 			}
 
+			// 選曲ではなく、単一作品用の項目としての管理変数を定義
 			if (j === 0) {
 				obj.musicTitle = obj.musicTitles[0];
 				obj.musicTitleForView = obj.musicTitlesForView[0];
@@ -5257,6 +5258,7 @@ const changeMSelect = (_num, _initFlg = false) => {
 	const musicMaxIdx = Math.max(...g_headerObj.musicNos);
 	const musicIdxTmpList = [...Array(musicMaxIdx + 1).keys()];
 
+	// 選択方向に合わせて楽曲リスト情報を再取得
 	for (let j = -g_settings.mSelectableTerms; j <= g_settings.mSelectableTerms; j++) {
 		const idx = (j + _num + g_settings.musicIdxNum + musicIdxTmpList.length * 10) % musicIdxTmpList.length;
 		if (j === 0) {
@@ -5268,9 +5270,10 @@ const changeMSelect = (_num, _initFlg = false) => {
 				`<span style="font-size:0.7em;line-height:9px"> / ${g_headerObj.artistNames[idx]}</span>`;
 		}
 	}
+	// 現在選択中の楽曲IDを再設定
 	g_settings.musicIdxNum = (g_settings.musicIdxNum + _num + musicIdxTmpList.length) % musicIdxTmpList.length;
 
-	// 選択した曲に対応する譜面番号を取得
+	// 選択した楽曲に対応する譜面番号、製作者情報、曲長を取得
 	g_headerObj.viewLists = [];
 	const tmpKeyList = [], tmpCreatorList = [], tmpPlayingFrameList = [];
 	g_headerObj.musicNos.forEach((val, j) => {
@@ -5287,6 +5290,7 @@ const changeMSelect = (_num, _initFlg = false) => {
 	const creatorLink = creatorIdx >= 0 ?
 		`<a href="${creatorUrl}" target="_blank">${creatorName}</a>` : creatorName;
 
+	// 選択した楽曲の情報表示
 	const idx = g_settings.musicIdxNum;
 	document.getElementById(`lblMusicSelect`).innerHTML =
 		`<span style="font-size:${getFontSize(g_headerObj.musicTitlesForView[idx].join(`<br>`), g_btnWidth(1 / 2), getBasicFont(), 18)}px;` +
@@ -5295,6 +5299,7 @@ const changeMSelect = (_num, _initFlg = false) => {
 		`Maker: ${creatorLink} / Artist: <a href="${g_headerObj.artistUrls[idx]}" target="_blank">` +
 		`${g_headerObj.artistNames[idx]}</a><br>Duration: ${playingFrames} / BPM: ${g_headerObj.bpms[idx]}`;
 
+	// 選択した楽曲で使われているキー種の一覧を作成
 	deleteChildspriteAll(`keyTitleSprite`);
 	makeDedupliArray(tmpKeyList).sort((a, b) => parseInt(a) - parseInt(b))
 		.forEach((val, j) => {
@@ -5306,7 +5311,10 @@ const changeMSelect = (_num, _initFlg = false) => {
 			)
 		});
 
+	// 選択した楽曲の選択位置を表示
 	lblMusicCnt.innerHTML = `${g_settings.musicIdxNum + 1} / ${musicMaxIdx + 1}`;
+
+	// 楽曲別のローカルストレージを再取得
 	loadLocalStorage(g_settings.musicIdxNum);
 	viewKeyStorage.cache = new Map();
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5303,14 +5303,11 @@ const changeMSelect = (_num, _initFlg = false) => {
 	// 選択した楽曲で使われているキー種の一覧を作成
 	deleteChildspriteAll(`keyTitleSprite`);
 	makeDedupliArray(tmpKeyList).sort((a, b) => parseInt(a) - parseInt(b))
-		.forEach((val, j) => {
-			keyTitleSprite.appendChild(
-				createDivCss2Label(`btnKeyTitle${val}`, val, {
-					x: 10 + j * 40, y: 0, w: 35, h: 16, siz: 14,
-					border: `solid 1px #666666`,
-				})
-			)
-		});
+		.forEach((val, j) => keyTitleSprite.appendChild(
+			createDivCss2Label(`btnKeyTitle${val}`, val,
+				Object.assign({ x: 10 + j * 40 }, g_lblPosObj.btnKeyTitle)
+			)));
+
 
 	// 選択した楽曲の選択位置を表示
 	lblMusicCnt.innerHTML = `${g_settings.musicIdxNum + 1} / ${musicMaxIdx + 1}`;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3848,8 +3848,9 @@ const headerConvert = _dosObj => {
 	g_stateObj.excessive = boolToSwitch(obj.excessiveJdgUse);
 	g_settings.excessiveNum = Number(obj.excessiveJdgUse);
 
-	// 譜面名に制作者名を付加するかどうかのフラグ
+	// 譜面名に制作者名を付加するかどうかのフラグ（選曲用に初期値を退避）
 	obj.makerView = setBoolVal(_dosObj.makerView);
+	obj.makerViewOrg = obj.makerView;
 
 	// shuffleUse=group 時のみshuffle用配列を組み替える
 	if (_dosObj.shuffleUse === `group`) {
@@ -5242,7 +5243,7 @@ const drawTitle = (_titleName = g_headerObj.musicTitleForView, _scoreId = ``) =>
  */
 const getCreatorInfo = (_creatorList) => {
 	const creatorName = makeDedupliArray(_creatorList).length === 1 ? _creatorList[0] : `Various`;
-	g_headerObj.makerView = creatorName === `Various`;
+	g_headerObj.makerView = g_headerObj.makerViewOrg ? true : creatorName === `Various`;
 	const creatorIdx = g_headerObj.tuningNames.findIndex(val => val === creatorName);
 	const creatorUrl = creatorIdx >= 0 ? g_headerObj.tuningUrls[creatorIdx] : ``;
 	return [creatorName, creatorUrl, creatorIdx];
@@ -5828,6 +5829,15 @@ const optionInit = () => {
 	const divRoot = document.getElementById(`divRoot`);
 	g_currentPage = `option`;
 	g_stateObj.filterKeys = ``;
+
+	// 楽曲データの表示
+	let text = `♪` + (g_headerObj.musicSelectUse ? `${g_headerObj.musicTitles[g_settings.musicIdxNum]} / ` : ``) +
+		`BPM: ${g_headerObj.bpms[g_settings.musicIdxNum]}`;
+	if (!g_headerObj.musicSelectUse && g_headerObj.bpms[g_settings.musicIdxNum] === `----`) {
+		text = ``;
+	}
+	divRoot.appendChild(createDivCss2Label(`lblMusicInfo`, text,
+		Object.assign({ siz: getFontSize(text, g_btnWidth(3 / 4), getBasicFont(), 12) }, g_lblPosObj.lblMusicInfo)));
 
 	// タイトル文字描画
 	divRoot.appendChild(getTitleDivLabel(`lblTitle`, g_lblNameObj.settings, 0, 15, `settings_Title`));

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2755,6 +2755,7 @@ const initialControl = async () => {
 
 /**
  * 作品別ローカルストレージの読み込み・初期設定
+ * @param {string} _musicId 楽曲ID
  */
 const loadLocalStorage = (_musicId = ``) => {
 	// URLからscoreId, h(高さ), debugを削除
@@ -4954,21 +4955,24 @@ const titleInit = (_initFlg = false) => {
 			);
 
 			let spriteOpacity = 1;
+			let fadeOpacity = null;
+			const fadeStartOpacity = setInterval(() => {
+				clearInterval(fadeStartOpacity);
+				setOpacity(spriteOpacity);
+			}, 2000);
+
 			const setOpacity = (_opacity) => {
 				if (_opacity <= 0) {
+					clearInterval(fadeOpacity);
 					mSelectTitleSprite.style.display = C_DIS_NONE;
 				} else {
 					mSelectTitleSprite.style.opacity = _opacity;
-					setInterval(() => {
+					fadeOpacity = setInterval(() => {
 						spriteOpacity -= 0.1;
 						setOpacity(spriteOpacity);
 					}, 50);
 				}
 			};
-			setInterval(() => {
-				spriteOpacity -= 0.1;
-				setOpacity(spriteOpacity);
-			}, 2000);
 		}
 	} else if (!g_headerObj.customTitleUse) {
 		// 曲名文字描画（曲名は譜面データから取得）

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2599,7 +2599,8 @@ const initialControl = async () => {
 		}
 	}
 	g_customJsObj.preTitle.forEach(func => func());
-	g_settings.musicIdxNum = getQueryParamVal(`musicId`) !== null ? Number(getQueryParamVal(`musicId`)) :
+	const queryMusicId = getQueryParamVal(`musicId`);
+	g_settings.musicIdxNum = queryMusicId !== null ? Number(queryMusicId) :
 		g_headerObj.musicNos[g_stateObj.scoreId] || g_headerObj.musicNos[0];
 	titleInit(true);
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -191,8 +191,8 @@ const getScMsg = {
  */
 const updateWindowSiz = () => {
     Object.assign(g_windowObj, {
-        keyTitleSprite: { x: g_btnX(1 / 4), y: g_sHeight / 2 + 25, w: g_btnWidth(1 / 2), h: 16 },
-        mSelectTitleSprite: { x: g_btnX(), y: 0, w: g_btnWidth(), h: g_sHeight, opacity: 0.7, background: `#000000`, clipPath: `inset(20% 0 20% 0)` },
+        keyTitleSprite: { x: g_btnX(1 / 4), y: g_sHeight / 2 - 5, w: g_btnWidth(1 / 2), h: 16 },
+        mSelectTitleSprite: { x: g_btnX(), y: 0, w: g_btnWidth(), h: g_sHeight, opacity: 0.7, background: `#000000`, clipPath: `inset(12% 0 8% 0)` },
         optionSprite: { x: (g_sWidth - 450) / 2, y: 65, w: 450, h: 325 },
         dataSprite: { x: g_btnX() + (g_sWidth - Math.max(g_sWidth - 100, 450)) / 2, y: 65, w: Math.max(g_sWidth - 100, 450), h: 325 },
         keyListSprite: { x: 0, y: g_limitObj.setLblHeight * 7.5 + 40, w: 150, h: g_sHeight - 380, overflow: C_DIS_AUTO },
@@ -245,35 +245,44 @@ const updateWindowSiz = () => {
         },
 
         lblMusicSelect: {
-            x: g_btnX(1 / 4), y: g_sHeight / 2 - 60,
-            w: g_btnWidth(5 / 8), h: 146, siz: 14, border: `solid 1px #006666`,
+            x: g_btnX(1 / 4), y: g_sHeight / 2 - 90,
+            w: g_btnWidth(5 / 8), h: 206, siz: 14, border: `solid 1px #006666`,
             align: C_ALIGN_LEFT, padding: `0 10px`, display: `inline-block`,
         },
         lblMusicSelectDetail: {
-            x: g_btnX(1 / 4), y: g_sHeight / 2 - 15,
+            x: g_btnX(1 / 4), y: g_sHeight / 2 - 45,
             w: g_btnWidth(5 / 8), h: 50, siz: 14,
             align: C_ALIGN_LEFT, padding: `0 10px`, display: `inline-block`,
             pointerEvents: C_DIS_INHERIT,
         },
         btnStart_music: {
-            x: g_btnX(13 / 16), y: g_sHeight / 2 - 60,
-            w: g_btnWidth(1 / 16), h: 146, siz: 24, padding: `0 10px`,
+            x: g_btnX(27 / 32), y: g_sHeight / 2 - 90,
+            w: g_btnWidth(1 / 16), h: 206, siz: 24, padding: `0 10px`,
             border: `solid 1px #006666`,
         },
         btnMusicSelectPrev: {
-            x: g_btnX(1 / 4), y: g_sHeight / 2 - 104,
+            x: g_btnX(1 / 4), y: g_sHeight / 2 - 134,
             w: 30, h: 40, siz: 20, padding: `0 10px`,
             border: `solid 1px #666600`,
         },
         btnMusicSelectNext: {
-            x: g_btnX(1 / 4), y: g_sHeight / 2 + 90,
+            x: g_btnX(1 / 4), y: g_sHeight / 2 + 120,
             w: 30, h: 40, siz: 20, padding: `0 10px`,
             border: `solid 1px #666600`,
         },
         btnMusicSelectRandom: {
-            x: g_btnX(1 / 4) - 80, y: g_sHeight / 2 - 104,
+            x: g_btnX(1 / 4) - 80, y: g_sHeight / 2 - 134,
             w: 55, h: 40, siz: 14, padding: `0 10px`,
             border: `solid 1px #666666`,
+        },
+        lblMusicCnt: {
+            x: g_btnX(1 / 4) - 80, y: g_sHeight / 2 - 90,
+            w: 80, h: 20, siz: 14, align: C_ALIGN_CENTER,
+        },
+        lblComment_music: {
+            x: g_btnX(1 / 4) + 10, y: g_sHeight / 2 + 15, w: g_btnWidth(7 / 12) - 5, h: 100,
+            siz: g_limitObj.difSelectorSiz, align: C_ALIGN_LEFT,
+            overflow: C_DIS_AUTO, whiteSpace: `normal`,
         },
 
         /** データ管理 */
@@ -4213,6 +4222,7 @@ const g_customJsObj = {
     preTitle: [],
     title: [],
     titleEnterFrame: [],
+    musicSelect: [],
     dataMgt: [],
     precondition: [],
     option: [],

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -191,6 +191,8 @@ const getScMsg = {
  */
 const updateWindowSiz = () => {
     Object.assign(g_windowObj, {
+        keyTitleSprite: { x: g_btnX(1 / 4), y: g_sHeight / 2 + 25, w: g_btnWidth(1 / 2), h: 16 },
+        mSelectTitleSprite: { x: g_btnX(), y: 0, w: g_btnWidth(), h: g_sHeight, opacity: 0.7, background: `#000000`, clipPath: `inset(20% 0 20% 0)` },
         optionSprite: { x: (g_sWidth - 450) / 2, y: 65, w: 450, h: 325 },
         dataSprite: { x: g_btnX() + (g_sWidth - Math.max(g_sWidth - 100, 450)) / 2, y: 65, w: Math.max(g_sWidth - 100, 450), h: 325 },
         keyListSprite: { x: 0, y: g_limitObj.setLblHeight * 7.5 + 40, w: 150, h: g_sHeight - 380, overflow: C_DIS_AUTO },
@@ -240,6 +242,38 @@ const updateWindowSiz = () => {
         },
         btnComment: {
             x: g_btnX(1) - 160, y: (g_sHeight / 2) + 150, w: 140, h: 50, siz: 20, border: `solid 1px #999999`,
+        },
+
+        lblMusicSelect: {
+            x: g_btnX(1 / 4), y: g_sHeight / 2 - 60,
+            w: g_btnWidth(5 / 8), h: 146, siz: 14, border: `solid 1px #006666`,
+            align: C_ALIGN_LEFT, padding: `0 10px`, display: `inline-block`,
+        },
+        lblMusicSelectDetail: {
+            x: g_btnX(1 / 4), y: g_sHeight / 2 - 15,
+            w: g_btnWidth(5 / 8), h: 50, siz: 14,
+            align: C_ALIGN_LEFT, padding: `0 10px`, display: `inline-block`,
+            pointerEvents: C_DIS_INHERIT,
+        },
+        btnStart_music: {
+            x: g_btnX(13 / 16), y: g_sHeight / 2 - 60,
+            w: g_btnWidth(1 / 16), h: 146, siz: 24, padding: `0 10px`,
+            border: `solid 1px #006666`,
+        },
+        btnMusicSelectPrev: {
+            x: g_btnX(1 / 4), y: g_sHeight / 2 - 104,
+            w: 30, h: 40, siz: 20, padding: `0 10px`,
+            border: `solid 1px #666600`,
+        },
+        btnMusicSelectNext: {
+            x: g_btnX(1 / 4), y: g_sHeight / 2 + 90,
+            w: 30, h: 40, siz: 20, padding: `0 10px`,
+            border: `solid 1px #666600`,
+        },
+        btnMusicSelectRandom: {
+            x: g_btnX(1 / 4) - 80, y: g_sHeight / 2 - 104,
+            w: 55, h: 40, siz: 14, padding: `0 10px`,
+            border: `solid 1px #666666`,
         },
 
         /** データ管理 */
@@ -948,6 +982,7 @@ let C_WOD_FRAME = 30;
 
 // 譜面データ持ち回り用
 const g_stateObj = {
+    keyInitial: false,
     dosDivideFlg: false,
     scoreLockFlg: false,
     scoreId: 0,
@@ -1063,6 +1098,7 @@ const makeSpeedList = (_minSpd, _maxSpd) => [...Array((_maxSpd - _minSpd) * 20 +
 // 設定系全般管理
 const g_settings = {
 
+    musicIdxNum: 0,
     dataMgtNum: {
         environment: 0,
         highscores: 0,
@@ -2019,6 +2055,8 @@ const g_shortcutObj = {
         ControlLeft_KeyC: { id: `` },
         KeyC: { id: `btnComment` },
         KeyD: { id: `btnReset` },
+        ArrowUp: { id: `btnMusicSelectPrev` },
+        ArrowDown: { id: `btnMusicSelectNext` },
     },
     dataMgt: {
         KeyE: { id: `btnEnvironment` },

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1118,6 +1118,8 @@ const g_settings = {
     keyStorages: [`reverse`, `keyCtrl`, `keyCtrlPtn`, `shuffle`, `color`, `stepRtn`],
     colorStorages: [`setColor`, `setShadowColor`, `frzColor`, `frzShadowColor`],
 
+    mSelectableTerms: 3,
+
     speeds: makeSpeedList(C_MIN_SPEED, C_MAX_SPEED),
     speedNum: 0,
     speedTerms: [20, 5, 1],

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -275,6 +275,10 @@ const updateWindowSiz = () => {
             w: 55, h: 40, siz: 14, padding: `0 10px`,
             border: `solid 1px #666666`,
         },
+        btnKeyTitle: {
+            y: 0, w: 35, h: 16, siz: 14,
+            border: `solid 1px #666666`,
+        },
         lblMusicCnt: {
             x: g_btnX(1 / 4) - 80, y: g_sHeight / 2 - 90,
             w: 80, h: 20, siz: 14, align: C_ALIGN_CENTER,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -192,7 +192,7 @@ const getScMsg = {
 const updateWindowSiz = () => {
     Object.assign(g_windowObj, {
         keyTitleSprite: { x: g_btnX(1 / 4), y: g_sHeight / 2 - 5, w: g_btnWidth(1 / 2), h: 16 },
-        mSelectTitleSprite: { x: g_btnX(), y: 0, w: g_btnWidth(), h: g_sHeight, opacity: 0.7, background: `#000000`, clipPath: `inset(12% 0 8% 0)` },
+        mSelectTitleSprite: { x: g_btnX(), y: 0, w: g_btnWidth(), h: g_sHeight, clipPath: `inset(12% 0 8% 0)` },
         optionSprite: { x: (g_sWidth - 450) / 2, y: 65, w: 450, h: 325 },
         dataSprite: { x: g_btnX() + (g_sWidth - Math.max(g_sWidth - 100, 450)) / 2, y: 65, w: Math.max(g_sWidth - 100, 450), h: 325 },
         keyListSprite: { x: 0, y: g_limitObj.setLblHeight * 7.5 + 40, w: 150, h: g_sHeight - 380, overflow: C_DIS_AUTO },
@@ -3533,6 +3533,7 @@ const g_lang_msgInfoObj = {
         W_0021: `クリップボードのコピーに失敗しました。`,
         W_0031: `セーフモード適用中です。ローカルストレージ情報を使わない設定になっています。<br>
         「Data Management」から解除が可能です。(W-0031)`,
+        W_0041: `選曲単品モードが有効になっています。<br><a href="{0}">[ 選曲画面へ戻る ]</a>`,
 
         E_0011: `アーティスト名が未入力です。(E-0011)`,
         E_0012: `曲名情報が未設定です。(E-0012)<br>
@@ -3588,6 +3589,7 @@ const g_lang_msgInfoObj = {
         W_0031: `Safe Mode is being applied. <br>
         The setting is set to not use local storage information <br>
         and can be removed from Data Management. (W-0031)`,
+        W_0041: `The single music selection mode is enabled.<br><a href="{0}">[ Return to the original page ]</a>`,
 
         E_0011: `The artist name is not set. (E-0011)`,
         E_0012: `The song title information is not set. (E-0012)<br>

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -348,8 +348,11 @@ const updateWindowSiz = () => {
             title: g_msgObj.dataSave, borderStyle: `solid`,
         },
 
+        lblMusicInfo: {
+            x: g_btnX(1 / 4), y: 0, w: g_btnWidth(3 / 4), h: 20, align: C_ALIGN_RIGHT
+        },
         lblBaseSpd: {
-            x: g_sWidth - 100, y: 0, w: 100, h: 20, siz: 14,
+            x: g_sWidth - 100, y: 11, w: 100, h: 20, siz: 13, align: C_ALIGN_RIGHT
         },
         btnReverse: {
             x: 160, y: 0, w: 90, h: 21, siz: g_limitObj.difSelectorSiz, borderStyle: `solid`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 選曲機能を実装
- タイトル画面上に選曲機能を実装しました。
- `|packageName=パッケージ名|`を指定することで、タイトルの代わりに選曲画面が表示されるようになります。
- デフォルトは最初にパッケージ名が表示された後、選曲画面を表示します。
`customTitleUse`を有効にすれば、最初の表示を非表示にすることもできます。

### 仕様・考え方

- 複数の譜面情報から、musicNoで割り当てた楽曲ごとに譜面の対応づけを行い、フィルターします。
- URLクエリに`musicId`(musicNoに対応)を指定することで、ダイレクトにその楽曲を表示します。
- `scoreId`がURLクエリとして渡されたときだけ、単品モードに変わります。
- 選曲機能有効時は、クレジットボタンが作成されません。Click Hereボタンは「>」ボタンに置き換えられます。
- 選曲機能及び、初期表示されるパッケージ名の表示位置は背景とマスクデータの間にいます。タイトル画面の背景・マスクはそのまま使えます。

### 2. musicTitle（楽曲情報）の仕様拡張

- musicTitleについて、5番目の項目としてBPM表記を追加しました。
- 4番目は別で使われているため、通常はカンマを2回つけることになります。

```
|musicTitle=
Destiny,Silvia,https://cw7.sakura.ne.jp/rdart/?artistId=11,,120-145
Destiny -Precious memories-,,,,145
JEWELS -more brightness mix-<br>(radio edit),Y.W,https://cw7.sakura.ne.jp/rdart/?artistId=2,,190
R176,Cranky,https://cw7.sakura.ne.jp/rdart/?artistId=1,,190
Careless Prince Came Back<br>from the Adventure - Web Style -,ASK,https://cw7.sakura.ne.jp/rdart/?artistId=20,,180
|
```

### 3. musicNo, startFrame, fadeFrame, endFrameの改行区切り対応

- 数が多くなると管理しづらいため、対応しました。
下記のように、楽曲ごとに改行することを想定しています。

```
|musicNo=
0
1
2$2$2$2$2
3$3$3$3$3$3$3$3$3
4|
```

### 4. tuning（製作者表示）の複数化対応

- 単品モード実装時に個別の製作者リンクが必要となるため、実装しました。
- ここでリストしておくと、選曲画面や単品モードで製作者名に一致したリンク名を取得することができます。

```
|tuning=
ティックル,https://...
製作者A,https://...
|
```

### 5. ローカルデータ保存のルール変更

- 異なる楽曲で同じ譜面名となる可能性があるため、
楽曲データごとにローカルストレージのキーを変えるようにしました。
- データ管理画面では、選択中の楽曲に対する情報のみを表示するようにします。
- `loadLocalStorage`関数に楽曲IDの引数を追加することで、
作品別のローカルストレージを再読み込みするようにしています。

### 6. makerView（譜面の製作者表示）の自動適用

- 選曲画面で1楽曲のクレジットが複数の場合、MakerをVariousに変更し、
自動でmakerViewを有効にするようにしました。

### 7. makeInfoWindow関数の引数追加

- 選曲単品モードの関連で固定表示させたい場合があるため、
テキスト色と選択可否のオプション引数を追加しました。

### 8. 選曲モード時の楽曲別のコメント表示が行える機能を実装 (commentVal*N*)

- commentVal*N* (*N*はmusicNoの番号)を使って、楽曲別のコメントを表示する機能を実装しました。
使い方はcommentValと同じです。

```
|commentVal0=
1曲目コメント
|
|commentVal1=
2曲目コメント
|
```

### 9. 選曲変更時のカスタムJS差し込み処理を追加

- 選曲変更時にカスタムJSを差し込みできるようにしました。
`g_customJsObj.musicSelect`に関数を追加します。引数は楽曲ID。

### 10. 設定画面に楽曲・BPM表記を追加

- 選曲モード(単品モード含む)のとき、設定画面右上に楽曲名とBPMを表示するようにしました。
- 従来の画面でも、BPM項目が設定されていればBPM項目のみ表示します。
- この変更に伴い、ウィンドウの高さが変わった場合の速度補正表記をずらしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. Resolves #1704 
2. 現行の選曲カスタムJSで実装された内容のため。
3. 選曲管理上、管理がしづらくなるため。
4. 選曲管理上、管理がしづらくなるため。
5. 譜面名の重複回避と、楽曲によってAdjustmentやVolumeを変えたいときがあるため。
6. 選曲内に持ち寄り合作があった場合に製作者の区別を都度行うのが大変なため。
7. 警告で無いメッセージのカスタム幅を広げるため。選曲単品モードでも使用。
8. 楽曲別にカスタムできた方が融通が利くと思われるため。
9. 楽曲別にカスタムできた方が融通が利くと思われるため。また、実装できなかった機能をカスタムJSで差し込みしやすくするため。
10. 現行の選曲カスタムJSで実装された内容のため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
- 選曲モードと選曲単品モード

<img src="https://github.com/user-attachments/assets/2640ac3f-9bc0-427c-8b47-a5c9140e7f61" width="50%"><img src="https://github.com/user-attachments/assets/27d46719-bb53-44fa-9e28-a5fad30fcd37" width="50%">

- 選曲モード時(単品モード含む)と通常モードでの楽曲情報表記

<img src="https://github.com/user-attachments/assets/dcb75016-b80f-4a9c-a939-fbbea353f091" width="50%">
<img src="https://github.com/user-attachments/assets/09a971dd-ac70-4ecc-a38d-ff9621c33474" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->

### 現行のカスタムJSにあり、実装が未定のもの

- 選曲画面中の音源再生、ボリューム調整
  - 現状のコードを見て判断。
     ⇒標準外のストリーミング再生を使っているため、標準としては見送り。

### その他

- 譜面番号の増加課題
  - この方式にした場合、譜面が増えたときの対応が大変になる。後ろに追加する分には問題なし。譜面データの分割など工夫ができないか検討する。
  ⇒ |setColor4=setColor3| のような略記指定が可能なため、当面はこの対応に任せる方向とする。