### PR TITLE
feat: [0941] 作品ルートパスの指定に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -61,7 +61,7 @@ const validatePath = (_input, _defaultUrl = ``) => {
 	// 相対パス（ルート相対 `/path/to/file` もしくは `./file`, `../file` ）
 	const relativePathPattern = /^\/|^\.{1,2}\//;
 
-	if (absoluteUrlPattern.test(_input) || relativePathPattern.test(_input)) {
+	if (_input && (absoluteUrlPattern.test(_input) || relativePathPattern.test(_input))) {
 		return _input;		// URL または相対パスが合致すればその値を返す
 	} else {
 		return _defaultUrl;	// 合致しなければ代替文字列を返す
@@ -86,7 +86,8 @@ const g_referenceDomains = [
 Object.freeze(g_referenceDomains);
 
 const g_rootPath = current().match(/(^.*\/)/)[0];
-const g_workPath = validatePath(getQueryParamVal(`baseUrl`), new URL(location.href).href.match(/(^.*\/)/)[0]);
+const g_workPath = validatePath(document.getElementById(`baseUrl`)?.value,
+	new URL(location.href).href.match(/(^.*\/)/)[0]);
 const hasRemoteDomain = _path => g_referenceDomains.some(domain => _path.match(`^https://${domain}/`) !== null);
 const g_remoteFlg = hasRemoteDomain(g_rootPath);
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -48,6 +48,26 @@ const getQueryParamVal = _name => {
 	return param !== null ? decodeURIComponent(param.replace(/\+/g, ` `)) : null;
 };
 
+/**
+ * URLのパスを検証し、絶対URLまたは相対パスであればその値を返す
+ * @param {string} _input 
+ * @param {string} _defaultUrl 
+ * @returns {string}
+ */
+const validatePath = (_input, _defaultUrl = ``) => {
+	// 絶対 URL（http, https, ftp, fileなど）
+	const absoluteUrlPattern = /^(https?:\/\/|ftp:\/\/|file:\/\/)/;
+
+	// 相対パス（ルート相対 `/path/to/file` もしくは `./file`, `../file` ）
+	const relativePathPattern = /^\/|^\.{1,2}\//;
+
+	if (absoluteUrlPattern.test(_input) || relativePathPattern.test(_input)) {
+		return _input;		// URL または相対パスが合致すればその値を返す
+	} else {
+		return _defaultUrl;	// 合致しなければ代替文字列を返す
+	}
+};
+
 // 常時デバッグを許可するドメイン
 const g_reservedDomains = [
 	`danonicw.skr.jp`,
@@ -66,7 +86,7 @@ const g_referenceDomains = [
 Object.freeze(g_referenceDomains);
 
 const g_rootPath = current().match(/(^.*\/)/)[0];
-const g_workPath = new URL(location.href).href.match(/(^.*\/)/)[0];
+const g_workPath = validatePath(getQueryParamVal(`baseUrl`), new URL(location.href).href.match(/(^.*\/)/)[0]);
 const hasRemoteDomain = _path => g_referenceDomains.some(domain => _path.match(`^https://${domain}/`) !== null);
 const g_remoteFlg = hasRemoteDomain(g_rootPath);
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 作品ルートパスの指定に対応
- WordPressなどページルートが変わるような場合、同じドメインにdanoni_main.jsなどをアップロードしていれば
URLのパスが変わってもそのまま使用できますが、CDNでは使用できない問題があります。
- あらかじめ、ベースとするパスを定義することでそのような場合に対応できるようにします。

```html
<input type="hidden" name="baseUrl" id="baseUrl" value="https://xxxx/danoni/js/">
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 上述の通りです。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
