### PR TITLE
feat: [0955] 1譜面目のみに適用する初期色設定（setColor1/frzColor1）の実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3016,12 +3016,12 @@ const resetGaugeSetting = _scoreId => {
  */
 const copySetColor = (_baseObj, _scoreId) => {
 	const obj = {};
-	const scoreIdHeader = setScoreIdHeader(_scoreId, g_stateObj.scoreLockFlg, true);
-	const idHeader = setScoreIdHeader(_scoreId, false, true);
+	const srcIdHeader = setScoreIdHeader(_scoreId, g_stateObj.scoreLockFlg, true);
+	const targetIdHeader = setScoreIdHeader(_scoreId, false, true);
 	[``, `Shadow`].forEach(pattern =>
 		[`set`, `frz`].filter(arrow => hasVal(_baseObj[`${arrow}${pattern}Color`]))
-			.forEach(arrow => obj[`${arrow}${pattern}Color${idHeader}`] =
-				(_baseObj[`${arrow}${pattern}Color${scoreIdHeader}`] ?? _baseObj[`${arrow}${pattern}Color`]).concat()));
+			.forEach(arrow => obj[`${arrow}${pattern}Color${targetIdHeader}`] =
+				(_baseObj[`${arrow}${pattern}Color${srcIdHeader}`] ?? _baseObj[`${arrow}${pattern}Color`]).concat()));
 	return obj;
 };
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 1譜面目のみに適用する初期色設定（setColor1/frzColor1）の実装
- 共通設定とは別に、1譜面目のみに適用する初期色設定（setColor1, frzColor1）を実装しました。
使い方は従来のsetColor/frzColorや、setColor2/frzColor2などと変わりません。

### 2. コードの整理
- 処理上同じで問題ない部分を共通化しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 共通設定ではなく、1譜面目の固有設定として使用したい場合があるため。
2. コードの見やすさのため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
