### PR TITLE
fix: [0951] layerGroupXに対するlayerTransXの対応ズレを修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -11535,7 +11535,7 @@ const mainInit = () => {
 			mainSpriteJ.appendChild(createColorObject2(`filterBar${j % 2 == 0 ? j + 1 : j - 1}_HS`, g_lblPosObj.filterBar, filterCss));
 		}
 		addTransform(`mainSprite${j}`, `mainSprite${j}`,
-			g_keyObj[`layerTrans${keyCtrlPtn}`]?.[0]?.[Math.floor(j / 2) + (j + Number(g_stateObj.reverse === C_FLG_ON)) % 2]);
+			g_keyObj[`layerTrans${keyCtrlPtn}`]?.[0]?.[Math.floor(j / 2) * 2 + (j + Number(g_stateObj.reverse === C_FLG_ON)) % 2]);
 
 		stepSprite.push(createEmptySprite(mainSpriteJ, `stepSprite${j}`, mainCommonPos));
 		arrowSprite.push(createEmptySprite(mainSpriteJ, `arrowSprite${j}`, Object.assign({ y: g_workObj.hitPosition * (j % 2 === 0 ? 1 : -1) }, mainCommonPos)));


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. layerGroupXに対するlayerTransXの対応ズレを修正
- カスタムキーで使用できる、layerGroupXについてlayerTransXの対応付けが間違っており、機能していませんでした。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 数式の適用間違いです。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/957891d2-1ee7-4515-9362-19bcc0184418" width="50%">

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- ver39.1.0以降の機能のため、それ以降に影響します。
 