### PR TITLE
improve: [0945] 7ikeyの最小横幅を600pxに変更

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3215,7 +3215,6 @@ const g_keyObj = {
     minWidthDefault: 600,
 
     minWidth5: 500,
-    minWidth7i: 550,
     minWidth9A: 650,
     minWidth9B: 650,
     minWidth9i: 650,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 7ikeyの最小横幅を600pxに変更
- 7ikeyが12keyコンバートを許容している関係で従来の550pxでは問題となるため、見直しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 上述の通りです。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
- 本来は過去バージョンも対応する必要がありますが、位置調整上の互換性問題が出るため、
最新バージョンのみの適用とします。