### PR TITLE
[ver43.6.4] 選曲画面でAudioからAudioPlayerに切り替えたときにAudioのイベントリスナーが削除されない問題を修正

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,9 +18,9 @@
 
 | Version      | Supported          | Latest Version                                                                 | Logs                                                                   | First Release | End of Support   |
 | ------------ | ------------------ | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------- | ------------- | ---------------- |
-| v43          | :heavy_check_mark: | [v43.6.3](https://github.com/cwtickle/danoniplus/releases/tag/v43.6.3)         | [:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-latest) | 2025-09-15    | (At Release v46) |
-| v42          | :heavy_check_mark: | [v42.5.9](https://github.com/cwtickle/danoniplus/releases/tag/v42.5.9)         | [:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v42) | 2025-05-24    | (At Release v45) |
-| v41          | :warning:          | [v41.4.15](https://github.com/cwtickle/danoniplus/releases/tag/v41.4.15)         | [:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v41) | 2025-04-12    | (At Release v44) |
+| v43          | :heavy_check_mark: | [v43.6.4](https://github.com/cwtickle/danoniplus/releases/tag/v43.6.4)         | [:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-latest) | 2025-09-15    | (At Release v46) |
+| v42          | :heavy_check_mark: | [v42.5.10](https://github.com/cwtickle/danoniplus/releases/tag/v42.5.10)         | [:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v42) | 2025-05-24    | (At Release v45) |
+| v41          | :warning:          | [v41.4.16](https://github.com/cwtickle/danoniplus/releases/tag/v41.4.16)         | [:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v41) | 2025-04-12    | (At Release v44) |
 | v40          | :x:          | [v40.7.7 (final)](https://github.com/cwtickle/danoniplus/releases/tag/v40.7.7)         | [:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v40) | 2025-03-01    | 2025-09-15 |
 | v39 :anchor: | :heavy_check_mark: | [v39.8.12](https://github.com/cwtickle/danoniplus/releases/tag/v39.8.12)         | [:memo:](https://github.com/cwtickle/danoniplus/wiki/Changelog-v39) | 2025-02-01    | (At Release v48) |
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4,12 +4,12 @@
  * 
  * Source by tickle
  * Created : 2018/10/08
- * Revised : 2026/01/26
+ * Revised : 2026/01/31
  *
  * https://github.com/cwtickle/danoniplus
  */
-const g_version = `Ver 43.6.3`;
-const g_revisedDate = `2026/01/26`;
+const g_version = `Ver 43.6.4`;
+const g_revisedDate = `2026/01/31`;
 
 // カスタム用バージョン (danoni_custom.js 等で指定可)
 let g_localVersion = ``;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danoniplus",
-  "version": "43.6.3",
+  "version": "43.6.4",
   "description": "Dancing☆Onigiri (CW Edition) - Web-based Rhythm Game",
   "main": "./js/danoni_main.js",
   "scripts": {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- #1946 