### PR TITLE
feat: [1052] 選曲画面で楽曲別コメントの上部に譜面情報を追加、関連機能の実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3870,6 +3870,7 @@ const headerConvert = _dosObj => {
 			} else {
 				obj.difLabels.push(`Normal`);
 				obj.creatorNames.push(obj.tuning);
+				obj.difficulties.push(0);
 			}
 
 			// 初期速度

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1445,6 +1445,32 @@ const getStrWidth = (_str, _fontsize, _font) => {
 	return g_ctx.measureText(unEscapeHtml(_str)).width;
 };
 
+const getStrHeight = (_str, _fontsize, _font = getBasicFont()) => {
+	g_ctx.font = `${wUnit(_fontsize)} ${_font}`;
+	const lines = unEscapeHtml(_str).split(`<br>`);
+
+	let totalHeight = 0;
+	const lineGap = 1;
+
+	lines.forEach((line, index) => {
+		const metrics = g_ctx.measureText(line);
+
+		// 基本の高さ（フォントサイズ）を取得
+		// fontBoundingBox が使えれば正確ですが、なければ _fontsize を使用
+		const h = metrics.fontBoundingBoxAscent
+			? (metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent)
+			: _fontsize;
+
+		if (index < lines.length - 1) {
+			totalHeight += h * lineGap; // 途中の行は行間を足す
+		} else {
+			totalHeight += h; // 最終行
+		}
+	});
+
+	return totalHeight;
+};
+
 /**
  * Canvas上で使用する絵文字を取得
  * - HTMLのdiv要素に絵文字を設定することで、Canvas上で使用できるようにする
@@ -3817,6 +3843,7 @@ const headerConvert = _dosObj => {
 		obj.lifeDamages = [];
 		obj.lifeInits = [];
 		obj.creatorNames = [];
+		obj.difficulties = [];
 		g_stateObj.scoreId = (g_stateObj.scoreId < difs.length ? g_stateObj.scoreId : 0);
 
 		difs.forEach(dif => {
@@ -3838,7 +3865,8 @@ const headerConvert = _dosObj => {
 			if (hasVal(difDetails[difpos.Name])) {
 				const difNameInfo = difDetails[difpos.Name].split(`::`);
 				obj.difLabels.push(escapeHtml(difNameInfo[0] ?? `Normal`));
-				obj.creatorNames.push(difNameInfo.length > 1 ? escapeHtml(difNameInfo[1]) : obj.tuning);
+				obj.creatorNames.push(setVal(escapeHtml(difNameInfo[1]), obj.tuning));
+				obj.difficulties.push(setIntVal(difNameInfo[2], `-`));
 			} else {
 				obj.difLabels.push(`Normal`);
 				obj.creatorNames.push(obj.tuning);
@@ -5343,7 +5371,13 @@ const titleInit = (_initFlg = false) => {
 				changeMSelect(Math.floor(Math.random() * (g_headerObj.musicIdxList.length - 1)) + 1),
 				g_lblPosObj.btnMusicSelectRandom, g_cssObj.button_Default),
 			createDivCss2Label(`lblMusicCnt`, ``, g_lblPosObj.lblMusicCnt),
-			createDivCss2Label(`lblCommentM`, ``, g_lblPosObj.lblComment_music),
+		);
+		createEmptySprite(divRoot, `lblCommentM`, g_lblPosObj.lblComment_music);
+		multiAppend(lblCommentM,
+			createDivCss2Label(`lblDifNameInfoM`, ``, g_lblPosObj.lblDifNameInfoM),
+			createDivCss2Label(`lblDiffiInfoM`, ``, g_lblPosObj.lblDiffiInfoM),
+			createDivCss2Label(`lblNotesInfoM`, ``, g_lblPosObj.lblNotesInfoM),
+			createDivCss2Label(`lblCommentInfoM`, ``, g_lblPosObj.lblCommentInfoM),
 		);
 
 		if (g_headerObj.bgmUseFlg) {
@@ -6035,20 +6069,23 @@ const changeMSelect = (_num, _initFlg = false) => {
 
 	// 選択した楽曲に対応する譜面番号、製作者情報、曲長を取得
 	g_headerObj.viewLists = [];
-	const tmpKeyList = [], tmpCreatorList = [], tmpPlayingFrameList = [], tmpBpmList = [];
+	const keyList = [], creatorList = [], playingFrameList = [], bpmList = [], difNameList = [], diffiList = [], notesList = [];
 	const targetIdx = g_headerObj.musicIdxList[(g_settings.musicIdxNum + g_headerObj.musicIdxList.length * 20) % g_headerObj.musicIdxList.length];
 	g_headerObj.musicNos.forEach((val, j) => {
 		if ((g_headerObj.musicGroups?.[val] ?? val) === targetIdx) {
 			g_headerObj.viewLists.push(j);
-			tmpKeyList.push(g_headerObj.keyLabels[j]);
-			tmpCreatorList.push(g_headerObj.creatorNames[j]);
-			tmpPlayingFrameList.push(g_detailObj.playingFrameWithBlank[j]);
-			tmpBpmList.push(g_headerObj.bpms[g_headerObj.musicNos[j]]);
+			keyList.push(g_headerObj.keyLabels[j]);
+			creatorList.push(g_headerObj.creatorNames[j]);
+			playingFrameList.push(g_detailObj.playingFrameWithBlank[j]);
+			bpmList.push(g_headerObj.bpms[g_headerObj.musicNos[j]]);
+			difNameList.push(`${g_headerObj.keyLabels[j]} / ${g_headerObj.difLabels[j]}`);
+			diffiList.push(g_headerObj.difficulties[j]);
+			notesList.push(`Arrows: ${sumData(g_detailObj.arrowCnt[j])}+${sumData(g_detailObj.frzCnt[j])}`);
 		}
 	});
-	const playingFrames = makeDedupliArray(tmpPlayingFrameList.map(val => transFrameToTimer(val))).join(`, `);
-	const bpm = makeDedupliArray(tmpBpmList).join(`, `);
-	const [creatorName, creatorUrl, creatorIdx] = getCreatorInfo(tmpCreatorList);
+	const playingFrames = makeDedupliArray(playingFrameList.map(val => transFrameToTimer(val))).join(`, `);
+	const bpm = makeDedupliArray(bpmList).join(`, `);
+	const [creatorName, creatorUrl, creatorIdx] = getCreatorInfo(creatorList);
 	const creatorLink = creatorIdx >= 0 ?
 		`<a href="${creatorUrl}" target="_blank">${creatorName}</a>` : creatorName;
 
@@ -6063,7 +6100,7 @@ const changeMSelect = (_num, _initFlg = false) => {
 
 	// 選択した楽曲で使われているキー種の一覧を作成
 	deleteChildspriteAll(`keyTitleSprite`);
-	makeDedupliArray(tmpKeyList).sort((a, b) => parseInt(a) - parseInt(b))
+	makeDedupliArray(keyList).sort((a, b) => parseInt(a) - parseInt(b))
 		.forEach((val, j) => keyTitleSprite.appendChild(
 			createDivCss2Label(`btnKeyTitle${val}`, val, { ...g_lblPosObj.btnKeyTitle, x: 10 + j * 40 })));
 
@@ -6080,8 +6117,23 @@ const changeMSelect = (_num, _initFlg = false) => {
 		g_settings.speedNum = getCurrentNo(g_settings.speeds, g_stateObj.speed);
 	}
 
-	// コメント文の加工
-	lblCommentM.innerHTML = convertStrToVal(g_headerObj[`commentVal${g_settings.musicIdxNum}`]);
+	// 譜面情報、コメント文の加工
+	lblDifNameInfoM.innerHTML = ``;
+	lblDiffiInfoM.innerHTML = ``;
+	lblNotesInfoM.innerHTML = ``;
+	for (let j = 0; j < difNameList.length; j++) {
+		lblDifNameInfoM.innerHTML += `${difNameList[j]}`;
+		if (makeDedupliArray(creatorList).length > 1) {
+			lblDifNameInfoM.innerHTML += ` (${creatorList[j]})`;
+		}
+		lblDifNameInfoM.innerHTML += `<br>`;
+		lblDiffiInfoM.innerHTML += `${diffiList[j]}<br>`;
+		lblNotesInfoM.innerHTML += `[${notesList[j]}]<br>`;
+	}
+	lblDifNameInfoM.style.fontSize = wUnit(getFontSize2(lblDifNameInfoM.innerHTML, 180, { maxSiz: 12, minSiz: 5 }));
+	lblDiffiInfoM.style.fontSize = lblDifNameInfoM.style.fontSize;
+	lblCommentInfoM.style.top = `${getStrHeight(lblDifNameInfoM.innerHTML, parseFloat(lblDifNameInfoM.style.fontSize))}px`;
+	lblCommentInfoM.innerHTML = convertStrToVal(g_headerObj[`commentVal${g_settings.musicIdxNum}`]);
 
 	// BGM再生処理
 	if (!g_stateObj.bgmMuteFlg) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3866,7 +3866,7 @@ const headerConvert = _dosObj => {
 				const difNameInfo = difDetails[difpos.Name].split(`::`);
 				obj.difLabels.push(escapeHtml(difNameInfo[0] ?? `Normal`));
 				obj.creatorNames.push(setVal(escapeHtml(difNameInfo[1]), obj.tuning));
-				obj.difficulties.push(setIntVal(difNameInfo[2], `-`));
+				obj.difficulties.push(setIntVal(difNameInfo[2], 0));
 			} else {
 				obj.difLabels.push(`Normal`);
 				obj.creatorNames.push(obj.tuning);
@@ -3903,6 +3903,18 @@ const headerConvert = _dosObj => {
 	} else {
 		obj.musicIdxList = [...Array(Math.max(...obj.musicNos) + 1).keys()];
 	}
+
+	// 難易度配色の設定（選曲画面でのみ使用）
+	obj.difColorList = [
+		{ threshold: Infinity, color: `` }
+	];
+	if (hasVal(_dosObj.difColor)) {
+		_dosObj.difColor.split(`,`).forEach(val => {
+			const difColorSet = val.split(`/`);
+			obj.difColorList.push({ threshold: setIntVal(difColorSet[0]), color: setVal(difColorSet[1], ``) });
+		})
+	}
+	obj.difColorList.sort((a, b) => a.threshold - b.threshold);
 
 	// 譜面変更セレクターの利用有無
 	obj.difSelectorUse = getDifSelectorUse(_dosObj.difSelectorUse, obj.viewLists);
@@ -6127,8 +6139,12 @@ const changeMSelect = (_num, _initFlg = false) => {
 			lblDifNameInfoM.innerHTML += ` (${creatorList[j]})`;
 		}
 		lblDifNameInfoM.innerHTML += `<br>`;
-		lblDiffiInfoM.innerHTML += `${diffiList[j]}<br>`;
-		lblNotesInfoM.innerHTML += `[${notesList[j]}]<br>`;
+
+		const difColorPart = g_headerObj.difColorList.find(val => diffiList[j] < val.threshold);
+		lblDiffiInfoM.innerHTML += `${diffiList[j] > 0
+			? `<span style="color:${difColorPart?.color || ''}">${diffiList[j]}</span>`
+			: `-`}<br>`;
+		lblNotesInfoM.innerHTML += `/ ${notesList[j]}<br>`;
 	}
 	lblDifNameInfoM.style.fontSize = wUnit(getFontSize2(lblDifNameInfoM.innerHTML,
 		g_lblPosObj.lblDifNameInfoM.w, { maxSiz: g_lblPosObj.lblDifNameInfoM.siz }));

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3907,22 +3907,50 @@ const headerConvert = _dosObj => {
 	}
 
 	// 難易度配色の設定（選曲画面でのみ使用）
+	const normalizeCssColor = _color => {
+		const tmp = document.createElement(`span`);
+		tmp.style.color = ``;
+		tmp.style.color = trimStr(_color ?? ``);
+		return tmp.style.color;
+	};
 	obj.difColorList = [
 		{ threshold: Infinity, color: `` }
 	];
 	if (hasVal(_dosObj.difColor)) {
 		_dosObj.difColor.split(`,`).forEach(val => {
 			const difColorSet = val.split(`/`);
-			obj.difColorList.push({ threshold: setIntVal(difColorSet[0]), color: setVal(difColorSet[1], ``) });
+			obj.difColorList.push({
+				threshold: setIntVal(difColorSet[0]),
+				color: hasVal(difColorSet[1]) ? normalizeCssColor(difColorSet[1]) : ``
+			});
 		})
 	}
 	obj.difColorList.sort((a, b) => a.threshold - b.threshold);
 
+	const sanitizeCustomLink = _link => {
+		try {
+			const raw = trimStr(_link);
+			if (!hasVal(raw)) return undefined;
+			const url = new URL(raw, location.href); // allows relative inputs
+			const allowed = g_isFile ? [`http:`, `https:`, `file:`] : [`http:`, `https:`];
+			return allowed.includes(url.protocol) ? url.href : undefined;
+		} catch {
+			return undefined;
+		}
+	};
 	obj.difCustomLink = [];
 	if (hasVal(_dosObj.difCustomLink)) {
 		splitLF2(_dosObj.difCustomLink).forEach(val => {
-			const linkPair = val.split(`,`);
-			obj.difCustomLink[roundZero(setIntVal(linkPair[0]))] = linkPair[1];
+			const commaPos = val.indexOf(`,`);
+			if (commaPos < 0) return;
+			const idxStr = trimStr(val.slice(0, commaPos));
+			const linkStr = val.slice(commaPos + 1);
+			const idx = setIntVal(idxStr, -1);
+			if (!Number.isFinite(idx) || idx < 0 || idx >= obj.difLabels.length) return;
+			const safeHref = sanitizeCustomLink(linkStr);
+			if (safeHref !== undefined) {
+				obj.difCustomLink[idx] = safeHref;
+			}
 		});
 	}
 
@@ -6167,6 +6195,7 @@ const changeMSelect = (_num, _initFlg = false) => {
 	lblNotesInfoM.style.fontSize = lblDifNameInfoM.style.fontSize;
 	lblCommentInfoM.style.top = `${getStrHeight(lblDifNameInfoM.innerHTML, parseFloat(lblDifNameInfoM.style.fontSize))}px`;
 	lblCommentInfoM.innerHTML = convertStrToVal(g_headerObj[`commentVal${g_settings.musicIdxNum}`]);
+	lblCommentM.scrollTop = 0;
 
 	// BGM再生処理
 	if (!g_stateObj.bgmMuteFlg) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3918,6 +3918,14 @@ const headerConvert = _dosObj => {
 	}
 	obj.difColorList.sort((a, b) => a.threshold - b.threshold);
 
+	obj.difCustomLink = [];
+	if (hasVal(_dosObj.difCustomLink)) {
+		splitLF2(_dosObj.difCustomLink).forEach(val => {
+			const linkPair = val.split(`,`);
+			obj.difCustomLink[roundZero(setIntVal(linkPair[0]))] = linkPair[1];
+		});
+	}
+
 	// 譜面変更セレクターの利用有無
 	obj.difSelectorUse = getDifSelectorUse(_dosObj.difSelectorUse, obj.viewLists);
 
@@ -6135,12 +6143,17 @@ const changeMSelect = (_num, _initFlg = false) => {
 	lblDifNameInfoM.innerHTML = ``;
 	lblDiffiInfoM.innerHTML = ``;
 	lblNotesInfoM.innerHTML = ``;
+	let notesInfo = ``;
 	for (let j = 0; j < difNameList.length; j++) {
-		lblDifNameInfoM.innerHTML += `${difNameList[j]}`;
+		let noteInfo = `${difNameList[j]}`;
 		if (makeDedupliArray(creatorList).length > 1) {
-			lblDifNameInfoM.innerHTML += ` (${creatorList[j]})`;
+			noteInfo += ` (${creatorList[j]})`;
 		}
+		lblDifNameInfoM.innerHTML += g_headerObj.difCustomLink[g_headerObj.viewLists[j]] !== undefined
+			? `<a href="${g_headerObj.difCustomLink[g_headerObj.viewLists[j]]}" target="_blank">${noteInfo}</a>`
+			: noteInfo;
 		lblDifNameInfoM.innerHTML += `<br>`;
+		notesInfo += `${noteInfo}<br>`;
 
 		const difColorPart = g_headerObj.difColorList.find(val => diffiList[j] < val.threshold);
 		lblDiffiInfoM.innerHTML += `${diffiList[j] > 0
@@ -6148,9 +6161,10 @@ const changeMSelect = (_num, _initFlg = false) => {
 			: `-`}<br>`;
 		lblNotesInfoM.innerHTML += `/ ${notesList[j]}<br>`;
 	}
-	lblDifNameInfoM.style.fontSize = wUnit(getFontSize2(lblDifNameInfoM.innerHTML,
+	lblDifNameInfoM.style.fontSize = wUnit(getFontSize2(notesInfo,
 		g_lblPosObj.lblDifNameInfoM.w, { maxSiz: g_lblPosObj.lblDifNameInfoM.siz }));
 	lblDiffiInfoM.style.fontSize = lblDifNameInfoM.style.fontSize;
+	lblNotesInfoM.style.fontSize = lblDifNameInfoM.style.fontSize;
 	lblCommentInfoM.style.top = `${getStrHeight(lblDifNameInfoM.innerHTML, parseFloat(lblDifNameInfoM.style.fontSize))}px`;
 	lblCommentInfoM.innerHTML = convertStrToVal(g_headerObj[`commentVal${g_settings.musicIdxNum}`]);
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3885,6 +3885,7 @@ const headerConvert = _dosObj => {
 		obj.lifeDamages = [40];
 		obj.lifeInits = [25];
 		obj.creatorNames = [obj.tuning];
+		obj.difficulties = [0];
 	}
 	const keyLists = makeDedupliArray(obj.keyLabels);
 	obj.viewLists = [...Array(obj.keyLabels.length).keys()];

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6178,7 +6178,7 @@ const changeMSelect = (_num, _initFlg = false) => {
 			noteInfo += ` (${creatorList[j]})`;
 		}
 		lblDifNameInfoM.innerHTML += g_headerObj.difCustomLink[g_headerObj.viewLists[j]] !== undefined
-			? `<a href="${g_headerObj.difCustomLink[g_headerObj.viewLists[j]]}" target="_blank">${noteInfo}</a>`
+			? `<a href="${g_headerObj.difCustomLink[g_headerObj.viewLists[j]]}" target="_blank" rel="noopener noreferrer">${noteInfo}</a>`
 			: noteInfo;
 		lblDifNameInfoM.innerHTML += `<br>`;
 		notesInfo += `${noteInfo}<br>`;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6130,7 +6130,8 @@ const changeMSelect = (_num, _initFlg = false) => {
 		lblDiffiInfoM.innerHTML += `${diffiList[j]}<br>`;
 		lblNotesInfoM.innerHTML += `[${notesList[j]}]<br>`;
 	}
-	lblDifNameInfoM.style.fontSize = wUnit(getFontSize2(lblDifNameInfoM.innerHTML, 180, { maxSiz: 12, minSiz: 5 }));
+	lblDifNameInfoM.style.fontSize = wUnit(getFontSize2(lblDifNameInfoM.innerHTML,
+		g_lblPosObj.lblDifNameInfoM.w, { maxSiz: g_lblPosObj.lblDifNameInfoM.siz }));
 	lblDiffiInfoM.style.fontSize = lblDifNameInfoM.style.fontSize;
 	lblCommentInfoM.style.top = `${getStrHeight(lblDifNameInfoM.innerHTML, parseFloat(lblDifNameInfoM.style.fontSize))}px`;
 	lblCommentInfoM.innerHTML = convertStrToVal(g_headerObj[`commentVal${g_settings.musicIdxNum}`]);

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -305,7 +305,7 @@ const updateWindowSiz = () => {
             w: 180, siz: 12, align: C_ALIGN_LEFT, pointerEvents: C_DIS_AUTO, lineHeight: `16px`,
         },
         lblDiffiInfoM: {
-            x: 180, w: 20, siz: 12, align: C_ALIGN_RIGHT, lineHeight: `16px`,
+            x: 180, w: 20, siz: 12, align: C_ALIGN_RIGHT, lineHeight: `16px`, fontWeight: `bold`,
         },
         lblNotesInfoM: {
             x: 220, w: 150, siz: 12, align: C_ALIGN_LEFT, lineHeight: `16px`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -302,13 +302,13 @@ const updateWindowSiz = () => {
             overflow: C_DIS_AUTO, whiteSpace: `normal`,
         },
         lblDifNameInfoM: {
-            w: 180, siz: 12, align: C_ALIGN_LEFT, pointerEvents: C_DIS_AUTO,
+            w: 180, siz: 12, align: C_ALIGN_LEFT, pointerEvents: C_DIS_AUTO, lineHeight: `16px`,
         },
         lblDiffiInfoM: {
-            x: 180, w: 20, siz: 12, align: C_ALIGN_RIGHT,
+            x: 180, w: 20, siz: 12, align: C_ALIGN_RIGHT, lineHeight: `16px`,
         },
         lblNotesInfoM: {
-            x: 220, w: 150, siz: 12, align: C_ALIGN_LEFT,
+            x: 220, w: 150, siz: 12, align: C_ALIGN_LEFT, lineHeight: `16px`,
         },
         lblCommentInfoM: {
             siz: g_limitObj.difSelectorSiz, align: C_ALIGN_LEFT, pointerEvents: C_DIS_AUTO,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -302,7 +302,7 @@ const updateWindowSiz = () => {
             overflow: C_DIS_AUTO, whiteSpace: `normal`,
         },
         lblDifNameInfoM: {
-            w: 180, siz: 12, align: C_ALIGN_LEFT,
+            w: 180, siz: 12, align: C_ALIGN_LEFT, pointerEvents: C_DIS_AUTO,
         },
         lblDiffiInfoM: {
             x: 180, w: 20, siz: 12, align: C_ALIGN_RIGHT,
@@ -311,7 +311,7 @@ const updateWindowSiz = () => {
             x: 220, w: 150, siz: 12, align: C_ALIGN_LEFT,
         },
         lblCommentInfoM: {
-            siz: g_limitObj.difSelectorSiz, align: C_ALIGN_LEFT,
+            siz: g_limitObj.difSelectorSiz, align: C_ALIGN_LEFT, pointerEvents: C_DIS_AUTO,
         },
         btnBgmMute: {
             x: g_btnX() + 90, y: g_sHeight - 105, w: 40, h: 35, siz: 30,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -301,6 +301,18 @@ const updateWindowSiz = () => {
             siz: g_limitObj.difSelectorSiz, align: C_ALIGN_LEFT,
             overflow: C_DIS_AUTO, whiteSpace: `normal`,
         },
+        lblDifNameInfoM: {
+            w: 180, siz: 12, align: C_ALIGN_LEFT,
+        },
+        lblDiffiInfoM: {
+            x: 180, w: 20, siz: 12, align: C_ALIGN_RIGHT,
+        },
+        lblNotesInfoM: {
+            x: 220, w: 150, siz: 12, align: C_ALIGN_LEFT,
+        },
+        lblCommentInfoM: {
+            siz: g_limitObj.difSelectorSiz, align: C_ALIGN_LEFT,
+        },
         btnBgmMute: {
             x: g_btnX() + 90, y: g_sHeight - 105, w: 40, h: 35, siz: 30,
         },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. 選曲画面で楽曲別コメントの上部に譜面情報を追加
- 楽曲別のコメントの上部に譜面情報を掲載するように変更しました。
- 新たに難易度を指定できるようになっています。指定方法はdifDataの製作者表記の拡張にて行います。
- この難易度指定は選曲画面時以外では現状使用しません。
```
|difData=
14,Normal::ティックル::9,3.5,70,2,10$14,Hard::tickle::17,3.5,70,2,14
9A,Hard::::7,3.5,70,2,10
```

### 2. 選曲画面について難易度配色の機能を追加
- 難易度配色の機能を追加しています。
- カンマ区切りでグループ、さらにスラッシュ区切りで境界難易度と色のペアを指定します。
- 境界値は「未満」で表記します（作品一覧と同じ）。
- 色の指定がない場合はデフォルト色になります。
```
|difColor=5/,10/#9999ff,15/#ff9999,20/#ffff00,25/#cc99ff|
```

### 3. 譜面別のカスタムリンク機能を追加
- 譜面別のリンク機能を追加しました。
- 現状、多様な使われ方をしていることから別窓とし、リンクを譜面ヘッダーで指定する形としました。

```
|difCustomLink=
4,https://xxxx.ne.jp/danonitest/x003_musicSelectTest.html?scoreId=4
5,https://xxxx.ne.jp/danonitest/x003_musicSelectTest.html?scoreId=5
|
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 実際の選曲画面での利用状況に合わせるため。
2. 1.と同様の理由です。
3. 1.と同様の理由です。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/66cf48e4-b0f7-4f0e-8540-dfe5690ee3e1" />
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/c68043aa-5997-4941-ba03-8d1b7f8057d7" />
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/1091451c-3da4-4a30-8918-6e060d2812b9" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
