### PR TITLE
improve: [0953] 同一スクロール条件を一部変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -11184,7 +11184,7 @@ const getArrowSettings = () => {
 			g_workObj[`frzHitShadowColors${type}`][j] = g_headerObj.frzShadowColor[colorj][1] || ``;
 		});
 	}
-	g_workObj.orgFlatFlg = g_workObj.dividePos.every(v => v === g_workObj.dividePos[0]);
+	g_workObj.orgFlatFlg = g_workObj.dividePos.every(v => v % 2 === g_workObj.dividePos[0] % 2);
 	g_stateObj.layerNumDf = Math.max(g_stateObj.layerNumDf, Math.ceil((Math.max(...g_workObj.dividePos) + 1) / 2) * 2);
 
 	// StepArea(Default, Halfway以外)によるレイヤー移動


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. レイヤー違いで同一スクロールになっているものを同一と見做すよう変更
- 一部のオプションで、同一スクロール扱いのものについて処理を変えている部分がありましたが、
その条件について、レイヤー違いであっても同一スクロールであれば同一と見做すよう変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 一部のオプションが有効にならなくなるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments

- PR #1752 関連の変更となります。