### PR TITLE
improve: [1082] SideScroll時の判定キャラクタ位置を変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -13220,6 +13220,10 @@ const mainInit = () => {
 		jdgY[0] += g_diffObj.arrowJdgY;
 		jdgY[1] += g_diffObj.frzJdgY;
 	}
+	if (g_stateObj.playWindow === `SideScroll`) {
+		jdgX[0] += 30;
+		jdgX[1] -= 60;
+	}
 
 	jdgGroups.forEach((jdg, j) => {
 		// キャラクタ表示


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. SideScroll時の判定キャラクタ位置を変更
- SideScrollのときの判定キャラクタ位置を通常よりやや中央寄りにしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. ステップゾーンと重なり、視認性がやや悪くなるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/c3c83969-e7fe-4627-aa20-b79ea7578ddc" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
