### PR TITLE
fix: [0973] 楽曲再生時のスケジューリング再生時間の適用不具合を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -115,6 +115,9 @@ const waitUntilLoaded = () => {
 // fps(デフォルトは60)
 let g_fps = 60;
 
+// プレイ画面再生時の内部スケジューリング用のマージン時間(100ms)
+let g_scheduleLead = 0.1;
+
 // 譜面データの&区切りを有効にするか
 let g_enableAmpersandSplit = true;
 
@@ -2363,14 +2366,11 @@ class AudioPlayer {
 		this._source.playbackRate.value = this.playbackRate;
 		this._source.connect(this._gain);
 
-		// 内部スケジューリング用のマージン時間(100ms)
-		const scheduleLead = 0.1;
-
 		// 実際の予約時刻（内部スケジューリング用のマージンを含む）
-		const startAt = this._context.currentTime + scheduleLead + _adjustmentTime;
+		const startAt = this._context.currentTime + g_scheduleLead + _adjustmentTime;
 		this._source.start(startAt, this._fadeinPosition);
 
-		// ゲーム側の論理的開始時刻（scheduleLead を含めない）
+		// ゲーム側の論理的開始時刻（g_scheduleLead を含めない）
 		this._startTime = this._context.currentTime + _adjustmentTime;
 	}
 
@@ -13058,7 +13058,7 @@ const mainInit = () => {
 	// WebAudioAPIが使用できる場合は小数フレーム分だけ音源位置を調整
 	if (g_audio instanceof AudioPlayer) {
 		const musicStartAdjustment = (g_headerObj.blankFrame - g_stateObj.decimalAdjustment + 1) / g_fps;
-		musicStartTime = performance.now() + musicStartAdjustment * 1000;
+		musicStartTime = performance.now() + (musicStartAdjustment + g_scheduleLead) * 1000;
 		g_audio.play(musicStartAdjustment);
 	}
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 楽曲再生時のスケジューリング再生時間の適用不具合を修正
- PR #1926 でコードを修正しましたが、最後に _source._startTime を修正した結果、タイミングが100msずれてしまっています。これを修正しています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. PR #1926 の考慮漏れ。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
