### PR TITLE
速度グラフ上にマウスオーバーで合計速度を自動計算する機能を追加

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -209,7 +209,7 @@ const updateWindowSiz = () => {
         difFilter: { x: 0, y: 66, w: 140, h: 204 + g_sHeight - 500, overflow: C_DIS_AUTO, pointerEvents: C_DIS_AUTO },
         displaySprite: { x: 25, y: 30, w: (g_sWidth - 450) / 2, h: g_limitObj.setLblHeight * 5 },
         scoreDetail: { x: 20, y: 85, w: (g_sWidth - 500) / 2 + 420, h: 245, visibility: `hidden`, pointerEvents: C_DIS_AUTO },
-        detailObj: { w: (g_sWidth - 500) / 2 + 420, h: 230, visibility: `hidden` },
+        detailObj: { w: (g_sWidth - 500) / 2 + 420, h: 230, visibility: `hidden`, pointerEvents: C_DIS_AUTO },
         keyconSprite: { y: 105, h: g_sHeight - 105, overflow: C_DIS_AUTO },
         loader: { y: g_sHeight - 10, h: 10, backgroundColor: `#333333` },
         playDataWindow: { x: g_sWidth / 2 - 225, y: 70, w: 450, h: 110 },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- 速度グラフ上にマウスオーバーすると、設定速度×全体加速×個別加速の合計を自動で計算する機能を追加しました

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
- 全体加速と個別加速を併用した譜面で計算が煩雑だったため

## :camera: スクリーンショット / Screenshot
<img width="633" height="528" alt="速度グラフ" src="https://github.com/user-attachments/assets/e33f9981-55b5-42b2-96d2-f2bf86e5f9ae" />

## :pencil: その他コメント / Other Comments
- 特になし
