### PR TITLE
feat: [1061] 譜面ミニマップで、譜面切り替え時に現在のスクロール位置（割合）を保持するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7855,10 +7855,13 @@ const drawMinimap = (_scoreId, { _initFlg = false, _fadeinFlg = false } = {}) =>
 	const subEl = document.getElementById(`detailMiniMapSub`);
 	const currentScrollTop = subEl ? subEl.scrollTop : 0;
 
+	// 前の譜面でスクロール可能な状態だったかを判定
+	const hasPreviousScrollRange = subEl && subEl.scrollHeight > subEl.clientHeight;
+
 	// 前の譜面での「スクロール位置の比率」を計算
 	// 完全に一番上のときは 0、一番下のときは 1 となる比率
 	let progressRatio = 0;
-	if (subEl && subEl.scrollHeight > subEl.clientHeight) {
+	if (hasPreviousScrollRange) {
 		const rawRatio = currentScrollTop / (subEl.scrollHeight - subEl.clientHeight);
 		// リバース時は「上が終点」なので、進行度としては反転させる
 		progressRatio = isRev ? (1.0 - rawRatio) : rawRatio;
@@ -7928,7 +7931,7 @@ const drawMinimap = (_scoreId, { _initFlg = false, _fadeinFlg = false } = {}) =>
 		targetScrollTop = visualFadeinPos;
 	} else if (_initFlg) {
 		// 【譜面切替時】
-		if (currentScrollTop > 0) {
+		if (hasPreviousScrollRange) {
 			// 以前の進行度を継承
 			const visualRatio = isRev ? (1.0 - progressRatio) : progressRatio;
 			targetScrollTop = scrollHeight * visualRatio;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7837,18 +7837,37 @@ const makeHighScore = _scoreId => {
 	}
 };
 
-const drawMinimap = (_scoreId, _initFlg = false) => {
+/**
+ * 譜面ミニマップを描画し、適切なスクロール位置へ調整する。
+ * デフォルトはスクロール反転で、現在位置を保つように上下反転する。
+ * @param {string} _scoreId - 描画対象の譜面ID
+ * @param {object} [_options={}] - オプションパラメータ
+ * @param {boolean} [_options._initFlg=false] - 譜面切替モード
+ * - 前の譜面での演奏進行度（時間軸の比率）を算出し、新しい譜面でも同じ進行位置を表示する。
+ *   位置記憶がない場合はフェードイン設定に基づく初期位置を表示。
+ * @param {boolean} [_options._fadeinFlg=false] - フェードインモード。フェードイン設定値を優先して移動する。
+ */
+const drawMinimap = (_scoreId, { _initFlg = false, _fadeinFlg = false } = {}) => {
 	const detailMiniMap = document.getElementById(`detailMiniMap`);
 	if (detailMiniMap === null) return;   // scoreDetailUse=false 等で未生成の場合は何もしない
 
-	const currentScrollTop = document.getElementById(`detailMiniMapSub`)
-		? document.getElementById(`detailMiniMapSub`).scrollTop : 0;
+	const isRev = g_stateObj.miniMapRevFlg;
+	const subEl = document.getElementById(`detailMiniMapSub`);
+	const currentScrollTop = subEl ? subEl.scrollTop : 0;
+
+	// 前の譜面での「スクロール位置の比率」を計算
+	// 完全に一番上のときは 0、一番下のときは 1 となる比率
+	let progressRatio = 0;
+	if (subEl && subEl.scrollHeight > subEl.clientHeight) {
+		const rawRatio = currentScrollTop / (subEl.scrollHeight - subEl.clientHeight);
+		// リバース時は「上が終点」なので、進行度としては反転させる
+		progressRatio = isRev ? (1.0 - rawRatio) : rawRatio;
+	}
 
 	// 再描画のため一度クリア
 	deleteChildspriteAll(`detailMiniMap`);
 
-	// drawMinimap 内の Canvas 追加部分
-	const isRev = g_stateObj.miniMapRevFlg;
+	// --- ミニマップ生成/取得 (Lazy Generation) ---
 	let savedCanvases = isRev
 		? g_detailObj.scoreMinimapReverse[_scoreId]
 		: g_detailObj.scoreMinimap[_scoreId];
@@ -7875,20 +7894,18 @@ const drawMinimap = (_scoreId, _initFlg = false) => {
 	const detailMiniMapSub = createEmptySprite(detailMiniMap, `detailMiniMapSub`, g_windowObj.detailMiniMapSub);
 	$id(`detailMiniMapSub`).top = (g_stateObj.miniMapRevFlg ? 0 : 15) + `px`;
 
-	detailMiniMapSub.style.overflowX = 'hidden';
-	detailMiniMapSub.style.overflowY = 'auto';
-	detailMiniMapSub.style.pointerEvents = 'auto';
-	detailMiniMapSub.style.display = 'block';
-	detailMiniMapSub.style.textAlign = 'left';
+	Object.assign(detailMiniMapSub.style, {
+		overflowX: 'hidden',
+		overflowY: 'auto',
+		pointerEvents: 'auto',
+		display: 'block',
+		textAlign: 'left',
+	});
 
 	if (savedCanvases && Array.isArray(savedCanvases)) {
 		// 退避したCanvasそのものをDOMに追加（再描画不要で高速）
-		detailMiniMapSub.style.overflow = C_DIS_AUTO;
-		detailMiniMapSub.style.pointerEvents = C_DIS_AUTO;
 		savedCanvases.forEach(canvas => {
-			canvas.style.position = 'static';
-			canvas.style.display = 'block';
-			canvas.style.height = 'auto';
+			Object.assign(canvas.style, { position: 'static', display: 'block', height: 'auto' });
 			detailMiniMapSub.appendChild(canvas);
 		});
 	}
@@ -7901,16 +7918,36 @@ const drawMinimap = (_scoreId, _initFlg = false) => {
 		getStartFrame(lastFrame, g_stateObj.fadein, _scoreId) - firstArrowFrame
 	));
 	const fadeinScrollTop = scrollHeight * fadeinFrameOffset / playingFrame;
-	detailMiniMapSub.scrollTop = g_stateObj.miniMapRevFlg
-		? (_initFlg ? scrollHeight - currentScrollTop : scrollHeight - fadeinScrollTop)
-		: (_initFlg ? scrollHeight - currentScrollTop : fadeinScrollTop);
+	const visualFadeinPos = isRev ? scrollHeight - fadeinScrollTop : fadeinScrollTop;
+
+	// --- スクロール位置の決定ロジック
+	let targetScrollTop = 0;
+
+	if (_fadeinFlg) {
+		// 【最優先】フェードイン操作時：設定値を強制適用
+		targetScrollTop = visualFadeinPos;
+	} else if (_initFlg) {
+		// 【譜面切替時】
+		if (currentScrollTop > 0) {
+			// 以前の進行度を継承
+			const visualRatio = isRev ? (1.0 - progressRatio) : progressRatio;
+			targetScrollTop = scrollHeight * visualRatio;
+		} else {
+			// 初回はフェードイン位置
+			targetScrollTop = visualFadeinPos;
+		}
+	} else {
+		// 【リバース切替時】物理反転
+		targetScrollTop = scrollHeight - currentScrollTop;
+	}
+	detailMiniMapSub.scrollTop = targetScrollTop;
 
 	if (document.getElementById(`lnkMiniMapRev`) === null) {
 		scoreDetail.appendChild(
 			makeDifLblCssButton(`lnkMiniMapRev`, g_lblNameObj.s_rev + `${g_stateObj.miniMapRevFlg ? `↑` : `↓`}`, 8, () => {
 				g_stateObj.miniMapRevFlg = !g_stateObj.miniMapRevFlg;
 				lnkMiniMapRev.textContent = g_lblNameObj.s_rev + `${g_stateObj.miniMapRevFlg ? `↑` : `↓`}`;
-				drawMinimap(g_stateObj.scoreId, true);
+				drawMinimap(g_stateObj.scoreId);
 				createScText(lnkMiniMapRev, `MiniMapRev`, { targetLabel: `lnkMiniMapRev`, x: -12 });
 			}, g_lblPosObj.lnkMiniMapRev)
 		);
@@ -8106,7 +8143,7 @@ const setDifficulty = (_initFlg) => {
 		drawDensityGraph(g_stateObj.scoreId);
 		makeDifInfo(g_stateObj.scoreId);
 		makeHighScore(g_stateObj.scoreId);
-		drawMinimap(g_stateObj.scoreId);
+		drawMinimap(g_stateObj.scoreId, { _initFlg: true });
 	}
 
 	// 楽曲データの表示
@@ -8404,7 +8441,7 @@ const createOptionWindow = _sprite => {
 		fadeinSlider.value = g_stateObj.fadein;
 		lnkFadein.textContent = `${g_stateObj.fadein}${g_lblNameObj.percent}`;
 		updateSettingSummary();
-		drawMinimap(g_stateObj.scoreId);
+		drawMinimap(g_stateObj.scoreId, { _fadeinFlg: true });
 	};
 
 	multiAppend(spriteList.fadein,
@@ -8423,7 +8460,7 @@ const createOptionWindow = _sprite => {
 	fadeinSlider.addEventListener(`input`, () => {
 		g_stateObj.fadein = inputSlider(fadeinSlider, lnkFadein, `fadein`);
 		updateSettingSummary();
-		drawMinimap(g_stateObj.scoreId);
+		drawMinimap(g_stateObj.scoreId, { _fadeinFlg: true });
 	}, false);
 
 	// ---------------------------------------------------


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. 譜面ミニマップで、譜面切り替え時に現在のスクロール位置（割合）を保持するよう変更
- 譜面ミニマップにおけるスクロール保持ルールを変更しました。
    1. フェードイン設定を変更した場合：フェードインの割合に応じて位置変更
    2. 譜面を変更した場合：現在スクロール位置を維持するように位置変更　※今回追加
    3. 「MapScroll」を押した場合：現在時刻を維持するように上下を反転
- フェードインを変更した場合は、優先的に変更されます。
その後に同じ画面でスクロール移動させた場合は、最後のスクロール位置が基準になります。
その後にフェードイン変更や画面移動するとリセットされます。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 譜面間で比較したいときに有用であるため。（Discord要望より）
https://discord.com/channels/698460971231870977/944491021918683196/1496174944722358333

なお、譜面の組合せによっては開始位置や長さが異なり、そこまで追従するのは大変なので
現在のスクロール位置を崩さない形で位置移動する仕様としています。ほとんどの場合は問題にならないはずです。
（＝途中から開始する譜面がある場合は譜面変更した際に途中から開始する分、位置がずれることになります）

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
