### PR TITLE
[ver41.3.1] 楽曲情報（musicTitle）の定義数より大きいmusicNoを定義した場合に、BPMが取得できない問題を修正

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@
 
 | Version      | Supported          | Latest Version                                                                 | Logs                                                                   | First Release | End of Support   |
 | ------------ | ------------------ | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------- | ------------- | ---------------- |
-| v41          | :heavy_check_mark: | [v41.3.0](https://github.com/cwtickle/danoniplus/releases/tag/v41.3.0)         | [:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-latest) | 2025-04-12    | (At Release v44) |
+| v41          | :heavy_check_mark: | [v41.3.1](https://github.com/cwtickle/danoniplus/releases/tag/v41.3.1)         | [:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-latest) | 2025-04-12    | (At Release v44) |
 | v40          | :heavy_check_mark: | [v40.7.3](https://github.com/cwtickle/danoniplus/releases/tag/v40.7.3)         | [:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v40) | 2025-03-01    | (At Release v43) |
 | v39 :anchor: | :heavy_check_mark: | [v39.8.4](https://github.com/cwtickle/danoniplus/releases/tag/v39.8.4)         | [:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v39) | 2025-02-01    | (At Release v48) |
 | v38          | :x:                | [v38.3.4 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v38.3.4)         | [:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v38) | 2024-11-04    | 2025-04-12 |

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2025/05/10
+ * Revised : 2025/05/15
  * 
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 41.3.0`;
-const g_revisedDate = `2025/05/10`;
+const g_version = `Ver 41.3.1`;
+const g_revisedDate = `2025/05/15`;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
 let g_localVersion = ``;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danoniplus",
-  "version": "41.3.0",
+  "version": "41.3.1",
   "description": "Dancing☆Onigiri (CW Edition) - Web-based Rhythm Game",
   "main": "./js/danoni_main.js",
   "scripts": {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- #1860 