### PR TITLE
feat: [0925] 選曲画面時にBGMを流す処理を実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5337,14 +5337,12 @@ const pauseBgm = () => {
 	if (g_audio) {
 		g_audio.pause();
 	}
-	if (g_stateObj.bgmLoaded) {
-		clearInterval(g_stateObj.bgmLoaded);
-		g_stateObj.bgmLoaded = null;
-	}
-	if (g_stateObj.bgmLooped) {
-		clearInterval(g_stateObj.bgmLooped);
-		g_stateObj.bgmLooped = null;
-	}
+	[`bgmLoaded`, `bgmLooped`, `bgmFadeIn`, `bgmFadeOut`].forEach(id => {
+		if (g_stateObj[id]) {
+			clearInterval(g_stateObj[id]);
+			g_stateObj[id] = null;
+		}
+	});
 };
 
 /**
@@ -5463,6 +5461,10 @@ const changeMSelect = async (_num, _initFlg = false) => {
 	const FADE_INTERVAL_MS = 100;
 	const FADE_DELAY_MS = 500;
 
+	/**
+	 * BGMのフェードアウトとシーク
+	 * @param {number} _targetTime 
+	 */
 	const fadeOutAndSeek = _targetTime => {
 		let volume = g_audio.volume;
 		const fadeInterval = setInterval(() => {
@@ -5471,6 +5473,7 @@ const changeMSelect = async (_num, _initFlg = false) => {
 				g_audio.volume = Math.max(volume, 0);
 			} else {
 				clearInterval(fadeInterval);
+				g_stateObj.bgmFadeOut = null;
 				g_audio.pause();
 				g_audio.currentTime = _targetTime;
 
@@ -5484,8 +5487,12 @@ const changeMSelect = async (_num, _initFlg = false) => {
 				}, FADE_DELAY_MS);
 			}
 		}, FADE_INTERVAL_MS);
+		g_stateObj.bgmFadeOut = fadeInterval;
 	};
 
+	/**
+	 * BGMのフェードイン
+	 */
 	const fadeIn = () => {
 		let volume = 0;
 		g_audio.play();
@@ -5495,10 +5502,15 @@ const changeMSelect = async (_num, _initFlg = false) => {
 				g_audio.volume = Math.min(volume, 1);
 			} else {
 				clearInterval(fadeInterval);
+				g_stateObj.bgmFadeIn = null;
 			}
 		}, FADE_INTERVAL_MS);
+		g_stateObj.bgmFadeIn = fadeInterval;
 	};
 
+	/**
+	 * BGMのループ処理
+	 */
 	const repeatBgm = () => {
 		if (encodeFlg) {
 			// base64エンコード時はtimeupdateイベントが発火しないため、setIntervalで時間を取得する

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5459,11 +5459,15 @@ const changeMSelect = async (_num, _initFlg = false) => {
 		g_audio.currentTime = g_headerObj.musicStarts?.[g_settings.musicIdxNum] ?? 0;
 	}
 
+	const FADE_STEP = 0.05;
+	const FADE_INTERVAL_MS = 100;
+	const FADE_DELAY_MS = 500;
+
 	const fadeOutAndSeek = _targetTime => {
 		let volume = g_audio.volume;
 		const fadeInterval = setInterval(() => {
-			if (volume > 0.05) {
-				volume -= 0.05;
+			if (volume > FADE_STEP) {
+				volume -= FADE_STEP;
 				g_audio.volume = Math.max(volume, 0);
 			} else {
 				clearInterval(fadeInterval);
@@ -5477,9 +5481,9 @@ const changeMSelect = async (_num, _initFlg = false) => {
 						// base64エンコード時はtimeupdateイベントが発火しないため、setIntervalで時間を取得する
 						repeatBgm();
 					}
-				}, 500);
+				}, FADE_DELAY_MS);
 			}
-		}, 100);
+		}, FADE_INTERVAL_MS);
 	};
 
 	const fadeIn = () => {
@@ -5487,12 +5491,12 @@ const changeMSelect = async (_num, _initFlg = false) => {
 		g_audio.play();
 		const fadeInterval = setInterval(() => {
 			if (volume < g_stateObj.bgmVolume / 100) {
-				volume += 0.05;
+				volume += FADE_STEP;
 				g_audio.volume = Math.min(volume, 1);
 			} else {
 				clearInterval(fadeInterval);
 			}
-		}, 100);
+		}, FADE_INTERVAL_MS);
 	};
 
 	const repeatBgm = () => {
@@ -5511,7 +5515,7 @@ const changeMSelect = async (_num, _initFlg = false) => {
 					clearInterval(repeatCheck);
 					g_stateObj.bgmLooped = null;
 				}
-			}, 100);
+			}, FADE_INTERVAL_MS);
 			g_stateObj.bgmLooped = repeatCheck;
 
 		} else {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5346,7 +5346,7 @@ const pauseBGM = () => {
 			g_audio.src = ``;
 		}
 	}
