### PR TITLE
fix: [0927] BGMフェードイン時にNotSupportedErrorが出ることがある問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5361,7 +5361,7 @@ const pauseBGM = () => {
 		g_handler.removeListener(g_stateObj.bgmTimeupdateEvtId);
 		g_audio.pause();
 		if (!(g_audio instanceof AudioPlayer)) {
-			g_audio.src = ``;
+			delete g_audio.src;
 		}
 	}
 	[`bgmLooped`, `bgmFadeIn`, `bgmFadeOut`].forEach(id => {
@@ -5425,6 +5425,9 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
 	 * BGMのフェードイン
 	 */
 	const fadeIn = () => {
+		if (!g_audio.src) {
+			return;
+		}
 		let volume = 0;
 		g_audio.play();
 		const fadeInterval = setInterval(() => {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5425,9 +5425,9 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
 	 * BGMのフェードイン
 	 */
 	const fadeIn = () => {
-		if (!g_audio.src) {
-			return;
-		}
+        if (!(g_audio instanceof AudioPlayer) && !g_audio.src) {
+            return;
+        }
 		let volume = 0;
 		g_audio.play();
 		const fadeInterval = setInterval(() => {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5361,7 +5361,8 @@ const pauseBGM = () => {
 		g_handler.removeListener(g_stateObj.bgmTimeupdateEvtId);
 		g_audio.pause();
 		if (!(g_audio instanceof AudioPlayer)) {
-			delete g_audio.src;
+			g_audio.removeAttribute('src');
+			g_audio.load();
 		}
 	}
 	[`bgmLooped`, `bgmFadeIn`, `bgmFadeOut`].forEach(id => {
@@ -5425,9 +5426,9 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
 	 * BGMのフェードイン
 	 */
 	const fadeIn = () => {
-        if (!(g_audio instanceof AudioPlayer) && !g_audio.src) {
-            return;
-        }
+		if (!(g_audio instanceof AudioPlayer) && !g_audio.src) {
+			return;
+		}
 		let volume = 0;
 		g_audio.play();
 		const fadeInterval = setInterval(() => {
@@ -5542,6 +5543,8 @@ const changeMSelect = (_num, _initFlg = false) => {
 	}
 	// 現在選択中の楽曲IDを再設定
 	g_settings.musicIdxNum = (g_settings.musicIdxNum + _num + g_headerObj.musicIdxList.length) % g_headerObj.musicIdxList.length;
+
+	// 楽曲の多重読込防止（この値が変化していれば読み込まない）
 	g_settings.musicLoopNum++;
 	const currentLoopNum = g_settings.musicLoopNum;
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. BGMフェードイン時にNotSupportedErrorが出ることがある問題を修正
- 選曲画面のBGMがフェードアウトした直後に設定画面へ移動すると、Uncaught (in promise) NotSupportedError: The element has no supported sources. が出ることがありました。
- Audio.srcを削除することで対応しています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 直接問題にはならないが、エラーとして表示されるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
