### PR TITLE
fix: [1078] 譜面明細子画面のショートカットキーの下キーの初期カーソル位置誤りを修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4613,7 +4613,7 @@ const headerConvert = _dosObj => {
 	g_settings.scoreDetailCursorsOrg = g_settings.scoreDetailCursors.concat();
 	g_settings.scoreDetailCursors.push(`btnGraphB`);
 	[`option`, `difSelector`, `scoreDetail`].forEach(page => g_shortcutObj[page].KeyQ.id = g_settings.scoreDetailCursors[0]);
-	g_shortcutObj.scoreDetail.ArrowDown.id = g_settings.scoreDetailCursorsOrg[0];
+	g_shortcutObj.scoreDetail.ArrowDown.id = g_settings.scoreDetailCursorsOrg[nextPos(0, 1, g_settings.scoreDetailCursorsOrg.length)];
 	g_shortcutObj.scoreDetail.ArrowUp.id = g_settings.scoreDetailCursorsOrg[nextPos(0, -1, g_settings.scoreDetailCursorsOrg.length)];
 
 	// 判定位置をBackgroundのON/OFFと連動してリセットする設定


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. 譜面明細子画面のショートカットキーの下キーの初期カーソル位置誤りを修正
- 譜面明細子画面のショートカットキーの下キーについて、初期位置に誤りがあり、
初回のみ下キーを2回押さないと次の明細にならないようになっていました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. PR #2090 の考慮漏れです。 

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
