### PR TITLE
improve: [0990] Appearanceのフィルターバーの位置設定を相対指定方法に変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -13472,12 +13472,12 @@ const changeAppearanceFilter = (_num = 10) => {
 		$id(`arrowSprite${topNum + j}`).clipPath = topShape;
 		$id(`arrowSprite${bottomNum + j}`).clipPath = bottomShape;
 
-		$id(`filterBar${topNum + j}`).top = wUnit(parseFloat($id(`arrowSprite${j}`).top) + topDist);
-		$id(`filterBar${bottomNum + j}`).top = wUnit(parseFloat($id(`arrowSprite${j + 1}`).top) + bottomDist);
+		addY(`filterBar${topNum + j}`, `appearance`, parseFloat($id(`arrowSprite${j}`).top) + topDist);
+		addY(`filterBar${bottomNum + j}`, `appearance`, parseFloat($id(`arrowSprite${j + 1}`).top) + bottomDist);
 
 		if (![`Default`, `Halfway`].includes(g_stateObj.stepArea)) {
-			$id(`filterBar${bottomNum + j}_HS`).top = wUnit(parseFloat($id(`arrowSprite${j}`).top) + bottomDist);
-			$id(`filterBar${topNum + j}_HS`).top = wUnit(parseFloat($id(`arrowSprite${j + 1}`).top) + topDist);
+			addY(`filterBar${bottomNum + j}_HS`, `appearance`, parseFloat($id(`arrowSprite${j}`).top) + topDist);
+			addY(`filterBar${topNum + j}_HS`, `appearance`, parseFloat($id(`arrowSprite${j + 1}`).top) + bottomDist);
 		}
 	}
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. Appearanceのフィルターバーの位置設定を相対指定方法に変更
- Appearanceのフィルターバーの位置設定をaddY関数を使った相対指定方法に変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. キリズマ＋ダンおにのように、フィルターバーをずらさないといけないときに、座標直接指定は問題となるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- 矢印・フリーズアローの移動についても相対指定しようと思えばできますが、
この変更とは影響規模が違うため別のタイミングでの対応とします。