### PR TITLE
improve: [0986] ゲージ設定における許容ミス数をテーブル上に収まるように変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8111,8 +8111,8 @@ const gaugeFormat = (_mode, _border, _rcv, _dmg, _init, _lifeValFlg) => {
 	const [rateText, allowableCntsText] = getAccuracy(borderVal, realRcv, realDmg, initVal, allCnt);
 	g_workObj.requiredAccuracy = rateText;
 
-	// 許容ミス数のみ、オンマウスで表示するためpointer-eventsを有効にする
-	return `<div id="gaugeDivCover" class="settings_gaugeDivCover">
+	// このテーブルのみpointer-eventsを有効にする（オンマウス許可）
+	return `<div id="gaugeDivCover" class="settings_gaugeDivCover" style="pointer-events: auto;">
 		<div id="lblGaugeDivTable" class="settings_gaugeDivTable">
 			<div id="lblGaugeStart" class="settings_gaugeDivTableCol settings_gaugeStart">
 				${g_lblNameObj.g_start}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. ゲージ設定における許容ミス数をテーブル上に収まるように変更
- ゲージ設定における許容ミス数をオンマウスではなく、Accuracyの下に常時表示するようにしました。
Accuracy=100%の場合は非表示とし、攻略不可能(100%超え)の場合は括弧を入れてマイナス値で表記します。

### 2. ゲージ設定の詳細が記載されているテーブルのマウスオーバーを許可するよう変更
- 元々許容ミス数用としてAccuracyの値部分のみ許可していましたが、
他でも利用できるようにテーブル全体を許可するように変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. オンマウスで確認できることに気づきにくいため。
常時表示とすることでミス数がわかりやすくなります。
2. 独自要素への拡張をしやすくするため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/6ed92518-8f8c-4a98-b6fd-f3a2f9b76283" /><img width="50%" alt="image" src="https://github.com/user-attachments/assets/f1e4fabf-20fa-4b2b-b1c7-5f63bd085ed7" />

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/20a03d42-a7b8-4fc1-8565-eaed6b24798e" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- レイアウト調整がソース直書きになっています。
本来はCSSファイルに書くのが望ましいですが、ここでしか利用しないため今回は直書きとしました。