### PR TITLE
improve: [1073] 譜面ミニマップ表示の改善、譜面明細画面のグラフのボーダーを廃止

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3385,7 +3385,7 @@ const storeBaseData = (_scoreId, _scoreObj, _keyCtrlPtn) => {
 			mmWidthBase: (g_sWidth - 500) / 2 + 290,
 			mmMarginY: 2,
 			get laneWidth() {
-				return Math.min(Math.floor((this.mmWidthBase - this.timeMargin) / keyNum), 40);
+				return Math.min((this.mmWidthBase - this.timeMargin) / keyNum, 40);
 			},
 			get logicalWidth() {
 				return this.timeMargin + (this.laneWidth * keyNum);
@@ -3510,7 +3510,7 @@ const createMinimapHeader = (_config, _keyCtrlPtn, _keyNum) => {
 	for (let j = 0; j < _keyNum; j++) {
 		// config.laneWidth を使って中央座標を計算
 		const x = timeMargin + j * laneWidth + laneWidth / 2;
-		const keyText = g_kCd[g_keyObj[`keyCtrl${_keyCtrlPtn}`][j][0]];
+		const keyText = g_kCd[g_keyObj[`keyCtrl${_keyCtrlPtn}`][j][0]].split(` `).join(``);
 
 		ctx.fillText(keyText, x, headerHeight / 2 + 2); // 視覚的な中央調整で +2px
 	}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3394,9 +3394,6 @@ const storeBaseData = (_scoreId, _scoreObj, _keyCtrlPtn) => {
 		},
 	};
 
-	// ヘッダー生成
-	g_detailObj.scoreMinimapHeader[_scoreId] = createMinimapHeader(g_detailObj.miniMapParams[_scoreId].config, _keyCtrlPtn, keyNum);
-
 	// Canvas保存用配列を空で初期化
 	g_detailObj.scoreMinimap[_scoreId] = null;
 	g_detailObj.scoreMinimapReverse[_scoreId] = null;
@@ -7880,9 +7877,14 @@ const drawMinimap = (_scoreId, { _initFlg = false, _fadeinFlg = false } = {}) =>
 		? g_detailObj.scoreMinimapReverse[_scoreId]
 		: g_detailObj.scoreMinimap[_scoreId];
 
+	const params = g_detailObj.miniMapParams[_scoreId];
+	const kPtn = params._keyCtrlPtn;
+	if (!g_detailObj.scoreMinimapHeader[kPtn]) {
+		// ヘッダーはキー種ごとに共通なので、未作成の場合のみ生成してキャッシュ
+		g_detailObj.scoreMinimapHeader[kPtn] = createMinimapHeader(params.config, kPtn, params._keyNum);
+	}
 	if (!savedCanvases) {
 		// 未作成の場合のみミニマップを生成（Lazy Generation）
-		const params = g_detailObj.miniMapParams[_scoreId];
 		savedCanvases = generateMinimapData(params, isRev);
 
 		// 生成したものをキャッシュに保存
@@ -7896,7 +7898,7 @@ const drawMinimap = (_scoreId, { _initFlg = false, _fadeinFlg = false } = {}) =>
 	// --- ヘッダー部分 ---
 	const detailMiniMapHeader = createEmptySprite(detailMiniMap, `detailMiniMapHeader`, g_windowObj.detailMiniMapHeader);
 	$id(`detailMiniMapHeader`).top = (g_stateObj.miniMapRevFlg ? 230 + g_sHeight - 500 : 0) + `px`;
-	detailMiniMapHeader.appendChild(g_detailObj.scoreMinimapHeader[_scoreId]);
+	detailMiniMapHeader.appendChild(g_detailObj.scoreMinimapHeader[kPtn]);
 
 	// --- メイン（譜面）部分 ---
 	const detailMiniMapSub = createEmptySprite(detailMiniMap, `detailMiniMapSub`, g_windowObj.detailMiniMapSub);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -3388,7 +3388,8 @@ const storeBaseData = (_scoreId, _scoreObj, _keyCtrlPtn) => {
 				return Math.min((this.mmWidthBase - this.timeMargin) / keyNum, 40);
 			},
 			get logicalWidth() {
-				return this.timeMargin + (this.laneWidth * keyNum);
+				const logicalWidth = this.timeMargin + (this.laneWidth * keyNum);
+				return Math.ceil(logicalWidth * this.dpr) / this.dpr;
 			}
 		},
 	};

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8243,7 +8243,6 @@ const createOptionWindow = _sprite => {
 				graphObj.style.top = wUnit(0);
 				graphObj.style.position = `absolute`;
 				graphObj.style.background = j === 0 ? bkColor : `#ffffff00`;
-				graphObj.style.border = `dotted ${wUnit(2)}`;
 				const ctx = graphObj.getContext(`2d`);
 				ctx.scale(dpr, dpr);
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. 譜面ミニマップ表示の改善
- 譜面ミニマップのキー別のレーン幅について、小数で丸めないように変更しました。
- 譜面ミニマップのキー表示で複数が同一キーにアサインされている場合の半角スペースをカットしました。

### 2. 譜面明細画面のグラフのボーダーを廃止
- 譜面密度グラフ、速度変化グラフのボーダーを廃止しました。

### 3. 譜面ミニマップのヘッダー部分の生成方法変更
- 譜面ミニマップのヘッダー部分について、キー種ごとに共通なため処理を見直しました。
- 後作成とすることで、customFontで指定したWebフォントなどが
読み込まれない可能性がある問題も解消しています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 見栄えの改善のため。
2. 譜面ミニマップとの整合のため。
3. 同じ処理の繰り返し作成を避けるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/c4e31b2f-bd61-4649-abca-b836ccb28f98" />

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/896a309c-dec5-4146-ac8b-8aeba28efe34" /><img width="50%" alt="image" src="https://github.com/user-attachments/assets/213fa518-5fb5-4df3-a45e-e8afb371375d" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
