### PR TITLE
fix: [0981] Audio->AudioPlayerのときにAudioのイベントリスナーが削除されない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5798,6 +5798,7 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
 			g_stateObj.bgmTimeupdateEvtId = null;
 		}
 		if (g_audioForMS instanceof AudioPlayer) {
+			g_musicdata = ``;
 			g_audioForMS.close();
 		}
 	};
@@ -5810,12 +5811,14 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
 				await loadScript2(url);
 				musicInit();
 				if (!isTitle()) {
+					g_musicdata = ``;
 					return;
 				}
 				const tmpAudio = new AudioPlayer();
 				const array = Uint8Array.from(atob(g_musicdata), v => v.charCodeAt(0));
 				await tmpAudio.init(array.buffer);
 				if (!isTitle()) {
+					g_musicdata = ``;
 					tmpAudio.close();
 					return;
 				}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. Audio->AudioPlayerに切り替えたときにAudioのイベントリスナーが削除されない問題を修正
- 選曲画面上の音楽切替で、通常の音源（mp3ファイルなど）とbase64エンコード音源が混在した場合に
通常の音源からbase64エンコード音源に切り替える際に
通常の音源側のtimeupdateを終了させていない問題が出ていました。
あまり大きな問題ではないですが、念のため対応しています。
また、逆のパターンと同じ処理のため関数化しました。

### 2. repeatBGMのコメント間違いを修正
- setIntervalは使っていないため、適切な内容に修正しました。
- この件のコードの修正はありません。


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 限定された場合ではあるものの、他と処理が統一されていないため。
2. 記述内容と異なる記述になっているため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
