### PR TITLE
improve: [1067] 速度変化(逆走)により矢印の生成・到達の順序が崩れた場合にアラートを出す仕様に変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10760,7 +10760,8 @@ const loadingScoreInit = async () => {
 	g_workObj.arrowReversalList = [];
 	pushArrows(g_scoreObj, speedOnFrame, arrivalFrame);
 	if (g_workObj.arrowReversalList.length > 0) {
-		makeWarningWindow(g_msgInfoObj.E_0202.split(`{0}`).join(g_workObj.arrowReversalList.join(`<br>`)), { backBtnUse: true });
+		const escapedList = g_workObj.arrowReversalList.map(s => escapeHtml(s)).join(`<br>`);
+		makeWarningWindow(g_msgInfoObj.E_0202.split(`{0}`).join(escapedList), { backBtnUse: true });
 		return;
 	}
 
@@ -11919,9 +11920,11 @@ const pushArrows = (_dataObj, _speedOnFrame, _firstArrivalFrame) => {
 			// 「自分より後ろのノーツ」の方が、「自分」よりも早く出現する場合、
 			// 配列の順序と出現時間の順序が入れ替わっている（逆転）とみなす。
 			if (minNotesFrame < startPoint[k]) {
-				const target = `Lane: ${g_keyObj[`chara${g_keyObj.currentKey}_0`][_j]}_data, Index: ${k / setcnt + 1}, Frame: ${arrowArrivalFrm}`;
+				const laneName = g_keyObj[`chara${g_keyObj.currentKey}_${g_keyObj.currentPtn}`]?.[_j]
+					?? g_keyObj[`chara${g_keyObj.currentKey}_0`]?.[_j] ?? _j;
+				const target = escapeHtml(`Lane: ${laneName}_data, Index: ${k / setcnt + 1}, Frame: ${arrowArrivalFrm}`);
 				console.warn(`[${g_msgObj.reversalAlert}] ${target}`);
-				g_workObj.arrowReversalList.push(target);
+				g_workObj.arrowReversalList.push(`- ${target}`);
 			}
 
 			// 最小値を更新

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10757,7 +10757,12 @@ const loadingScoreInit = async () => {
 	calcLifeVals(g_fullArrows);
 
 	// 矢印・フリーズアロー・速度/色変化格納処理
+	g_workObj.arrowReversalList = [];
 	pushArrows(g_scoreObj, speedOnFrame, arrivalFrame);
+	if (g_workObj.arrowReversalList.length > 0) {
+		makeWarningWindow(g_msgInfoObj.E_0202.split(`{0}`).join(g_workObj.arrowReversalList.join(`<br>`)), { backBtnUse: true });
+		return;
+	}
 
 	// メインに入る前の最終初期化処理
 	getArrowSettings();
@@ -11858,6 +11863,7 @@ const pushArrows = (_dataObj, _speedOnFrame, _firstArrivalFrame) => {
 		g_workObj.arrivalFrame[frmPrev] = tmpObj.arrivalFrm;
 		g_workObj.motionFrame[frmPrev] = tmpObj.motionFrm;
 		g_workObj.initBoostY[frmPrev] = calcInitBoostY(frmPrev);
+		let minNotesFrame = startPoint[lastk];
 
 		if (_frzFlg) {
 			g_workObj[`mk${camelHeader}Length`][_j] = [];
@@ -11904,6 +11910,23 @@ const pushArrows = (_dataObj, _speedOnFrame, _firstArrivalFrame) => {
 				g_workObj.arrivalFrame[frmPrev] = tmpObj.arrivalFrm;
 				g_workObj.motionFrame[frmPrev] = tmpObj.motionFrm;
 				g_workObj.initBoostY[frmPrev] = calcInitBoostY(frmPrev);
+			}
+
+			// --- 逆転検知ロジック ---
+			// 後ろからループしているため、minNotesFrameには「自分より譜面上後ろにあるノーツ」の
+			// 最小生成フレーム（最も早く出現するもの）が入っている。
+
+			// 「自分より後ろのノーツ」の方が、「自分」よりも早く出現する場合、
+			// 配列の順序と出現時間の順序が入れ替わっている（逆転）とみなす。
+			if (minNotesFrame < startPoint[k]) {
+				const target = `Lane: ${g_keyObj[`chara${g_keyObj.currentKey}_0`][_j]}_data, Index: ${k / setcnt + 1}, Frame: ${arrowArrivalFrm}`;
+				console.warn(`[${g_msgObj.reversalAlert}] ${target}`);
+				g_workObj.arrowReversalList.push(target);
+			}
+
+			// 最小値を更新
+			if (startPoint[k] < minNotesFrame) {
+				minNotesFrame = startPoint[k];
 			}
 
 			// 出現タイミングを保存

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -4343,7 +4343,8 @@ const g_lang_msgInfoObj = {
         Undefined keymode is assigned to 7key.`,
 
         E_0201: `The color change target specified in the color change data does not exist. [pattern={0}] (E-0201)`,
-        E_0202: `Due to a velocity change (reverse playback), the order in which notes appear has been altered in some sections. Please review the velocity changes in the chart. (E-0202)<br>{0}`,
+        E_0202: `Due to a velocity change (reverse playback), the order in which notes appear has been altered in some sections. <br>` +
+            `Please review the velocity changes in the chart. (E-0202)<br>{0}`,
 
         I_0001: `Your result data is copied to the clipboard!`,
         I_0002: `The specified key cannot be assigned. Please specify another key.`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -4293,6 +4293,7 @@ const g_lang_msgInfoObj = {
         未定義のキーは7keyに割り当てられます。`,
 
         E_0201: `色変化データで指定した色変化対象が存在しません。[pattern={0}] (E-0201)`,
+        E_0202: `速度変化(逆走)により、ノーツの生成順序が入れ替わっている箇所があります。<br>譜面の速度変化を見直してください。(E-0202)<br>{0}`,
 
         I_0001: `リザルトデータをクリップボードにコピーしました！`,
         I_0002: `入力したキーは割り当てできません。他のキーを指定してください。`,
@@ -4342,6 +4343,7 @@ const g_lang_msgInfoObj = {
         Undefined keymode is assigned to 7key.`,
 
         E_0201: `The color change target specified in the color change data does not exist. [pattern={0}] (E-0201)`,
+        E_0202: `Due to a velocity change (reverse playback), the order in which notes appear has been altered in some sections. Please review the velocity changes in the chart. (E-0202)<br>{0}`,
 
         I_0001: `Your result data is copied to the clipboard!`,
         I_0002: `The specified key cannot be assigned. Please specify another key.`,
@@ -4865,6 +4867,7 @@ const g_lang_msgObj = {
         pickColorReset: `矢印・フリーズアローの配色を元に戻します。`,
 
         customFunctionError: `初回の実行エラーが発生しました。修正されるまでこの処理は無視されます。`,
+        reversalAlert: `矢印生成位置逆転アラート`,
     },
 
     En: {
@@ -4965,6 +4968,7 @@ const g_lang_msgObj = {
         pickColorReset: `Restore the color scheme for arrows and freeze arrows.`,
 
         customFunctionError: `An error occurred during the first execution. This process will be ignored until the error is resolved.`,
+        reversalAlert: `Arrow Generation Position Reversal Alert`,
     },
 
 };


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. 速度変化(逆走)により矢印の生成・到達の順序が崩れた場合にアラートを出す仕様に変更
- 本体の処理では、矢印・フリーズアローの生成順と到達順が同じであることが想定されていますが、
速度変化(逆走)により、生成順と到達順が異なることがあります。
この場合にプレイ時にエラーを出すことがあるため、ロード時に警告し止める処理を追加しました。

再現用データ
```
|left_data=200,230|down_data=|up_data=|right_data=|space_data=|frzLeft_data=|frzDown_data=|frzUp_data=|frzRight_data=|frzSpace_data=|
|speed_data=200,-1.2,215,1|boost_data=|
|es_keyKind=5|es_blankFrame=200|es_label=1|es_startNumber=0|es_bpm=120|es_pageBlockNumber=8|es_scoreNumber=1|es_scorePrefix=|
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. Discordでの指摘より。
https://discord.com/channels/698460971231870977/944491021918683196/1497347676675506277
根本的には修正が必要になりますが、大掛かりな修正が必要なため検知できる仕組みを追加することにしました。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/5effe876-565f-401a-9b53-c4abd6ab82e9" />

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/0d801b18-f636-4877-81d8-794837b8282a" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
