### PR TITLE
improve: [0942] 音楽データの読み込みパスの仕様を他のファイルと統一

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3018,9 +3018,16 @@ const getMusicUrl = _scoreId =>
 const getFullMusicUrl = (_musicUrl = ``) => {
 	let baseMusicUrl = _musicUrl;
 	let baseDir = `../${g_headerObj.musicFolder}/`;
+
 	if (_musicUrl.includes(C_MRK_CURRENT_DIRECTORY)) {
+		// musicUrl, musicFolder両方にカレントパス指定がある場合は、musicUrlの値を優先
+
 	} else if (g_headerObj.musicFolder.includes(C_MRK_CURRENT_DIRECTORY)) {
+		// musicFolderにカレントパス指定がある場合は、ファイル名にmusicFolderの値も含める
 		baseMusicUrl = `${g_headerObj.musicFolder}/${_musicUrl}`;
+	}
+	if (g_headerObj.musicFolder.includes(C_MRK_CURRENT_DIRECTORY)) {
+		// musicFolderにカレントパス指定がある場合は、ディレクトリは指定しない
 		baseDir = ``;
 	}
 	const [musicFile, musicPath] = getFilePath(baseMusicUrl, baseDir);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3016,13 +3016,15 @@ const getMusicUrl = _scoreId =>
  * @returns {string}
  */
 const getFullMusicUrl = (_musicUrl = ``) => {
-	let url = `${g_rootPath}../${g_headerObj.musicFolder}/${_musicUrl}`;
-	if (_musicUrl.indexOf(C_MRK_CURRENT_DIRECTORY) !== -1) {
-		url = _musicUrl.split(C_MRK_CURRENT_DIRECTORY)[1];
-	} else if (g_headerObj.musicFolder.indexOf(C_MRK_CURRENT_DIRECTORY) !== -1) {
-		url = `${g_headerObj.musicFolder.split(C_MRK_CURRENT_DIRECTORY)[1]}/${_musicUrl}`;
+	let baseMusicUrl = _musicUrl;
+	let baseDir = `../${g_headerObj.musicFolder}/`;
+	if (_musicUrl.includes(C_MRK_CURRENT_DIRECTORY)) {
+	} else if (g_headerObj.musicFolder.includes(C_MRK_CURRENT_DIRECTORY)) {
+		baseMusicUrl = `${g_headerObj.musicFolder}/${_musicUrl}`;
+		baseDir = ``;
 	}
-	return url;
+	const [musicFile, musicPath] = getFilePath(baseMusicUrl, baseDir);
+	return `${musicPath}${musicFile}`;
 }
 
 /**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 音楽データの読み込みパスの仕様を他のファイルと統一
- jsファイルやcssファイルについてはカレントパス指定時、`g_workPath`の値を基準にパスを決定する方式でした。
ただし、音楽データについてはmusicUrlとmusicFolderの組合せのみで、
カレントパスを指定しても`g_workPath`の値を使用していないため、 基本的には同じ仕様ですが条件によっては異なる条件になっていました。
musicFolderの仕様を考慮しつつ、getFilePath関数を利用するように見直しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. コードの整理及び、仕様をわかりやすくするため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
