### PR TITLE
ノーツ数依存のときの回復、ダメージ値を厳密に計算するように修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10403,7 +10403,7 @@ const calcLifeVals = _allArrows => {
  * @param {number} _val 
  * @param {number} _allArrows 
  */
-const calcLifeVal = (_val, _allArrows) => Math.round(_val * g_headerObj.maxLifeVal * 100 / _allArrows) / 100;
+const calcLifeVal = (_val, _allArrows) => _val * g_headerObj.maxLifeVal / _allArrows;
 
 /**
  * 最終フレーム数の取得


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

- ノーツ数依存のときの回復、ダメージ値を小数点2桁で四捨五入せずに扱うようにしました

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

- 通常のプレイにはほとんど影響はありませんが、chipさんのPermilleゲージのように、PFでちょうどゲージMaxになる想定のゲージでMaxにならない場合があったため修正しました

## :camera: スクリーンショット / Screenshot


## :pencil: その他コメント / Other Comments
