### PR TITLE
fix: [1053] カスタムJSのフレーム毎処理で、エラーが発生したフレーム数がタイトルと結果画面のみ想定しない値になる問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -1206,7 +1206,7 @@ const safeExecuteCustomHooks = (_hookName, _funcArray, ...args) => {
 			} else if (errorCache && !errorCache[index]?.has(func)) {
 				// ループがある場合のエラー処理（初回のみ）
 				console.group(`${unEscapeEmoji(g_emojiObj.crossMark)} Custom Function Error: [${_hookName}] (Index: ${index}${func.name ? `, Func: ${func.name}` : ``})`);
-				console.error(`${unEscapeEmoji(g_emojiObj.policeLight)} [${g_scoreObj.baseFrame} Frame] ${g_msgObj.customFunctionError}`, e);
+				console.error(`${unEscapeEmoji(g_emojiObj.policeLight)} [${g_errorFrames[_hookName]()} Frame] ${g_msgObj.customFunctionError}`, e);
 				console.groupEnd();
 				errorCache[index] = new Set();
 				errorCache[index].add(func);

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -5036,6 +5036,12 @@ const g_errorCache = {
     'g_customJsObj.resultEnterFrame': [],
 };
 
+const g_errorFrames = {
+    'g_customJsObj.titleEnterFrame': () => g_scoreObj.titleFrameNum,
+    'g_customJsObj.mainEnterFrame': () => g_scoreObj.baseFrame,
+    'g_customJsObj.resultEnterFrame': () => g_scoreObj.resultFrameNum,
+};
+
 /**
  * 従来のカスタム関数をg_customJsObj, g_skinJsObjへ追加
  * - customjsファイルを読み込んだ直後にこの関数を呼び出している


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. カスタムJSのフレーム毎処理で、エラーが発生したフレーム数がタイトルと結果画面のみ想定しない値になる問題を修正
- 画面の種類によらず`g_scoreObj.baseFrame`を見るのではなく、
画面の種類によって変数を切り替えるように修正しました。


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 発生したフレーム数について、`g_scoreObj.baseFrame`を見ていましたが、
これはプレイ画面用であり、タイトルと結果画面用は別の変数のため、機能していませんでした。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- ver46.5.0での考慮漏れになります。