### PR TITLE
improve: [0987] FrzReturn設定適用時、回転に奥行きを付けるよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1895,6 +1895,8 @@ const clearWindow = (_redrawFlg = false, _customDisplayName = ``) => {
 
 	// ボタン、オブジェクトをクリア (divRoot配下のもの)
 	deleteChildspriteAll(`divRoot`);
+	divRoot.style.perspective = ``;
+	divRoot.style.perspectiveOrigin = ``;
 
 	// 拡張範囲を取得
 	const diffX = (_customDisplayName === `Main` && g_workObj.nonDefaultSc ?


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. FrzReturn設定適用時、回転に奥行きを付けるよう変更
- CSSのperspective属性を使うことで、FrzReturn（特にX軸、X-Y軸、X-Z軸）について
より回転するように見せるようにしました。
- また、裏面になる場合は少し透明度をつけて裏面がわかるように改善しています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 平面的な回転のため、X軸回転では半周回って戻るような挙動に見えてしまうため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/48dd2332-0cde-45cc-924a-73645203ac50" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
