### PR TITLE
improve: [0934] 必要以上にキャッシュクリアを行わないよう処理を見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -71,6 +71,8 @@ const hasRemoteDomain = _path => g_referenceDomains.some(domain => _path.match(`
 const g_remoteFlg = hasRemoteDomain(g_rootPath);
 
 const g_randTime = Date.now();
+const g_versionForUrl = g_version.slice(4);    // URL用に先頭の"Ver "を削除
+
 const g_isFile = location.href.match(/^file/);
 const g_isLocal = location.href.match(/^file/) || location.href.indexOf(`localhost`) !== -1;
 const g_isDebug = g_isLocal ||
@@ -95,13 +97,13 @@ const waitUntilLoaded = () => {
 	g_currentPage = `initial`;
 	const links = document.querySelectorAll(`link`);
 	if (Array.from(links).filter(elem => elem.getAttribute(`href`).indexOf(`danoni_main.css`) !== -1).length === 0) {
-		await importCssFile2(`${g_rootPath}../css/danoni_main.css?${g_randTime}`);
+		await importCssFile2(`${g_rootPath}../css/danoni_main.css?${g_versionForUrl}`);
 	}
 
 	// ロード直後に定数・初期化ファイル、旧バージョン定義関数を読込
-	await loadScript2(`${g_rootPath}../js/lib/danoni_localbinary.js?${g_randTime}`, false);
-	await loadScript2(`${g_rootPath}../js/lib/danoni_constants.js?${g_randTime}`);
-	await loadScript2(`${g_rootPath}../js/lib/legacy_functions.js?${g_randTime}`, false);
+	await loadScript2(`${g_rootPath}../js/lib/danoni_localbinary.js?${g_versionForUrl}`, false);
+	await loadScript2(`${g_rootPath}../js/lib/danoni_constants.js?${g_versionForUrl}`);
+	await loadScript2(`${g_rootPath}../js/lib/legacy_functions.js?${g_versionForUrl}`, false);
 	initialControl();
 })();
 
@@ -1097,7 +1099,9 @@ const importCssFile2 = (_href, { crossOrigin = `anonymous` } = {}) => {
  */
 const loadMultipleFiles2 = async (_fileData, _loadType) => {
 	await Promise.all(_fileData.map(async filePart => {
-		const filePath = `${filePart[1]}${filePart[0]}?${g_randTime}`;
+		const urlCacheName = listMatching(filePart[1], g_referenceDomains, { prefix: `^`, suffix: `$` })
+			? g_versionForUrl : g_randTime;
+		const filePath = `${filePart[1]}${filePart[0]}?${urlCacheName}`;
 		if (filePart[0].endsWith(`.css`)) {
 			_loadType = `css`;
 		}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -101,9 +101,10 @@ const waitUntilLoaded = () => {
 	}
 
 	// ロード直後に定数・初期化ファイル、旧バージョン定義関数を読込
-	await loadScript2(`${g_rootPath}../js/lib/danoni_localbinary.js?${g_versionForUrl}`, false);
+	// 旧バージョン定義関数はメジャーバージョンが変わった場合にのみ再ロードが掛かるようにする
+	await loadScript2(`${g_rootPath}../js/lib/danoni_localbinary.js`, false);
 	await loadScript2(`${g_rootPath}../js/lib/danoni_constants.js?${g_versionForUrl}`);
-	await loadScript2(`${g_rootPath}../js/lib/legacy_functions.js?${g_versionForUrl}`, false);
+	await loadScript2(`${g_rootPath}../js/lib/legacy_functions.js?${g_versionForUrl.split(`.`)[0]}`, false);
 	initialControl();
 })();
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1099,6 +1099,8 @@ const importCssFile2 = (_href, { crossOrigin = `anonymous` } = {}) => {
  */
 const loadMultipleFiles2 = async (_fileData, _loadType) => {
 	await Promise.all(_fileData.map(async filePart => {
+
+		// ファイルが属するドメインがリモートの場合は、キャッシュが使えるようにする
 		const urlCacheName = listMatching(filePart[1], g_referenceDomains, { prefix: `^`, suffix: `$` })
 			? g_versionForUrl : g_randTime;
 		const filePath = `${filePart[1]}${filePart[0]}?${urlCacheName}`;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 必要以上にキャッシュクリアを行わないよう処理を見直し
- これまで、danoni_main.jsに付随して読み込まれるjsファイルおよびcssファイルについては
読込ごとに既存のキャッシュを使わないようにしていました。
- ただ、同じバージョンと判断できる場合やドメインがCDNといった場合はキャッシュを使っても支障がないため、
今回の変更でこのような場合にキャッシュを使えるように変更しています。
- これまで、URLに「`?`+ 現在日付を使った文字列」で読み込んでいた部分が、
同じバージョンと判断できる場合やドメインがCDNといった場合に「`?`+ バージョン名」に変わります。
  - danoni_localbinary.jsについては基本変更がないため、キャッシュクリアの対策自体削除しました。
  - legacy_functions.jsについてはメジャーバージョンアップ時以外の変更はないため、
  「`?`+ メジャーバージョン名」としています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 毎回ファイルを読み込み直すことで、ロードに時間が掛かるため。
なお、画像ファイルについてはもともとキャッシュを許可しています。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
