### PR TITLE
fix: [0980] データ管理画面内で選曲画面のBGMが流れる問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5177,7 +5177,9 @@ const titleInit = (_initFlg = false) => {
 		const setBGMVolume = (_num = 1) => {
 			g_settings.bgmVolumeNum = nextPos(g_settings.bgmVolumeNum, _num, g_settings.volumes.length);
 			g_stateObj.bgmVolume = g_settings.volumes[g_settings.bgmVolumeNum];
-			g_audioForMS.volume = g_stateObj.bgmVolume / 100;
+			if (g_audioForMS) {
+				g_audioForMS.volume = g_stateObj.bgmVolume / 100;
+			}
 			btnBgmVolume.textContent = `${g_stateObj.bgmVolume}${g_lblNameObj.percent}`;
 		};
 
@@ -5256,7 +5258,9 @@ const titleInit = (_initFlg = false) => {
 
 		// 初期表示用 (2秒後に選曲画面を表示)
 		if (_initFlg && !g_headerObj.customTitleUse) {
-			g_audioForMS.muted = true;
+			if (g_audioForMS) {
+				g_audioForMS.muted = true;
+			}
 			const mSelectTitleSprite = createEmptySprite(divRoot, `mSelectTitleSprite`,
 				g_windowObj.mSelectTitleSprite, g_cssObj.settings_DifSelector);
 			multiAppend(mSelectTitleSprite,
@@ -5275,7 +5279,7 @@ const titleInit = (_initFlg = false) => {
 				if (_opacity <= 0) {
 					clearTimeout(fadeOpacity);
 					mSelectTitleSprite.style.display = C_DIS_NONE;
-					if (!g_stateObj.bgmMuteFlg) {
+					if (!g_stateObj.bgmMuteFlg && g_audioForMS) {
 						g_audioForMS.muted = false;
 						g_audioForMS.currentTime = g_headerObj.musicStarts[g_headerObj.musicIdxList[g_settings.musicIdxNum]] ?? 0;
 						if (g_audioForMS instanceof AudioPlayer) {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. データ管理画面内で選曲画面のBGMが流れる問題を修正
- タイトルからデータ管理画面へ移動する際にBGMを止めていなかったため、
そのまま流れる問題が発生していました。
安全を見て、設定画面・デバッグ画面・プレイ直後の処理に同様の停止処理を追加しています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 想定していないBGMの流れ方のため。
また、他の画面の先頭にも同様の処理を加えることでBGMが他の画面遷移時に流れないようにします。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- フェードアウト・インの際に画面移動を行ったためにBGMが流れ続ける問題は #1925 にて対処しています。
- 通常時の音楽再生と混じる可能性がある問題は #1942 にて対処済みです。