### PR TITLE
fix: [0922] 通常モードで製作者情報が省略されたときにデフォルトの製作者URLが取得できない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5034,7 +5034,8 @@ const titleInit = (_initFlg = false) => {
 			}, g_cssObj.button_Start),
 
 			// 製作者表示
-			createCreditBtn(`lnkMaker`, `${g_lblNameObj.maker}: ${g_headerObj.musicSelectUse ? creatorName : g_headerObj.tuningInit}`, creatorUrl),
+			createCreditBtn(`lnkMaker`, `${g_lblNameObj.maker}: ${g_headerObj.musicSelectUse ? creatorName : g_headerObj.tuningInit}`,
+				g_headerObj.musicSelectUse ? creatorUrl : g_headerObj.creatorUrl),
 
 			// アーティスト表示
 			createCreditBtn(`lnkArtist`, `${g_lblNameObj.artist}: ${g_headerObj.artistNames[g_settings.musicIdxNum]}`, g_headerObj.artistUrls[g_settings.musicIdxNum]),


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 通常モードで製作者情報が省略されたときにデフォルトの製作者URLが取得できない問題を修正
- 譜面ヘッダーのtuning項目を省略したとき、共通設定ファイルの製作者情報を取得する処理があります。
このとき、製作者名は取得できるようになっていますが、URLが対応できていませんでした。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. PR #1839 の考慮漏れと思われます。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
