### PR TITLE
improve: [0988] リモート参照先がわかるようにバージョン名に追記するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -66,16 +66,22 @@ const g_referenceDomains = [
 Object.freeze(g_referenceDomains);
 
 // ドメイン管理リスト
-const g_domainList = [`jsdelivr`, `unpkg`];
+const g_domainList = [
+	{ label: `jsdelivr`, hosts: [`cdn.jsdelivr.net`] },
+	{ label: `unpkg`, hosts: [`unpkg.com`, `www.unpkg.com`] },
+];
+Object.freeze(g_domainList);
 
 const g_rootPath = current().match(/(^.*\/)/)[0];
 let g_workPath;
 const hasRemoteDomain = _path => g_referenceDomains.some(domain => _path.match(`^https://${domain}/`) !== null);
 const detectDomain = _url => {
-	const host = new URL(_url).hostname; // 例: "cdn.jsdelivr.net"
-
-	// ドメインリストのどれかが hostname に含まれていれば返す
-	return g_domainList.find(domain => host.includes(domain)) ?? null;
+	try {
+		const host = new URL(_url).hostname; // 例: "cdn.jsdelivr.net"
+		return g_domainList.find(({ hosts }) => hosts.some(h => host === h || host.endsWith(`.${h}`)))?.label ?? null;
+	} catch {
+		return null;
+	}
 }
 const g_remoteFlg = hasRemoteDomain(g_rootPath);
 const g_remoteDomain = detectDomain(g_rootPath);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. CDNの参照先がわかるようにバージョン名に追記するよう変更
- jsdelivrやunpkgを利用している場合にそれがわかるようにタイトルに明記するようにしました。


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 問題が出ているときの特定に使用できるため。
現状jsdelivrやunpkgを利用している方はほぼいませんが、今後のために組み込みだけしておきます。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
- 実際にはjsdelivrやunpkgに組み込まないとわからないため、テスト的にlocalhostを入れた場合の表記を入れておきます。

<img width="60%" alt="image" src="https://github.com/user-attachments/assets/4adfd58e-ca07-418a-bf0d-cb3f3217eafd" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
