### PR TITLE
improve: [1055] ジャストフレームについてデバッグモード時のみ0フレームになるように見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4393,7 +4393,7 @@ const headerConvert = _dosObj => {
 		obj.playingLayout = g_presetObj.playingLayout ?? true;
 	}
 
-	// ジャストフレームの設定 (ローカル: 0フレーム, リモートサーバ上: 1フレーム以内)
+	// ジャストフレームの設定 (ローカル/デバッグ時: 0フレーム, 通常時: 1フレーム以内)
 	obj.justFrames = g_isDebug ? 0 : 1;
 
 	// リザルトデータのカスタマイズ

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4394,7 +4394,7 @@ const headerConvert = _dosObj => {
 	}
 
 	// ジャストフレームの設定 (ローカル: 0フレーム, リモートサーバ上: 1フレーム以内)
-	obj.justFrames = (g_isLocal) ? 0 : 1;
+	obj.justFrames = (g_isLocal || g_remoteFlg) ? 0 : 1;
 
 	// リザルトデータのカスタマイズ
 	obj.resultFormat = escapeHtmlForEnabledTag(_dosObj.resultFormat ?? g_presetObj.resultFormat ?? g_templateObj.resultFormatDf);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4394,7 +4394,7 @@ const headerConvert = _dosObj => {
 	}
 
 	// ジャストフレームの設定 (ローカル: 0フレーム, リモートサーバ上: 1フレーム以内)
-	obj.justFrames = (g_isLocal || g_remoteFlg) ? 0 : 1;
+	obj.justFrames = g_isDebug ? 0 : 1;
 
 	// リザルトデータのカスタマイズ
 	obj.resultFormat = escapeHtmlForEnabledTag(_dosObj.resultFormat ?? g_presetObj.resultFormat ?? g_templateObj.resultFormatDf);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. ジャストフレームについてデバッグモード時のみ0フレームになるように見直し
- ジャストフレームについて、デバッグモード時のみ1フレーム誤差でFast/Slowを表示するように変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. Dancing☆Onigiri Previewやデバッグモードでは実質ローカルと同様のため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
