### PR TITLE
fix: [0959] 個別色変化先に初期色が含まれていると色変化が意図しないタイミングになる問題を修正（暫定）

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3045,6 +3045,8 @@ const resetGaugeSetting = _scoreId => {
  */
 const copySetColor = (_baseObj, _scoreId) => {
 	const obj = {};
+	// Todo: dosIdを引数にして、dosIdと一致するscoreIdを算出
+	//       算出したscoreIdすべてに対して下記処理を実行
 	const srcIdHeader = setScoreIdHeader(_scoreId, g_stateObj.scoreLockFlg, true);
 	const targetIdHeader = setScoreIdHeader(_scoreId, false, true);
 	[``, `Shadow`].forEach(pattern =>
@@ -11211,20 +11213,33 @@ const getArrowSettings = () => {
 		g_workObj.dividePos[j] = baseLayer * 2 + ((posj <= divideCnt ? 0 : 1) + (scrollDirOptions[j] === 1 ? 0 : 1) + (g_stateObj.reverse === C_FLG_OFF ? 0 : 1)) % 2;
 		g_workObj.scrollDir[j] = (posj <= divideCnt ? 1 : -1) * scrollDirOptions[j] * (g_stateObj.reverse === C_FLG_OFF ? 1 : -1);
 
-		eachOrAll.forEach(type => {
-			g_workObj[`arrowColors${type}`][j] = g_headerObj.setColor[colorj];
-			g_workObj[`dummyArrowColors${type}`][j] = g_headerObj.setDummyColor[colorj];
-			g_workObj[`arrowShadowColors${type}`][j] = g_headerObj.setShadowColor[colorj] || ``;
-			g_workObj[`dummyArrowShadowColors${type}`][j] = g_headerObj.setDummyColor[colorj] || ``;
+		// 個別色設定
+		g_workObj.arrowColors[j] = g_headerObj.setColor[colorj];
+		g_workObj.dummyArrowColors[j] = g_headerObj.setDummyColor[colorj];
+		g_workObj.arrowShadowColors[j] = g_headerObj.setShadowColor[colorj] || ``;
+		g_workObj.dummyArrowShadowColors[j] = g_headerObj.setDummyColor[colorj] || ``;
 
-			g_typeLists.frzColor.forEach((frzType, k) => {
-				g_workObj[`frz${frzType}Colors${type}`][j] = g_headerObj.frzColor[colorj][k] || ``;
-				g_workObj[`dummyFrz${frzType}Colors${type}`][j] =
-					frzType.includes(`Shadow`) ? `` : g_headerObj.setDummyColor[colorj] || ``;
-			});
-			g_workObj[`frzNormalShadowColors${type}`][j] = g_headerObj.frzShadowColor[colorj][0] || ``;
-			g_workObj[`frzHitShadowColors${type}`][j] = g_headerObj.frzShadowColor[colorj][1] || ``;
+		g_typeLists.frzColor.forEach((frzType, k) => {
+			g_workObj[`frz${frzType}Colors`][j] = g_headerObj.frzColor[colorj][k] || ``;
+			g_workObj[`dummyFrz${frzType}Colors`][j] =
+				frzType.includes(`Shadow`) ? `` : g_headerObj.setDummyColor[colorj] || ``;
 		});
+		g_workObj.frzNormalShadowColors[j] = g_headerObj.frzShadowColor[colorj][0] || ``;
+		g_workObj.frzHitShadowColors[j] = g_headerObj.frzShadowColor[colorj][1] || ``;
+
+		// 全体色設定
+		g_workObj.arrowColorsAll[j] = ``;
+		g_workObj.dummyArrowColorsAll[j] = ``;
+		g_workObj.arrowShadowColorsAll[j] = ``;
+		g_workObj.dummyArrowShadowColorsAll[j] = ``;
+
+		g_typeLists.frzColor.forEach((frzType, k) => {
+			g_workObj[`frz${frzType}ColorsAll`][j] = ``;
+			g_workObj[`dummyFrz${frzType}ColorsAll`][j] = ``;
+		});
+		g_workObj.frzNormalShadowColorsAll[j] = ``;
+		g_workObj.frzHitShadowColorsAll[j] = ``;
+
 	}
 	g_workObj.orgFlatFlg = g_workObj.dividePos.every(v => v % 2 === g_workObj.dividePos[0] % 2);
 	g_stateObj.layerNumDf = Math.max(g_stateObj.layerNumDf, Math.ceil((Math.max(...g_workObj.dividePos) + 1) / 2) * 2);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 個別色変化先に初期色が含まれていると色変化が意図しないタイミングになる問題を修正（暫定）
- 個別色変化で指定したカラーコードの中に、矢印の初期色（setColor/frzColor/frzColorInit）が含まれていると
矢印速度により、意図しないタイミングでの色変化になる問題を部分修正しました。

#### 事象確認データ
```
|setColor=0xFF9999,0xFFFFFF,0xCCFFFF,0xFF6600,0xFF6600|
|frzColor=0xFFFFFF,0xFFFFFF,0xFFFFFF,0xFFFF99|
|frzLeft_data=290,315,323,347,356,380,388,413|
|ncolor_data=
200,g0:FN/HA/HB,#FFCCFF
290,g0:FN/HA/HB,#FF9999
355,g0:FN/HA/HB,#FFFF99
|
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".

1. Discordでの指摘より。
全体色変化データの初期値に初期色を割り当てているため、それと一致すると条件式がおかしくなるのが原因でした。
全体色変化データの初期値を空にすることで暫定対応しています。
https://discord.com/channels/698460971231870977/944491021918683196/1408727693545046077

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- この対応は暫定措置です。
個別色変化をサンプルデータとしたうえで、全体色変化に初期値とイコールの値を与えてしまうと、
同様の事象が発生してしまう問題が残存します。
原因がすぐにわからないため、一旦事象回避としてプルリクエストします。