### PR TITLE
improve: [1064] Canvasの解像度を上げて見やすくするよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7290,6 +7290,7 @@ const drawSpeedGraph = _scoreId => {
 		speed: { frame: [0], speed: [1], cnt: 0, strokeColor: g_graphColorObj.speed },
 		boost: { frame: [0], speed: [1], cnt: 0, strokeColor: g_graphColorObj.boost }
 	};
+	const dpr = window.devicePixelRatio || 1;
 
 	const tmpSpeedPoint = [0];
 	Object.keys(speedObj).forEach(speedType => {
@@ -8233,13 +8234,18 @@ const createOptionWindow = _sprite => {
 				const bkColor = window.getComputedStyle(textBaseObj, ``).backgroundColor;
 
 				graphObj.id = `graph${_name}${j > 0 ? j + 1 : ``}`;
-				graphObj.width = g_limitObj.graphWidth;
-				graphObj.height = g_limitObj.graphHeight;
+				const dpr = window.devicePixelRatio || 1;
+				graphObj.width = g_limitObj.graphWidth * dpr;
+				graphObj.height = g_limitObj.graphHeight * dpr;
+				graphObj.style.width = wUnit(g_limitObj.graphWidth);
+				graphObj.style.height = wUnit(g_limitObj.graphHeight);
 				graphObj.style.left = wUnit(125);
 				graphObj.style.top = wUnit(0);
 				graphObj.style.position = `absolute`;
 				graphObj.style.background = j === 0 ? bkColor : `#ffffff00`;
 				graphObj.style.border = `dotted ${wUnit(2)}`;
+				const ctx = graphObj.getContext(`2d`);
+				ctx.scale(dpr, dpr);
 
 				detailObj.appendChild(graphObj);
 			}
@@ -15737,15 +15743,19 @@ const resultInit = () => {
 		tmpDiv.style.background = `#000000cc`;
 		const canvas = document.createElement(`canvas`);
 		const artistName = g_headerObj.artistNames[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.artistName;
+		const dpr = window.devicePixelRatio || 1;
 
 		canvas.id = `resultImage`;
-		canvas.width = 400;
-		canvas.height = g_sHeight - 90;
-		canvas.style.left = wUnit((g_sWidth - canvas.width) / 2);
+		canvas.width = 400 * dpr;
+		canvas.height = (g_sHeight - 90) * dpr;
+		canvas.style.width = wUnit(400);
+		canvas.style.height = wUnit(g_sHeight - 90);
+		canvas.style.left = wUnit((g_sWidth - parseFloat(canvas.style.width)) / 2);
 		canvas.style.top = wUnit(20);
 		canvas.style.position = `absolute`;
 
 		const context = canvas.getContext(`2d`);
+		context.scale(dpr, dpr);
 		const drawText = (_text, { x = 30, dy = 0, hy, siz = 15, color = `#cccccc`, align = C_ALIGN_LEFT, font } = {}) => {
 			context.font = `${wUnit(siz)} ${getBasicFont(font)}`;
 			context.fillStyle = color;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -15744,12 +15744,14 @@ const resultInit = () => {
 		const canvas = document.createElement(`canvas`);
 		const artistName = g_headerObj.artistNames[g_headerObj.musicNos[g_stateObj.scoreId]] || g_headerObj.artistName;
 		const dpr = window.devicePixelRatio || 1;
+		const logicalWidth = 400;
+		const logicalHeight = g_sHeight - 90;
 
 		canvas.id = `resultImage`;
-		canvas.width = 400 * dpr;
-		canvas.height = (g_sHeight - 90) * dpr;
-		canvas.style.width = wUnit(400);
-		canvas.style.height = wUnit(g_sHeight - 90);
+		canvas.width = logicalWidth * dpr;
+		canvas.height = logicalHeight * dpr;
+		canvas.style.width = wUnit(logicalWidth);
+		canvas.style.height = wUnit(logicalHeight);
 		canvas.style.left = wUnit((g_sWidth - parseFloat(canvas.style.width)) / 2);
 		canvas.style.top = wUnit(20);
 		canvas.style.position = `absolute`;
@@ -15762,7 +15764,7 @@ const resultInit = () => {
 			context.textAlign = align;
 			context.fillText(_text, x, 35 + hy * 18 + dy);
 		};
-		makeBgCanvas(context, { h: canvas.height });
+		makeBgCanvas(context, { w: logicalWidth, h: logicalHeight });
 
 		drawText(`R`, { dy: -5, hy: 0, siz: 40, color: `#9999ff` });
 		drawText(`ESULT`, { x: 57, dy: -5, hy: 0, siz: 25 });


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. Canvasの解像度を上げて見やすくするよう変更
- 譜面密度グラフ、速度変化グラフ、リザルト画像で使っているCanvasについて、
解像度を上げて見やすくしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. にじみのような表示になっていたため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/4ebaca52-5daa-4595-bd67-5ec07738b7b7" /><img width="50%" alt="image" src="https://github.com/user-attachments/assets/ed765c63-39af-4516-a1ab-fd4f13af39a4" />
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/d0dc98b7-5a08-4110-8704-dafbd6e19c52" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- 仕組みとしては譜面ミニマップで行っている方法と同じです。