### PR TITLE
improve: [0947] 9key系のデフォルトの最小横幅を本来必要な横幅長に戻す

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3216,10 +3216,6 @@ const g_keyObj = {
 
     minWidth5: 500,
     minWidth7i: 550,
-    minWidth9A: 650,
-    minWidth9B: 650,
-    minWidth9i: 650,
-    minWidth9d: 650,
     minWidth11i: 650,
     minWidth11j: 650,
     minWidth12i: 675,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 9key系のデフォルトの最小横幅を本来必要な横幅長に戻す
- 9A, 9B, 9i, 9dkeyの最小横幅をデフォルトの600pxに変更しました。
- |transKeyUse=false|に設定していない限りは11ikeyの横幅である650pxに引きずられるので、実影響は限定的です。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 必要な横幅を指定し、必要以上に横幅が広がるのを防ぐため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- 16ikeyも同形状だが、こちらは9key系と違いステップゾーン間の距離が
7keyと同じ55px（9key系は52.5px）のため据え置きとする。
