### PR TITLE
fix: [0930] 選曲画面のBGMが設定画面以降に流れてしまうことがある問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5478,19 +5478,20 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
 		}
 	};
 
+	const musicPlayCheck = () => _currentLoopNum !== g_settings.musicLoopNum && g_currentPage !== `title`;
 	if (encodeFlg) {
 		try {
 			// base64エンコードは読込に時間が掛かるため、曲変更時のみ読込
 			if (!hasVal(g_musicdata) || Math.abs(_num) % g_headerObj.musicIdxList.length !== 0) {
 				await loadScript2(url);
 				musicInit();
-				if (_currentLoopNum !== g_settings.musicLoopNum) {
+				if (musicPlayCheck()) {
 					return;
 				}
 				const tmpAudio = new AudioPlayer();
 				const array = Uint8Array.from(atob(g_musicdata), v => v.charCodeAt(0));
 				await tmpAudio.init(array.buffer);
-				if (_currentLoopNum !== g_settings.musicLoopNum) {
+				if (musicPlayCheck()) {
 					tmpAudio.close();
 					return;
 				}
@@ -5513,7 +5514,7 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
 		g_audio.volume = g_stateObj.bgmVolume / 100;
 		const loadedMeta = g_handler.addListener(g_audio, `loadedmetadata`, () => {
 			g_handler.removeListener(loadedMeta);
-			if (_currentLoopNum !== g_settings.musicLoopNum) {
+			if (musicPlayCheck()) {
 				return;
 			}
 			g_audio.currentTime = musicStart;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5478,7 +5478,7 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
 		}
 	};
 
-	const musicPlayCheck = () => _currentLoopNum !== g_settings.musicLoopNum && g_currentPage !== `title`;
+	const musicPlayCheck = () => _currentLoopNum !== g_settings.musicLoopNum || g_currentPage !== `title`;
 	if (encodeFlg) {
 		try {
 			// base64エンコードは読込に時間が掛かるため、曲変更時のみ読込


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 選曲画面のBGMが設定画面以降に流れてしまうことがある問題を修正
- playBGM関数について、現在の画面位置を見ていなかったためロード中に設定画面に移動してしまうと
その後にBGMが流れる問題が発生していました。この問題を修正しています。


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. PR #1850 の考慮漏れです。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
