### PR TITLE
fix: [1057] サイトの設定により譜面ミニマップが左寄せにならないことがある問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7758,6 +7758,8 @@ const drawMinimap = (_scoreId, _initFlg = false) => {
 	detailMiniMapSub.style.overflowX = 'hidden';
 	detailMiniMapSub.style.overflowY = 'auto';
 	detailMiniMapSub.style.pointerEvents = 'auto';
+	detailMiniMapSub.style.display = 'block';
+	detailMiniMapSub.style.textAlign = 'left';
 
 	if (savedCanvases && Array.isArray(savedCanvases)) {
 		// 退避したCanvasそのものをDOMに追加（再描画不要で高速）


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. サイトの設定により譜面ミニマップが左寄せにならないことがある問題を修正
- 親divにcenterタグなどがいる場合に、譜面ミニマップが左寄せにならずずれる事象が発生していました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 親divへの依存度を減らすため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
https://discord.com/channels/698460971231870977/944491021918683196/1495418454990389418