### PR TITLE
fix: [0958] 譜面番号固定時に初期色が想定通り取得できない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3012,6 +3012,16 @@ const resetColorSetting = _scoreId => {
 	// 初期矢印・フリーズアロー色の再定義
 	if (g_stateObj.scoreLockFlg) {
 		Object.assign(g_rootObj, copySetColor(g_rootObj, _scoreId));
+
+		// 分割先のファイルで初期色が未定義の場合はデフォルト値を適用
+		[``, `Shadow`].forEach(pattern =>
+			[`set`, `frz`].forEach(arrow => {
+				// frzShadowColorStrのみ、空で構成された初期配列があるためその条件を追加して除外条件とする
+				if (!hasVal(g_rootObj[`${arrow}${pattern}Color${_scoreId + 1}`]) && !g_headerObj[`${arrow}${pattern}ColorStr`].join(``).includes(`,,`)) {
+					g_rootObj[`${arrow}${pattern}Color`] = g_headerObj[`${arrow}${pattern}ColorStr`].join(`,`);
+				}
+			})
+		);
 	}
 	Object.assign(g_headerObj, resetBaseColorList(g_headerObj, g_rootObj, { scoreId: _scoreId, scoreLockFlg: false }));
 };

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3013,7 +3013,7 @@ const resetColorSetting = _scoreId => {
 	if (g_stateObj.scoreLockFlg) {
 		Object.assign(g_rootObj, copySetColor(g_rootObj, _scoreId));
 	}
-	Object.assign(g_headerObj, resetBaseColorList(g_headerObj, g_rootObj, { scoreId: _scoreId }));
+	Object.assign(g_headerObj, resetBaseColorList(g_headerObj, g_rootObj, { scoreId: _scoreId, scoreLockFlg: false }));
 };
 
 /**
@@ -3037,9 +3037,9 @@ const copySetColor = (_baseObj, _scoreId) => {
 	const srcIdHeader = setScoreIdHeader(_scoreId, g_stateObj.scoreLockFlg, true);
 	const targetIdHeader = setScoreIdHeader(_scoreId, false, true);
 	[``, `Shadow`].forEach(pattern =>
-		[`set`, `frz`].filter(arrow => hasVal(_baseObj[`${arrow}${pattern}Color`]))
+		[`set`, `frz`].filter(arrow => hasVal(_baseObj[`${arrow}${pattern}Color${srcIdHeader}`] || _baseObj[`${arrow}${pattern}Color`]))
 			.forEach(arrow => obj[`${arrow}${pattern}Color${targetIdHeader}`] =
-				(_baseObj[`${arrow}${pattern}Color${srcIdHeader}`] ?? _baseObj[`${arrow}${pattern}Color`]).concat()));
+				_baseObj[`${arrow}${pattern}Color${srcIdHeader}`] || _baseObj[`${arrow}${pattern}Color`]));
 	return obj;
 };
 
@@ -4253,12 +4253,13 @@ const addGaugeFulls = _obj => _obj.map(key => g_gaugeOptionObj.customFulls[key] 
  * @param {object} _baseObj 
  * @param {object} _dosObj
  * @param {string} [object.scoreId=''] 
+ * @param {boolean} [object.scoreLockFlg=g_stateObj.scoreLockFlg]
  * @returns {object} ※Object.assign(obj, resetBaseColorList(...))の形で呼び出しが必要
  */
-const resetBaseColorList = (_baseObj, _dosObj, { scoreId = `` } = {}) => {
+const resetBaseColorList = (_baseObj, _dosObj, { scoreId = ``, scoreLockFlg = g_stateObj.scoreLockFlg } = {}) => {
 
 	const obj = {};
-	const idHeader = setScoreIdHeader(scoreId, g_stateObj.scoreLockFlg, scoreId !== ``);
+	const idHeader = setScoreIdHeader(scoreId, scoreLockFlg, scoreId !== ``);
 	const getRefData = (_header, _dataName) => {
 		const data = _dosObj[`${_header}${_dataName}`];
 		return data?.startsWith(_header) ? _dosObj[data] : data;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3695,7 +3695,7 @@ const g_checkStr = {
 
     // 譜面分割あり、譜面番号固定時のみ譜面データを一時クリアする際の条件
     resetDosHeader: [`gauge`],
-    resetDosFooter: [`_data`, `_change`, `Color`, `customGauge`],
+    resetDosFooter: [`_data`, `_change`, `Color`, `Color1`, `customGauge`],
 };
 
 /** 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 譜面番号固定時に初期色が想定通り取得できない問題を修正
- 譜面番号固定時に2ファイル名以降の初期色が別定義されているとき、初期色が反映されない問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. copySetColor関数における考慮漏れです。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