-	[`bgmLoaded`, `bgmLooped`, `bgmFadeIn`, `bgmFadeOut`].forEach(id => {
+	[`bgmLooped`, `bgmFadeIn`, `bgmFadeOut`].forEach(id => {
 		if (g_stateObj[id]) {
 			clearInterval(g_stateObj[id]);
 			g_stateObj[id] = null;
@@ -5379,18 +5379,10 @@ const playBGM = async (_num = 0) => {
 				await g_audio.init(array.buffer);
 			}
 			g_audio.volume = g_stateObj.bgmVolume / 100;
-
-			const timeupdate = setInterval(() => {
-				if (g_audio.readyState === 4 && g_stateObj.bgmLoaded !== null) {
-					if (g_currentPage === `title`) {
-						g_audio.currentTime = musicStart;
-						g_audio.play();
-					}
-					clearInterval(timeupdate);
-					g_stateObj.bgmLoaded = null;
-				}
-			}, 100);
-			g_stateObj.bgmLoaded = timeupdate;
+			if (g_currentPage === `title`) {
+				g_audio.currentTime = musicStart;
+				g_audio.play();
+			}
 		} catch (e) {
 			// 音源の読み込みに失敗した場合、エラーを表示
 			console.warn(`BGM load error: ${e}`);
@@ -5465,7 +5457,7 @@ const playBGM = async (_num = 0) => {
 			// base64エンコード時はtimeupdateイベントが発火しないため、setIntervalで時間を取得する
 			const repeatCheck = setInterval((num = g_settings.musicIdxNum) => {
 				try {
-					if (((g_audio.elapsedTime >= musicEnd && g_stateObj.bgmLoaded === null) ||
+					if (((g_audio.elapsedTime >= musicEnd) ||
 						num !== g_settings.musicIdxNum) && g_stateObj.bgmLooped !== null) {
 						clearInterval(repeatCheck);
 						g_stateObj.bgmLooped = null;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5347,90 +5347,6 @@ const pauseBgm = () => {
 };
 
 /**
- * 選曲ボタンを押したときの処理
- * @param {number} _num 
- * @param {boolean} _initFlg 
- */
-const changeMSelect = (_num, _initFlg = false) => {
-	const limitedMLength = 35;
-	pauseBgm();
-
-	// 選択方向に合わせて楽曲リスト情報を再取得
-	for (let j = -g_settings.mSelectableTerms; j <= g_settings.mSelectableTerms; j++) {
-		const idx = g_headerObj.musicIdxList[(j + _num + g_settings.musicIdxNum + g_headerObj.musicIdxList.length * 10) % g_headerObj.musicIdxList.length];
-		if (j === 0) {
-		} else {
-			document.getElementById(`btnMusicSelect${j}`).style.fontSize =
-				getFontSize(g_headerObj.musicTitles[idx].slice(0, limitedMLength), g_btnWidth(1 / 2), getBasicFont(), 14);
-			document.getElementById(`btnMusicSelect${j}`).innerHTML =
-				`${g_headerObj.musicTitles[idx].slice(0, limitedMLength)}${g_headerObj.musicTitles[idx].length > limitedMLength ? '...' : ''}<br>` +
-				`<span style="font-size:0.7em;line-height:9px"> / ${g_headerObj.artistNames[idx]}</span>`;
-		}
-	}
-	// 現在選択中の楽曲IDを再設定
-	g_settings.musicIdxNum = (g_settings.musicIdxNum + _num + g_headerObj.musicIdxList.length) % g_headerObj.musicIdxList.length;
-
-	// 選択した楽曲に対応する譜面番号、製作者情報、曲長を取得
-	g_headerObj.viewLists = [];
-	const tmpKeyList = [], tmpCreatorList = [], tmpPlayingFrameList = [], tmpBpmList = [];
-	const targetIdx = g_headerObj.musicIdxList[(g_settings.musicIdxNum + g_headerObj.musicIdxList.length * 20) % g_headerObj.musicIdxList.length];
-	g_headerObj.musicNos.forEach((val, j) => {
-		if ((g_headerObj.musicGroups?.[val] ?? val) === targetIdx) {
-			g_headerObj.viewLists.push(j);
-			tmpKeyList.push(g_headerObj.keyLabels[j]);
-			tmpCreatorList.push(g_headerObj.creatorNames[j]);
-			tmpPlayingFrameList.push(g_detailObj.playingFrameWithBlank[j]);
-			tmpBpmList.push(g_headerObj.bpms[g_headerObj.musicNos[j]]);
-		}
-	});
-	const playingFrames = makeDedupliArray(tmpPlayingFrameList.map(val => transFrameToTimer(val))).join(`, `);
-	const bpm = makeDedupliArray(tmpBpmList).join(`, `);
-	const [creatorName, creatorUrl, creatorIdx] = getCreatorInfo(tmpCreatorList);
-	const creatorLink = creatorIdx >= 0 ?
-		`<a href="${creatorUrl}" target="_blank">${creatorName}</a>` : creatorName;
-
-	// 選択した楽曲の情報表示
-	const idx = g_headerObj.musicIdxList[g_settings.musicIdxNum];
-	document.getElementById(`lblMusicSelect`).innerHTML =
-		`<span style="font-size:${getFontSize(g_headerObj.musicTitlesForView[idx].join(`<br>`), g_btnWidth(1 / 2), getBasicFont(), 18)}px;` +
-		`font-weight:bold">${g_headerObj.musicTitlesForView[idx].join(`<br>`)}</span>`;
-	document.getElementById(`lblMusicSelectDetail`).innerHTML =
-		`Maker: ${creatorLink} / Artist: <a href="${g_headerObj.artistUrls[idx]}" target="_blank">` +
-		`${g_headerObj.artistNames[idx]}</a><br>Duration: ${playingFrames} / BPM: ${bpm}`;
-
-	// 選択した楽曲で使われているキー種の一覧を作成
-	deleteChildspriteAll(`keyTitleSprite`);
-	makeDedupliArray(tmpKeyList).sort((a, b) => parseInt(a) - parseInt(b))
-		.forEach((val, j) => keyTitleSprite.appendChild(
-			createDivCss2Label(`btnKeyTitle${val}`, val,
-				Object.assign({ x: 10 + j * 40 }, g_lblPosObj.btnKeyTitle)
-			)));
-
-
-	// 選択した楽曲の選択位置を表示
-	lblMusicCnt.innerHTML = `${g_settings.musicIdxNum + 1} / ${g_headerObj.musicIdxList.length}`;
-
-	// 楽曲別のローカルストレージを再取得
-	loadLocalStorage(g_settings.musicIdxNum);
-	viewKeyStorage.cache = new Map();
-
-	// 初期化もしくは楽曲変更時に速度を初期化
-	if (_initFlg || _num % g_headerObj.musicIdxList.length !== 0) {
-		g_stateObj.speed = g_headerObj.initSpeeds[g_headerObj.viewLists[0]];
-		g_settings.speedNum = getCurrentNo(g_settings.speeds, g_stateObj.speed);
-	}
-
-	// コメント文の加工
-	lblComment.innerHTML = convertStrToVal(g_headerObj[`commentVal${g_settings.musicIdxNum}`]);
-
-	// BGM再生処理
-	playBGM(_num);
-
-	// 選曲変更時のカスタム関数実行
-	g_customJsObj.musicSelect.forEach(func => func(g_settings.musicIdxNum));
-};
-
-/**
  * BGM再生処理
  * @param {number} _num 
  */
@@ -5562,6 +5478,90 @@ const playBGM = async (_num = 0) => {
 	if (g_headerObj.musicEnds?.[g_settings.musicIdxNum]) {
 		repeatBgm(encodeFlg);
 	}
+};
+
+/**
+ * 選曲ボタンを押したときの処理
+ * @param {number} _num 
+ * @param {boolean} _initFlg 
+ */
+const changeMSelect = (_num, _initFlg = false) => {
+	const limitedMLength = 35;
+	pauseBgm();
+
+	// 選択方向に合わせて楽曲リスト情報を再取得
+	for (let j = -g_settings.mSelectableTerms; j <= g_settings.mSelectableTerms; j++) {
+		const idx = g_headerObj.musicIdxList[(j + _num + g_settings.musicIdxNum + g_headerObj.musicIdxList.length * 10) % g_headerObj.musicIdxList.length];
+		if (j === 0) {
+		} else {
+			document.getElementById(`btnMusicSelect${j}`).style.fontSize =
+				getFontSize(g_headerObj.musicTitles[idx].slice(0, limitedMLength), g_btnWidth(1 / 2), getBasicFont(), 14);
+			document.getElementById(`btnMusicSelect${j}`).innerHTML =
+				`${g_headerObj.musicTitles[idx].slice(0, limitedMLength)}${g_headerObj.musicTitles[idx].length > limitedMLength ? '...' : ''}<br>` +
+				`<span style="font-size:0.7em;line-height:9px"> / ${g_headerObj.artistNames[idx]}</span>`;
+		}
+	}
+	// 現在選択中の楽曲IDを再設定
+	g_settings.musicIdxNum = (g_settings.musicIdxNum + _num + g_headerObj.musicIdxList.length) % g_headerObj.musicIdxList.length;
+
+	// 選択した楽曲に対応する譜面番号、製作者情報、曲長を取得
+	g_headerObj.viewLists = [];
+	const tmpKeyList = [], tmpCreatorList = [], tmpPlayingFrameList = [], tmpBpmList = [];
+	const targetIdx = g_headerObj.musicIdxList[(g_settings.musicIdxNum + g_headerObj.musicIdxList.length * 20) % g_headerObj.musicIdxList.length];
+	g_headerObj.musicNos.forEach((val, j) => {
+		if ((g_headerObj.musicGroups?.[val] ?? val) === targetIdx) {
+			g_headerObj.viewLists.push(j);
+			tmpKeyList.push(g_headerObj.keyLabels[j]);
+			tmpCreatorList.push(g_headerObj.creatorNames[j]);
+			tmpPlayingFrameList.push(g_detailObj.playingFrameWithBlank[j]);
+			tmpBpmList.push(g_headerObj.bpms[g_headerObj.musicNos[j]]);
+		}
+	});
+	const playingFrames = makeDedupliArray(tmpPlayingFrameList.map(val => transFrameToTimer(val))).join(`, `);
+	const bpm = makeDedupliArray(tmpBpmList).join(`, `);
+	const [creatorName, creatorUrl, creatorIdx] = getCreatorInfo(tmpCreatorList);
+	const creatorLink = creatorIdx >= 0 ?
+		`<a href="${creatorUrl}" target="_blank">${creatorName}</a>` : creatorName;
+
+	// 選択した楽曲の情報表示
+	const idx = g_headerObj.musicIdxList[g_settings.musicIdxNum];
+	document.getElementById(`lblMusicSelect`).innerHTML =
+		`<span style="font-size:${getFontSize(g_headerObj.musicTitlesForView[idx].join(`<br>`), g_btnWidth(1 / 2), getBasicFont(), 18)}px;` +
+		`font-weight:bold">${g_headerObj.musicTitlesForView[idx].join(`<br>`)}</span>`;
+	document.getElementById(`lblMusicSelectDetail`).innerHTML =
+		`Maker: ${creatorLink} / Artist: <a href="${g_headerObj.artistUrls[idx]}" target="_blank">` +
+		`${g_headerObj.artistNames[idx]}</a><br>Duration: ${playingFrames} / BPM: ${bpm}`;
+
+	// 選択した楽曲で使われているキー種の一覧を作成
+	deleteChildspriteAll(`keyTitleSprite`);
+	makeDedupliArray(tmpKeyList).sort((a, b) => parseInt(a) - parseInt(b))
+		.forEach((val, j) => keyTitleSprite.appendChild(
+			createDivCss2Label(`btnKeyTitle${val}`, val,
+				Object.assign({ x: 10 + j * 40 }, g_lblPosObj.btnKeyTitle)
+			)));
+
+
+	// 選択した楽曲の選択位置を表示
+	lblMusicCnt.innerHTML = `${g_settings.musicIdxNum + 1} / ${g_headerObj.musicIdxList.length}`;
+
+	// 楽曲別のローカルストレージを再取得
+	loadLocalStorage(g_settings.musicIdxNum);
+	viewKeyStorage.cache = new Map();
+
+	// 初期化もしくは楽曲変更時に速度を初期化
+	if (_initFlg || _num % g_headerObj.musicIdxList.length !== 0) {
+		g_stateObj.speed = g_headerObj.initSpeeds[g_headerObj.viewLists[0]];
+		g_settings.speedNum = getCurrentNo(g_settings.speeds, g_stateObj.speed);
+	}
+
+	// コメント文の加工
+	lblComment.innerHTML = convertStrToVal(g_headerObj[`commentVal${g_settings.musicIdxNum}`]);
+
+	// BGM再生処理
+	playBGM(_num);
+
+	// 選曲変更時のカスタム関数実行
+	g_customJsObj.musicSelect.forEach(func => func(g_settings.musicIdxNum));
 };
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2962,7 +2962,7 @@ const getMusicUrl = _scoreId =>
  * @param {string} _musicUrl 
  * @returns {string}
  */
-const getLoadMusicUrl = (_musicUrl = ``) => {
+const getFullMusicUrl = (_musicUrl = ``) => {
 	let url = `${g_rootPath}../${g_headerObj.musicFolder}/${_musicUrl}`;
 	if (_musicUrl.indexOf(C_MRK_CURRENT_DIRECTORY) !== -1) {
 		url = _musicUrl.split(C_MRK_CURRENT_DIRECTORY)[1];
@@ -5356,7 +5356,7 @@ const playBGM = async (_num = 0) => {
 	const FADE_DELAY_MS = 500;
 
 	const musicUrl = getMusicUrl(g_headerObj.viewLists[0]);
-	const url = getLoadMusicUrl(musicUrl);
+	const url = getFullMusicUrl(musicUrl);
 	const encodeFlg = listMatching(musicUrl, [`.js`, `.txt`], { suffix: `$` });
 	const musicStart = g_headerObj.musicStarts?.[g_headerObj.musicIdxList[g_settings.musicIdxNum]] ?? 0;
 	const musicEnd = g_headerObj.musicEnds?.[g_headerObj.musicIdxList[g_settings.musicIdxNum]] ?? 0;
@@ -9083,7 +9083,7 @@ const loadMusic = () => {
 	g_currentPage = `loading`;
 
 	const musicUrl = getMusicUrl(g_stateObj.scoreId);
-	const url = getLoadMusicUrl(musicUrl);
+	const url = getFullMusicUrl(musicUrl);
 	g_headerObj.musicUrl = musicUrl;
 	g_musicEncodedFlg = listMatching(musicUrl, [`.js`, `.txt`], { suffix: `$` });
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5427,8 +5427,8 @@ const changeMSelect = async (_num, _initFlg = false) => {
 	const url = getLoadMusicUrl(musicUrl);
 	const encodeFlg = listMatching(musicUrl, [`.js`, `.txt`], { suffix: `$` });
 	if (encodeFlg) {
-		await loadScript2(url);
 		try {
+			await loadScript2(url);
 			musicInit();
 			g_audio = new AudioPlayer();
 			const array = Uint8Array.from(atob(g_musicdata), v => v.charCodeAt(0))
@@ -5514,7 +5514,7 @@ const changeMSelect = async (_num, _initFlg = false) => {
 		let volume = 0;
 		g_audio.play();
 		const fadeInterval = setInterval(() => {
-			if (volume < 50 / 100) {
+			if (volume < g_stateObj.bgmVolume / 100) {
 				volume += 0.05;
 				g_audio.volume = Math.min(volume, 1);
 			} else {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5419,7 +5419,8 @@ const playBGM = async (_num = 0) => {
 					setTimeout(() => {
 						fadeIn();
 						if (encodeFlg) {
-							// base64エンコード時はtimeupdateイベントが発火しないため、setIntervalで時間を取得する
+							// base64エンコード時はtimeupdateイベントが発火しないため、
+							// setIntervalで時間を取得する
 							repeatBGM();
 						}
 					}, FADE_DELAY_MS);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5436,7 +5436,7 @@ const changeMSelect = async (_num, _initFlg = false) => {
 			g_audio.volume = g_stateObj.bgmVolume / 100;
 
 			const timeupdate = setInterval(() => {
-				if (g_audio.readyState === 4) {
+				if (g_audio.readyState === 4 && g_stateObj.bgmLoaded !== null) {
 					g_audio.currentTime = g_headerObj.musicStarts?.[g_settings.musicIdxNum] ?? 0;
 					g_audio.play();
 					clearInterval(timeupdate);
@@ -5463,7 +5463,8 @@ const changeMSelect = async (_num, _initFlg = false) => {
 			const repeatCheck = setInterval((num = g_settings.musicIdxNum) => {
 				try {
 					const elapsedTime = g_audio._context.currentTime - g_audio._startTime + g_audio._fadeinPosition;
-					if ((elapsedTime >= g_headerObj.musicEnds?.[g_settings.musicIdxNum] && g_stateObj.bgmLoaded === null) || num !== g_settings.musicIdxNum) {
+					if (((elapsedTime >= g_headerObj.musicEnds?.[g_settings.musicIdxNum] && g_stateObj.bgmLoaded === null) ||
+						num !== g_settings.musicIdxNum) && g_stateObj.bgmLooped !== null) {
 						clearInterval(repeatCheck);
 						g_stateObj.bgmLooped = null;
 						fadeOutAndSeek(g_headerObj.musicStarts?.[g_settings.musicIdxNum] ?? 0);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4952,7 +4952,7 @@ const titleInit = (_initFlg = false) => {
 		 * 選曲画面上の音量調整
 		 * @param {number} _num 
 		 */
-		const setBgmVolume = (_num = 1) => {
+		const setBGMVolume = (_num = 1) => {
 			g_settings.bgmVolumeNum = nextPos(g_settings.bgmVolumeNum, _num, g_settings.volumes.length);
 			g_stateObj.bgmVolume = g_settings.volumes[g_settings.bgmVolumeNum];
 			g_audio.volume = g_stateObj.bgmVolume / 100;
@@ -4971,7 +4971,7 @@ const titleInit = (_initFlg = false) => {
 			createCss2Button(`btnStart`,
 				`>`, () => {
 					clearTimeout(g_timeoutEvtTitleId);
-					pauseBgm();
+					pauseBGM();
 					g_handler.removeListener(wheelHandler);
 					g_keyObj.prevKey = `Dummy${g_settings.musicIdxNum}`;
 				}, Object.assign({
@@ -4988,13 +4988,13 @@ const titleInit = (_initFlg = false) => {
 			createDivCss2Label(`lblComment`, ``, g_lblPosObj.lblComment_music),
 
 			createDivCss2Label(`lblBgmVolume`, `BGM Volume`, g_lblPosObj.lblBgmVolume),
-			createCss2Button(`btnBgmVolume`, `${g_stateObj.bgmVolume}${g_lblNameObj.percent}`, () => setBgmVolume(),
+			createCss2Button(`btnBgmVolume`, `${g_stateObj.bgmVolume}${g_lblNameObj.percent}`, () => setBGMVolume(),
 				Object.assign({
-					cxtFunc: () => setBgmVolume(-1),
+					cxtFunc: () => setBGMVolume(-1),
 				}, g_lblPosObj.btnBgmVolume), g_cssObj.button_Default),
-			createCss2Button(`btnBgmVolumeL`, `<`, () => setBgmVolume(-1),
+			createCss2Button(`btnBgmVolumeL`, `<`, () => setBGMVolume(-1),
 				g_lblPosObj.btnBgmVolumeL, g_cssObj.button_Setting),
-			createCss2Button(`btnBgmVolumeR`, `>`, () => setBgmVolume(),
+			createCss2Button(`btnBgmVolumeR`, `>`, () => setBGMVolume(),
 				g_lblPosObj.btnBgmVolumeR, g_cssObj.button_Setting),
 		);
 		changeMSelect(0, _initFlg);
@@ -5333,7 +5333,7 @@ const getCreatorInfo = (_creatorList) => {
 /**
  * BGMの停止
  */
-const pauseBgm = () => {
+const pauseBGM = () => {
 	if (g_audio) {
 		g_handler.removeListener(g_stateObj.bgmTimeupdateEvtId);
 		g_audio.pause();
@@ -5418,7 +5418,7 @@ const playBGM = async (_num = 0) => {
 						fadeIn();
 						if (encodeFlg) {
 							// base64エンコード時はtimeupdateイベントが発火しないため、setIntervalで時間を取得する
-							repeatBgm();
+							repeatBGM();
 						}
 					}, FADE_DELAY_MS);
 				}
@@ -5448,7 +5448,7 @@ const playBGM = async (_num = 0) => {
 	/**
 	 * BGMのループ処理
 	 */
-	const repeatBgm = () => {
+	const repeatBGM = () => {
 		if (encodeFlg) {
 			// base64エンコード時はtimeupdateイベントが発火しないため、setIntervalで時間を取得する
 			const repeatCheck = setInterval((num = g_settings.musicIdxNum) => {
@@ -5476,7 +5476,7 @@ const playBGM = async (_num = 0) => {
 		}
 	};
 	if (g_headerObj.musicEnds?.[g_settings.musicIdxNum]) {
-		repeatBgm(encodeFlg);
+		repeatBGM(encodeFlg);
 	}
 };
 
@@ -5487,7 +5487,7 @@ const playBGM = async (_num = 0) => {
  */
 const changeMSelect = (_num, _initFlg = false) => {
 	const limitedMLength = 35;
-	pauseBgm();
+	pauseBGM();
 
 	// 選択方向に合わせて楽曲リスト情報を再取得
 	for (let j = -g_settings.mSelectableTerms; j <= g_settings.mSelectableTerms; j++) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5436,7 +5436,7 @@ const changeMSelect = async (_num, _initFlg = false) => {
 			g_audio.volume = g_stateObj.bgmVolume / 100;
 
 			const timeupdate = setInterval(() => {
-				if (g_audio.readyState === 4 && g_stateObj.bgmLoaded !== null) {
+				if (g_audio.readyState === 4 && g_stateObj.bgmLoaded !== null && g_currentPage === `title`) {
 					g_audio.currentTime = g_headerObj.musicStarts?.[g_settings.musicIdxNum] ?? 0;
 					g_audio.play();
 					clearInterval(timeupdate);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3781,8 +3781,8 @@ const headerConvert = _dosObj => {
 			obj.musicUrls[j] = musicUrlPair[0] || ``;
 			if (musicUrlPair[1] !== undefined) {
 				const musicBGMTime = musicUrlPair[1].split(`-`).map(str => str.trim());
-				obj.musicStarts[j] = Math.floor(transTimerToFrame(musicBGMTime[0] ?? `0:00`) / g_fps);
-				obj.musicEnds[j] = Math.floor(transTimerToFrame(musicBGMTime[1] ?? `0:20`) / g_fps);
+				obj.musicStarts[j] = Math.floor(transTimerToFrame(musicBGMTime[0] ?? 0) / g_fps);
+				obj.musicEnds[j] = Math.floor((transTimerToFrame(musicBGMTime[1] ?? 0) + transTimerToFrame(`0:20`)) / g_fps);
 			} else {
 				obj.musicStarts[j] = 0;
 				obj.musicEnds[j] = 20;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5389,14 +5389,15 @@ const playBGM = async (_num = 0) => {
 		}
 
 	} else {
-		g_audio = new Audio();
-		g_audio.src = url;
-		g_audio.autoplay = true;
-		g_audio.volume = g_stateObj.bgmVolume / 100;
-		g_handler.addListener(g_audio, `loadedmetadata`, () => {
-			g_audio.currentTime = musicStart;
-		}, { once: true });
-	}
+        g_audio = new Audio();
+        g_audio.src = url;
+        g_audio.autoplay = false;
+        g_audio.volume = g_stateObj.bgmVolume / 100;
+        g_handler.addListener(g_audio, `loadedmetadata`, () => {
+            g_audio.currentTime = musicStart;
+            g_audio.play();
+        }, { once: true });
+    }
 
 	/**
 	 * BGMのフェードアウトとシーク

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5350,7 +5350,7 @@ const pauseBgm = () => {
  * @param {number} _num 
  * @param {boolean} _initFlg 
  */
-const changeMSelect = async (_num, _initFlg = false) => {
+const changeMSelect = (_num, _initFlg = false) => {
 	const limitedMLength = 35;
 	pauseBgm();
 
@@ -5423,6 +5423,21 @@ const changeMSelect = async (_num, _initFlg = false) => {
 	lblComment.innerHTML = convertStrToVal(g_headerObj[`commentVal${g_settings.musicIdxNum}`]);
 
 	// BGM再生処理
+	playBGM(_num);
+
+	// 選曲変更時のカスタム関数実行
+	g_customJsObj.musicSelect.forEach(func => func(g_settings.musicIdxNum));
+};
+
+/**
+ * BPM再生処理
+ * @param {number} _num 
+ */
+const playBGM = async (_num = 0) => {
+	const FADE_STEP = 0.05;
+	const FADE_INTERVAL_MS = 100;
+	const FADE_DELAY_MS = 500;
+
 	const musicUrl = getMusicUrl(g_headerObj.viewLists[0]);
 	const url = getLoadMusicUrl(musicUrl);
 	const encodeFlg = listMatching(musicUrl, [`.js`, `.txt`], { suffix: `$` });
@@ -5461,10 +5476,6 @@ const changeMSelect = async (_num, _initFlg = false) => {
 		g_audio.volume = g_stateObj.bgmVolume / 100;
 		g_audio.currentTime = g_headerObj.musicStarts?.[g_settings.musicIdxNum] ?? 0;
 	}
-
-	const FADE_STEP = 0.05;
-	const FADE_INTERVAL_MS = 100;
-	const FADE_DELAY_MS = 500;
 
 	/**
 	 * BGMのフェードアウトとシーク
@@ -5548,9 +5559,6 @@ const changeMSelect = async (_num, _initFlg = false) => {
 	if (g_headerObj.musicEnds?.[g_settings.musicIdxNum]) {
 		repeatBgm(encodeFlg);
 	}
-
-	// 選曲変更時のカスタム関数実行
-	g_customJsObj.musicSelect.forEach(func => func(g_settings.musicIdxNum));
 };
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5361,7 +5361,7 @@ const pauseBGM = () => {
  * @param {number} _num 
  */
 const playBGM = async (_num = 0) => {
-	const FADE_STEP = 0.05;
+	const FADE_STEP = 0.05 * g_stateObj.bgmVolume / 100;
 	const FADE_INTERVAL_MS = 100;
 	const FADE_DELAY_MS = 500;
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3782,7 +3782,9 @@ const headerConvert = _dosObj => {
 			if (musicUrlPair[1] !== undefined) {
 				const musicBGMTime = musicUrlPair[1].split(`-`).map(str => str.trim());
 				obj.musicStarts[j] = Math.floor(transTimerToFrame(musicBGMTime[0] ?? 0) / g_fps);
-				obj.musicEnds[j] = Math.floor((transTimerToFrame(musicBGMTime[1] ?? 0) + transTimerToFrame(`0:20`)) / g_fps);
+				obj.musicEnds[j] = musicBGMTime[1] !== undefined ?
+					Math.floor((transTimerToFrame(musicBGMTime[1] ?? 0)) / g_fps) :
+					Math.floor((transTimerToFrame(musicBGMTime[0] ?? 0) + transTimerToFrame(`0:20`)) / g_fps);
 			} else {
 				obj.musicStarts[j] = 0;
 				obj.musicEnds[j] = 20;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1012,7 +1012,6 @@ let C_WOD_FRAME = 30;
 const g_stateObj = {
     keyInitial: false,
     bgmVolume: 50,
-    bgmLoaded: null,
     bgmLooped: null,
     bgmFadeIn: null,
     bgmFadeOut: null,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -288,6 +288,18 @@ const updateWindowSiz = () => {
             siz: g_limitObj.difSelectorSiz, align: C_ALIGN_LEFT,
             overflow: C_DIS_AUTO, whiteSpace: `normal`,
         },
+        lblBgmVolume: {
+            x: g_btnX(), y: g_sHeight - 85, w: g_btnWidth(1 / 4), h: 20, siz: 12, align: C_ALIGN_LEFT,
+        },
+        btnBgmVolume: {
+            x: g_btnX() + 20, y: g_sHeight - 70, w: g_btnWidth(1 / 4) - 40, h: 20, siz: 14,
+        },
+        btnBgmVolumeL: {
+            x: g_btnX(), y: g_sHeight - 70, w: 20, h: 20, siz: 12,
+        },
+        btnBgmVolumeR: {
+            x: g_btnX() + g_btnWidth(1 / 4) - 20, y: g_sHeight - 70, w: 20, h: 20, siz: 12,
+        },
 
         /** データ管理 */
         btnResetBack: {
@@ -999,6 +1011,10 @@ let C_WOD_FRAME = 30;
 // 譜面データ持ち回り用
 const g_stateObj = {
     keyInitial: false,
+    bgmVolume: 50,
+    bgmLoaded: null,
+    bgmLooped: null,
+
     dosDivideFlg: false,
     scoreLockFlg: false,
     scoreId: 0,
@@ -1015,6 +1031,7 @@ const g_stateObj = {
     hitPosition: 0,
     fadein: 0,
     volume: 100,
+
     lifeRcv: 2,
     lifeDmg: 7,
     lifeMode: `Border`,
@@ -1163,6 +1180,7 @@ const g_settings = {
 
     volumes: [0, 0.5, 1, 2, 5, 10, 25, 50, 75, 100],
     volumeNum: 0,
+    bgmVolumeNum: 0,
 
     appearances: [`Visible`, `Hidden`, `Hidden+`, `Sudden`, `Sudden+`, `Hid&Sud+`],
     appearanceNum: 0,
@@ -1239,6 +1257,7 @@ const g_settings = {
 };
 
 g_settings.volumeNum = g_settings.volumes.length - 1;
+g_settings.bgmVolumeNum = g_settings.volumes.findIndex(v => v === g_stateObj.bgmVolume);
 g_settings.opacityNum = g_settings.opacitys.length - 1;
 
 /**

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1014,6 +1014,8 @@ const g_stateObj = {
     bgmVolume: 50,
     bgmLoaded: null,
     bgmLooped: null,
+    bgmFadeIn: null,
+    bgmFadeOut: null,
 
     dosDivideFlg: false,
     scoreLockFlg: false,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2097,6 +2097,8 @@ const g_shortcutObj = {
         KeyD: { id: `btnReset` },
         ArrowUp: { id: `btnMusicSelectPrev` },
         ArrowDown: { id: `btnMusicSelectNext` },
+        ArrowLeft: { id: `btnBgmVolumeL` },
+        ArrowRight: { id: `btnBgmVolumeR` },
     },
     dataMgt: {
         KeyE: { id: `btnEnvironment` },

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1257,7 +1257,7 @@ const g_settings = {
 };
 
 g_settings.volumeNum = g_settings.volumes.length - 1;
-g_settings.bgmVolumeNum = g_settings.volumes.findIndex(v => v === g_stateObj.bgmVolume);
+g_settings.bgmVolumeNum = roundZero(g_settings.volumes.findIndex(v => v === g_stateObj.bgmVolume));
 g_settings.opacityNum = g_settings.opacitys.length - 1;
 
 /**

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1016,6 +1016,7 @@ const g_stateObj = {
     bgmLooped: null,
     bgmFadeIn: null,
     bgmFadeOut: null,
+    bgmTimeupdateEvtId: null,
 
     dosDivideFlg: false,
     scoreLockFlg: false,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 選曲画面時にBGMを流す処理を実装
- 選曲画面時にBGMを流すようにしました。初期値は50%で、左下のボタンから増減が可能です。
ショートカットキーは左右キーに対応しています。
- 譜面ヘッダー：musicUrlにカンマでつなげて区間設定を行います。既定は0:00-0:20。
```
|musicUrl=
0365_Destiny.mp3,1:12-1:40
0365_Destiny_precious.mp3
0252_JEWELS_brightness.mp3,0:30-0:50
0043_R176.mp3,0:40-0:50
0200_CarelessPrince.mp3,0:20-0:30
0320_TrickStyle.js,0:25-0:35
|
|musicGroup=,-1|
```
- base64エンコードの音源のとき、ロードの関係で再生にやや時間がかかります。

### 2. 選曲ランダムが使えていない問題を修正
- ランダムの処理の問題で、同一曲が選択されやすくなっていました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 選曲時に、どの音源かをわかりやすくするため。
2. PR #1848 起因と思われます。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/389e837a-b080-43af-a267-98dce26416f3" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->