### PR TITLE
feat: [1085] キーコンフィグ画面にキーボードマッププレビューを追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10394,6 +10394,9 @@ const keyconfigKeyboardPreview = (() => {
 		mappedStroke: `#4488ff`,
 		mappedText: `#aaddff`,
 		bgFill: `#0d0d1a`,
+		altFill: `#3e3e1a`,
+		altStroke: `#777755`,
+		altText: `#eeeecc`,
 		legendText: `#888899`,
 	};
 
@@ -10409,7 +10412,7 @@ const keyconfigKeyboardPreview = (() => {
 	// Y: g_sHeight に対して垂直センタリング（init で動的計算）
 
 	// 凡例エリアの高さ
-	const LEGEND_H = 22;
+	const LEGEND_H = 25;
 
 	// -------------------------------------------------------------------------
 	// キーレイアウト定義
@@ -10482,7 +10485,7 @@ const keyconfigKeyboardPreview = (() => {
 				{ kc: 82, w: 1 }, { kc: 84, w: 1 }, { kc: 89, w: 1 },
 				{ kc: 85, w: 1 }, { kc: 73, w: 1 }, { kc: 79, w: 1 },
 				{ kc: 80, w: 1 }, { kc: 192, w: 1 }, { kc: 219, w: 1 },
-				{ kc: 13, w: 1.25 },
+				{ kc: 13, w: 1.25, h: () => g_localeObj.val === `Ja` ? 2 : 1 },  // Enter（日本語配列は縦長）
 			],
 		},
 		// Row3: ASDF
@@ -10541,7 +10544,8 @@ const keyconfigKeyboardPreview = (() => {
 	// -------------------------------------------------------------------------
 	const _state = {
 		visible: false,
-		mappedSet: new Set(),
+		mappedSet: new Set(),   // メインキー（各矢印の index 0）
+		altSet: new Set(),   // 代替キー（各矢印の index 1 以降）
 		canvasBase: null,
 		canvasMap: null,
 		keyRects: [],     // { kc, x, y, w, h, label } — drawMap で照合するキャッシュ
@@ -10619,7 +10623,7 @@ const keyconfigKeyboardPreview = (() => {
 	// -------------------------------------------------------------------------
 
 	const kw = w => Math.floor(w * BASE_KEY_W * _state.scale + (w - 1) * BASE_KEY_GAP * _state.scale);
-	const kh = () => Math.floor(BASE_KEY_H * _state.scale);
+	const kh = h => Math.floor(h * BASE_KEY_H * _state.scale + (h - 1) * BASE_KEY_GAP * _state.scale);
 	const kg = () => Math.max(1, Math.round(BASE_KEY_GAP * _state.scale));
 	const kr = () => Math.max(2, Math.round(4 * _state.scale));
 
@@ -10656,8 +10660,7 @@ const keyconfigKeyboardPreview = (() => {
 		ctx.fillText(primary, x + keyW / 2, y + keyH / 2 + (sub ? 2 : 0));
 	};
 
-	const drawOneKey = (ctx, x, y, keyW, fill, stroke, lw, primary, sub, textColor, subColor) => {
-		const keyH = kh();
+	const drawOneKey = (ctx, x, y, keyW, keyH, fill, stroke, lw, primary, sub, textColor, subColor) => {
 		roundRect(ctx, x + 0.5, y + 0.5, keyW - 1, keyH - 1, kr());
 		ctx.fillStyle = fill;
 		ctx.strokeStyle = stroke;
@@ -10682,17 +10685,18 @@ const keyconfigKeyboardPreview = (() => {
 	 */
 	const layoutSection = (ctx, rows, originX, originY) => {
 		const gap = kg();
-		const keyH = kh();
+		const baseKeyH = kh(1);
 
 		rows.forEach((rowDef, rowIdx) => {
 			if (rowDef.keys.length === 0) return;
 
-			const rowY = originY + rowIdx * (keyH + gap);
+			const rowY = originY + rowIdx * (baseKeyH + gap);
 			const startX = originX + Math.floor(rowDef.offsetX * BASE_KEY_W * _state.scale);
 			let curX = startX;
 
 			rowDef.keys.forEach(keyDef => {
 				const keyW = kw(keyDef.w);
+				const keyH = kh(typeof keyDef.h === C_TYP_FUNCTION ? keyDef.h() : keyDef.h || 1);
 
 				if (keyDef.kc >= 0) {
 					_state.keyRects.push({
@@ -10705,7 +10709,7 @@ const keyconfigKeyboardPreview = (() => {
 					});
 					const [primary, sub] = getKeyLabels(keyDef.kc, keyDef.label);
 					drawOneKey(
-						ctx, curX, rowY, keyW,
+						ctx, curX, rowY, keyW, keyH,
 						C_COLOR.keyFill, C_COLOR.keyStroke, 1,
 						primary, sub, C_COLOR.keyText, C_COLOR.keySubText
 					);
@@ -10767,7 +10771,7 @@ const keyconfigKeyboardPreview = (() => {
 		ctx.fillStyle = C_COLOR.legendText;
 		ctx.fillText(g_lblNameObj.unallocated, 22, ly + 5);
 
-		roundRect(ctx, 95, ly, 10, 10, 2);
+		roundRect(ctx, 95, ly - 5, 10, 10, 2);
 		ctx.fillStyle = C_COLOR.mappedFill;
 		ctx.fill();
 		ctx.strokeStyle = C_COLOR.mappedStroke;
@@ -10775,11 +10779,21 @@ const keyconfigKeyboardPreview = (() => {
 		ctx.stroke();
 		ctx.fillStyle = C_COLOR.legendText;
 		ctx.fillText(g_lblNameObj.allocated, 109, ly + 5);
+
+		roundRect(ctx, 195, ly - 5, 10, 10, 2);
+		ctx.fillStyle = C_COLOR.altFill;
+		ctx.fill();
+		ctx.strokeStyle = C_COLOR.altStroke;
+		ctx.lineWidth = 1;
+		ctx.stroke();
+		ctx.fillStyle = C_COLOR.legendText;
+		ctx.fillText(g_lblNameObj.altAllocated, 209, ly + 5);
 	};
 
 	/**
 	 * マッピング強調レイヤーを再描画する。
-	 * _state.keyRects と _state.mappedSet を照合して強調表示する。
+	 * メインキー（mappedSet）と代替キー（altSet）を色分けして描画する。
+	 * 同一キーにメインと代替が重なる場合はメインを優先する。
 	 */
 	const drawMap = () => {
 		const canvas = _state.canvasMap;
@@ -10796,20 +10810,25 @@ const keyconfigKeyboardPreview = (() => {
 		ctx.scale(dpr, dpr);
 		ctx.clearRect(0, 0, _state.cvsW, _state.cvsH);
 
-		_state.keyRects.forEach(rect => {
-			if (!_state.mappedSet.has(rect.kc)) return;
+		// 代替キーを先に描画し、メインキーを上書きすることで優先度を表現
+		const drawKey = (fill, stroke, text) => rect => {
 			const [primary, sub] = getKeyLabels(rect.kc, rect.label);
 			roundRect(ctx, rect.x + 0.5, rect.y + 0.5, rect.w - 1, rect.h - 1, kr());
-			ctx.fillStyle = C_COLOR.mappedFill;
-			ctx.strokeStyle = C_COLOR.mappedStroke;
+			ctx.fillStyle = fill;
+			ctx.strokeStyle = stroke;
 			ctx.lineWidth = 1.5;
 			ctx.fill();
 			ctx.stroke();
-			drawKeyLabel(
-				ctx, rect.x, rect.y, rect.w, rect.h,
-				primary, sub, C_COLOR.mappedText, C_COLOR.mappedText
-			);
-		});
+			drawKeyLabel(ctx, rect.x, rect.y, rect.w, rect.h, primary, sub, text, text);
+		};
+
+		_state.keyRects
+			.filter(rect => _state.altSet.has(rect.kc) && !_state.mappedSet.has(rect.kc))
+			.forEach(drawKey(C_COLOR.altFill, C_COLOR.altStroke, C_COLOR.altText));
+
+		_state.keyRects
+			.filter(rect => _state.mappedSet.has(rect.kc))
+			.forEach(drawKey(C_COLOR.mappedFill, C_COLOR.mappedStroke, C_COLOR.mappedText));
 	};
 
 	// -------------------------------------------------------------------------
@@ -10894,9 +10913,12 @@ const keyconfigKeyboardPreview = (() => {
 			g_keyObj[`keyGroupOrder${tkObj.keyCtrlPtn}`] ?? tkObj.keyGroupList;
 		const ctrl = g_keyObj[`keyCtrl${tkObj.keyCtrlPtn}`]
 			.filter((val, idx) => tkObj.keyGroupMaps[idx].includes(configKeyGroupList[g_keycons.keySwitchNum]));
-		_state.mappedSet = ctrl
-			? new Set(ctrl.flat().filter(v => v > 0))
-			: new Set();
+
+		// index 0 がメインキー、index 1 以降が代替キー
+		_state.mappedSet = new Set(ctrl.map(arr => arr[0]).filter(v => v > 0));
+		_state.altSet = new Set(
+			ctrl.flatMap(arr => arr.slice(1)).filter(v => v > 0)
+		);
 		if (_state.visible) drawMap();
 	};
 
@@ -10907,6 +10929,7 @@ const keyconfigKeyboardPreview = (() => {
 	const dispose = () => {
 		_state.visible = false;
 		_state.mappedSet = new Set();
+		_state.altSet = new Set();
 		_state.keyRects = [];
 		_state.canvasBase = null;
 		_state.canvasMap = null;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10440,91 +10440,154 @@ const keyconfigKeyboardPreview = (() => {
 	//   ASDF    0u  CapsLk を 2.25u にして L)Shift 左端と揃える
 	//   ZXCV    0.25u  標準キーボードの行オフセットを offsetX + L)Shift 拡大で再現
 	//   スペース行 0u
-	const MAIN_ROWS = [
-		// Row0: Fn キー行
-		{
-			offsetX: 0,
-			keys: [
-				{ kc: 27, w: 1 },                   // Esc
-				{ kc: -1, w: 0.5 },                   // スペーサー
-				{ kc: 112, w: 1 }, { kc: 113, w: 1 }, { kc: 114, w: 1 }, { kc: 115, w: 1 },
-				{ kc: -1, w: 0.25 },                   // スペーサー
-				{ kc: 116, w: 1 }, { kc: 117, w: 1 }, { kc: 118, w: 1 }, { kc: 119, w: 1 },
-				{ kc: -1, w: 0.25 },                   // スペーサー
-				{ kc: 120, w: 1 }, { kc: 121, w: 1 }, { kc: 122, w: 1 }, { kc: 123, w: 1 },
-			],
-		},
-		// Row1: 数字行
-		{
-			offsetX: 0,
-			keys: [
-				{ kc: 229, w: 1 },
-				{ kc: 49, w: 1 }, { kc: 50, w: 1 }, { kc: 51, w: 1 },
-				{ kc: 52, w: 1 }, { kc: 53, w: 1 }, { kc: 54, w: 1 },
-				{ kc: 55, w: 1 }, { kc: 56, w: 1 }, { kc: 57, w: 1 },
-				{ kc: 48, w: 1 }, { kc: 189, w: 1 }, { kc: 222, w: 1 }, { kc: 220, w: 0.75 },
-				{ kc: 8, w: 1.5 },
-			],
-		},
-		// Row2: QWERTY（Tab=1.5u、左端は数字行と揃う）
-		{
-			offsetX: 0,
-			keys: [
-				{ kc: 9, w: 1.5 },
-				{ kc: 81, w: 1 }, { kc: 87, w: 1 }, { kc: 69, w: 1 },
-				{ kc: 82, w: 1 }, { kc: 84, w: 1 }, { kc: 89, w: 1 },
-				{ kc: 85, w: 1 }, { kc: 73, w: 1 }, { kc: 79, w: 1 },
-				{ kc: 80, w: 1 }, { kc: 192, w: 1 }, { kc: 219, w: 1 }, { kc: -1, w: 0.5 },
-				{ kc: 13, w: 1.25, h: () => g_localeObj.val === `Ja` ? 2 : 1 },  // JIS配列は縦長
-			],
-		},
-		// Row3: ASDF（CapsLk を 2.25u にして L)Shift 左端と揃える）
-		{
-			offsetX: 0,
-			keys: [
-				{ kc: 20, w: 2.25, label: `CapsLk` },
-				{ kc: 65, w: 1 }, { kc: 83, w: 1 }, { kc: 68, w: 1 },
-				{ kc: 70, w: 1 }, { kc: 71, w: 1 }, { kc: 72, w: 1 },
-				{ kc: 74, w: 1 }, { kc: 75, w: 1 }, { kc: 76, w: 1 },
-				{ kc: 187, w: 1 }, { kc: 186, w: 1 }, { kc: 221, w: 1 },
-			],
-		},
-		// Row4: ZXCV（標準配列は ASDF より約 0.25u 右にオフセット）
-		{
-			offsetX: 0.25,
-			keys: [
-				{ kc: 16, w: 2.5 },
-				{ kc: 90, w: 1 }, { kc: 88, w: 1 }, { kc: 67, w: 1 },
-				{ kc: 86, w: 1 }, { kc: 66, w: 1 }, { kc: 78, w: 1 },
-				{ kc: 77, w: 1 }, { kc: 188, w: 1 }, { kc: 190, w: 1 },
-				{ kc: 191, w: 1 }, { kc: 226, w: 1 },
-				{ kc: 256, w: 1.25 },
-			],
-		},
-		// Row5: スペースバー行
-		{
-			offsetX: 0,
-			keys: [
-				{ kc: 17, w: 1.25 },
-				{ kc: 91, w: 1 },
-				{ kc: 18, w: 1 },
-				{ kc: 32, w: 7.25 },
-				{ kc: 258, w: 1 },
-				{ kc: 91, w: 1 },
-				{ kc: 257, w: 1.25 },
-			],
-		},
-	];
-
+	//
+	// JIS と US の主な違い:
+	//   数字行: JIS は intlYen(220) あり、US はなし（BackSpace が広い）
+	//   QWERTY: JIS は [ の右にスペーサー、US はなし（Enter が横長）
+	//   ASDF  : JIS は ¥(221) あり、US はなし（Enter が横長）
+	//   ZXCV  : JIS は intlRo(226) あり、US はなし（R)Shift が広い）
+	//   Enter : JIS は縦長(h=2)、US は横長(h=1, w=2.25)
+	/**
+	 * g_localeObj.val に応じた MAIN_ROWS を生成して返す。
+	 * drawBase / calcScale の都度呼び出し、locale 変化を反映する。
+	 *
+	 * @returns {Array} MAIN_ROWS 相当の配列
+	 */
+	const buildMainRows = () => {
+		const isJa = g_localeObj.val === `Ja`;
+		return [
+			// Row0: Fn キー行（JIS/US 共通）
+			{
+				offsetX: 0,
+				keys: [
+					{ kc: 27, w: 1 },                   // Esc
+					{ kc: -1, w: 0.5 },                   // スペーサー
+					{ kc: 112, w: 1 }, { kc: 113, w: 1 }, { kc: 114, w: 1 }, { kc: 115, w: 1 },
+					{ kc: -1, w: 0.25 },                   // スペーサー
+					{ kc: 116, w: 1 }, { kc: 117, w: 1 }, { kc: 118, w: 1 }, { kc: 119, w: 1 },
+					{ kc: -1, w: 0.25 },                   // スペーサー
+					{ kc: 120, w: 1 }, { kc: 121, w: 1 }, { kc: 122, w: 1 }, { kc: 123, w: 1 },
+				],
+			},
+			// Row1: 数字行
+			// JIS: ..., 222, 220(intlYen, 0.75u), BS(1.5u)
+			// US : ..., 222,                      BS(2.25u)
+			{
+				offsetX: 0,
+				keys: [
+					{ kc: 229, w: 1 },
+					{ kc: 49, w: 1 }, { kc: 50, w: 1 }, { kc: 51, w: 1 },
+					{ kc: 52, w: 1 }, { kc: 53, w: 1 }, { kc: 54, w: 1 },
+					{ kc: 55, w: 1 }, { kc: 56, w: 1 }, { kc: 57, w: 1 },
+					{ kc: 48, w: 1 }, { kc: 189, w: 1 }, { kc: 222, w: 1 },
+					...(isJa
+						? [{ kc: 220, w: 0.75 }, { kc: 8, w: 1.5 }]  // JIS: intlYen + BS
+						: [{ kc: 8, w: 2.25 }]   // US : BS のみ（広い）
+					),
+				],
+			},
+			// Row2: QWERTY
+			// JIS: ..., [, スペーサー(0.5u), Enter(縦長 h=2, w=1.25)
+			// US : ..., [, ]
+			{
+				offsetX: 0,
+				keys: [
+					{ kc: 9, w: 1.5 },
+					{ kc: 81, w: 1 }, { kc: 87, w: 1 }, { kc: 69, w: 1 },
+					{ kc: 82, w: 1 }, { kc: 84, w: 1 }, { kc: 89, w: 1 },
+					{ kc: 85, w: 1 }, { kc: 73, w: 1 }, { kc: 79, w: 1 },
+					{ kc: 80, w: 1 }, { kc: 192, w: 1 },
+					...(isJa
+						? [{ kc: 219, w: 1 }, { kc: -1, w: 0.5 }, { kc: 13, w: 1.25, h: 2 }]  // JIS: [, スペーサー, Enter縦長
+						: [{ kc: 219, w: 1 }, { kc: 221, w: 1 }]  // US : [, ]
+					),
+				],
+			},
+			// Row3: ASDF
+			// JIS: ..., L, ;, ', ¥(221)
+			// US : ..., L, ;, '      ← ¥なし（Enter が下まで伸びる縦長分を吸収）
+			{
+				offsetX: 0,
+				keys: [
+					{ kc: 20, w: 2.25, label: `CapsLk` },
+					{ kc: 65, w: 1 }, { kc: 83, w: 1 }, { kc: 68, w: 1 },
+					{ kc: 70, w: 1 }, { kc: 71, w: 1 }, { kc: 72, w: 1 },
+					{ kc: 74, w: 1 }, { kc: 75, w: 1 }, { kc: 76, w: 1 },
+					{ kc: 187, w: 1 }, { kc: 186, w: 1 },
+					...(isJa
+						? [{ kc: 221, w: 1 }]  // JIS: ¥
+						: [{ kc: 13, w: 2.25 }] // US : Enter横長
+					),
+				],
+			},
+			// Row4: ZXCV（標準配列は ASDF より約 0.25u 右にオフセット）
+			// JIS: ..., /, intlRo(226), R)Shift(1.25u)
+			// US : ..., /,              R)Shift(2.5u)
+			{
+				offsetX: 0.25,
+				keys: [
+					{ kc: 16, w: 2.5 },
+					{ kc: 90, w: 1 }, { kc: 88, w: 1 }, { kc: 67, w: 1 },
+					{ kc: 86, w: 1 }, { kc: 66, w: 1 }, { kc: 78, w: 1 },
+					{ kc: 77, w: 1 }, { kc: 188, w: 1 }, { kc: 190, w: 1 },
+					{ kc: 191, w: 1 },
+					...(isJa
+						? [{ kc: 226, w: 1 }, { kc: 256, w: 1.25 }]  // JIS: intlRo + R)Shift
+						: [{ kc: 256, w: 2.5 }]   // US : R)Shift のみ（広い）
+					),
+				],
+			},
+			// Row5: スペースバー行（JIS/US 共通）
+			{
+				offsetX: 0,
+				keys: [
+					{ kc: 17, w: 1.25 },
+					{ kc: 91, w: 1 },
+					{ kc: 18, w: 1 },
+					...(isJa
+						? [
+							{ kc: 29, w: 1 },
+							{ kc: 32, w: 5.25 },
+							{ kc: 28, w: 1 },
+							{ kc: 242, w: 1 },
+						]
+						: [
+							{ kc: 32, w: 8.25 },
+						]
+					),
+					{ kc: 258, w: 1 },
+					{ kc: 91, w: 1 },
+					{ kc: 257, w: 1.25 },
+				],
+			},
+		];
+	};
 	// 編集キークラスター（Insert/Delete/Home/End/PgUp/PgDn + 矢印キー）
 	// MAIN_ROWS と行インデックスを揃えて配置する。空行はスキップされる。
 	const NAV_ROWS = [
+		{ offsetX: 0, keys: [{ kc: 44, w: 1, label: `PrintSc` }, { kc: 145, w: 1, label: `ScrollLk` }, { kc: 19, w: 1 }] },  // PrintSc ScrollLk Pause
 		{ offsetX: 0, keys: [{ kc: 45, w: 1 }, { kc: 36, w: 1 }, { kc: 33, w: 1 }] },  // Insert Home PgUp
 		{ offsetX: 0, keys: [{ kc: 46, w: 1 }, { kc: 35, w: 1 }, { kc: 34, w: 1 }] },  // Delete End  PgDn
-		{ offsetX: 0, keys: [] },                                                          // QWERTY行：空
 		{ offsetX: 0, keys: [] },                                                          // ASDF行：空
 		{ offsetX: 0, keys: [{ kc: -1, w: 1 }, { kc: 38, w: 1 }, { kc: -1, w: 1 }] },  // ↑
 		{ offsetX: 0, keys: [{ kc: 37, w: 1 }, { kc: 40, w: 1 }, { kc: 39, w: 1 }] },  // ← ↓ →
+	];
+
+	// テンキー（Space行の下に余白を空けて横に羅列）
+	// kc は g_kCd 定義に従う: 96〜111=テンキー各種, 144=NumLk
+	// 標準テンキーレイアウト:
+	//   [NumLk] [T/] [T*] [T-]
+	//   [T7][T8][T9] [T+]
+	//   [T4][T5][T6] [T+]  ← T+ は縦2u
+	//   [T1][T2][T3] [TEnter]
+	//   [  T0  ][T_] [TEnter]  ← T0 は横2u、TEnter は縦2u
+	const NUM_ROWS = [
+		{ offsetX: 0, keys: [] },
+		{ offsetX: 0, keys: [{ kc: 144, w: 1 }, { kc: 111, w: 1 }, { kc: 106, w: 1 }, { kc: 109, w: 1 }] },  // NumLk T/ T* T-
+		{ offsetX: 0, keys: [{ kc: 103, w: 1 }, { kc: 104, w: 1 }, { kc: 105, w: 1 }, { kc: 107, w: 1, h: 2 }] },  // T7 T8 T9 T+(縦2u)
+		{ offsetX: 0, keys: [{ kc: 100, w: 1 }, { kc: 101, w: 1 }, { kc: 102, w: 1 }] },                           // T4 T5 T6
+		{ offsetX: 0, keys: [{ kc: 97, w: 1 }, { kc: 98, w: 1 }, { kc: 99, w: 1 }, { kc: 108, w: 1, h: 2 }] }, // T1 T2 T3 TEnter(縦2u)
+		{ offsetX: 0, keys: [{ kc: 96, w: 2 }, { kc: 110, w: 1 }] },                           // T0(横2u) T.
 	];
 
 	// -------------------------------------------------------------------------
@@ -10558,26 +10621,39 @@ const keyconfigKeyboardPreview = (() => {
 	const BASE_KEY_W = 28;
 	const BASE_KEY_H = 28;
 	const BASE_KEY_GAP = 3;
+	const MAIN_ROWS_LEN = 6;  // MAIN_ROWS の行数（Fn行を含む）
 
-	// MAIN_ROWS で最も横幅が広い行の幅を計算（スペーサー含む）
+	// 行幅計算（スペーサー含む）
 	const calcRowBaseW = row =>
 		row.keys.reduce((acc, k) => acc + k.w * BASE_KEY_W + BASE_KEY_GAP, -BASE_KEY_GAP);
 
-	const BASE_MAIN_W = Math.max(...MAIN_ROWS.map(calcRowBaseW));
 	const BASE_NAV_W = 3 * BASE_KEY_W + 2 * BASE_KEY_GAP;  // NAV は 3列固定
-	const BASE_TOTAL_W = BASE_MAIN_W + BASE_KEY_GAP * 2 + BASE_NAV_W + BASE_KEY_GAP * 2;
-	const BASE_TOTAL_H = MAIN_ROWS.length * (BASE_KEY_H + BASE_KEY_GAP) - BASE_KEY_GAP;
+	const BASE_ROW_H = MAIN_ROWS_LEN * (BASE_KEY_H + BASE_KEY_GAP) - BASE_KEY_GAP;  // MAIN+NAV 分の高さ
+	const NUM_ROWS_LEN = 6;  // テンキーの行数
+	const NUM_GAP_H = BASE_KEY_H * 0.4;  // テンキー上部の余白（基準キー高の40%）
+	const BASE_NUM_ROW_H = NUM_ROWS_LEN * (BASE_KEY_H + BASE_KEY_GAP) - BASE_KEY_GAP;  // テンキー部の高さ
+	const BASE_NUM_W = 4 * BASE_KEY_W + 3 * BASE_KEY_GAP;  // テンキー横幅（4列固定）
 
 	const calcScale = () => {
+		// locale に依存した行幅を毎回計算する
+		const rows = buildMainRows();
+		const baseMainW = Math.max(...rows.map(calcRowBaseW));
+		// 横幅: メイン + NAV + テンキー + 余白
+		const totalW = baseMainW + BASE_KEY_GAP * 2 + BASE_NAV_W + BASE_KEY_GAP * 2
+			+ BASE_KEY_GAP * 3 + BASE_NUM_W;
+
 		const availW = g_btnWidth();
 		const availH = g_sHeight - 200 - LEGEND_H;  // 下部 UI ぶんを除いた高さ
 
-		const scaleW = availW / BASE_TOTAL_W;
-		const scaleH = availH / BASE_TOTAL_H;
+		// 縦幅基準: MAIN/NAV 高さ と テンキー高さ（余白込み）の大きい方
+		const totalH = Math.max(BASE_ROW_H, BASE_NUM_ROW_H + Math.ceil(NUM_GAP_H));
+
+		const scaleW = availW / totalW;
+		const scaleH = availH / totalH;
 		_state.scale = Math.min(scaleW, scaleH, 1.5);  // 最大 1.5 倍まで拡大可
 
-		_state.cvsW = Math.floor(BASE_TOTAL_W * _state.scale);
-		_state.cvsH = Math.floor(BASE_TOTAL_H * _state.scale) + LEGEND_H;
+		_state.cvsW = Math.floor(totalW * _state.scale);
+		_state.cvsH = Math.floor(totalH * _state.scale) + LEGEND_H;
 	};
 
 	// -------------------------------------------------------------------------
@@ -10731,13 +10807,23 @@ const keyconfigKeyboardPreview = (() => {
 
 		_state.keyRects = [];
 
+		const mainRows = buildMainRows();
 		const gap = kg();
-		const mainW = Math.floor(BASE_MAIN_W * _state.scale);
+		const baseMainW = Math.max(...mainRows.map(calcRowBaseW));
+		const mainW = Math.floor(baseMainW * _state.scale);
 		const originY = gap;
 		const navOriginX = mainW + gap * 3;
 
-		layoutSection(ctx, MAIN_ROWS, 0, originY);
+		// テンキー: NAV クラスターの右に gap*3 の余白を空けて配置
+		const numOriginX = navOriginX + Math.floor(BASE_NAV_W * _state.scale) + gap * 3;
+		// テンキーは MAIN 全体に対して縦方向センタリング
+		const numH = Math.floor(BASE_NUM_ROW_H * _state.scale);
+		const mainH = Math.floor(BASE_ROW_H * _state.scale);
+		const numOriginY = originY + Math.floor((mainH - numH) / 2);
+
+		layoutSection(ctx, mainRows, 0, originY);
 		layoutSection(ctx, NAV_ROWS, navOriginX, originY);
+		layoutSection(ctx, NUM_ROWS, numOriginX, numOriginY);
 
 		// 凡例
 		const ly = _state.cvsH - 10;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10853,7 +10853,7 @@ const keyconfigKeyboardPreview = (() => {
 			btn.textContent = _state.visible ? `↑ Preview` : `↓ Preview`;
 		}, {
 			x: btnX, y: BTN_Y, w: btnW, h: BTN_H,
-			title: `キーボードレイアウトのプレビューを表示/非表示`,
+			title: g_msgObj.kcPreview,
 		}, g_cssObj.button_Setting);
 		btn.style.fontSize = `${BTN_FS}px`;
 		divRoot.appendChild(btn);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10386,18 +10386,18 @@ const keyconfigKeyboardPreview = (() => {
 
 	// 色定義（既存ゲームの配色に合わせたダーク系）
 	const C_COLOR = {
-		keyFill: `#1a1a2e`,
-		keyStroke: `#555577`,
-		keyText: `#ccccdd`,
-		keySubText: `#888899`,
-		mappedFill: `#003366`,
-		mappedStroke: `#4488ff`,
-		mappedText: `#aaddff`,
-		bgFill: `#0d0d1a`,
-		altFill: `#3e3e1a`,
-		altStroke: `#777755`,
-		altText: `#eeeecc`,
-		legendText: `#888899`,
+		keyFill: `#1a1a2e`,   // 通常キー背景
+		keyStroke: `#555577`,   // 通常キー枠
+		keyText: `#ccccdd`,   // 通常キー文字
+		keySubText: `#888899`,   // サブラベル（Shift面）
+		mappedFill: `#003366`,   // メインキー背景
+		mappedStroke: `#4488ff`,   // メインキー枠
+		mappedText: `#aaddff`,   // メインキー文字
+		altFill: `#3e3e1a`,   // 代替キー背景
+		altStroke: `#777755`,   // 代替キー枠
+		altText: `#eeeecc`,   // 代替キー文字
+		bgFill: `#0d0d1a`,   // Canvas 背景
+		legendText: `#888899`,   // 凡例テキスト
 	};
 
 	// ボタン配置
@@ -10408,7 +10408,7 @@ const keyconfigKeyboardPreview = (() => {
 	const BTN_FS = 11;   // ボタンのフォントサイズ(px)
 
 	// プレビューエリア
-	// X: canvas をdivRoot 内で水平センタリング（init で動的計算）
+	// X: canvas を divRoot 内で水平センタリング（init で動的計算）
 	// Y: g_sHeight に対して垂直センタリング（init で動的計算）
 
 	// 凡例エリアの高さ
@@ -10417,39 +10417,29 @@ const keyconfigKeyboardPreview = (() => {
 	// -------------------------------------------------------------------------
 	// キーレイアウト定義
 	//
-	// 構造: SECTIONS の配列。各セクションは独立した描画ブロック。
-	//   - rows  : キー行の配列
-	//   - offX  : セクション原点からの X オフセット（単位: KEY_W + KEY_GAP）
-	//             ※ スケール後に適用するためキー単位で持つ
+	// 各行: { offsetX, keys }
+	//   offsetX : 行左端の水平オフセット（単位: BASE_KEY_W）。正の値 = 右にずらす。
+	//   keys    : キー定義の配列
 	//
-	// 各キー:
-	//   kc    : keyCode（数値）
-	//   w     : 幅倍率（KEY_W 基準）
-	//   label : 省略時は g_kCd[kc] を参照。空文字のキーや左右区別したいキーに指定。
+	// 各キー: { kc, w, h?, label? }
+	//   kc    : keyCode（数値）。-1 はスペーサー（描画・キャッシュなし）。
+	//   w     : 幅倍率（BASE_KEY_W 基準）
+	//   h     : 高さ倍率（省略時 1）。関数を渡すと呼び出し結果を使用。
+	//   label : 省略時は g_kCd[kc] を参照。g_kCd が空文字のキーや
+	//           左右を区別したいキーに指定する。
 	//
 	// 右Shift/Ctrl/Alt は danoniplus 独自コード 256〜258 を使用。
 	// -------------------------------------------------------------------------
 
-	// メインキーボード部（Fnキー行 + 数字行 + QWERTY + ASDF + ZXCV + スペース行）
+	// メインキーボード部（Fn行 + 数字行 + QWERTY + ASDF + ZXCV + スペース行）
 	//
-	// offsetX: 各行の左端を「数字行の左端」を 0 とした相対オフセット（基準KEY_W単位）
-	//   数字行  offset=0    (229キーが左端)
-	//   QWERTY  offset=0    (Tabが左端、幅1.5だが左端位置は揃える)
-	//   ASDF    offset=0    ← CapsLk左端 = L)Shiftの左端に揃える
-	//   ZXCV    offset=0    (L)Shift左端)
-	//   Space   offset=0
-	//   Fn行    offset=0    (Escが左端)
-	//
-	// 実際のキーボードの行オフセット（標準JIS/US準拠）を px 単位で offsetX に持つ。
-	// 単位は BASE_KEY_W。正の値 = 右にずらす。
-	//
-	// 標準的なオフセット比較（1u = 1キー幅）:
-	//   数字行: 0u
-	//   QWERTY: 0u  (Tabは1.5uだが左端は揃う)
-	//   ASDF  : 0u  (CapsLkは1.75u。L)Shiftは2.25u → 差は0.5u)
-	//             → CapsLk左端をL)Shift左端に合わせるには offsetX=0 のまま、
-	//               ASDF行の先頭キー幅を 2.25 にすればよい
-	//   ZXCV  : 0u
+	// 各行の offsetX 設計（1u = BASE_KEY_W）:
+	//   Fn行    0u  Esc が左端
+	//   数字行  0u  229(IME/`) が左端
+	//   QWERTY  0u  Tab(1.5u) が左端、左端位置は数字行と揃う
+	//   ASDF    0u  CapsLk を 2.25u にして L)Shift 左端と揃える
+	//   ZXCV    0.25u  標準キーボードの行オフセットを offsetX + L)Shift 拡大で再現
+	//   スペース行 0u
 	const MAIN_ROWS = [
 		// Row0: Fn キー行
 		{
@@ -10472,11 +10462,11 @@ const keyconfigKeyboardPreview = (() => {
 				{ kc: 49, w: 1 }, { kc: 50, w: 1 }, { kc: 51, w: 1 },
 				{ kc: 52, w: 1 }, { kc: 53, w: 1 }, { kc: 54, w: 1 },
 				{ kc: 55, w: 1 }, { kc: 56, w: 1 }, { kc: 57, w: 1 },
-				{ kc: 48, w: 1 }, { kc: 189, w: 1 }, { kc: 222, w: 1 },
-				{ kc: 8, w: 1.75 },
+				{ kc: 48, w: 1 }, { kc: 189, w: 1 }, { kc: 222, w: 1 }, { kc: 220, w: 0.75 },
+				{ kc: 8, w: 1.5 },
 			],
 		},
-		// Row2: QWERTY  (Tab=1.5u、左端は数字行と揃う)
+		// Row2: QWERTY（Tab=1.5u、左端は数字行と揃う）
 		{
 			offsetX: 0,
 			keys: [
@@ -10484,25 +10474,22 @@ const keyconfigKeyboardPreview = (() => {
 				{ kc: 81, w: 1 }, { kc: 87, w: 1 }, { kc: 69, w: 1 },
 				{ kc: 82, w: 1 }, { kc: 84, w: 1 }, { kc: 89, w: 1 },
 				{ kc: 85, w: 1 }, { kc: 73, w: 1 }, { kc: 79, w: 1 },
-				{ kc: 80, w: 1 }, { kc: 192, w: 1 }, { kc: 219, w: 1 },
-				{ kc: 13, w: 1.25, h: () => g_localeObj.val === `Ja` ? 2 : 1 },  // Enter（日本語配列は縦長）
+				{ kc: 80, w: 1 }, { kc: 192, w: 1 }, { kc: 219, w: 1 }, { kc: -1, w: 0.5 },
+				{ kc: 13, w: 1.25, h: () => g_localeObj.val === `Ja` ? 2 : 1 },  // JIS配列は縦長
 			],
 		},
-		// Row3: ASDF
-		// CapsLk幅を 2.25 にすることで左端が L)Shift(2.25u) と揃う
+		// Row3: ASDF（CapsLk を 2.25u にして L)Shift 左端と揃える）
 		{
 			offsetX: 0,
 			keys: [
-				{ kc: 20, w: 2.25, label: `CapsLk` },  // L)Shiftと幅を揃えて左端を一致させる
+				{ kc: 20, w: 2.25, label: `CapsLk` },
 				{ kc: 65, w: 1 }, { kc: 83, w: 1 }, { kc: 68, w: 1 },
 				{ kc: 70, w: 1 }, { kc: 71, w: 1 }, { kc: 72, w: 1 },
 				{ kc: 74, w: 1 }, { kc: 75, w: 1 }, { kc: 76, w: 1 },
-				{ kc: 187, w: 1 }, { kc: 186, w: 1 },
+				{ kc: 187, w: 1 }, { kc: 186, w: 1 }, { kc: 221, w: 1 },
 			],
 		},
-		// Row4: ZXCV
-		// 標準キーボードではZXCV行はASDF行より約0.25u右にオフセットされる
-		// L)Shiftを2.5uに拡大してその分右へずらすことで再現
+		// Row4: ZXCV（標準配列は ASDF より約 0.25u 右にオフセット）
 		{
 			offsetX: 0.25,
 			keys: [
@@ -10521,7 +10508,7 @@ const keyconfigKeyboardPreview = (() => {
 				{ kc: 17, w: 1.25 },
 				{ kc: 91, w: 1 },
 				{ kc: 18, w: 1 },
-				{ kc: 32, w: 5.25 },
+				{ kc: 32, w: 7.25 },
 				{ kc: 258, w: 1 },
 				{ kc: 91, w: 1 },
 				{ kc: 257, w: 1.25 },
@@ -10529,12 +10516,13 @@ const keyconfigKeyboardPreview = (() => {
 		},
 	];
 
-	// 編集キークラスター（Insert/Delete/Home/End/PgUp/PgDn + 矢印）
+	// 編集キークラスター（Insert/Delete/Home/End/PgUp/PgDn + 矢印キー）
+	// MAIN_ROWS と行インデックスを揃えて配置する。空行はスキップされる。
 	const NAV_ROWS = [
 		{ offsetX: 0, keys: [{ kc: 45, w: 1 }, { kc: 36, w: 1 }, { kc: 33, w: 1 }] },  // Insert Home PgUp
 		{ offsetX: 0, keys: [{ kc: 46, w: 1 }, { kc: 35, w: 1 }, { kc: 34, w: 1 }] },  // Delete End  PgDn
-		{ offsetX: 0, keys: [] },                                                           // QWERTY行：空
-		{ offsetX: 0, keys: [] },                                                           // ASDF行：空
+		{ offsetX: 0, keys: [] },                                                          // QWERTY行：空
+		{ offsetX: 0, keys: [] },                                                          // ASDF行：空
 		{ offsetX: 0, keys: [{ kc: -1, w: 1 }, { kc: 38, w: 1 }, { kc: -1, w: 1 }] },  // ↑
 		{ offsetX: 0, keys: [{ kc: 37, w: 1 }, { kc: 40, w: 1 }, { kc: 39, w: 1 }] },  // ← ↓ →
 	];
@@ -10548,10 +10536,10 @@ const keyconfigKeyboardPreview = (() => {
 		altSet: new Set(),   // 代替キー（各矢印の index 1 以降）
 		canvasBase: null,
 		canvasMap: null,
-		keyRects: [],     // { kc, x, y, w, h, label } — drawMap で照合するキャッシュ
-		scale: 1,      // KEY_W/KEY_H に掛けるスケール係数
-		cvsW: 500,    // 実際の Canvas 幅（スケール計算後）
-		cvsH: 240,    // 実際の Canvas 高さ（スケール計算後）
+		keyRects: [],          // { kc, x, y, w, h, label } — drawMap で照合するキャッシュ
+		scale: 1,           // BASE_KEY_W/H に掛けるスケール係数
+		cvsW: 500,         // 実際の Canvas 幅（スケール計算後）
+		cvsH: 240,         // 実際の Canvas 高さ（スケール計算後）
 	};
 
 	// -------------------------------------------------------------------------
@@ -10562,33 +10550,31 @@ const keyconfigKeyboardPreview = (() => {
 	 * g_btnWidth() / g_sHeight を元にスケール係数と Canvas サイズを算出して
 	 * _state に書き込む。init 時に呼ぶ。
 	 *
-	 * フルキーボード（メイン + ナビ）の基準サイズ:
-	 *   横: MAIN最大行幅 + GAP + NAV幅(3キー)
-	 *   縦: 行数 6行 × (KEY_H + KEY_GAP) + LEGEND_H
-	 * KEY_W = KEY_H = 28px(基準)、KEY_GAP = 3px を基準に比率を求める。
+	 * 基準サイズ（フルキーボード = メイン + ナビクラスター）:
+	 *   横: MAIN最大行幅 + ナビ幅(3キー) + 余白
+	 *   縦: 6行 × (BASE_KEY_H + BASE_KEY_GAP) - BASE_KEY_GAP
+	 *   BASE_KEY_W = BASE_KEY_H = 28px、BASE_KEY_GAP = 3px を基準とする。
 	 */
 	const BASE_KEY_W = 28;
 	const BASE_KEY_H = 28;
 	const BASE_KEY_GAP = 3;
 
-	// MAIN_ROWS で最も横幅が広い行の幅を計算（スペーサー kc:-1 含む）
+	// MAIN_ROWS で最も横幅が広い行の幅を計算（スペーサー含む）
 	const calcRowBaseW = row =>
 		row.keys.reduce((acc, k) => acc + k.w * BASE_KEY_W + BASE_KEY_GAP, -BASE_KEY_GAP);
 
 	const BASE_MAIN_W = Math.max(...MAIN_ROWS.map(calcRowBaseW));
-	const BASE_NAV_W = 3 * BASE_KEY_W + 2 * BASE_KEY_GAP;  // 3列
+	const BASE_NAV_W = 3 * BASE_KEY_W + 2 * BASE_KEY_GAP;  // NAV は 3列固定
 	const BASE_TOTAL_W = BASE_MAIN_W + BASE_KEY_GAP * 2 + BASE_NAV_W + BASE_KEY_GAP * 2;
 	const BASE_TOTAL_H = MAIN_ROWS.length * (BASE_KEY_H + BASE_KEY_GAP) - BASE_KEY_GAP;
 
 	const calcScale = () => {
-		// 横: divRoot 全幅をキャンバス幅として使用
 		const availW = g_btnWidth();
-		// 縦: g_sHeight - 200 を上限（凡例含む）
-		const availH = g_sHeight - 200 - LEGEND_H;
+		const availH = g_sHeight - 200 - LEGEND_H;  // 下部 UI ぶんを除いた高さ
 
 		const scaleW = availW / BASE_TOTAL_W;
 		const scaleH = availH / BASE_TOTAL_H;
-		_state.scale = Math.min(scaleW, scaleH, 1.5);  // 最大1.5倍まで拡大可
+		_state.scale = Math.min(scaleW, scaleH, 1.5);  // 最大 1.5 倍まで拡大可
 
 		_state.cvsW = Math.floor(BASE_TOTAL_W * _state.scale);
 		_state.cvsH = Math.floor(BASE_TOTAL_H * _state.scale) + LEGEND_H;
@@ -10601,9 +10587,10 @@ const keyconfigKeyboardPreview = (() => {
 	/**
 	 * keyCode に対応する [primaryLabel, subLabel] を返す。
 	 * kc が -1（スペーサー）の場合は [``, ``] を返す。
+	 * g_kCd の値は `"primary"` または `"primary sub"` 形式の文字列。
 	 *
 	 * @param {number}           kc
-	 * @param {string|undefined} forcedLabel
+	 * @param {string|undefined} forcedLabel - ROWS の label 指定がある場合に優先
 	 * @returns {string[]} [primary, sub]
 	 */
 	const getKeyLabels = (kc, forcedLabel) => {
@@ -10622,6 +10609,7 @@ const keyconfigKeyboardPreview = (() => {
 	// Canvas ヘルパー
 	// -------------------------------------------------------------------------
 
+	// スケール済みの各寸法を返すヘルパー
 	const kw = w => Math.floor(w * BASE_KEY_W * _state.scale + (w - 1) * BASE_KEY_GAP * _state.scale);
 	const kh = h => Math.floor(h * BASE_KEY_H * _state.scale + (h - 1) * BASE_KEY_GAP * _state.scale);
 	const kg = () => Math.max(1, Math.round(BASE_KEY_GAP * _state.scale));
@@ -10675,7 +10663,7 @@ const keyconfigKeyboardPreview = (() => {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * ROWS 配列から各キーの矩形座標を計算し、
+	 * rows 配列から各キーの矩形座標を計算し、
 	 * canvas に描画しながら keyRects へキャッシュする。
 	 *
 	 * @param {CanvasRenderingContext2D} ctx
@@ -10745,54 +10733,35 @@ const keyconfigKeyboardPreview = (() => {
 
 		const gap = kg();
 		const mainW = Math.floor(BASE_MAIN_W * _state.scale);
-
-		// Fn行（Row0）の高さのみ微小に小さくして隙間を設ける（実装簡略化のため同一高で可）
 		const originY = gap;
 		const navOriginX = mainW + gap * 3;
 
-		// メインキーボード描画
 		layoutSection(ctx, MAIN_ROWS, 0, originY);
-
-		// ナビゲーションクラスター描画
 		layoutSection(ctx, NAV_ROWS, navOriginX, originY);
 
 		// 凡例
 		const ly = _state.cvsH - 10;
-		ctx.font = `${Math.max(9, Math.floor(10 * _state.scale))}px ${getBasicFont()}`;
+		const fnt = `${Math.max(9, Math.floor(10 * _state.scale))}px ${getBasicFont()}`;
+		ctx.font = fnt;
 		ctx.textAlign = `left`;
 		ctx.textBaseline = `middle`;
 
-		roundRect(ctx, 8, ly, 10, 10, 2);
-		ctx.fillStyle = C_COLOR.keyFill;
-		ctx.fill();
-		ctx.strokeStyle = C_COLOR.keyStroke;
-		ctx.lineWidth = 1;
-		ctx.stroke();
-		ctx.fillStyle = C_COLOR.legendText;
-		ctx.fillText(g_lblNameObj.unallocated, 22, ly + 5);
+		const drawLegend = (x, fill, stroke, label) => {
+			roundRect(ctx, x, ly, 10, 10, 2);
+			ctx.fillStyle = fill; ctx.fill();
+			ctx.strokeStyle = stroke; ctx.lineWidth = 1; ctx.stroke();
+			ctx.fillStyle = C_COLOR.legendText;
+			ctx.fillText(label, x + 14, ly + 5);
+		};
 
-		roundRect(ctx, 95, ly, 10, 10, 2);
-		ctx.fillStyle = C_COLOR.mappedFill;
-		ctx.fill();
-		ctx.strokeStyle = C_COLOR.mappedStroke;
-		ctx.lineWidth = 1;
-		ctx.stroke();
-		ctx.fillStyle = C_COLOR.legendText;
-		ctx.fillText(g_lblNameObj.allocated, 109, ly + 5);
-
-		roundRect(ctx, 195, ly, 10, 10, 2);
-		ctx.fillStyle = C_COLOR.altFill;
-		ctx.fill();
-		ctx.strokeStyle = C_COLOR.altStroke;
-		ctx.lineWidth = 1;
-		ctx.stroke();
-		ctx.fillStyle = C_COLOR.legendText;
-		ctx.fillText(g_lblNameObj.altAllocated, 209, ly + 5);
+		drawLegend(8, C_COLOR.keyFill, C_COLOR.keyStroke, g_lblNameObj.unallocated);
+		drawLegend(95, C_COLOR.mappedFill, C_COLOR.mappedStroke, g_lblNameObj.allocated);
+		drawLegend(182, C_COLOR.altFill, C_COLOR.altStroke, g_lblNameObj.altAllocated);
 	};
 
 	/**
 	 * マッピング強調レイヤーを再描画する。
-	 * メインキー（mappedSet）と代替キー（altSet）を色分けして描画する。
+	 * メインキー（mappedSet）を青系、代替キー（altSet）を黄系で色分けする。
 	 * 同一キーにメインと代替が重なる場合はメインを優先する。
 	 */
 	const drawMap = () => {
@@ -10810,7 +10779,7 @@ const keyconfigKeyboardPreview = (() => {
 		ctx.scale(dpr, dpr);
 		ctx.clearRect(0, 0, _state.cvsW, _state.cvsH);
 
-		// 代替キーを先に描画し、メインキーを上書きすることで優先度を表現
+		// 代替キーを先に描画し、メインキーで上書きすることで優先度を表現
 		const drawKey = (fill, stroke, text) => rect => {
 			const [primary, sub] = getKeyLabels(rect.kc, rect.label);
 			roundRect(ctx, rect.x + 0.5, rect.y + 0.5, rect.w - 1, rect.h - 1, kr());
@@ -10863,8 +10832,8 @@ const keyconfigKeyboardPreview = (() => {
 		const areaY = 130;
 
 		const areaDiv = createEmptySprite(divRoot, C_PREVIEW_ID, {
-			x: areaX, y: areaY - 60, w: _state.cvsW, h: _state.cvsH + 80, pointerEvents: C_DIS_AUTO,
-			background: `#00000080`,
+			x: areaX, y: areaY - 60, w: _state.cvsW, h: _state.cvsH + 80,
+			pointerEvents: C_DIS_AUTO, background: `#00000080`,
 		});
 		areaDiv.style.display = `none`;
 		areaDiv.style.position = `absolute`;
@@ -10900,12 +10869,12 @@ const keyconfigKeyboardPreview = (() => {
 	};
 
 	/**
-	 * g_keyObj から現在のキー割り当てを取得して mappedSet を更新し、
+	 * g_keyObj から現在のキー割り当てを取得して mappedSet / altSet を更新し、
 	 * プレビューが表示中なら即時再描画する。
 	 *
-	 * g_keyObj[`keyCtrl${currentKey}_${currentPtn}`] は二次元配列:
-	 *   [ [矢印0のkeyCode, 代替keyCode, ...], [矢印1のkeyCode, ...], ... ]
-	 * flat() して 0 より大きい値のみ Set に格納する。
+	 * g_keyObj[`keyCtrl${keyCtrlPtn}`] は二次元配列:
+	 *   [ [矢印0のメインkeyCode, 代替keyCode, ...], [矢印1のメインkeyCode, ...], ... ]
+	 * 各サブ配列の index 0 がメインキー、index 1 以降が代替キー。
 	 */
 	const refresh = () => {
 		const tkObj = getKeyInfo();
@@ -10914,11 +10883,8 @@ const keyconfigKeyboardPreview = (() => {
 		const ctrl = g_keyObj[`keyCtrl${tkObj.keyCtrlPtn}`]
 			.filter((val, idx) => tkObj.keyGroupMaps[idx].includes(configKeyGroupList[g_keycons.keySwitchNum]));
 
-		// index 0 がメインキー、index 1 以降が代替キー
 		_state.mappedSet = new Set(ctrl.map(arr => arr[0]).filter(v => v > 0));
-		_state.altSet = new Set(
-			ctrl.flatMap(arr => arr.slice(1)).filter(v => v > 0)
-		);
+		_state.altSet = new Set(ctrl.flatMap(arr => arr.slice(1)).filter(v => v > 0));
 		if (_state.visible) drawMap();
 	};
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10771,7 +10771,7 @@ const keyconfigKeyboardPreview = (() => {
 		ctx.fillStyle = C_COLOR.legendText;
 		ctx.fillText(g_lblNameObj.unallocated, 22, ly + 5);
 
-		roundRect(ctx, 95, ly - 5, 10, 10, 2);
+		roundRect(ctx, 95, ly, 10, 10, 2);
 		ctx.fillStyle = C_COLOR.mappedFill;
 		ctx.fill();
 		ctx.strokeStyle = C_COLOR.mappedStroke;
@@ -10780,7 +10780,7 @@ const keyconfigKeyboardPreview = (() => {
 		ctx.fillStyle = C_COLOR.legendText;
 		ctx.fillText(g_lblNameObj.allocated, 109, ly + 5);
 
-		roundRect(ctx, 195, ly - 5, 10, 10, 2);
+		roundRect(ctx, 195, ly, 10, 10, 2);
 		ctx.fillStyle = C_COLOR.altFill;
 		ctx.fill();
 		ctx.strokeStyle = C_COLOR.altStroke;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10194,6 +10194,9 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	// カーソル位置の初期化
 	appearConfigSteps(g_keycons.keySwitchNum);
 
+	keyconfigKeyboardPreview.dispose();
+	keyconfigKeyboardPreview.init(divRoot);
+
 	// ラベル・ボタン描画
 	multiAppend(divRoot,
 
@@ -10341,6 +10344,577 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	document.onkeyup = evt => commonKeyUp(evt);
 	document.oncontextmenu = () => false;
 };
+
+/**
+ * キーボードレイアウトプレビュー（Canvas版）
+ *
+ * キーコンフィグ画面(divRoot)配下に以下の要素を追加する:
+ *   - [Preview] ボタン (createCss2Button)
+ *   - プレビュー用コンテナ div (createEmptySprite)
+ *     ├ キーボード背景 canvas  (_state.canvasBase)  ← 起動時のみ描画
+ *     └ マッピング強調 canvas  (_state.canvasMap)   ← キー変更・表示時に再描画
+ *
+ * 前提:
+ *   - g_kCd         : グローバル定義済み。ロケール切替後は g_lang_kCd がマージ済み。
+ *                     未設定キーは空文字列 `""` で初期化。
+ *                     右Shift/Ctrl/Alt は 256/257/258 の独自コードで定義。
+ *   - g_btnWidth()  : 画面の横幅(px)を返すグローバル関数。
+ *   - g_sHeight     : 画面の縦幅(px)を保持するグローバル変数。
+ *   - createCss2Button, createEmptySprite : danoniplus 本体のグローバル関数。
+ *
+ * 使い方:
+ *   【初期化時】
+ *     keyconfigKeyboardPreview.init(divRoot);
+ *
+ *   【キー割り当てが変わった時】
+ *     keyconfigKeyboardPreview.refresh();
+ *     ※ g_keyObj.currentKey / currentPtn から自動取得する
+ *
+ *   【キーコンフィグ画面を離脱する時】
+ *     keyconfigKeyboardPreview.dispose();
+ */
+
+const keyconfigKeyboardPreview = (() => {
+
+	// -------------------------------------------------------------------------
+	// 定数
+	// -------------------------------------------------------------------------
+	const C_PREVIEW_ID = `kbPreviewArea`;
+	const C_BTN_ID = `btnKbPreview`;
+	const C_CANVAS_BASE_ID = `kbCanvasBase`;
+	const C_CANVAS_MAP_ID = `kbCanvasMap`;
+
+	// 色定義（既存ゲームの配色に合わせたダーク系）
+	const C_COLOR = {
+		keyFill: `#1a1a2e`,
+		keyStroke: `#555577`,
+		keyText: `#ccccdd`,
+		keySubText: `#888899`,
+		mappedFill: `#003366`,
+		mappedStroke: `#4488ff`,
+		mappedText: `#aaddff`,
+		bgFill: `#0d0d1a`,
+		legendText: `#888899`,
+	};
+
+	// ボタン配置
+	// X・W は init() 内で動的計算（g_btnWidth() 依存）
+	// Y: KeyConfig テキスト上の余白に収まるよう小さく設定
+	const BTN_H = 18;   // ボタン高さ
+	const BTN_Y = 3;    // divRoot 内 Y 座標
+	const BTN_FS = 11;   // ボタンのフォントサイズ(px)
+
+	// プレビューエリア
+	// X: canvas をdivRoot 内で水平センタリング（init で動的計算）
+	// Y: g_sHeight に対して垂直センタリング（init で動的計算）
+
+	// 凡例エリアの高さ
+	const LEGEND_H = 22;
+
+	// -------------------------------------------------------------------------
+	// キーレイアウト定義
+	//
+	// 構造: SECTIONS の配列。各セクションは独立した描画ブロック。
+	//   - rows  : キー行の配列
+	//   - offX  : セクション原点からの X オフセット（単位: KEY_W + KEY_GAP）
+	//             ※ スケール後に適用するためキー単位で持つ
+	//
+	// 各キー:
+	//   kc    : keyCode（数値）
+	//   w     : 幅倍率（KEY_W 基準）
+	//   label : 省略時は g_kCd[kc] を参照。空文字のキーや左右区別したいキーに指定。
+	//
+	// 右Shift/Ctrl/Alt は danoniplus 独自コード 256〜258 を使用。
+	// -------------------------------------------------------------------------
+
+	// メインキーボード部（Fnキー行 + 数字行 + QWERTY + ASDF + ZXCV + スペース行）
+	//
+	// offsetX: 各行の左端を「数字行の左端」を 0 とした相対オフセット（基準KEY_W単位）
+	//   数字行  offset=0    (229キーが左端)
+	//   QWERTY  offset=0    (Tabが左端、幅1.5だが左端位置は揃える)
+	//   ASDF    offset=0    ← CapsLk左端 = L)Shiftの左端に揃える
+	//   ZXCV    offset=0    (L)Shift左端)
+	//   Space   offset=0
+	//   Fn行    offset=0    (Escが左端)
+	//
+	// 実際のキーボードの行オフセット（標準JIS/US準拠）を px 単位で offsetX に持つ。
+	// 単位は BASE_KEY_W。正の値 = 右にずらす。
+	//
+	// 標準的なオフセット比較（1u = 1キー幅）:
+	//   数字行: 0u
+	//   QWERTY: 0u  (Tabは1.5uだが左端は揃う)
+	//   ASDF  : 0u  (CapsLkは1.75u。L)Shiftは2.25u → 差は0.5u)
+	//             → CapsLk左端をL)Shift左端に合わせるには offsetX=0 のまま、
+	//               ASDF行の先頭キー幅を 2.25 にすればよい
+	//   ZXCV  : 0u
+	const MAIN_ROWS = [
+		// Row0: Fn キー行
+		{
+			offsetX: 0,
+			keys: [
+				{ kc: 27, w: 1 },                   // Esc
+				{ kc: -1, w: 0.5 },                   // スペーサー
+				{ kc: 112, w: 1 }, { kc: 113, w: 1 }, { kc: 114, w: 1 }, { kc: 115, w: 1 },
+				{ kc: -1, w: 0.25 },                   // スペーサー
+				{ kc: 116, w: 1 }, { kc: 117, w: 1 }, { kc: 118, w: 1 }, { kc: 119, w: 1 },
+				{ kc: -1, w: 0.25 },                   // スペーサー
+				{ kc: 120, w: 1 }, { kc: 121, w: 1 }, { kc: 122, w: 1 }, { kc: 123, w: 1 },
+			],
+		},
+		// Row1: 数字行
+		{
+			offsetX: 0,
+			keys: [
+				{ kc: 229, w: 1 },
+				{ kc: 49, w: 1 }, { kc: 50, w: 1 }, { kc: 51, w: 1 },
+				{ kc: 52, w: 1 }, { kc: 53, w: 1 }, { kc: 54, w: 1 },
+				{ kc: 55, w: 1 }, { kc: 56, w: 1 }, { kc: 57, w: 1 },
+				{ kc: 48, w: 1 }, { kc: 189, w: 1 }, { kc: 222, w: 1 },
+				{ kc: 8, w: 1.75 },
+			],
+		},
+		// Row2: QWERTY  (Tab=1.5u、左端は数字行と揃う)
+		{
+			offsetX: 0,
+			keys: [
+				{ kc: 9, w: 1.5 },
+				{ kc: 81, w: 1 }, { kc: 87, w: 1 }, { kc: 69, w: 1 },
+				{ kc: 82, w: 1 }, { kc: 84, w: 1 }, { kc: 89, w: 1 },
+				{ kc: 85, w: 1 }, { kc: 73, w: 1 }, { kc: 79, w: 1 },
+				{ kc: 80, w: 1 }, { kc: 192, w: 1 }, { kc: 219, w: 1 },
+				{ kc: 13, w: 1.25 },
+			],
+		},
+		// Row3: ASDF
+		// CapsLk幅を 2.25 にすることで左端が L)Shift(2.25u) と揃う
+		{
+			offsetX: 0,
+			keys: [
+				{ kc: 20, w: 2.25, label: `CapsLk` },  // L)Shiftと幅を揃えて左端を一致させる
+				{ kc: 65, w: 1 }, { kc: 83, w: 1 }, { kc: 68, w: 1 },
+				{ kc: 70, w: 1 }, { kc: 71, w: 1 }, { kc: 72, w: 1 },
+				{ kc: 74, w: 1 }, { kc: 75, w: 1 }, { kc: 76, w: 1 },
+				{ kc: 187, w: 1 }, { kc: 186, w: 1 },
+			],
+		},
+		// Row4: ZXCV
+		// 標準キーボードではZXCV行はASDF行より約0.25u右にオフセットされる
+		// L)Shiftを2.5uに拡大してその分右へずらすことで再現
+		{
+			offsetX: 0.25,
+			keys: [
+				{ kc: 16, w: 2.5 },
+				{ kc: 90, w: 1 }, { kc: 88, w: 1 }, { kc: 67, w: 1 },
+				{ kc: 86, w: 1 }, { kc: 66, w: 1 }, { kc: 78, w: 1 },
+				{ kc: 77, w: 1 }, { kc: 188, w: 1 }, { kc: 190, w: 1 },
+				{ kc: 191, w: 1 }, { kc: 226, w: 1 },
+				{ kc: 256, w: 1.25 },
+			],
+		},
+		// Row5: スペースバー行
+		{
+			offsetX: 0,
+			keys: [
+				{ kc: 17, w: 1.25 },
+				{ kc: 91, w: 1 },
+				{ kc: 18, w: 1 },
+				{ kc: 32, w: 5.25 },
+				{ kc: 258, w: 1 },
+				{ kc: 91, w: 1 },
+				{ kc: 257, w: 1.25 },
+			],
+		},
+	];
+
+	// 編集キークラスター（Insert/Delete/Home/End/PgUp/PgDn + 矢印）
+	const NAV_ROWS = [
+		{ offsetX: 0, keys: [{ kc: 45, w: 1 }, { kc: 36, w: 1 }, { kc: 33, w: 1 }] },  // Insert Home PgUp
+		{ offsetX: 0, keys: [{ kc: 46, w: 1 }, { kc: 35, w: 1 }, { kc: 34, w: 1 }] },  // Delete End  PgDn
+		{ offsetX: 0, keys: [] },                                                           // QWERTY行：空
+		{ offsetX: 0, keys: [] },                                                           // ASDF行：空
+		{ offsetX: 0, keys: [{ kc: -1, w: 1 }, { kc: 38, w: 1 }, { kc: -1, w: 1 }] },  // ↑
+		{ offsetX: 0, keys: [{ kc: 37, w: 1 }, { kc: 40, w: 1 }, { kc: 39, w: 1 }] },  // ← ↓ →
+	];
+
+	// -------------------------------------------------------------------------
+	// 内部状態
+	// -------------------------------------------------------------------------
+	const _state = {
+		visible: false,
+		mappedSet: new Set(),
+		canvasBase: null,
+		canvasMap: null,
+		keyRects: [],     // { kc, x, y, w, h, label } — drawMap で照合するキャッシュ
+		scale: 1,      // KEY_W/KEY_H に掛けるスケール係数
+		cvsW: 500,    // 実際の Canvas 幅（スケール計算後）
+		cvsH: 240,    // 実際の Canvas 高さ（スケール計算後）
+	};
+
+	// -------------------------------------------------------------------------
+	// スケール計算
+	// -------------------------------------------------------------------------
+
+	/**
+	 * g_btnWidth() / g_sHeight を元にスケール係数と Canvas サイズを算出して
+	 * _state に書き込む。init 時に呼ぶ。
+	 *
+	 * フルキーボード（メイン + ナビ）の基準サイズ:
+	 *   横: MAIN最大行幅 + GAP + NAV幅(3キー)
+	 *   縦: 行数 6行 × (KEY_H + KEY_GAP) + LEGEND_H
+	 * KEY_W = KEY_H = 28px(基準)、KEY_GAP = 3px を基準に比率を求める。
+	 */
+	const BASE_KEY_W = 28;
+	const BASE_KEY_H = 28;
+	const BASE_KEY_GAP = 3;
+
+	// MAIN_ROWS で最も横幅が広い行の幅を計算（スペーサー kc:-1 含む）
+	const calcRowBaseW = row =>
+		row.keys.reduce((acc, k) => acc + k.w * BASE_KEY_W + BASE_KEY_GAP, -BASE_KEY_GAP);
+
+	const BASE_MAIN_W = Math.max(...MAIN_ROWS.map(calcRowBaseW));
+	const BASE_NAV_W = 3 * BASE_KEY_W + 2 * BASE_KEY_GAP;  // 3列
+	const BASE_TOTAL_W = BASE_MAIN_W + BASE_KEY_GAP * 2 + BASE_NAV_W + BASE_KEY_GAP * 2;
+	const BASE_TOTAL_H = MAIN_ROWS.length * (BASE_KEY_H + BASE_KEY_GAP) - BASE_KEY_GAP;
+
+	const calcScale = () => {
+		// 横: divRoot 全幅をキャンバス幅として使用
+		const availW = g_btnWidth();
+		// 縦: g_sHeight - 200 を上限（凡例含む）
+		const availH = g_sHeight - 200 - LEGEND_H;
+
+		const scaleW = availW / BASE_TOTAL_W;
+		const scaleH = availH / BASE_TOTAL_H;
+		_state.scale = Math.min(scaleW, scaleH, 1.5);  // 最大1.5倍まで拡大可
+
+		_state.cvsW = Math.floor(BASE_TOTAL_W * _state.scale);
+		_state.cvsH = Math.floor(BASE_TOTAL_H * _state.scale) + LEGEND_H;
+	};
+
+	// -------------------------------------------------------------------------
+	// ラベル取得
+	// -------------------------------------------------------------------------
+
+	/**
+	 * keyCode に対応する [primaryLabel, subLabel] を返す。
+	 * kc が -1（スペーサー）の場合は [``, ``] を返す。
+	 *
+	 * @param {number}           kc
+	 * @param {string|undefined} forcedLabel
+	 * @returns {string[]} [primary, sub]
+	 */
+	const getKeyLabels = (kc, forcedLabel) => {
+		if (kc < 0) return [``, ``];
+		if (forcedLabel !== undefined) return [forcedLabel, ``];
+
+		const raw = g_kCd[kc];
+		if (raw && raw !== `- - -` && raw !== `Unknown`) {
+			const parts = raw.split(` `);
+			return [parts[0] || ``, parts[1] || ``];
+		}
+		return [`?`, ``];
+	};
+
+	// -------------------------------------------------------------------------
+	// Canvas ヘルパー
+	// -------------------------------------------------------------------------
+
+	const kw = w => Math.floor(w * BASE_KEY_W * _state.scale + (w - 1) * BASE_KEY_GAP * _state.scale);
+	const kh = () => Math.floor(BASE_KEY_H * _state.scale);
+	const kg = () => Math.max(1, Math.round(BASE_KEY_GAP * _state.scale));
+	const kr = () => Math.max(2, Math.round(4 * _state.scale));
+
+	const roundRect = (ctx, x, y, w, h, r) => {
+		ctx.beginPath();
+		ctx.moveTo(x + r, y);
+		ctx.lineTo(x + w - r, y);
+		ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+		ctx.lineTo(x + w, y + h - r);
+		ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+		ctx.lineTo(x + r, y + h);
+		ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+		ctx.lineTo(x, y + r);
+		ctx.quadraticCurveTo(x, y, x + r, y);
+		ctx.closePath();
+	};
+
+	const drawKeyLabel = (ctx, x, y, keyW, keyH, primary, sub, textColor, subColor) => {
+		const fs = primary.length >= 5
+			? Math.max(6, Math.floor(8 * _state.scale))
+			: Math.max(7, Math.floor(11 * _state.scale));
+
+		if (sub) {
+			ctx.fillStyle = subColor;
+			ctx.font = `bold ${Math.max(6, Math.floor(8 * _state.scale))}px monospace`;
+			ctx.textAlign = `right`;
+			ctx.textBaseline = `top`;
+			ctx.fillText(sub, x + keyW - 2, y + 2);
+		}
+		ctx.fillStyle = textColor;
+		ctx.font = `bold ${fs}px monospace`;
+		ctx.textAlign = `center`;
+		ctx.textBaseline = `middle`;
+		ctx.fillText(primary, x + keyW / 2, y + keyH / 2 + (sub ? 2 : 0));
+	};
+
+	const drawOneKey = (ctx, x, y, keyW, fill, stroke, lw, primary, sub, textColor, subColor) => {
+		const keyH = kh();
+		roundRect(ctx, x + 0.5, y + 0.5, keyW - 1, keyH - 1, kr());
+		ctx.fillStyle = fill;
+		ctx.strokeStyle = stroke;
+		ctx.lineWidth = lw;
+		ctx.fill();
+		ctx.stroke();
+		drawKeyLabel(ctx, x, y, keyW, keyH, primary, sub, textColor, subColor);
+	};
+
+	// -------------------------------------------------------------------------
+	// レイアウト計算・描画
+	// -------------------------------------------------------------------------
+
+	/**
+	 * ROWS 配列から各キーの矩形座標を計算し、
+	 * canvas に描画しながら keyRects へキャッシュする。
+	 *
+	 * @param {CanvasRenderingContext2D} ctx
+	 * @param {Array}  rows    - MAIN_ROWS または NAV_ROWS（{offsetX, keys} 形式）
+	 * @param {number} originX - セクション左端の X 座標（canvas 座標）
+	 * @param {number} originY - セクション上端の Y 座標（canvas 座標）
+	 */
+	const layoutSection = (ctx, rows, originX, originY) => {
+		const gap = kg();
+		const keyH = kh();
+
+		rows.forEach((rowDef, rowIdx) => {
+			if (rowDef.keys.length === 0) return;
+
+			const rowY = originY + rowIdx * (keyH + gap);
+			const startX = originX + Math.floor(rowDef.offsetX * BASE_KEY_W * _state.scale);
+			let curX = startX;
+
+			rowDef.keys.forEach(keyDef => {
+				const keyW = kw(keyDef.w);
+
+				if (keyDef.kc >= 0) {
+					_state.keyRects.push({
+						kc: keyDef.kc,
+						x: curX,
+						y: rowY,
+						w: keyW,
+						h: keyH,
+						label: keyDef.label,
+					});
+					const [primary, sub] = getKeyLabels(keyDef.kc, keyDef.label);
+					drawOneKey(
+						ctx, curX, rowY, keyW,
+						C_COLOR.keyFill, C_COLOR.keyStroke, 1,
+						primary, sub, C_COLOR.keyText, C_COLOR.keySubText
+					);
+				}
+
+				curX += keyW + gap;
+			});
+		});
+	};
+
+	/**
+	 * キーボード背景レイヤーを描画し keyRects をキャッシュする。
+	 * init 時に呼ぶ。
+	 */
+	const drawBase = () => {
+		const canvas = _state.canvasBase;
+		if (!canvas) return;
+
+		const dpr = window.devicePixelRatio || 1;
+		canvas.style.top = wUnit(40);
+		canvas.width = _state.cvsW * dpr;
+		canvas.height = _state.cvsH * dpr;
+		canvas.style.width = wUnit(_state.cvsW);
+		canvas.style.height = wUnit(_state.cvsH);
+
+		const ctx = canvas.getContext(`2d`);
+		ctx.scale(dpr, dpr);
+		ctx.clearRect(0, 0, _state.cvsW, _state.cvsH);
+		ctx.fillStyle = C_COLOR.bgFill;
+		ctx.fillRect(0, 0, _state.cvsW, _state.cvsH);
+
+		_state.keyRects = [];
+
+		const gap = kg();
+		const mainW = Math.floor(BASE_MAIN_W * _state.scale);
+
+		// Fn行（Row0）の高さのみ微小に小さくして隙間を設ける（実装簡略化のため同一高で可）
+		const originY = gap;
+		const navOriginX = mainW + gap * 3;
+
+		// メインキーボード描画
+		layoutSection(ctx, MAIN_ROWS, 0, originY);
+
+		// ナビゲーションクラスター描画
+		layoutSection(ctx, NAV_ROWS, navOriginX, originY);
+
+		// 凡例
+		const ly = _state.cvsH - 10;
+		ctx.font = `${Math.max(9, Math.floor(10 * _state.scale))}px ${getBasicFont()}`;
+		ctx.textAlign = `left`;
+		ctx.textBaseline = `middle`;
+
+		roundRect(ctx, 8, ly, 10, 10, 2);
+		ctx.fillStyle = C_COLOR.keyFill;
+		ctx.fill();
+		ctx.strokeStyle = C_COLOR.keyStroke;
+		ctx.lineWidth = 1;
+		ctx.stroke();
+		ctx.fillStyle = C_COLOR.legendText;
+		ctx.fillText(g_lblNameObj.unallocated, 22, ly + 5);
+
+		roundRect(ctx, 95, ly, 10, 10, 2);
+		ctx.fillStyle = C_COLOR.mappedFill;
+		ctx.fill();
+		ctx.strokeStyle = C_COLOR.mappedStroke;
+		ctx.lineWidth = 1;
+		ctx.stroke();
+		ctx.fillStyle = C_COLOR.legendText;
+		ctx.fillText(g_lblNameObj.allocated, 109, ly + 5);
+	};
+
+	/**
+	 * マッピング強調レイヤーを再描画する。
+	 * _state.keyRects と _state.mappedSet を照合して強調表示する。
+	 */
+	const drawMap = () => {
+		const canvas = _state.canvasMap;
+		if (!canvas) return;
+
+		const dpr = window.devicePixelRatio || 1;
+		canvas.style.top = wUnit(40);
+		canvas.width = _state.cvsW * dpr;
+		canvas.height = _state.cvsH * dpr;
+		canvas.style.width = wUnit(_state.cvsW);
+		canvas.style.height = wUnit(_state.cvsH);
+
+		const ctx = canvas.getContext(`2d`);
+		ctx.scale(dpr, dpr);
+		ctx.clearRect(0, 0, _state.cvsW, _state.cvsH);
+
+		_state.keyRects.forEach(rect => {
+			if (!_state.mappedSet.has(rect.kc)) return;
+			const [primary, sub] = getKeyLabels(rect.kc, rect.label);
+			roundRect(ctx, rect.x + 0.5, rect.y + 0.5, rect.w - 1, rect.h - 1, kr());
+			ctx.fillStyle = C_COLOR.mappedFill;
+			ctx.strokeStyle = C_COLOR.mappedStroke;
+			ctx.lineWidth = 1.5;
+			ctx.fill();
+			ctx.stroke();
+			drawKeyLabel(
+				ctx, rect.x, rect.y, rect.w, rect.h,
+				primary, sub, C_COLOR.mappedText, C_COLOR.mappedText
+			);
+		});
+	};
+
+	// -------------------------------------------------------------------------
+	// 公開 API
+	// -------------------------------------------------------------------------
+
+	/**
+	 * キーボードプレビューを初期化し、ボタンと Canvas コンテナを divRoot に追加する。
+	 *
+	 * @param {HTMLElement} divRoot - キーコンフィグ画面のルート div
+	 */
+	const init = divRoot => {
+		calcScale();
+
+		// ボタン: キャンバス横幅中央に配置、小さいサイズ
+		const btnW = 80;
+		const btnX = Math.floor((g_btnWidth() - btnW) / 2);
+
+		// "↓ Preview" → 展開、"↑ Preview" → 閉じる のトグルボタン
+		const btn = createCss2Button(C_BTN_ID, `↓ Preview`, () => {
+			togglePreview();
+			btn.textContent = _state.visible ? `↑ Preview` : `↓ Preview`;
+		}, {
+			x: btnX, y: BTN_Y, w: btnW, h: BTN_H,
+			title: `キーボードレイアウトのプレビューを表示/非表示`,
+		}, g_cssObj.button_Setting);
+		btn.style.fontSize = `${BTN_FS}px`;
+		divRoot.appendChild(btn);
+
+		// プレビューエリア: 水平・垂直センタリング
+		const areaX = Math.floor((g_btnWidth() - _state.cvsW) / 2);
+		const areaY = 130;
+
+		const areaDiv = createEmptySprite(divRoot, C_PREVIEW_ID, {
+			x: areaX, y: areaY - 60, w: _state.cvsW, h: _state.cvsH + 80, pointerEvents: C_DIS_AUTO,
+			background: `#00000080`,
+		});
+		areaDiv.style.display = `none`;
+		areaDiv.style.position = `absolute`;
+		areaDiv.style.overflow = `hidden`;
+
+		const canvasBase = document.createElement(`canvas`);
+		canvasBase.id = C_CANVAS_BASE_ID;
+		canvasBase.style.cssText = `position:absolute;left:0;top:0;`;
+		areaDiv.appendChild(canvasBase);
+		_state.canvasBase = canvasBase;
+
+		const canvasMap = document.createElement(`canvas`);
+		canvasMap.id = C_CANVAS_MAP_ID;
+		canvasMap.style.cssText = `position:absolute;left:0;top:0;`;
+		areaDiv.appendChild(canvasMap);
+		_state.canvasMap = canvasMap;
+
+		drawBase();
+	};
+
+	/**
+	 * プレビューの表示 / 非表示を切り替える。
+	 * 表示するたびにマッピングレイヤーを最新化する。
+	 */
+	const togglePreview = () => {
+		const area = document.getElementById(C_PREVIEW_ID);
+		if (!area) return;
+
+		_state.visible = !_state.visible;
+		area.style.display = _state.visible ? `block` : `none`;
+
+		if (_state.visible) refresh();
+	};
+
+	/**
+	 * g_keyObj から現在のキー割り当てを取得して mappedSet を更新し、
+	 * プレビューが表示中なら即時再描画する。
+	 *
+	 * g_keyObj[`keyCtrl${currentKey}_${currentPtn}`] は二次元配列:
+	 *   [ [矢印0のkeyCode, 代替keyCode, ...], [矢印1のkeyCode, ...], ... ]
+	 * flat() して 0 より大きい値のみ Set に格納する。
+	 */
+	const refresh = () => {
+		const tkObj = getKeyInfo();
+		const configKeyGroupList = g_headerObj.keyGroupOrder[g_stateObj.scoreId] ??
+			g_keyObj[`keyGroupOrder${tkObj.keyCtrlPtn}`] ?? tkObj.keyGroupList;
+		const ctrl = g_keyObj[`keyCtrl${tkObj.keyCtrlPtn}`]
+			.filter((val, idx) => tkObj.keyGroupMaps[idx].includes(configKeyGroupList[g_keycons.keySwitchNum]));
+		_state.mappedSet = ctrl
+			? new Set(ctrl.flat().filter(v => v > 0))
+			: new Set();
+		if (_state.visible) drawMap();
+	};
+
+	/**
+	 * プレビューを強制非表示にしてリセットする。
+	 * キーコンフィグ画面の離脱時に呼ぶ。
+	 */
+	const dispose = () => {
+		_state.visible = false;
+		_state.mappedSet = new Set();
+		_state.keyRects = [];
+		_state.canvasBase = null;
+		_state.canvasMap = null;
+	};
+
+	return { init, refresh, togglePreview, dispose };
+
+})();
 
 /**
  * 回転できないオブジェクトの場合に設定の自動絞り込みを行う

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -4736,6 +4736,9 @@ const g_lang_lblNameObj = {
         'u_±120deg': `±120°`,
         'u_±360deg': `±360°`,
 
+        unallocated: `未割当`,
+        allocated: `割当済`,
+
         j_ii: "(・∀・)ｲｲ!!",
         j_shakin: "(`・ω・)ｼｬｷﾝ",
         j_matari: "( ´∀`)ﾏﾀｰﾘ",
@@ -4786,6 +4789,9 @@ const g_lang_lblNameObj = {
         'u_Pendulum': `Pendulum`,
         'u_±120deg': `±120deg`,
         'u_±360deg': `±360deg`,
+
+        unallocated: `Unallocated`,
+        allocated: `Allocated`,
 
         j_ii: ":D Perfect!!",
         j_shakin: ":) Great!",

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -4738,6 +4738,7 @@ const g_lang_lblNameObj = {
 
         unallocated: `未割当`,
         allocated: `割当済`,
+        altAllocated: `代替キー`,
 
         j_ii: "(・∀・)ｲｲ!!",
         j_shakin: "(`・ω・)ｼｬｷﾝ",
@@ -4792,6 +4793,7 @@ const g_lang_lblNameObj = {
 
         unallocated: `Unallocated`,
         allocated: `Allocated`,
+        altAllocated: `Alternate Keys`,
 
         j_ii: ":D Perfect!!",
         j_shakin: ":) Great!",

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -4920,6 +4920,7 @@ const g_lang_msgObj = {
         shuffleGroup: `Mirror/X-Mirror/Turning/Random/S-Random選択時、シャッフルするグループを変更します。\n矢印の上にある同じ数字同士でシャッフルします。`,
         stepRtnGroup: `矢印などノーツの種類、回転に関するパターンを切り替えます。\nあらかじめ設定されている場合のみ変更可能です。`,
         kcReset: `対応するキーの割り当てを元に戻します。`,
+        kcPreview: `キーボードレイアウトのプレビューを表示/非表示します。`,
 
         pickArrow: `色番号ごとの矢印色（枠、塗りつぶし）、通常時のフリーズアロー色（枠、帯）を\nカラーピッカーから選んで変更できます。`,
         pickColorR: `設定する矢印色の種類を切り替えます。`,
@@ -5023,6 +5024,7 @@ const g_lang_msgObj = {
         shuffleGroup: `Change the shuffle group when Mirror, X-Mirror, Turning, Random or S-Random are selected.\nShuffle with the same numbers listed above.`,
         stepRtnGroup: `Switches the type of notes, such as arrows, and the pattern regarding rotation.\nThis can only be changed if it has been set in advance.`,
         kcReset: `Restores the corresponding key assignments.`,
+        kcPreview: `Show/hide the preview of the keyboard layout.`,
 
         pickArrow: `Change the frame or fill of arrow color and the frame or bar of normal freeze-arrow color\nfor each color number from the color picker.`,
         pickColorR: `Switches the arrow color type to be set.`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2294,6 +2294,7 @@ for (let j = 0; j < 260; j++) {
 // キーボード配列の言語設定
 const g_lang_kCd = {
     Ja: {
+        13: `Enter`,
         48: `0`,
         49: `1`,
         50: `2`,
@@ -2319,6 +2320,7 @@ const g_lang_kCd = {
         229: `IME`,
     },
     En: {
+        13: `Return`,
         48: `0 )`,
         49: `1 !`,
         50: `2 @`,
@@ -2435,6 +2437,7 @@ g_kCd[134] = `FN`;
 g_kCd[144] = `NumLk`;
 g_kCd[145] = `SL`;
 g_kCd[240] = `CapsLk`;
+g_kCd[242] = `Kana`;
 g_kCd[256] = `R)Shift`;
 g_kCd[257] = `R)Ctrl`;
 g_kCd[258] = `R)Alt`;
@@ -2554,6 +2557,7 @@ g_kCdN[222] = `Equal`;
 g_kCdN[226] = `IntlRo`;
 g_kCdN[229] = `Backquote`;
 g_kCdN[240] = `CapsLock`;
+g_kCdN[242] = `KanaMode`;
 g_kCdN[256] = `ShiftRight`;
 g_kCdN[257] = `ControlRight`;
 g_kCdN[258] = `AltRight`;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. キーコンフィグ画面にキーボードマッププレビューを追加
- キーコンフィグ画面上部に「Preview」ボタンを追加し、
キーボードマップ上に割り当てキーをマッピングした内容を表示する機能を実装しました。
- JIS/USキーボードに対応しています。
- トランスキーの場合は、keyGroupごとの表示になるように制御しています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 実際のキー割当先をわかりやすくするため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/21a72cb2-4777-4e89-8425-4d7363bba41b" /><img width="50%" alt="image" src="https://github.com/user-attachments/assets/b9554783-3849-49cd-bb7c-5e5c279d2680" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
