### PR TITLE
improve: [0950] 曲個別のコメントと作品全体のコメントが共存できるよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5110,7 +5110,7 @@ const titleInit = (_initFlg = false) => {
 		let wheelCnt = 0;
 		wheelHandler = g_handler.addListener(divRoot, `wheel`, e => {
 
-			if (lblComment.style.display === C_DIS_INHERIT) {
+			if (document.getElementById(`lblComment`) !== null && lblComment.style.display === C_DIS_INHERIT) {
 				return;
 			}
 			// コメント欄（lblCommentM）のスクロール可能性をチェック

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5110,6 +5110,9 @@ const titleInit = (_initFlg = false) => {
 		let wheelCnt = 0;
 		wheelHandler = g_handler.addListener(divRoot, `wheel`, e => {
 
+			if (lblComment.style.display === C_DIS_INHERIT) {
+				return;
+			}
 			// コメント欄（lblCommentM）のスクロール可能性をチェック
 			const isScrollable = lblCommentM.scrollHeight > lblCommentM.clientHeight;
 
@@ -5624,6 +5627,9 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
  * @param {boolean} _initFlg 
  */
 const changeMSelect = (_num, _initFlg = false) => {
+	if (document.getElementById(`lblComment`) !== null && lblComment.style.display === C_DIS_INHERIT) {
+		return;
+	}
 	const limitedMLength = 35;
 	pauseBGM();
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5088,7 +5088,7 @@ const titleInit = (_initFlg = false) => {
 				changeMSelect(Math.floor(Math.random() * (g_headerObj.musicIdxList.length - 1)) + 1),
 				g_lblPosObj.btnMusicSelectRandom, g_cssObj.button_Default),
 			createDivCss2Label(`lblMusicCnt`, ``, g_lblPosObj.lblMusicCnt),
-			createDivCss2Label(`lblComment`, ``, g_lblPosObj.lblComment_music),
+			createDivCss2Label(`lblCommentM`, ``, g_lblPosObj.lblComment_music),
 
 			createDivCss2Label(`lblBgmVolume`, `BGM Volume`, g_lblPosObj.lblBgmVolume),
 			createCss2Button(`btnBgmMute`, g_stateObj.bgmMuteFlg ? g_emojiObj.muted : g_emojiObj.speaker, evt => {
@@ -5110,14 +5110,14 @@ const titleInit = (_initFlg = false) => {
 		let wheelCnt = 0;
 		wheelHandler = g_handler.addListener(divRoot, `wheel`, e => {
 
-			// コメント欄（lblComment）のスクロール可能性をチェック
-			const isScrollable = lblComment.scrollHeight > lblComment.clientHeight;
+			// コメント欄（lblCommentM）のスクロール可能性をチェック
+			const isScrollable = lblCommentM.scrollHeight > lblCommentM.clientHeight;
 
 			// マウスがコメント欄上にあり、スクロールが可能ならイベントをスキップ
-			if (lblComment.contains(e.target) && isScrollable) {
+			if (lblCommentM.contains(e.target) && isScrollable) {
 				// スクロール位置の判定
-				const atTop = lblComment.scrollTop === 0 && e.deltaY < 0;
-				const atBottom = (lblComment.scrollTop + lblComment.clientHeight >= lblComment.scrollHeight) && e.deltaY > 0;
+				const atTop = lblCommentM.scrollTop === 0 && e.deltaY < 0;
+				const atBottom = (lblCommentM.scrollTop + lblCommentM.clientHeight >= lblCommentM.scrollHeight) && e.deltaY > 0;
 
 				// スクロール可能＆上端または下端ではないなら処理をスキップ
 				if (!atTop && !atBottom) {
@@ -5286,6 +5286,9 @@ const titleInit = (_initFlg = false) => {
 					lblComment.style.display = (lblCommentDef === C_DIS_NONE ? C_DIS_INHERIT : C_DIS_NONE);
 				}, g_lblPosObj.btnComment, g_cssObj.button_Default),
 			);
+			if (g_headerObj.musicSelectUse && getQueryParamVal(`scoreId`) === null) {
+				lblComment.style.height = `${g_sHeight - 100}px`;
+			}
 			setUserSelect(lblComment.style, `text`);
 		}
 	}
@@ -5694,7 +5697,7 @@ const changeMSelect = (_num, _initFlg = false) => {
 	}
 
 	// コメント文の加工
-	lblComment.innerHTML = convertStrToVal(g_headerObj[`commentVal${g_settings.musicIdxNum}`]);
+	lblCommentM.innerHTML = convertStrToVal(g_headerObj[`commentVal${g_settings.musicIdxNum}`]);
 
 	// BGM再生処理
 	if (!g_stateObj.bgmMuteFlg) {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 曲個別のコメントと作品全体のコメントが共存できるよう変更
- 選曲モード時、作品全体のコメント機能を使えるように見直しました。
- 曲別のコメントのidを`lblCommentM`に変更しています。
- 選曲モードのときだけ、作品全体のコメント欄が若干大きくなっています（ボタンの関係）。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 曲別と作品全体で同じidを使用していたため。
元々両方を使う想定はありませんでしたが、共存できた方が便利で、中途半端に設定だけ残っていたため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/cf8684ab-c29c-4c45-a201-8af8840e3898" width="50%"><img src="https://github.com/user-attachments/assets/747487af-e37e-4af4-bef7-c61a95a7f8ad" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- 不具合というより機能追加ですが、v41では共存できるかのような挙動になるので、
v41の場合は共存機能が使えないように修正する予定です。