### PR TITLE
feat: [0928] ミュート・ミュート解除ボタンを実装、ショートカットキーの追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5011,6 +5011,11 @@ const titleInit = (_initFlg = false) => {
 			createDivCss2Label(`lblComment`, ``, g_lblPosObj.lblComment_music),
 
 			createDivCss2Label(`lblBgmVolume`, `BGM Volume`, g_lblPosObj.lblBgmVolume),
+			createCss2Button(`btnBgmMute`, g_stateObj.bgmMuteFlg ? `&#x1f507;` : `&#x1f50a;`, evt => {
+				g_stateObj.bgmMuteFlg = !g_stateObj.bgmMuteFlg;
+				g_stateObj.bgmMuteFlg ? pauseBGM() : playBGM(0);
+				evt.target.innerHTML = g_stateObj.bgmMuteFlg ? `&#x1f507;` : `&#x1f50a;`;
+			}, g_lblPosObj.btnBgmMute, g_cssObj.button_Default),
 			createCss2Button(`btnBgmVolume`, `${g_stateObj.bgmVolume}${g_lblNameObj.percent}`, () => setBGMVolume(),
 				Object.assign({
 					cxtFunc: () => setBGMVolume(-1),
@@ -5602,14 +5607,16 @@ const changeMSelect = (_num, _initFlg = false) => {
 	lblComment.innerHTML = convertStrToVal(g_headerObj[`commentVal${g_settings.musicIdxNum}`]);
 
 	// BGM再生処理
-	if (_initFlg) {
-		playBGM(_num);
-	} else {
-		setTimeout(() => {
-			if (currentLoopNum === g_settings.musicLoopNum) {
-				playBGM(_num, currentLoopNum);
-			}
-		}, 500);
+	if (!g_stateObj.bgmMuteFlg) {
+		if (_initFlg) {
+			playBGM(_num);
+		} else {
+			setTimeout(() => {
+				if (currentLoopNum === g_settings.musicLoopNum) {
+					playBGM(_num, currentLoopNum);
+				}
+			}, 500);
+		}
 	}
 
 	// 選曲変更時のカスタム関数実行

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -288,6 +288,9 @@ const updateWindowSiz = () => {
             siz: g_limitObj.difSelectorSiz, align: C_ALIGN_LEFT,
             overflow: C_DIS_AUTO, whiteSpace: `normal`,
         },
+        btnBgmMute: {
+            x: g_btnX() + 90, y: g_sHeight - 105, w: 40, h: 35, siz: 30,
+        },
         lblBgmVolume: {
             x: g_btnX(), y: g_sHeight - 85, w: g_btnWidth(1 / 4), h: 20, siz: 12, align: C_ALIGN_LEFT,
         },
@@ -1016,6 +1019,7 @@ const g_stateObj = {
     bgmFadeIn: null,
     bgmFadeOut: null,
     bgmTimeupdateEvtId: null,
+    bgmMuteFlg: false,
 
     dosDivideFlg: false,
     scoreLockFlg: false,
@@ -2099,6 +2103,8 @@ const g_shortcutObj = {
         ArrowDown: { id: `btnMusicSelectNext` },
         ArrowLeft: { id: `btnBgmVolumeL` },
         ArrowRight: { id: `btnBgmVolumeR` },
+        KeyM: { id: `btnBgmMute` },
+        KeyR: { id: `btnMusicSelectRandom` },
     },
     dataMgt: {
         KeyE: { id: `btnEnvironment` },
@@ -2457,7 +2463,7 @@ Object.keys(g_btnWaitFrame).forEach(key => {
 // - btn + プロパティ名に合致するボタンid名に対して、
 //   どの位置(X方向)にショートカット名を表示するかを設定
 const g_btnPatterns = {
-    title: { Start: 0, Comment: -10 },
+    title: { Start: 0, Comment: -10, MusicSelectRandom: -10 },
     dataMgt: { Back: 0, Environment: -35, Highscores: -35, CustomKey: -35, Others: -35 },
     precondition: { Back: 0 },
     option: { Back: 0, KeyConfig: 0, Play: 0, Display: -5, Save: -10, Graph: -25 },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. ミュート・ミュート解除ボタンを実装
- 選曲画面のBGM音量設定の横にミュート・ミュート解除ボタンを追加しました。
- 「M」キーでも動作します。

### 2. ランダム選曲ボタンにショートカットキーを追加
- 他のランダムと同様、「R」キーで動作するように変更しました。


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 音量を出したくないときに手軽にOFFにできるため。
2. 他の機能との整合のため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/0dc122c5-4d52-4fa1-bc15-f45033eda1cd" width="60%">


## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
