### PR TITLE
fix: [0920] difDataで製作者名を含む場合にタイトル画面のMaker表記が想定と異なることがある問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5034,7 +5034,7 @@ const titleInit = (_initFlg = false) => {
 			}, g_cssObj.button_Start),
 
 			// 製作者表示
-			createCreditBtn(`lnkMaker`, `${g_lblNameObj.maker}: ${creatorName}`, creatorUrl),
+			createCreditBtn(`lnkMaker`, `${g_lblNameObj.maker}: ${g_headerObj.musicSelectUse ? creatorName : g_headerObj.tuningInit}`, creatorUrl),
 
 			// アーティスト表示
 			createCreditBtn(`lnkArtist`, `${g_lblNameObj.artist}: ${g_headerObj.artistNames[g_settings.musicIdxNum]}`, g_headerObj.artistUrls[g_settings.musicIdxNum]),


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 通常モードのとき、difDataで製作者名を含む場合にタイトル画面のMaker表記が想定と異なることがある問題を修正
- 通常モードでdifDataに製作者名が含まれていた場合、
タイトル画面のMaker表記がdifDataの製作者名になることがあります。
その問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. PR #1839 の考慮漏れ。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
