### PR TITLE
improve: [0979] 選曲画面用と通常用の音楽再生変数を分離

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5276,12 +5276,14 @@ const titleInit = (_initFlg = false) => {
 				if (_opacity <= 0) {
 					clearTimeout(fadeOpacity);
 					mSelectTitleSprite.style.display = C_DIS_NONE;
-					g_audioForMS.muted = false;
-					g_audioForMS.currentTime = g_headerObj.musicStarts[g_headerObj.musicIdxList[g_settings.musicIdxNum]] ?? 0;
-					if (g_audioForMS instanceof AudioPlayer) {
-						// AudioPlayerはシークを適用するために再起動が必要
-						g_audioForMS.pause();
-						g_audioForMS.play();
+					if (!g_stateObj.bgmMuteFlg) {
+						g_audioForMS.muted = false;
+						g_audioForMS.currentTime = g_headerObj.musicStarts[g_headerObj.musicIdxList[g_settings.musicIdxNum]] ?? 0;
+						if (g_audioForMS instanceof AudioPlayer) {
+							// AudioPlayerはシークを適用するために再起動が必要
+							g_audioForMS.pause();
+							g_audioForMS.play();
+						}
 					}
 				} else {
 					mSelectTitleSprite.style.opacity = _opacity;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 選曲画面用と通常用の音楽再生変数を分離

- 選曲画面用と通常用の音楽再生用の変数として`g_audio`が使われていますが、
何らかの事情で両者の再生順序に影響があった場合に原因の切り分けが難しくなるため
変数自体を分けるようにしました。
- 安全のため、loadMusic関数に入った場合には選曲画面用の再生を止める（parse）処理を追加しています。

### 2. AudioPlayerクラスにmutedメソッドを追加、volumeメソッドのgetter/setterを見直し

- base64エンコードされた音源でも動作するように、新たにmutedメソッドの追加と
volumeメソッドのgetter/setterの修正を行いました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 通常再生が必要な場合に、選曲用の音源が交じり合うのを防ぐため。
また、処理している内容が通常再生か選曲用かを明確にするため。
2. AudioPlayerクラスで一部動作しないメソッドが存在するため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
