### PR TITLE
fix: [0972] 環境により数フレーム曲再生がずれる問題を改善

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2366,11 +2366,12 @@ class AudioPlayer {
 		// 内部スケジューリング用のマージン時間(100ms)
 		const scheduleLead = 0.1;
 
-		// マージンした分を先に予約して開始
+		// 実際の予約時刻（内部スケジューリング用のマージンを含む）
 		const startAt = this._context.currentTime + scheduleLead + _adjustmentTime;
-
-		this._startTime = startAt;
 		this._source.start(startAt, this._fadeinPosition);
+
+		// ゲーム側の論理的開始時刻（scheduleLead を含めない）
+		this._startTime = this._context.currentTime + _adjustmentTime;
 	}
 
 	pause() {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 環境により数フレーム曲再生がずれる問題を改善
- 音源再生開始時のタイミングずれを解消するため、Web Audio API の再生処理を
「即時 start()」から「未来時刻での予約 start()」に変更しました。

- Chrome で JS スレッド遅延が発生した際、再生開始が 5〜6frame（約80ms）遅れるケースが報告されていたため、
再生開始を currentTime + 0.1sec に予約する方式へ切り替えています。
※ゲーム内の開始時間を変えるわけではありません。WebAudio上の内部的な開始時間のみ0.1秒加算します。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 作品により、再生開始時にずれが不定期に起こる事象が報告されているため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
