### PR TITLE
improve: [0931] 選曲画面のBGM音量のローカル保存に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2824,6 +2824,11 @@ const loadLocalStorage = (_musicId = ``) => {
 	if (g_langStorage.safeMode === undefined) {
 		g_langStorage.safeMode = C_FLG_OFF;
 	}
+	if (g_langStorage.bgmVolume === undefined) {
+		g_langStorage.bgmVolume = 50;
+	}
+	g_stateObj.bgmVolume = g_langStorage.bgmVolume;
+	g_settings.bgmVolumeNum = g_settings.volumes.findIndex(val => val === g_stateObj.bgmVolume);
 	Object.assign(g_msgInfoObj, g_lang_msgInfoObj[g_localeObj.val]);
 	Object.assign(g_kCd, g_lang_kCd[g_localeObj.val]);
 
@@ -4997,6 +5002,8 @@ const titleInit = (_initFlg = false) => {
 					pauseBGM();
 					g_handler.removeListener(wheelHandler);
 					g_keyObj.prevKey = `Dummy${g_settings.musicIdxNum}`;
+					g_langStorage.bgmVolume = g_stateObj.bgmVolume;
+					localStorage.setItem(`danoni-locale`, JSON.stringify(g_langStorage));
 				}, Object.assign({
 					resetFunc: () => optionInit(),
 				}, g_lblPosObj.btnStart_music), g_cssObj.button_Tweet),


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 選曲画面のBGM音量のローカル保存に対応
- サイト共通のローカルストレージ（danoni-locale）に対象を追加し、保存するようにしました。


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 利便性向上のため。
また、作品別というよりはサイト全体で保存すべき内容のため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
