### PR TITLE
improve: [0943] 絵文字を直接ソースコード上に表示しないよう改善

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1206,6 +1206,7 @@ const reviseCssText = _str => {
 /*-----------------------------------------------------------*/
 /* 色・グラデーション設定                                      */
 /*-----------------------------------------------------------*/
+const g_ctx = document.createElement(`canvas`).getContext(`2d`);
 
 /**
  * 対象のカラーコードが明暗どちらかを判定 (true: 明色, false: 暗色)
@@ -1225,9 +1226,8 @@ const checkLightOrDark = _colorStr => {
  * @returns {string}
  */
 const colorNameToCode = _color => {
-	const cxt = document.createElement(`canvas`).getContext(`2d`);
-	cxt.fillStyle = _color;
-	return cxt.fillStyle;
+	g_ctx.fillStyle = _color;
+	return g_ctx.fillStyle;
 };
 
 /**
@@ -1357,7 +1357,6 @@ const makeColorGradation = (_colorStr, { _defaultColorgrd = g_headerObj.defaultC
 const getBasicFont = (_priorityFont = ``) =>
 	[_priorityFont, g_headerObj.customFont, C_LBL_BASICFONT].filter(value => value !== ``).join(`,`);
 
-const g_ctx = document.createElement(`canvas`).getContext(`2d`);
 /**
  * フォントサイズに応じた横幅を取得
  * @param {string} _str 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 絵文字を直接ソースコード上に表示しないよう改善
- UTF-8の絵文字が一部ソースコード上に直接記述されている箇所を見直しました。
- 従来、Canvasに描画する関係でそのまま絵文字を表示している箇所がありましたが、
一度div要素のinnerHTMLに反映することで絵文字の直接表示が不要になったため、見直しました。

|絵文字|対応する文字列|
|----|----|
|&#x1f4f7;|`&#x1f4f7;`|
|&#x1f4dd;|`&#x1f4dd;`|
|&#x1f3b5;|`&#x1f3b5;`|

### 2. 確認のためだけに作成しているCanvas要素を使いまわすよう変更
- 長さ、色取得でCanvas要素を一時的に作成している箇所を見直し、Canvas要素を使いまわすようにしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. テキストエディターによっては絵文字に対応していない場合があり、文字化けする問題が出ていました。
2. あえて作り直す必要がないため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
