### PR TITLE
fix: [0961] musicTitleの4番目要素の反映方法における問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3574,7 +3574,7 @@ const headerConvert = _dosObj => {
 			obj.bpms[j] = musics[4] || obj.bpms[0];
 
 			// 代替タイトル名
-			if (j === 0) {
+			if (j === 0 && hasVal(_dosObj.musicNo)) {
 				alternativeTitle = musics[3];
 			}
 		}
@@ -5209,8 +5209,11 @@ const titleInit = (_initFlg = false) => {
 		}
 	} else if (!g_headerObj.customTitleUse) {
 		// 曲名文字描画（曲名は譜面データから取得）
-		divRoot.appendChild(drawTitle(g_headerObj.musicTitlesForView[g_settings.musicIdxNum],
-			g_headerObj.musicSelectUse ? g_headerObj.viewLists[0] + 1 : ``))
+		divRoot.appendChild(
+			g_headerObj.musicSelectUse
+				? drawTitle(g_headerObj.musicTitlesForView[g_settings.musicIdxNum], g_headerObj.viewLists[0] + 1)
+				: drawTitle()
+		);
 	}
 
 	// クレジット表示


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. musicNoの指定が無い場合にmusicTitleの4番目要素の値が反映されてしまう問題を修正
- musicTitleの4番目要素の表示はmusicNoの値が存在する場合のみタイトル画面に表示する項目ですが、
musicNoが無くても表示するようになっていました。

### 2. 通常モード時にURLにscoreId=Xが指定されていた場合で、musicTitleの4番目要素の値が無視されることがある問題を修正
- 選曲モードの有無によらず、musicNoの値に応じた楽曲名が表示されるようになっていました。
- 従来通り、選曲モードで無い場合はmusicTitleの4番目要素を利用するよう修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. Discordでの指摘より。
2. 想定された動きになっていなかったため。

参考：musicTitle
https://github.com/cwtickle/danoniplus/wiki/dos-h0001-musicTitle

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- PR #1860 (ver41.3.1) 以降で発生した問題と思われます。