### PR TITLE
improve: [0992] Hidden+/Sudden+/Hid&Sud+のとき、フィルターロック時に限りフィルター位置を結果画面へ反映

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -14305,7 +14305,8 @@ const resultInit = () => {
 		withOptions(g_stateObj.motion, C_FLG_OFF),
 		`${withOptions(g_stateObj.reverse, C_FLG_OFF,
 			getStgDetailName(g_stateObj.scroll !== '---' ? 'R-' : 'Reverse'))}${withOptions(g_stateObj.scroll, '---')}`,
-		withOptions(g_stateObj.appearance, `Visible`),
+		withOptions(g_stateObj.appearance, `Visible`) +
+		((g_appearanceRanges.includes(g_stateObj.appearance) && g_stateObj.filterLock === C_FLG_ON) ? `(${g_hidSudObj.filterPos}%)` : ``),
 		withOptions(g_stateObj.gauge, g_settings.gauges[0]),
 		withOptions(g_stateObj.playWindow, `Default`),
 		withOptions(g_stateObj.stepArea, `Default`),


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. Hidden+/Sudden+/Hid&Sud+のとき、フィルターロック時に限りフィルター位置を結果画面へ反映
- Hidden+/Sudden+/Hid&Sud+のとき、フィルターロック時に限り
フィルター位置を結果画面に表示するようにしました。


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. フィルターロック時であれば位置が固定され、表示する意味があるため。

## :camera: スクリーンショット / Screenshot

<img width="60%" alt="image" src="https://github.com/user-attachments/assets/81c3c9a8-ec24-4c72-aba9-c1ca8eb9f069" /><img width="40%" alt="image" src="https://github.com/user-attachments/assets/f2bbeb10-1830-4e24-b9e9-c7bd08c38864" />


## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
