### PR TITLE
fix: [0949] 選曲画面で楽曲フェードアウト中にカーソル移動すると、再生されたままになることがある問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5468,11 +5468,13 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
 	const FADE_INTERVAL_MS = 100;
 	const FADE_DELAY_MS = 500;
 
+	const currentIdx = g_headerObj.musicIdxList[g_settings.musicIdxNum];
 	const musicUrl = getMusicUrl(g_headerObj.viewLists[0]);
 	const url = getFullMusicUrl(musicUrl);
 	const encodeFlg = listMatching(musicUrl, [`.js`, `.txt`], { suffix: `$` });
-	const musicStart = g_headerObj.musicStarts?.[g_headerObj.musicIdxList[g_settings.musicIdxNum]] ?? 0;
-	const musicEnd = g_headerObj.musicEnds?.[g_headerObj.musicIdxList[g_settings.musicIdxNum]] ?? 0;
+	const musicStart = g_headerObj.musicStarts?.[currentIdx] ?? 0;
+	const musicEnd = g_headerObj.musicEnds?.[currentIdx] ?? 0;
+	const isTitle = () => g_currentPage === `title`;
 
 	/**
 	 * BGMのフェードアウトとシーク
@@ -5480,7 +5482,7 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
 	const fadeOutAndSeek = () => {
 		let volume = g_audio.volume;
 		const fadeInterval = setInterval(() => {
-			if (volume > FADE_STEP && g_currentPage === `title`) {
+			if (volume > FADE_STEP && isTitle()) {
 				volume -= FADE_STEP;
 				g_audio.volume = Math.max(volume, 0);
 			} else {
@@ -5490,7 +5492,7 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
 				g_audio.currentTime = musicStart;
 
 				// フェードイン開始
-				if (g_currentPage === `title`) {
+				if (isTitle()) {
 					setTimeout(() => {
 						fadeIn();
 						if (encodeFlg) {
@@ -5517,10 +5519,17 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
 		let volume = 0;
 		g_audio.play();
 		const fadeInterval = setInterval(() => {
-			if (volume < g_stateObj.bgmVolume / 100 && g_currentPage === `title`) {
+			if (volume < g_stateObj.bgmVolume / 100 && isTitle()) {
 				volume += FADE_STEP;
 				g_audio.volume = Math.min(volume, 1);
 			} else {
+				clearInterval(fadeInterval);
+				g_stateObj.bgmFadeIn = null;
+			}
+
+			// フェードイン中に楽曲が変更された場合は停止
+			if (currentIdx !== g_headerObj.musicIdxList[g_settings.musicIdxNum]) {
+				pauseBGM();
 				clearInterval(fadeInterval);
 				g_stateObj.bgmFadeIn = null;
 			}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 選曲画面で楽曲フェードアウト中にカーソル移動すると、再生されたままになることがある問題を修正

- 楽曲フェードアウト後、フェードインに入った直後に別曲に変わったとき、
別曲に変わったことを検知できていなかったため、曲が流れっぱなしになることがありました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 上述の通りです。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- ver41.2.0以降で発生する問題です。