### PR TITLE
fix: [0991] Appearanceフィルター位置がX-Flower/Alt-Crossingの場合のみ想定と異なる問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -13476,8 +13476,8 @@ const changeAppearanceFilter = (_num = 10) => {
 		addY(`filterBar${bottomNum + j}`, `appearance`, parseFloat($id(`arrowSprite${j + 1}`).top) + bottomDist);
 
 		if (![`Default`, `Halfway`].includes(g_stateObj.stepArea)) {
-			addY(`filterBar${bottomNum + j}_HS`, `appearance`, parseFloat($id(`arrowSprite${j}`).top) + topDist);
-			addY(`filterBar${topNum + j}_HS`, `appearance`, parseFloat($id(`arrowSprite${j + 1}`).top) + bottomDist);
+			addY(`filterBar${bottomNum + j}_HS`, `appearance`, parseFloat($id(`arrowSprite${j}`).top) + bottomDist);
+			addY(`filterBar${topNum + j}_HS`, `appearance`, parseFloat($id(`arrowSprite${j + 1}`).top) + topDist);
 		}
 	}
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. Appearanceフィルター位置がX-Flower/Alt-Crossingの場合のみ想定と異なる問題を修正
- X-Flower/Alt-Crossingの場合のみ使用するAppearanceフィルター位置がスクロールがデフォルト/リバースで想定と逆になっている問題を修正しました。


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. PR #1962 対応時のコード補完ミスです。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
