### PR TITLE
improve: [0926] 選曲画面でキー押しっぱなしにより複数の楽曲が同時に再生されないよう対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2312,12 +2312,16 @@ class AudioPlayer {
 
 	close() {
 		if (this._context) {
-			this._context.close();
+			this._context.close()?.catch(() => {/* ignore double-close */ });
 			this._buffer = null;
 		}
 		if (this._source) {
 			this._source.disconnect(this._gain);
 			this._source = null;
+		}
+		if (this._gain) {
+			this._gain.disconnect();
+			this._gain = null;
 		}
 	}
 
@@ -5470,6 +5474,9 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
 			if (!hasVal(g_musicdata) || Math.abs(_num) % g_headerObj.musicIdxList.length !== 0) {
 				await loadScript2(url);
 				musicInit();
+				if (_currentLoopNum !== g_settings.musicLoopNum) {
+					return;
+				}
 				const tmpAudio = new AudioPlayer();
 				const array = Uint8Array.from(atob(g_musicdata), v => v.charCodeAt(0));
 				await tmpAudio.init(array.buffer);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5390,9 +5390,8 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
 
 	/**
 	 * BGMのフェードアウトとシーク
-	 * @param {number} _targetTime
 	 */
-	const fadeOutAndSeek = _targetTime => {
+	const fadeOutAndSeek = () => {
 		let volume = g_audio.volume;
 		const fadeInterval = setInterval(() => {
 			if (volume > FADE_STEP && g_currentPage === `title`) {
@@ -5402,7 +5401,7 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
 				clearInterval(fadeInterval);
 				g_stateObj.bgmFadeOut = null;
 				g_audio.pause();
-				g_audio.currentTime = _targetTime;
+				g_audio.currentTime = musicStart;
 
 				// フェードイン開始
 				if (g_currentPage === `title`) {
@@ -5414,6 +5413,8 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
 							repeatBGM();
 						}
 					}, FADE_DELAY_MS);
+				} else {
+					pauseBGM();
 				}
 			}
 		}, FADE_INTERVAL_MS);
@@ -5450,7 +5451,7 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
 						num !== g_settings.musicIdxNum) && g_stateObj.bgmLooped !== null) {
 						clearInterval(repeatCheck);
 						g_stateObj.bgmLooped = null;
-						fadeOutAndSeek(musicStart);
+						fadeOutAndSeek();
 					}
 				} catch (e) {
 					clearInterval(repeatCheck);
@@ -5462,7 +5463,7 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
 		} else {
 			g_stateObj.bgmTimeupdateEvtId = g_handler.addListener(g_audio, "timeupdate", () => {
 				if (g_audio.currentTime >= musicEnd) {
-					fadeOutAndSeek(musicStart);
+					fadeOutAndSeek();
 				}
 			});
 		}
@@ -5501,7 +5502,8 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
 		g_audio.src = url;
 		g_audio.autoplay = false;
 		g_audio.volume = g_stateObj.bgmVolume / 100;
-		g_handler.addListener(g_audio, `loadedmetadata`, () => {
+		const loadedMeta = g_handler.addListener(g_audio, `loadedmetadata`, () => {
+			g_handler.removeListener(loadedMeta);
 			if (_currentLoopNum !== g_settings.musicLoopNum) {
 				return;
 			}

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1134,6 +1134,7 @@ const makeSpeedList = (_minSpd, _maxSpd) => [...Array((_maxSpd - _minSpd) * 20 +
 const g_settings = {
 
     musicIdxNum: 0,
+    musicLoopNum: 0,
     dataMgtNum: {
         environment: 0,
         highscores: 0,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 選曲画面でキー押しっぱなしにより複数の楽曲が同時に再生されないよう対応
- 前のPRの状態の場合、上下キーを押しっぱなしにするとBGM再生処理が
同時並行に複数再生されてしまう問題がありました。
- 今回の修正で、次の場合にはBGMを再生しないように変更しています。一周回って同じ曲を指す場合も同様です。
  - 500ms以内に別の曲が選択されている場合
  - 楽曲読み込み後の再生前に別の曲が選択されている場合

### 2. AudioPlayerクラスにclose()を追加
- BGM再生で使うことがあり、途中で不要になることがあることからclose()を実装しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. PR #1850 の考慮漏れのため。
2. レビュー結果を踏まえた内容より。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
