### PR TITLE
fix: [0932] 楽曲情報（musicTitle）の定義数より大きいmusicNoを定義した場合に、BPMが取得できない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3462,7 +3462,8 @@ const headerConvert = _dosObj => {
 	if (hasVal(dosMusicTitle)) {
 		const musicData = splitLF2(dosMusicTitle);
 
-		for (let j = 0; j <= Math.max(...obj.musicNos, musicData.length - 1); j++) {
+		const lastIdx = Math.max(...obj.musicNos, musicData.length - 1);
+		for (let j = 0; j <= lastIdx; j++) {
 			const musics = splitComma(musicData[j]);
 
 			obj.musicTitles[j] = musics[0] !== undefined

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3465,11 +3465,15 @@ const headerConvert = _dosObj => {
 		for (let j = 0; j <= Math.max(...obj.musicNos, musicData.length - 1); j++) {
 			const musics = splitComma(musicData[j]);
 
-			obj.musicTitles[j] = escapeHtml(getMusicNameSimple(musics[0] || obj.musicTitles[0]));
+			obj.musicTitles[j] = musics[0] !== undefined
+				? escapeHtml(getMusicNameSimple(musics[0]))
+				: obj.musicTitles[0];
 			obj.musicTitlesForView[j] = obj.musicTitlesForView[j] = musics[0] !== undefined
 				? escapeHtmlForArray(getMusicNameMultiLine(musics[0]))
 				: obj.musicTitlesForView[0];
-			obj.artistNames[j] = escapeHtml(musics[1] || obj.artistNames[0]);
+			obj.artistNames[j] = musics[1] !== undefined
+				? escapeHtml(musics[1])
+				: obj.artistNames[0];
 			obj.artistUrls[j] = musics[2] || obj.artistUrls[0];
 			obj.bpms[j] = musics[4] || obj.bpms[0];
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3469,7 +3469,7 @@ const headerConvert = _dosObj => {
 			obj.musicTitles[j] = musics[0] !== undefined
 				? escapeHtml(getMusicNameSimple(musics[0]))
 				: obj.musicTitles[0];
-			obj.musicTitlesForView[j] = obj.musicTitlesForView[j] = musics[0] !== undefined
+			obj.musicTitlesForView[j] = musics[0] !== undefined
 				? escapeHtmlForArray(getMusicNameMultiLine(musics[0]))
 				: obj.musicTitlesForView[0];
 			obj.artistNames[j] = musics[1] !== undefined

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3466,13 +3466,13 @@ const headerConvert = _dosObj => {
 		for (let j = 0; j <= lastIdx; j++) {
 			const musics = splitComma(musicData[j]);
 
-			obj.musicTitles[j] = musics[0] !== undefined
+			obj.musicTitles[j] = hasVal(musics[0])
 				? escapeHtml(getMusicNameSimple(musics[0]))
 				: obj.musicTitles[0];
-			obj.musicTitlesForView[j] = musics[0] !== undefined
+			obj.musicTitlesForView[j] = hasVal(musics[0])
 				? escapeHtmlForArray(getMusicNameMultiLine(musics[0]))
 				: obj.musicTitlesForView[0];
-			obj.artistNames[j] = musics[1] !== undefined
+			obj.artistNames[j] = hasVal(musics[1])
 				? escapeHtml(musics[1])
 				: obj.artistNames[0];
 			obj.artistUrls[j] = musics[2] || obj.artistUrls[0];

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3454,7 +3454,7 @@ const headerConvert = _dosObj => {
 	obj.artistUrls = [``];
 	obj.bpms = [`----`];
 	obj.musicNos = hasVal(_dosObj.musicNo)
-		? splitLF2(_dosObj.musicNo).map(val => Number(val))
+		? splitLF2(_dosObj.musicNo).map(Number).map(val => isNaN(val) ? 0 : val)
 		: fillArray(_dosObj.difData?.split(`$`).length ?? 1);
 
 	const dosMusicTitle = getHeader(_dosObj, `musicTitle`);
@@ -3466,7 +3466,9 @@ const headerConvert = _dosObj => {
 			const musics = splitComma(musicData[j]);
 
 			obj.musicTitles[j] = escapeHtml(getMusicNameSimple(musics[0] || obj.musicTitles[0]));
-			obj.musicTitlesForView[j] = escapeHtmlForArray(getMusicNameMultiLine(musics[0] || obj.musicTitlesForView[0]));
+			obj.musicTitlesForView[j] = obj.musicTitlesForView[j] = musics[0] !== undefined
+				? escapeHtmlForArray(getMusicNameMultiLine(musics[0]))
+				: obj.musicTitlesForView[0];
 			obj.artistNames[j] = escapeHtml(musics[1] || obj.artistNames[0]);
 			obj.artistUrls[j] = musics[2] || obj.artistUrls[0];
 			obj.bpms[j] = musics[4] || obj.bpms[0];
@@ -3490,6 +3492,8 @@ const headerConvert = _dosObj => {
 		obj.artistName = `artistName`;
 	}
 	obj.artistUrl = obj.artistUrls[0];
+
+	// 代替タイトル名は曲名定義の後に設定する（複数曲を束ねる名前であり、曲名ではないため）
 	if (hasVal(alternativeTitle)) {
 		obj.musicTitles[0] = escapeHtml(getMusicNameSimple(alternativeTitle));
 		obj.musicTitlesForView[0] = escapeHtmlForArray(getMusicNameMultiLine(alternativeTitle));


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 楽曲情報（musicTitle）の定義数より大きいmusicNoを定義した場合に、BPMが取得できない問題を修正
- 1つの曲に対して複数譜面があり、それぞれ別々の曲を流す場合にBPMが取得できなくなっていました。
- BPM以外の項目はそれぞれ単一楽曲用の変数があったため対応できていましたが、
BPMは後から足された項目で、その部分の考慮ができていませんでした。
（単一楽曲用の変数は互換のために残している項目であり、本来は不要）
- この部分の処理自体、わかりにくいため処理を見直しています。
  - musicNoで定義される最大数とmusicTitleの定義曲数の多い方で定義する曲数を決定する方式としました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. PR #1839 の考慮漏れ。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- v41.0.0以降でのみ発生する問題です。
- 処理的にはv40以前のものも直した方が良いですが、動作上の問題はないのでそのままとします。