### PR TITLE
improve: [0970] ノーツ数依存のゲージ設定表示を小数第二位まで表示するように変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7824,7 +7824,7 @@ const gaugeFormat = (_mode, _border, _rcv, _dmg, _init, _lifeValFlg) => {
 	const initVal = g_headerObj.maxLifeVal * _init / 100;
 	const borderVal = g_headerObj.maxLifeVal * _border / 100;
 
-	// 整形用にライフ初期値を整数、回復・ダメージ量を小数第1位で丸める
+	// 整形用にライフ初期値を整数、回復・ダメージ量を小数第2位に丸める
 	const init = Math.round(initVal);
 	const borderText = (_mode === C_LFE_BORDER && _border !== 0 ? Math.round(borderVal) : `-`);
 	const round2 = _val => Math.round(_val * 100) / 100;
@@ -7834,6 +7834,8 @@ const gaugeFormat = (_mode, _border, _rcv, _dmg, _init, _lifeValFlg) => {
 	const allCnt = sumData(g_detailObj.arrowCnt[g_stateObj.scoreId]) +
 		(g_headerObj.frzStartjdgUse ? 2 : 1) * sumData(g_detailObj.frzCnt[g_stateObj.scoreId]);
 
+	// ゲージ設定が矢印数依存の場合、実際の値に変換して表示する
+	// 表示上、計算した値は小数第二位までの表示とする（それ以外はそのまま）
 	if (_lifeValFlg === C_FLG_ON) {
 		rcvText = ``, dmgText = ``;
 		if (allCnt > 0) {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. ノーツ数依存のゲージ設定表示を小数第二位まで表示するように変更
- ノーツ数依存のゲージ設定表示について、小数第二位に丸める表示になっていましたが、
丸めた結果ちょうど整数になってしまう場合などは小数が表示されなくなっていました。
ノーツ数依存のゲージ設定表示のみ、（結果整数になった場合も含めて）小数第二位まで表示するように変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. ノーツ数依存の場合は計算が入る関係で、小数第二位まで表示した方がわかりやすいため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="912" height="109" alt="image" src="https://github.com/user-attachments/assets/2f5390b7-52e6-4ccb-8dac-d201d880396a" />
<img width="866" height="88" alt="image" src="https://github.com/user-attachments/assets/59ff0589-05da-41af-9e86-83eccc9f5815" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- 小数第二位まで表示するのはノーツ数依存のゲージ設定表示だけであり、
計算せずそのままの場合はその値がそのまま入る仕組みになっている。