### PR TITLE
feat: [0924] 選曲モードで複数楽曲を部分的にまとめる機能を実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2601,7 +2601,8 @@ const initialControl = async () => {
 	g_customJsObj.preTitle.forEach(func => func());
 	const queryMusicId = getQueryParamVal(`musicId`);
 	g_settings.musicIdxNum = queryMusicId !== null ? Number(queryMusicId) :
-		g_headerObj.musicNos[g_stateObj.scoreId] || g_headerObj.musicNos[0];
+		g_headerObj.musicGroups?.[g_headerObj.musicNos[g_stateObj.scoreId]] ??
+		g_headerObj.musicNos[g_stateObj.scoreId] ?? g_headerObj.musicNos[0];
 	titleInit(true);
 
 	// 未使用のg_keyObjプロパティを削除
@@ -3581,6 +3582,14 @@ const headerConvert = _dosObj => {
 	obj.undefinedKeyLists = obj.keyLists.filter(key => g_keyObj[`${g_keyObj.defaultProp}${key}_0`] === undefined);
 	if (obj.musicNos.length === 0) {
 		obj.musicNos = fillArray(obj.keyLabels.length);
+	}
+
+	// 楽曲別のグループ化設定（選曲モードのみ）
+	if (hasVal(_dosObj.musicGroup)) {
+		obj.musicGroups = _dosObj.musicGroup.split(`,`).map((val, j) => setVal(val, j, C_TYP_NUMBER));
+		obj.musicIdxList = makeDedupliArray(obj.musicGroups);
+	} else {
+		obj.musicIdxList = [...Array(Math.max(...obj.musicNos) + 1).keys()];
 	}
 
 	// 譜面変更セレクターの利用有無
@@ -4874,7 +4883,7 @@ const titleInit = (_initFlg = false) => {
 		if (getQueryParamVal(`scoreId`) !== null) {
 			g_headerObj.viewLists = [];
 			g_headerObj.musicNos.forEach((val, j) => {
-				if (val === g_settings.musicIdxNum) {
+				if ((g_headerObj.musicGroups?.[val] ?? val) === g_settings.musicIdxNum) {
 					g_headerObj.viewLists.push(j);
 					tmpCreatorList.push(g_headerObj.creatorNames[j]);
 				}
@@ -4893,8 +4902,6 @@ const titleInit = (_initFlg = false) => {
 
 		// 選曲画面の初期化
 		const wheelCycle = 2;
-		const musicMaxIdx = Math.max(...g_headerObj.musicNos);
-		const musicIdxTmpList = [...Array(musicMaxIdx + 1).keys()];
 
 		/**
 		 * メイン以外の選曲ボタンの作成
@@ -4931,7 +4938,7 @@ const titleInit = (_initFlg = false) => {
 			createCss2Button(`btnMusicSelectNext`, `↓`, () => changeMSelect(1),
 				g_lblPosObj.btnMusicSelectNext, g_cssObj.button_Setting),
 			createCss2Button(`btnMusicSelectRandom`, `Random`, () =>
-				changeMSelect(Math.floor(Math.random() * musicIdxTmpList.length)),
+				changeMSelect(g_headerObj.musicIdxList[Math.floor(Math.random() * g_headerObj.musicIdxList.length)]),
 				g_lblPosObj.btnMusicSelectRandom, g_cssObj.button_Default),
 			createDivCss2Label(`lblMusicCnt`, ``, g_lblPosObj.lblMusicCnt),
 			createDivCss2Label(`lblComment`, ``, g_lblPosObj.lblComment_music),
@@ -5258,12 +5265,10 @@ const getCreatorInfo = (_creatorList) => {
  */
 const changeMSelect = (_num, _initFlg = false) => {
 	const limitedMLength = 35;
-	const musicMaxIdx = Math.max(...g_headerObj.musicNos);
-	const musicIdxTmpList = [...Array(musicMaxIdx + 1).keys()];
 
 	// 選択方向に合わせて楽曲リスト情報を再取得
 	for (let j = -g_settings.mSelectableTerms; j <= g_settings.mSelectableTerms; j++) {
-		const idx = (j + _num + g_settings.musicIdxNum + musicIdxTmpList.length * 10) % musicIdxTmpList.length;
+		const idx = g_headerObj.musicIdxList[(j + _num + g_settings.musicIdxNum + g_headerObj.musicIdxList.length * 10) % g_headerObj.musicIdxList.length];
 		if (j === 0) {
 		} else {
 			document.getElementById(`btnMusicSelect${j}`).style.fontSize =
@@ -5274,14 +5279,14 @@ const changeMSelect = (_num, _initFlg = false) => {
 		}
 	}
 	// 現在選択中の楽曲IDを再設定
-	g_settings.musicIdxNum = (g_settings.musicIdxNum + _num + musicIdxTmpList.length) % musicIdxTmpList.length;
+	g_settings.musicIdxNum = (g_settings.musicIdxNum + _num + g_headerObj.musicIdxList.length) % g_headerObj.musicIdxList.length;
 
 	// 選択した楽曲に対応する譜面番号、製作者情報、曲長を取得
 	g_headerObj.viewLists = [];
 	const tmpKeyList = [], tmpCreatorList = [], tmpPlayingFrameList = [];
+	const targetIdx = g_headerObj.musicIdxList[(g_settings.musicIdxNum + g_headerObj.musicIdxList.length * 20) % g_headerObj.musicIdxList.length];
 	g_headerObj.musicNos.forEach((val, j) => {
-		if (val === (g_settings.musicIdxNum + musicIdxTmpList.length * 20) %
-			musicIdxTmpList.length) {
+		if ((g_headerObj.musicGroups?.[val] ?? val) === targetIdx) {
 			g_headerObj.viewLists.push(j);
 			tmpKeyList.push(g_headerObj.keyLabels[j]);
 			tmpCreatorList.push(g_headerObj.creatorNames[j]);
@@ -5294,7 +5299,7 @@ const changeMSelect = (_num, _initFlg = false) => {
 		`<a href="${creatorUrl}" target="_blank">${creatorName}</a>` : creatorName;
 
 	// 選択した楽曲の情報表示
-	const idx = g_settings.musicIdxNum;
+	const idx = g_headerObj.musicIdxList[g_settings.musicIdxNum];
 	document.getElementById(`lblMusicSelect`).innerHTML =
 		`<span style="font-size:${getFontSize(g_headerObj.musicTitlesForView[idx].join(`<br>`), g_btnWidth(1 / 2), getBasicFont(), 18)}px;` +
 		`font-weight:bold">${g_headerObj.musicTitlesForView[idx].join(`<br>`)}</span>`;
@@ -5312,7 +5317,7 @@ const changeMSelect = (_num, _initFlg = false) => {
 
 
 	// 選択した楽曲の選択位置を表示
-	lblMusicCnt.innerHTML = `${g_settings.musicIdxNum + 1} / ${musicMaxIdx + 1}`;
+	lblMusicCnt.innerHTML = `${g_settings.musicIdxNum + 1} / ${g_headerObj.musicIdxList.length}`;
 
 	// 楽曲別のローカルストレージを再取得
 	loadLocalStorage(g_settings.musicIdxNum);
@@ -5830,11 +5835,7 @@ const optionInit = () => {
 	g_stateObj.filterKeys = ``;
 
 	// 楽曲データの表示
-	let text = `♪` + (g_headerObj.musicSelectUse ? `${g_headerObj.musicTitles[g_settings.musicIdxNum]} / ` : ``) +
-		`BPM: ${g_headerObj.bpms[g_settings.musicIdxNum]}`;
-	if (!g_headerObj.musicSelectUse && g_headerObj.bpms[g_settings.musicIdxNum] === `----`) {
-		text = ``;
-	}
+	const text = getMusicInfoView();
 	divRoot.appendChild(createDivCss2Label(`lblMusicInfo`, text,
 		Object.assign({ siz: getFontSize(text, g_btnWidth(3 / 4), getBasicFont(), 12) }, g_lblPosObj.lblMusicInfo)));
 
@@ -5856,6 +5857,20 @@ const optionInit = () => {
 	g_initialFlg = true;
 
 	g_skinJsObj.option.forEach(func => func());
+};
+
+/**
+ * 設定画面に表示する楽曲・BPM情報の取得
+ * @returns {string}
+ */
+const getMusicInfoView = () => {
+	const idx = g_headerObj.musicNos[g_stateObj.scoreId];
+	let text = `♪` + (g_headerObj.musicSelectUse ? `${g_headerObj.musicTitles[idx]} / ` : ``) +
+		`BPM: ${g_headerObj.bpms[idx]}`;
+	if (!g_headerObj.musicSelectUse && g_headerObj.bpms[idx] === `----`) {
+		text = ``;
+	}
+	return text;
 };
 
 /**
@@ -6685,6 +6700,10 @@ const setDifficulty = (_initFlg) => {
 		makeDifInfo(g_stateObj.scoreId);
 		makeHighScore(g_stateObj.scoreId);
 	}
+
+	// 楽曲データの表示
+	lblMusicInfo.textContent = getMusicInfoView();
+	lblMusicInfo.style.fontSize = wUnit(getFontSize(lblMusicInfo.textContent, g_btnWidth(3 / 4), getBasicFont(), 12));
 
 	// ユーザカスタムイベント(初期)
 	g_customJsObj.difficulty.forEach(func => func(_initFlg, g_canLoadDifInfoFlg));

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3586,7 +3586,12 @@ const headerConvert = _dosObj => {
 
 	// 楽曲別のグループ化設定（選曲モードのみ）
 	if (hasVal(_dosObj.musicGroup)) {
-		obj.musicGroups = _dosObj.musicGroup.split(`,`).map((val, j) => setVal(val, j, C_TYP_NUMBER));
+		obj.musicGroups = _dosObj.musicGroup.split(`,`)
+			.map((val, j) => setVal(val, j, C_TYP_NUMBER))
+			.map((val, j) => val < 0 ? j + val : val);
+		for (let k = obj.musicGroups.length; k <= Math.max(...obj.musicNos); k++) {
+			obj.musicGroups[k] = k;
+		}
 		obj.musicIdxList = makeDedupliArray(obj.musicGroups);
 	} else {
 		obj.musicIdxList = [...Array(Math.max(...obj.musicNos) + 1).keys()];

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4952,6 +4952,21 @@ const titleInit = (_initFlg = false) => {
 
 		let wheelCnt = 0;
 		wheelHandler = g_handler.addListener(divRoot, `wheel`, e => {
+
+			// コメント欄（lblComment）のスクロール可能性をチェック
+			const isScrollable = lblComment.scrollHeight > lblComment.clientHeight;
+
+			// マウスがコメント欄上にあり、スクロールが可能ならイベントをスキップ
+			if (lblComment.contains(e.target) && isScrollable) {
+				// スクロール位置の判定
+				const atTop = lblComment.scrollTop === 0 && e.deltaY < 0;
+				const atBottom = (lblComment.scrollTop + lblComment.clientHeight >= lblComment.scrollHeight) && e.deltaY > 0;
+
+				// スクロール可能＆上端または下端ではないなら処理をスキップ
+				if (!atTop && !atBottom) {
+					return;
+				}
+			}
 			e.preventDefault();
 			if (g_stateObj.keyInitial && wheelCnt === 0) {
 				changeMSelect(e.deltaY > 0 ? 1 : -1);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5303,7 +5303,7 @@ const changeMSelect = (_num, _initFlg = false) => {
 
 	// 選択した楽曲に対応する譜面番号、製作者情報、曲長を取得
 	g_headerObj.viewLists = [];
-	const tmpKeyList = [], tmpCreatorList = [], tmpPlayingFrameList = [];
+	const tmpKeyList = [], tmpCreatorList = [], tmpPlayingFrameList = [], tmpBpmList = [];
 	const targetIdx = g_headerObj.musicIdxList[(g_settings.musicIdxNum + g_headerObj.musicIdxList.length * 20) % g_headerObj.musicIdxList.length];
 	g_headerObj.musicNos.forEach((val, j) => {
 		if ((g_headerObj.musicGroups?.[val] ?? val) === targetIdx) {
@@ -5311,9 +5311,11 @@ const changeMSelect = (_num, _initFlg = false) => {
 			tmpKeyList.push(g_headerObj.keyLabels[j]);
 			tmpCreatorList.push(g_headerObj.creatorNames[j]);
 			tmpPlayingFrameList.push(g_detailObj.playingFrameWithBlank[j]);
+			tmpBpmList.push(g_headerObj.bpms[g_headerObj.musicNos[j]]);
 		}
 	});
-	const playingFrames = makeDedupliArray(tmpPlayingFrameList.sort((a, b) => a - b).map(val => transFrameToTimer(val))).join(`, `);
+	const playingFrames = makeDedupliArray(tmpPlayingFrameList.map(val => transFrameToTimer(val))).join(`, `);
+	const bpm = makeDedupliArray(tmpBpmList).join(`, `);
 	const [creatorName, creatorUrl, creatorIdx] = getCreatorInfo(tmpCreatorList);
 	const creatorLink = creatorIdx >= 0 ?
 		`<a href="${creatorUrl}" target="_blank">${creatorName}</a>` : creatorName;
@@ -5325,7 +5327,7 @@ const changeMSelect = (_num, _initFlg = false) => {
 		`font-weight:bold">${g_headerObj.musicTitlesForView[idx].join(`<br>`)}</span>`;
 	document.getElementById(`lblMusicSelectDetail`).innerHTML =
 		`Maker: ${creatorLink} / Artist: <a href="${g_headerObj.artistUrls[idx]}" target="_blank">` +
-		`${g_headerObj.artistNames[idx]}</a><br>Duration: ${playingFrames} / BPM: ${g_headerObj.bpms[idx]}`;
+		`${g_headerObj.artistNames[idx]}</a><br>Duration: ${playingFrames} / BPM: ${bpm}`;
 
 	// 選択した楽曲で使われているキー種の一覧を作成
 	deleteChildspriteAll(`keyTitleSprite`);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 選曲モードで複数楽曲を部分的にまとめる機能を実装
- 選曲対象の楽曲がオリジナルの派生といった場合、別々でなく1つにまとめたいことがあります。
その際に1つにまとめる機能を実装しました。
- 譜面ヘッダー：musicGroupを使用します。
musicUrlの1つ1つに対して、どの楽曲に集約するかを指定します。
指定方法はmusicNoで指定する番号と同じく、0, 1, 2, ...の順で指定します。
- 下記の例の場合、`0365_Destiny.mp3` と `0365_Destiny_precious.mp3` を1つにまとめます。
```
|musicUrl=
0365_Destiny.mp3
0365_Destiny_precious.mp3
0252_JEWELS_brightness.mp3
0043_R176.mp3
0200_CarelessPrince.mp3
|
|musicGroup=0,0,2,3,4|
```

#### 補足
- 譜面ヘッダー：musicGroupについては相対指定が可能です。
-1, -2などを指定することで現在番号から-1, -2した方に集約するようになります。
また、特に集約しない場合は省略が可能です。
```
|musicGroup=0,-1|
```

### 2. 選曲モードで複数楽曲がまとまっている場合に、設定画面で表示する楽曲名・BPMを切り替えるよう変更
- 譜面名を切り替えるごとに、楽曲名やBPMが切り替わるようにしました。
- 選曲モードでない場合も、BPMが変わる場合は切り替わります。

### 3. 選曲モードで楽曲別のコメント欄のスクロールがあるとき、楽曲を切り替えないよう変更
- 楽曲別のコメント欄にスクロールがあるとき、ホイール処理が動かないようにしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 上述の通りです。
2. 1.の変更に伴い、対応しました。
3. 意図しないホイールを防ぐため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/d3333cf3-9323-4e8a-9c7d-92ce773dd006" width="50%"><img src="https://github.com/user-attachments/assets/1909f7b9-024c-4139-8470-7da4a997d08b" width="50%">

<img src="https://github.com/user-attachments/assets/1c14bac4-3116-4a52-be33-7d92db97c0e2" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
