### PR TITLE
fix: [0921] ゲージ設定の許容ミス数が表示されない問題を修正、選曲画面の曲表示部分の高さ修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7333,6 +7333,7 @@ const gaugeFormat = (_mode, _border, _rcv, _dmg, _init, _lifeValFlg) => {
 	const [rateText, allowableCntsText] = getAccuracy(borderVal, realRcv, realDmg, initVal, allCnt);
 	g_workObj.requiredAccuracy = rateText;
 
+	// 許容ミス数のみ、オンマウスで表示するためpointer-eventsを有効にする
 	return `<div id="gaugeDivCover" class="settings_gaugeDivCover">
 		<div id="lblGaugeDivTable" class="settings_gaugeDivTable">
 			<div id="lblGaugeStart" class="settings_gaugeDivTableCol settings_gaugeStart">

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7364,7 +7364,8 @@ const gaugeFormat = (_mode, _border, _rcv, _dmg, _init, _lifeValFlg) => {
 			<div id="dataGaugeDamage" class="settings_gaugeDivTableCol settings_gaugeVal settings_gaugeEtc">
 				${dmgText}
 			</div>
-			<div id="dataGaugeRate" class="settings_gaugeDivTableCol settings_gaugeVal settings_gaugeEtc" title="${allowableCntsText}">
+			<div id="dataGaugeRate" class="settings_gaugeDivTableCol settings_gaugeVal settings_gaugeEtc" 
+				title="${allowableCntsText}" style="pointer-events: auto;">
 				${rateText}
 			</div>
 		</div>

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -251,7 +251,7 @@ const updateWindowSiz = () => {
         },
         lblMusicSelectDetail: {
             x: g_btnX(1 / 4), y: g_sHeight / 2 - 45,
-            w: g_btnWidth(5 / 8), h: 50, siz: 14,
+            w: g_btnWidth(5 / 8), h: 35, siz: 14,
             align: C_ALIGN_LEFT, padding: `0 10px`, display: `inline-block`,
             pointerEvents: C_DIS_INHERIT,
         },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. ゲージ設定の許容ミス数が表示されない問題を修正
- ゲージ設定のAccuracyをオンマウスで許容ミス数が表示されるようになっていましたが、
ソース更新により表示されていませんでした。

### 2. 選曲画面の曲詳細表示部分の高さ修正
- 選曲画面の曲詳細表示部分の高さが、他の情報に重なっている状況が発生していたため、修正しました。
- 特に不具合というわけではありませんが、ボタン等を配置する際に問題となる可能性があり、対応しています。


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. ver39.4.1以降で発生。PR #1762 の考慮漏れです。
2. div要素の重ね合わせの際の支障を取り除くため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/27e50132-6f40-4fd1-bd4f-61ab36eb4e0e" width="60%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
