### PR TITLE
feat: [0963] 譜面毎の空押し設定に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4020,7 +4020,7 @@ const headerConvert = _dosObj => {
 	});
 	if ((obj.excessiveUses?.length || 0) < obj.difLabels.length) {
 		obj.excessiveUses = makeBaseArray(obj.excessiveUses, obj.difLabels.length,
-			setBoolVal(obj.excessiveUses?.[0] ?? setBoolVal(obj.excessiveUse, g_presetObj.excessiveUse) ?? true));
+			setBoolVal(obj.excessiveUses?.[0] ?? _dosObj.excessiveUse ?? g_presetObj.excessiveUse, true));
 		obj.excessiveJdgUses = makeBaseArray(obj.excessiveJdgUses, obj.difLabels.length,
 			setBoolVal(obj.excessiveJdgUses?.[0] ?? g_presetObj.excessiveJdgUse ?? false));
 	}
@@ -7889,7 +7889,6 @@ const getAccuracy = (_border, _rcv, _dmg, _init, _allCnt) => {
 const setExcessive = (_btn, _val) => {
 	const curExcessive = Number(g_settings.excessiveNum);
 	g_settings.excessiveNum = _val ?? (curExcessive + 1) % 2;
-	console.log(_val)
 
 	g_stateObj.excessive = g_settings.excessives[g_settings.excessiveNum];
 	if ((curExcessive + g_settings.excessiveNum) % 2 !== 0) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7147,14 +7147,14 @@ const setDifficulty = (_initFlg) => {
 	lnkAutoPlay.textContent = getStgDetailName(g_stateObj.autoPlay);
 
 	// 譜面毎のExcessive再設定
-	g_stateObj.excessive = g_headerObj.excessiveJdgUses[g_stateObj.scoreId];
+	g_stateObj.excessive = boolToSwitch(g_headerObj.excessiveJdgUses[g_stateObj.scoreId]);
 	g_headerObj.excessiveUse = g_headerObj.excessiveUses[g_stateObj.scoreId];
 	g_headerObj.excessiveJdgUse = g_headerObj.excessiveJdgUses[g_stateObj.scoreId];
 	if (g_headerObj.excessiveUse) {
-		setExcessive(document.getElementById(`lnkExcessive`), g_stateObj.excessive);
+		setExcessive(document.getElementById(`lnkExcessive`), g_stateObj.excessive === C_FLG_ON);
 		lnkExcessive.style.display = C_DIS_INHERIT;
 	} else {
-		lblExcessive.style.display = (g_stateObj.excessive ? C_DIS_INHERIT : C_DIS_NONE);
+		lblExcessive.style.display = (g_stateObj.excessive === C_FLG_ON ? C_DIS_INHERIT : C_DIS_NONE);
 		lnkExcessive.style.display = C_DIS_NONE;
 	}
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4008,8 +4008,31 @@ const headerConvert = _dosObj => {
 	// フリーズアローの始点で通常矢印の判定を行うか(dotさんソース方式)
 	obj.frzStartjdgUse = setBoolVal(_dosObj.frzStartjdgUse ?? g_presetObj.frzStartjdgUse);
 
-	// 空押し判定を行うか
-	obj.excessiveJdgUse = setBoolVal(_dosObj.excessiveJdgUse ?? g_presetObj.excessiveJdgUse);
+	// 空押し判定の設定
+	// excessiveUses   : 譜面毎の空押し有効化設定
+	// excessiveJdgUses: 譜面毎の空押し初期設定
+	obj.excessiveUses = [];
+	obj.excessiveJdgUses = [];
+	splitLF2(_dosObj.excessiveUse)?.forEach(val => {
+		const tmpVal = val.split(`,`);
+		obj.excessiveUses.push(setBoolVal(tmpVal[0]));
+		obj.excessiveJdgUses.push(setVal(tmpVal[1], C_FLG_OFF, C_TYP_SWITCH) === C_FLG_ON);
+	});
+	if ((obj.excessiveUses?.length || 0) < obj.difLabels.length) {
+		obj.excessiveUses = makeBaseArray(obj.excessiveUses, obj.difLabels.length,
+			setBoolVal(obj.excessiveUses?.[0] ?? setBoolVal(obj.excessiveUse, g_presetObj.excessiveUse) ?? true));
+		obj.excessiveJdgUses = makeBaseArray(obj.excessiveJdgUses, obj.difLabels.length,
+			setBoolVal(obj.excessiveJdgUses?.[0] ?? g_presetObj.excessiveJdgUse ?? false));
+	}
+
+	// excessiveJdgUseが有効な場合は全譜面に対して強制的に上書き
+	if (_dosObj.excessiveJdgUse !== undefined) {
+		const excessiveJdg = setBoolVal(_dosObj.excessiveJdgUse);
+		if (excessiveJdg) {
+			obj.excessiveJdgUses = obj.excessiveJdgUses.map(val => true);
+		}
+	}
+	obj.excessiveJdgUse = obj.excessiveJdgUses[0];
 	g_stateObj.excessive = boolToSwitch(obj.excessiveJdgUse);
 	g_settings.excessiveNum = Number(obj.excessiveJdgUse);
 
@@ -7123,6 +7146,18 @@ const setDifficulty = (_initFlg) => {
 	g_stateObj.autoPlay = g_settings.autoPlays[g_settings.autoPlayNum];
 	lnkAutoPlay.textContent = getStgDetailName(g_stateObj.autoPlay);
 
+	// 譜面毎のExcessive再設定
+	g_stateObj.excessive = g_headerObj.excessiveJdgUses[g_stateObj.scoreId];
+	g_headerObj.excessiveUse = g_headerObj.excessiveUses[g_stateObj.scoreId];
+	g_headerObj.excessiveJdgUse = g_headerObj.excessiveJdgUses[g_stateObj.scoreId];
+	if (g_headerObj.excessiveUse) {
+		setExcessive(document.getElementById(`lnkExcessive`), g_stateObj.excessive);
+		lnkExcessive.style.display = C_DIS_INHERIT;
+	} else {
+		lblExcessive.style.display = (g_stateObj.excessive ? C_DIS_INHERIT : C_DIS_NONE);
+		lnkExcessive.style.display = C_DIS_NONE;
+	}
+
 	// 譜面明細画面の再描画
 	if (g_settings.scoreDetails.length > 0) {
 		drawSpeedGraph(g_stateObj.scoreId);
@@ -7366,20 +7401,17 @@ const createOptionWindow = _sprite => {
 	}
 
 	// 空押し判定設定 (Excessive)
-	if (g_headerObj.excessiveUse) {
-		spriteList.gauge.appendChild(
-			createCss2Button(`lnkExcessive`, g_lblNameObj.Excessive, evt => setExcessive(evt.target),
-				Object.assign(g_lblPosObj.btnExcessive, {
-					title: g_msgObj.excessive, cxtFunc: evt => setExcessive(evt.target),
-				}), g_cssObj.button_Default, g_cssObj[`button_Rev${g_stateObj.excessive}`])
-		);
-	} else if (g_headerObj.excessiveJdgUse) {
-		spriteList.gauge.appendChild(
-			createDivCss2Label(`lnkExcessive`, `${g_lblNameObj.Excessive}:${C_FLG_ON}`,
-				Object.assign(g_lblPosObj.btnExcessive, { x: 0, w: 100, border: C_DIS_NONE }), g_cssObj[`button_Disabled${C_FLG_ON}`]
-			)
-		);
-	}
+	spriteList.gauge.appendChild(
+		createDivCss2Label(`lblExcessive`, `${g_lblNameObj.Excessive}:${C_FLG_ON}`,
+			g_lblPosObj.lblExcessive, g_cssObj[`button_Disabled${C_FLG_ON}`]
+		)
+	);
+	spriteList.gauge.appendChild(
+		createCss2Button(`lnkExcessive`, g_lblNameObj.Excessive, evt => setExcessive(evt.target),
+			Object.assign(g_lblPosObj.btnExcessive, {
+				title: g_msgObj.excessive, cxtFunc: evt => setExcessive(evt.target),
+			}), g_cssObj.button_Default, g_cssObj[`button_Rev${g_stateObj.excessive}`])
+	);
 
 	// ---------------------------------------------------
 	// タイミング調整 (Adjustment)
@@ -7854,11 +7886,16 @@ const getAccuracy = (_border, _rcv, _dmg, _init, _allCnt) => {
  * 空押し判定の設定
  * @param {HTMLDivElement} _btn
  */
-const setExcessive = _btn => {
-	g_settings.excessiveNum = (g_settings.excessiveNum + 1) % 2;
+const setExcessive = (_btn, _val) => {
+	const curExcessive = Number(g_settings.excessiveNum);
+	g_settings.excessiveNum = _val ?? (curExcessive + 1) % 2;
+	console.log(_val)
+
 	g_stateObj.excessive = g_settings.excessives[g_settings.excessiveNum];
-	_btn.classList.replace(g_cssObj[`button_Rev${g_settings.excessives[(g_settings.excessiveNum + 1) % 2]}`],
-		g_cssObj[`button_Rev${g_settings.excessives[g_settings.excessiveNum]}`]);
+	if ((curExcessive + g_settings.excessiveNum) % 2 !== 0) {
+		_btn.classList.replace(g_cssObj[`button_Rev${g_settings.excessives[curExcessive]}`],
+			g_cssObj[`button_Rev${g_settings.excessives[Number(g_settings.excessiveNum)]}`]);
+	}
 };
 
 /**

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -376,6 +376,9 @@ const updateWindowSiz = () => {
         btnReverse: {
             x: 160, y: 0, w: 90, h: 21, siz: g_limitObj.difSelectorSiz, borderStyle: `solid`,
         },
+        lblExcessive: {
+            x: 5, y: 27, w: 90, h: 18, siz: 12,
+        },
         btnExcessive: {
             x: 5, y: 25, w: 90, h: 21, siz: g_limitObj.difSelectorSiz, borderStyle: `solid`,
         },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 譜面毎の空押し設定に対応

- 譜面毎に空押し設定の初期設定と有効化有無を設定できるようにしました。
- いずれも`excessiveUse`で指定します。$区切りで譜面毎、有効化有無/初期設定の組合せで指定します。
- 初期設定の指定がない場合はOFFが既定になります。
```
|excessiveUse=false,ON$true,OFF|
```

- excessiveJdgUseは全体設定用としての役割になり、`true`が指定されると一律初期設定が有効になります。
- 譜面毎の設定に変更になった関係で、譜面毎にExcessiveの設定がリセットされるように変更になりました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 譜面毎に切り替える需要があるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
