### PR TITLE
fix: [0960] 全体色変化と個別色変化が短いスパンで変わるとき、前の色に戻ることがある問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -12490,9 +12490,12 @@ const mainInit = () => {
 		// フリーズアロー色の設定
 		// - 通常時 (矢印枠/矢印塗りつぶし/帯): g_attrObj[frzName].Normal / NormalShadow / NormalBar
 		// - ヒット時 (矢印枠/矢印塗りつぶし/帯): g_attrObj[frzName].Hit / HitShadow / HitBar
+		// - ヒット時（矢印枠/矢印塗りつぶし/帯別の生成時全体色）: g_attrObj[frzName].HitAll / HitShadowAll / HitBarAll
 		g_typeLists.frzColor.forEach(val => {
 			g_attrObj[frzName][val] = g_workObj[`${_name}${val}Colors`][_j];
-			g_attrObj[frzName][`${val}All`] = g_workObj[`${_name}${val}ColorsAll`][_j];
+			if (val.startsWith(`Hit`)) {
+				g_attrObj[frzName][`${val}All`] = g_workObj[`${_name}${val}ColorsAll`][_j];
+			}
 		});
 		arrowSprite[g_workObj.dividePos[_j]].appendChild(frzRoot);
 		let shadowColor = _shadowColor === `Default` ? _normalColor : _shadowColor;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 全体色変化と個別色変化が短いスパンで変わるとき、前の色に戻ることがある問題を修正
- 以下の場合にフリーズアローヒット色が速度により、`#FFFF99`⇒`#FFCCFF`と戻る事象が発生していました。
- 速度によって全体色変化と個別色変化の順序が変わる件については考慮しません。（仕様）
- フリーズアロー生成時の全体色と、ヒット開始時の全体色を比較して、
変化がなければその間の全体色変化は発生しなかったものとして続行する仕様に変更しています。
（フリーズアロー生成時にセットするべきヒット色は定義済みのため全体色変化があれば、その色に変えるという考え方）

```
|setColor=0xFF9999,0xFFFFFF,0xCCFFFF,0xFF6600,0xFF6600|
|frzColor=0xFFFFFF,0xFFFFFF,0xFFFFFF,0xFFFF99|
|frzLeft_data=290,315,323,347,356,380,388,413|
|ncolor_data=
200,g0:FN/HA/HB,#FFCCFF,all
290,g0:FN/HA/HB,#FF9999,all
355,g0:FN/HA/HB,#FFFF99
|
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. Resolves #1904 

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- ver36.1.0以降で発生する問題です。PR #1902 の追加対応。