### PR TITLE
fix: [0977] ハイスコアデータのCopyResultでフリーズアロー数が取得できない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7164,7 +7164,7 @@ const makeHighScore = _scoreId => {
 
 		let tweetFrzJdg = ``;
 		let tweetMaxCombo = `${g_localStorage.highscores?.[scoreName]?.maxCombo}`;
-		if (g_allFrz > 0) {
+		if (sumData(g_detailObj.frzCnt[_scoreId]) > 0) {
 			tweetFrzJdg = `${g_localStorage.highscores?.[scoreName]?.kita}-${g_localStorage.highscores?.[scoreName]?.iknai}`;
 			tweetMaxCombo += `-${g_localStorage.highscores?.[scoreName]?.fmaxCombo}`;
 		}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. ハイスコアデータのCopyResultでフリーズアロー数が取得できない問題を修正
- CopyResultの仕様では、譜面中にフリーズアローがない場合はフリーズアロー部分をカットする仕様がありましたが、
ハイスコアの方ではフリーズアローが存在する場合でもカットされていました。結果画面の方は問題ありません。
結果画面のCopyResultの処理をそのまま移植したことによる影響と考えられます。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 表示内容と差異が生じているため。
参照している`g_allFrz`はプレイ開始時に作成されるため、そのまま使うには不適切でした。
譜面情報を管理している`g_detailObj.frzCnt`を使う方法に変更しています。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- 実装当初からの不具合と思われます。