### PR TITLE
feat: [0969] 古いキー定義のハイスコアの引継ぎに対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -14068,23 +14068,28 @@ const resultInit = () => {
 
 	if (highscoreCondition) {
 
-		if (!hasVal(g_localStorage.highscores?.[scoreName])) {
+		// 古いキー定義の情報を検索
+		const relatedKeys = Object.entries(g_keyObj.keyTransPattern)
+			.filter(([key, value]) => value === g_headerObj.keyLabels[g_stateObj.scoreId])
+			.map(([key]) => key);
 
-			// 古いキー定義のハイスコアを新しいキー定義に移行する処理
-			const relatedKeys = Object.entries(g_keyObj.keyTransPattern)
-				.filter(([key, value]) => value === g_headerObj.keyLabels[g_stateObj.scoreId])
-				.map(([key]) => key);
-
-			// 古いキー定義のスコアデータを新しいキー定義に移行
-			for (const legacyKey of relatedKeys) {
-				let tmpScoreName = getStorageKeyName(legacyKey, transKeyName, assistFlg, mirrorName, g_stateObj.scoreId);
-				const src = g_localStorage.highscores?.[tmpScoreName];
-				if (hasVal(src)) {
-					g_localStorage.highscores[scoreName] = structuredClone(src);
-					delete g_localStorage.highscores[tmpScoreName];
-					break;
-				}
+		// 古いキー定義のスコアデータを現行キー定義に移行
+		for (const legacyKey of relatedKeys) {
+			let tmpScoreName = getStorageKeyName(
+				legacyKey, transKeyName, assistFlg, mirrorName, g_stateObj.scoreId
+			);
+			const src = g_localStorage.highscores?.[tmpScoreName];
+			if (!hasVal(src)) {
+				continue;
 			}
+
+			// 現行キー定義にスコアデータが存在しない場合、移行元のスコアデータをコピー
+			if (!hasVal(g_localStorage.highscores?.[scoreName])) {
+				g_localStorage.highscores[scoreName] = structuredClone(src);
+			}
+
+			// 古いキー定義は見つかった最初の1件のみ移行し、以降は削除
+			delete g_localStorage.highscores[tmpScoreName];
 		}
 
 		Object.keys(jdgScoreObj).filter(judge => judge !== ``)


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 古いキー定義のハイスコアの引継ぎに対応
- 例えば過去のバージョンで himsiyauz keyとしてハイスコア保存された譜面で、
v41以降に 9h keyとして移行した場合に、ハイスコアが引継ぎできていませんでした。
- 今回の変更で、移行先のハイスコアが存在しなかった場合に限り、引継ぎできるようになります。
- 内部的には g_keyObj.keyTransPattern を参照しています。これまでは初期しか利用がなかったため自動消去の対象になっていましたが、上記に対応するため消去しないように変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 今後も同様なキーコンバートが発生しないとは限らないため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
