### PR TITLE
fix: [0929] 設定画面で表示する曲名のエスケープ文字が残ってしまう問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6152,7 +6152,7 @@ const optionInit = () => {
  */
 const getMusicInfoView = () => {
 	const idx = g_headerObj.musicNos[g_stateObj.scoreId];
-	let text = `♪` + (g_headerObj.musicSelectUse ? `${g_headerObj.musicTitles[idx]} / ` : ``) +
+	let text = `♪` + (g_headerObj.musicSelectUse ? `${unEscapeHtml(g_headerObj.musicTitles[idx])} / ` : ``) +
 		`BPM: ${g_headerObj.bpms[idx]}`;
 	if (!g_headerObj.musicSelectUse && g_headerObj.bpms[idx] === `----`) {
 		text = ``;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 設定画面で表示する曲名のエスケープ文字が残ってしまう問題を修正
- 設定画面右上に表示している曲名にエスケープ文字（`&quot;`など）がそのまま表示されてしまう問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. PR #1839 の考慮漏れです。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
