### PR TITLE
improve: [1072] 譜面明細画面のレイアウト調整

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7290,7 +7290,6 @@ const drawSpeedGraph = _scoreId => {
 		speed: { frame: [0], speed: [1], cnt: 0, strokeColor: g_graphColorObj.speed },
 		boost: { frame: [0], speed: [1], cnt: 0, strokeColor: g_graphColorObj.boost }
 	};
-	const dpr = window.devicePixelRatio || 1;
 
 	const tmpSpeedPoint = [0];
 	Object.keys(speedObj).forEach(speedType => {
@@ -7509,7 +7508,7 @@ const updateScoreDetailLabel = (_name, _label, _value, _pos = 0, _labelname = _l
 	const baseLabel = (_bLabel, _bLabelname, _bAlign) =>
 		document.getElementById(`detail${_name}`).appendChild(
 			createDivCss2Label(_bLabel, _bLabelname, {
-				x: 10, y: 110 + _pos * 20, w: 100, h: 20, siz: g_limitObj.difSelectorSiz, align: _bAlign,
+				x: 10, y: 130 + _pos * 16, w: 100, h: 16, siz: g_limitObj.difSelectorSiz, align: _bAlign,
 			})
 		);
 	if (document.getElementById(`data${_label}`) === null) {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -489,31 +489,31 @@ const updateWindowSiz = () => {
             x: 290, y: 145, w: 120, h: 20, siz: 50, align: C_ALIGN_CENTER,
         },
         lblSpdHeader: {
-            x: 5, y: 180, w: 100, h: 20, siz: g_limitObj.difSelectorSiz, align: C_ALIGN_LEFT,
+            x: 5, y: 190, w: 100, h: 20, siz: g_limitObj.difSelectorSiz, align: C_ALIGN_LEFT,
         },
         lblSpdBase: {
-            x: 0, y: 200, w: 40, h: 20, siz: 11.5, fontWeight: `bold`,
+            x: 0, y: 210, w: 40, h: 20, siz: 11.5, fontWeight: `bold`,
         },
         lblSpdOverall: {
-            x: 40, y: 200, w: 40, h: 20, siz: 11.5,
+            x: 40, y: 210, w: 40, h: 20, siz: 11.5,
             color: g_graphColorObj.speedChara, fontWeight: `bold`,
         },
         lblSpdBoost: {
-            x: 80, y: 200, w: 40, h: 20, siz: 11.5,
+            x: 80, y: 210, w: 40, h: 20, siz: 11.5,
             color: g_graphColorObj.boostChara, fontWeight: `bold`,
         },
         lblSpdTotal: {
-            x: 5, y: 215, w: 100, h: 20, siz: g_limitObj.difSelectorSiz,
+            x: 5, y: 225, w: 100, h: 20, siz: g_limitObj.difSelectorSiz,
             align: C_ALIGN_LEFT, fontWeight: `bold`,
         },
         lblSpdFrame: {
-            x: 70, y: 218, w: 50, h: 20, siz: 12, fontWeight: `bold`,
+            x: 70, y: 228, w: 50, h: 20, siz: 12, fontWeight: `bold`,
         },
         btnSpdCursorL: {
-            x: 85, y: 180, w: 15, h: 20, siz: 12,
+            x: 85, y: 190, w: 15, h: 20, siz: 12,
         },
         btnSpdCursorR: {
-            x: 100, y: 180, w: 15, h: 20, siz: 12,
+            x: 100, y: 190, w: 15, h: 20, siz: 12,
         },
         lnkMiniMapRev: {
             w: g_limitObj.difCoverWidth, h: 20, borderStyle: `solid`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. 譜面明細画面のレイアウト調整
- 譜面明細画面の文字間のレイアウトをやや狭くしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 今後のボタン拡張の余地を残すため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/254afafc-f459-453a-9c5b-cb88fbf199d7" /><img width="50%" alt="image" src="https://github.com/user-attachments/assets/55f97ae4-5842-4e86-b063-20d897bcd077" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
