### PR TITLE
fix: [0923] 選曲モード時、選曲スクロールに合わせてブラウザもスクロールする問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4940,8 +4940,8 @@ const titleInit = (_initFlg = false) => {
 
 		let wheelCnt = 0;
 		wheelHandler = g_handler.addListener(divRoot, `wheel`, e => {
+			e.preventDefault();
 			if (g_stateObj.keyInitial && wheelCnt === 0) {
-				e.preventDefault();
 				changeMSelect(e.deltaY > 0 ? 1 : -1);
 			}
 			wheelCnt = (wheelCnt + 1) % wheelCycle;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 選曲モード時、選曲スクロールに合わせてブラウザもスクロールする問題を修正
- 選曲モードで縦スクロールするときに、ブラウザもスクロールするようになっていました。
画面上のみスクロールブロックするようにしていたつもりでしたが、条件式の中だったため反応していませんでした。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. PR #1839 の考慮漏れです。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
