### PR TITLE
improve: [1087] キーボードマッププレビューの配置調整、ショートカットキー表示に対応、コメント見直し

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10540,8 +10540,8 @@ const keyconfigKeyboardPreview = (() => {
 							{ kc: 32, w: 8.25 },
 						]
 					),
-					{ kc: 93 },
 					{ kc: 258 },
+					{ kc: 93 },
 					...(isJa
 						? [
 							{ kc: 257, w: 1.2 },

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10421,7 +10421,7 @@ const keyconfigKeyboardPreview = (() => {
 	//   offsetX : 行左端の水平オフセット（単位: BASE_KEY_W）。正の値 = 右にずらす。
 	//   keys    : キー定義の配列
 	//
-	// 各キー: { kc, w, h?, label? }
+	// 各キー: { kc, w?, h?, label? }
 	//   kc    : keyCode（数値）。-1 はスペーサー（描画・キャッシュなし）。
 	//   w     : 幅倍率（BASE_KEY_W 基準。省略時 1）
 	//   h     : 高さ倍率（省略時 1）
@@ -10430,23 +10430,6 @@ const keyconfigKeyboardPreview = (() => {
 	//
 	// 右Shift/Ctrl/Alt は danoniplus 独自コード 256〜258 を使用。
 	// -------------------------------------------------------------------------
-
-	// メインキーボード部（Fn行 + 数字行 + QWERTY + ASDF + ZXCV + スペース行）
-	//
-	// 各行の offsetX 設計（1u = BASE_KEY_W）:
-	//   Fn行    0u  Esc が左端
-	//   数字行  0u  229(IME/`) が左端
-	//   QWERTY  0u  Tab(1.5u) が左端、左端位置は数字行と揃う
-	//   ASDF    0u  CapsLk を 2.25u にして L)Shift 左端と揃える
-	//   ZXCV    0.25u  標準キーボードの行オフセットを offsetX + L)Shift 拡大で再現
-	//   スペース行 0u
-	//
-	// JIS と US の主な違い:
-	//   数字行: JIS は intlYen(220) あり、US はなし（BackSpace が広い）
-	//   QWERTY: JIS は [ の右にスペーサー、US はなし（Enter が横長）
-	//   ASDF  : JIS は ¥(221) あり、US はなし（Enter が横長）
-	//   ZXCV  : JIS は intlRo(226) あり、US はなし（R)Shift が広い）
-	//   Enter : JIS は縦長(h=2)、US は横長(h=1, w=2.25)
 	/**
 	 * g_localeObj.val に応じた MAIN_ROWS を生成して返す。
 	 * drawBase / calcScale の都度呼び出し、locale 変化を反映する。
@@ -10470,8 +10453,8 @@ const keyconfigKeyboardPreview = (() => {
 				],
 			},
 			// Row1: 数字行
-			// JIS: ..., 222, 220(intlYen, 0.75u), BS(1.5u)
-			// US : ..., 222,                      BS(2.25u)
+			// JIS: ..., 222, 220(intlYen), BS
+			// US : ..., 222,               BS
 			{
 				offsetX: 0,
 				keys: [
@@ -10481,13 +10464,13 @@ const keyconfigKeyboardPreview = (() => {
 					{ kc: 55 }, { kc: 56 }, { kc: 57 },
 					{ kc: 48 }, { kc: 189 }, { kc: 222 },
 					...(isJa
-						? [{ kc: 220, w: 0.75 }, { kc: 8, w: 1.5 }]  // JIS: intlYen + BS
-						: [{ kc: 8, w: 2.25 }]   // US : BS のみ（広い）
+						? [{ kc: 220, w: 0.75 }, { kc: 8 }]  // JIS: intlYen + BS
+						: [{ kc: 8, w: 1.7 }]   // US : BS のみ（広い）
 					),
 				],
 			},
 			// Row2: QWERTY
-			// JIS: ..., [, スペーサー(0.5u), Enter(縦長 h=2, w=1.25)
+			// JIS: ..., [, Enter
 			// US : ..., [, ]
 			{
 				offsetX: 0,
@@ -10498,46 +10481,48 @@ const keyconfigKeyboardPreview = (() => {
 					{ kc: 85 }, { kc: 73 }, { kc: 79 },
 					{ kc: 80 }, { kc: 192 },
 					...(isJa
-						? [{ kc: 219 }, { kc: -1, w: 0.5 }, { kc: 13, w: 1.25, h: 2 }]  // JIS: [, スペーサー, Enter縦長
-						: [{ kc: 219 }, { kc: 221 }]  // US : [, ]
+						? [{ kc: 219 }, { kc: 13, w: 1.25, h: 2 }]  // JIS: [, Enter縦長
+						: [{ kc: 219 }, { kc: 221, w: 1.2 }]  // US : [, ]
 					),
 				],
 			},
 			// Row3: ASDF
 			// JIS: ..., L, ;, ', ¥(221)
-			// US : ..., L, ;, '      ← ¥なし（Enter が下まで伸びる縦長分を吸収）
+			// US : ..., L, ;, ', Enter(13)
 			{
 				offsetX: 0,
 				keys: [
-					{ kc: 20, w: 2.25, label: `CapsLk` },
+					{ kc: 20, w: 1.75, label: `CapsLk` },
 					{ kc: 65 }, { kc: 83 }, { kc: 68 },
 					{ kc: 70 }, { kc: 71 }, { kc: 72 },
 					{ kc: 74 }, { kc: 75 }, { kc: 76 },
 					{ kc: 187 }, { kc: 186 },
 					...(isJa
 						? [{ kc: 221 }]  // JIS: ¥
-						: [{ kc: 13, w: 2.25 }] // US : Enter横長
+						: [{ kc: 13, w: 1.9 }] // US : Enter横長
 					),
 				],
 			},
-			// Row4: ZXCV（標準配列は ASDF より約 0.25u 右にオフセット）
-			// JIS: ..., /, intlRo(226), R)Shift(1.25u)
-			// US : ..., /,              R)Shift(2.5u)
+			// Row4: ZXCV
+			// JIS: ..., /, intlRo(226), R)Shift
+			// US : ..., /,              R)Shift
 			{
-				offsetX: 0.25,
+				offsetX: 0,
 				keys: [
-					{ kc: 16, w: 2.5 },
+					{ kc: 16, w: 2.25 },
 					{ kc: 90 }, { kc: 88 }, { kc: 67 },
 					{ kc: 86 }, { kc: 66 }, { kc: 78 },
 					{ kc: 77 }, { kc: 188 }, { kc: 190 },
 					{ kc: 191 },
 					...(isJa
-						? [{ kc: 226 }, { kc: 256, w: 1.25 }]  // JIS: intlRo + R)Shift
-						: [{ kc: 256, w: 2.5 }]   // US : R)Shift のみ（広い）
+						? [{ kc: 226 }, { kc: 256, w: 1.5 }]  // JIS: intlRo + R)Shift
+						: [{ kc: 256, w: 2.4 }]   // US : R)Shift のみ（広い）
 					),
 				],
 			},
-			// Row5: スペースバー行（JIS/US 共通）
+			// Row5: スペースバー行
+			// JIS: ..., NoConv(29), Space(32), Conv(28), ...
+			// US:  ..., Space(32), ...
 			{
 				offsetX: 0,
 				keys: [
@@ -10557,12 +10542,19 @@ const keyconfigKeyboardPreview = (() => {
 					),
 					{ kc: 258 },
 					{ kc: 91 },
-					{ kc: 257, w: 1.25 },
+					...(isJa
+						? [
+							{ kc: 257, w: 1.2 },
+						]
+						: [
+							{ kc: 257, w: 1.05 },
+						]
+					),
 				],
 			},
 		];
 	};
-	// 編集キークラスター（Insert/Delete/Home/End/PgUp/PgDn + 矢印キー）
+	// 編集キークラスター（PrintSc/ScrollLk/Pause/Insert/Delete/Home/End/PgUp/PgDn + 矢印キー）
 	// MAIN_ROWS と行インデックスを揃えて配置する。空行はスキップされる。
 	const NAV_ROWS = [
 		{ offsetX: 0, keys: [{ kc: 44, label: `PrintSc` }, { kc: 145, label: `ScrollLk` }, { kc: 19 }] },  // PrintSc ScrollLk Pause
@@ -10583,11 +10575,11 @@ const keyconfigKeyboardPreview = (() => {
 	//   [  T0  ][T_] [TEnter]  ← T0 は横2u、TEnter は縦2u
 	const NUM_ROWS = [
 		{ offsetX: 0, keys: [] },
-		{ offsetX: 0, keys: [{ kc: 144 }, { kc: 111 }, { kc: 106 }, { kc: 109 }] },  // NumLk T/ T* T-
+		{ offsetX: 0, keys: [{ kc: 144 }, { kc: 111 }, { kc: 106 }, { kc: 109 }] },        // NumLk T/ T* T-
 		{ offsetX: 0, keys: [{ kc: 103 }, { kc: 104 }, { kc: 105 }, { kc: 107, h: 2 }] },  // T7 T8 T9 T+(縦2u)
-		{ offsetX: 0, keys: [{ kc: 100 }, { kc: 101 }, { kc: 102 }] },                           // T4 T5 T6
-		{ offsetX: 0, keys: [{ kc: 97 }, { kc: 98 }, { kc: 99 }, { kc: 108, h: 2 }] }, // T1 T2 T3 TEnter(縦2u)
-		{ offsetX: 0, keys: [{ kc: 96, w: 2 }, { kc: 110 }] },                           // T0(横2u) T.
+		{ offsetX: 0, keys: [{ kc: 100 }, { kc: 101 }, { kc: 102 }] },                     // T4 T5 T6
+		{ offsetX: 0, keys: [{ kc: 97 }, { kc: 98 }, { kc: 99 }, { kc: 108, h: 2 }] },     // T1 T2 T3 TEnter(縦2u)
+		{ offsetX: 0, keys: [{ kc: 96, w: 2 }, { kc: 110 }] },                             // T0(横2u) T.
 	];
 
 	// -------------------------------------------------------------------------
@@ -10833,11 +10825,11 @@ const keyconfigKeyboardPreview = (() => {
 		ctx.textBaseline = `middle`;
 
 		const drawLegend = (x, fill, stroke, label) => {
-			roundRect(ctx, x, ly, 10, 10, 2);
+			roundRect(ctx, x, ly - 5, 10, 10, 2);
 			ctx.fillStyle = fill; ctx.fill();
 			ctx.strokeStyle = stroke; ctx.lineWidth = 1; ctx.stroke();
 			ctx.fillStyle = C_COLOR.legendText;
-			ctx.fillText(label, x + 14, ly + 5);
+			ctx.fillText(label, x + 14, ly);
 		};
 
 		drawLegend(8, C_COLOR.keyFill, C_COLOR.keyStroke, g_lblNameObj.unallocated);

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10396,6 +10396,9 @@ const keyconfigKeyboardPreview = (() => {
 		altFill: `#3e3e1a`,   // 代替キー背景
 		altStroke: `#777755`,   // 代替キー枠
 		altText: `#eeeecc`,   // 代替キー文字
+		shortcutFill: `#330011`,   // ショートカットキー背景
+		shortcutStroke: `#ff4466`,   // ショートカットキー枠
+		shortcutText: `#ffaacc`,   // ショートカットキー文字
 		bgFill: `#0d0d1a`,   // Canvas 背景
 		legendText: `#888899`,   // 凡例テキスト
 	};
@@ -10418,17 +10421,19 @@ const keyconfigKeyboardPreview = (() => {
 	// キーレイアウト定義
 	//
 	// 各行: { offsetX, keys }
-	//   offsetX : 行左端の水平オフセット（単位: BASE_KEY_W）。正の値 = 右にずらす。
+	//   offsetX : 行左端の水平オフセット（単位: BASE_KEY_W）。全行 0 で統一し、
+	//             L)Shift の幅で行頭位置を調整する。
 	//   keys    : キー定義の配列
 	//
 	// 各キー: { kc, w?, h?, label? }
 	//   kc    : keyCode（数値）。-1 はスペーサー（描画・キャッシュなし）。
 	//   w     : 幅倍率（BASE_KEY_W 基準。省略時 1）
-	//   h     : 高さ倍率（省略時 1）
+	//   h     : 高さ倍率（BASE_KEY_H 基準。省略時 1）
 	//   label : 省略時は g_kCd[kc] を参照。g_kCd が空文字のキーや
 	//           左右を区別したいキーに指定する。
 	//
 	// 右Shift/Ctrl/Alt は danoniplus 独自コード 256〜258 を使用。
+	// Appli キーは 93 を使用（g_kCd[93] = `Appli`）。
 	// -------------------------------------------------------------------------
 	/**
 	 * g_localeObj.val に応じた MAIN_ROWS を生成して返す。
@@ -10443,18 +10448,18 @@ const keyconfigKeyboardPreview = (() => {
 			{
 				offsetX: 0,
 				keys: [
-					{ kc: 27 },                   // Esc
-					{ kc: -1, w: 0.5 },                   // スペーサー
+					{ kc: 27 },                    // Esc
+					{ kc: -1, w: 0.5 },            // スペーサー
 					{ kc: 112 }, { kc: 113 }, { kc: 114 }, { kc: 115 },
-					{ kc: -1, w: 0.25 },                   // スペーサー
+					{ kc: -1, w: 0.25 },           // スペーサー
 					{ kc: 116 }, { kc: 117 }, { kc: 118 }, { kc: 119 },
-					{ kc: -1, w: 0.25 },                   // スペーサー
+					{ kc: -1, w: 0.25 },           // スペーサー
 					{ kc: 120 }, { kc: 121 }, { kc: 122 }, { kc: 123 },
 				],
 			},
 			// Row1: 数字行
-			// JIS: ..., 222, 220(intlYen), BS
-			// US : ..., 222,               BS
+			// JIS: ..., 220(intlYen), BS
+			// US : ...,               BS
 			{
 				offsetX: 0,
 				keys: [
@@ -10465,12 +10470,12 @@ const keyconfigKeyboardPreview = (() => {
 					{ kc: 48 }, { kc: 189 }, { kc: 222 },
 					...(isJa
 						? [{ kc: 220, w: 0.75 }, { kc: 8 }]  // JIS: intlYen + BS
-						: [{ kc: 8, w: 1.7 }]   // US : BS のみ（広い）
+						: [{ kc: 8, w: 1.7 }]                 // US : BS のみ（広い）
 					),
 				],
 			},
 			// Row2: QWERTY
-			// JIS: ..., [, Enter
+			// JIS: ..., [, Enter(13)
 			// US : ..., [, ]
 			{
 				offsetX: 0,
@@ -10482,7 +10487,7 @@ const keyconfigKeyboardPreview = (() => {
 					{ kc: 80 }, { kc: 192 },
 					...(isJa
 						? [{ kc: 219 }, { kc: 13, w: 1.25, h: 2 }]  // JIS: [, Enter縦長
-						: [{ kc: 219 }, { kc: 221, w: 1.2 }]  // US : [, ]
+						: [{ kc: 219 }, { kc: 221, w: 1.2 }]        // US : [, ]
 					),
 				],
 			},
@@ -10498,14 +10503,15 @@ const keyconfigKeyboardPreview = (() => {
 					{ kc: 74 }, { kc: 75 }, { kc: 76 },
 					{ kc: 187 }, { kc: 186 },
 					...(isJa
-						? [{ kc: 221 }]  // JIS: ¥
-						: [{ kc: 13, w: 1.9 }] // US : Enter横長
+						? [{ kc: 221 }]           // JIS: ¥
+						: [{ kc: 13, w: 1.9 }]    // US : Enter横長
 					),
 				],
 			},
 			// Row4: ZXCV
-			// JIS: ..., /, intlRo(226), R)Shift
-			// US : ..., /,              R)Shift
+			// L)Shift の幅で行頭位置を揃える
+			// JIS: L)Shift, ..., intlRo(226), R)Shift
+			// US : L)Shift, ...,              R)Shift
 			{
 				offsetX: 0,
 				keys: [
@@ -10516,13 +10522,13 @@ const keyconfigKeyboardPreview = (() => {
 					{ kc: 191 },
 					...(isJa
 						? [{ kc: 226 }, { kc: 256, w: 1.5 }]  // JIS: intlRo + R)Shift
-						: [{ kc: 256, w: 2.4 }]   // US : R)Shift のみ（広い）
+						: [{ kc: 256, w: 2.4 }]                // US : R)Shift のみ（広い）
 					),
 				],
 			},
 			// Row5: スペースバー行
-			// JIS: ..., NoConv(29), Space(32), Conv(28), ...
-			// US:  ..., Space(32), ...
+			// JIS: ..., NoConv(29), Space, Conv(28), カタカナひらがな(242), ...
+			// US : ..., Space, ...
 			{
 				offsetX: 0,
 				keys: [
@@ -10543,12 +10549,8 @@ const keyconfigKeyboardPreview = (() => {
 					{ kc: 258 },
 					{ kc: 93 },
 					...(isJa
-						? [
-							{ kc: 257, w: 1.2 },
-						]
-						: [
-							{ kc: 257, w: 1.05 },
-						]
+						? [{ kc: 257, w: 1.2 }]
+						: [{ kc: 257, w: 1.05 }]
 					),
 				],
 			},
@@ -10560,19 +10562,19 @@ const keyconfigKeyboardPreview = (() => {
 		{ offsetX: 0, keys: [{ kc: 44, label: `PrintSc` }, { kc: 145, label: `ScrollLk` }, { kc: 19 }] },  // PrintSc ScrollLk Pause
 		{ offsetX: 0, keys: [{ kc: 45 }, { kc: 36 }, { kc: 33 }] },  // Insert Home PgUp
 		{ offsetX: 0, keys: [{ kc: 46 }, { kc: 35 }, { kc: 34 }] },  // Delete End  PgDn
-		{ offsetX: 0, keys: [] },                                                          // ASDF行：空
+		{ offsetX: 0, keys: [] },                                    // ASDF行：空
 		{ offsetX: 0, keys: [{ kc: -1 }, { kc: 38 }, { kc: -1 }] },  // ↑
 		{ offsetX: 0, keys: [{ kc: 37 }, { kc: 40 }, { kc: 39 }] },  // ← ↓ →
 	];
 
-	// テンキー（Space行の下に余白を空けて横に羅列）
+	// テンキー（MAIN_ROWS と行インデックスを揃えて配置。1行目は空行で Fn行に揃える）
 	// kc は g_kCd 定義に従う: 96〜111=テンキー各種, 144=NumLk
-	// 標準テンキーレイアウト:
+	// 標準テンキーレイアウト（2行目から）:
 	//   [NumLk] [T/] [T*] [T-]
 	//   [T7][T8][T9] [T+]
 	//   [T4][T5][T6] [T+]  ← T+ は縦2u
 	//   [T1][T2][T3] [TEnter]
-	//   [  T0  ][T_] [TEnter]  ← T0 は横2u、TEnter は縦2u
+	//   [  T0  ][T.] [TEnter]  ← T0 は横2u、TEnter は縦2u
 	const NUM_ROWS = [
 		{ offsetX: 0, keys: [] },
 		{ offsetX: 0, keys: [{ kc: 144 }, { kc: 111 }, { kc: 106 }, { kc: 109 }] },        // NumLk T/ T* T-
@@ -10587,14 +10589,15 @@ const keyconfigKeyboardPreview = (() => {
 	// -------------------------------------------------------------------------
 	const _state = {
 		visible: false,
-		mappedSet: new Set(),   // メインキー（各矢印の index 0）
-		altSet: new Set(),   // 代替キー（各矢印の index 1 以降）
+		mappedSet: new Set(),     // メインキー（各矢印の index 0）
+		altSet: new Set(),        // 代替キー（各矢印の index 1 以降）
+		shortcutSet: new Set(),   // プレイ中ショートカット（keyRetry / keyTitleBack / PgDn / PgUp）
 		canvasBase: null,
 		canvasMap: null,
-		keyRects: [],          // { kc, x, y, w, h, label } — drawMap で照合するキャッシュ
-		scale: 1,           // BASE_KEY_W/H に掛けるスケール係数
-		cvsW: 500,         // 実際の Canvas 幅（スケール計算後）
-		cvsH: 240,         // 実際の Canvas 高さ（スケール計算後）
+		keyRects: [],             // { kc, x, y, w, h, label } — drawMap で照合するキャッシュ
+		scale: 1,                 // BASE_KEY_W/H に掛けるスケール係数
+		cvsW: 500,                // 実際の Canvas 幅（スケール計算後）
+		cvsH: 240,                // 実際の Canvas 高さ（スケール計算後）
 	};
 
 	// -------------------------------------------------------------------------
@@ -10621,7 +10624,7 @@ const keyconfigKeyboardPreview = (() => {
 
 	const BASE_NAV_W = 3 * BASE_KEY_W + 2 * BASE_KEY_GAP;  // NAV は 3列固定
 	const BASE_ROW_H = MAIN_ROWS_LEN * (BASE_KEY_H + BASE_KEY_GAP) - BASE_KEY_GAP;  // MAIN+NAV 分の高さ
-	const NUM_ROWS_LEN = 6;  // テンキーの行数
+	const NUM_ROWS_LEN = 6;  // テンキーの行数（1行目は空行、2行目からテンキー配置）
 	const NUM_GAP_H = BASE_KEY_H * 0.4;  // テンキー上部の余白（基準キー高の40%）
 	const BASE_NUM_ROW_H = NUM_ROWS_LEN * (BASE_KEY_H + BASE_KEY_GAP) - BASE_KEY_GAP;  // テンキー部の高さ
 	const BASE_NUM_W = 4 * BASE_KEY_W + 3 * BASE_KEY_GAP;  // テンキー横幅（4列固定）
@@ -10835,6 +10838,7 @@ const keyconfigKeyboardPreview = (() => {
 		drawLegend(8, C_COLOR.keyFill, C_COLOR.keyStroke, g_lblNameObj.unallocated);
 		drawLegend(95, C_COLOR.mappedFill, C_COLOR.mappedStroke, g_lblNameObj.allocated);
 		drawLegend(182, C_COLOR.altFill, C_COLOR.altStroke, g_lblNameObj.altAllocated);
+		drawLegend(269, C_COLOR.shortcutFill, C_COLOR.shortcutStroke, g_lblNameObj.shortcutKey);
 	};
 
 	/**
@@ -10857,7 +10861,7 @@ const keyconfigKeyboardPreview = (() => {
 		ctx.scale(dpr, dpr);
 		ctx.clearRect(0, 0, _state.cvsW, _state.cvsH);
 
-		// 代替キーを先に描画し、メインキーで上書きすることで優先度を表現
+		// 優先度: ショートカット > メイン > 代替（後から描くほど優先）
 		const drawKey = (fill, stroke, text) => rect => {
 			const [primary, sub] = getKeyLabels(rect.kc, rect.label);
 			roundRect(ctx, rect.x + 0.5, rect.y + 0.5, rect.w - 1, rect.h - 1, kr());
@@ -10869,13 +10873,22 @@ const keyconfigKeyboardPreview = (() => {
 			drawKeyLabel(ctx, rect.x, rect.y, rect.w, rect.h, primary, sub, text, text);
 		};
 
+		// 1. 代替キー（メイン・ショートカットと重複しない場合のみ）
 		_state.keyRects
-			.filter(rect => _state.altSet.has(rect.kc) && !_state.mappedSet.has(rect.kc))
+			.filter(rect => _state.altSet.has(rect.kc)
+				&& !_state.mappedSet.has(rect.kc)
+				&& !_state.shortcutSet.has(rect.kc))
 			.forEach(drawKey(C_COLOR.altFill, C_COLOR.altStroke, C_COLOR.altText));
 
+		// 2. メインキー（ショートカットと重複しない場合のみ）
 		_state.keyRects
-			.filter(rect => _state.mappedSet.has(rect.kc))
+			.filter(rect => _state.mappedSet.has(rect.kc) && !_state.shortcutSet.has(rect.kc))
 			.forEach(drawKey(C_COLOR.mappedFill, C_COLOR.mappedStroke, C_COLOR.mappedText));
+
+		// 3. ショートカット（常に最前面）
+		_state.keyRects
+			.filter(rect => _state.shortcutSet.has(rect.kc))
+			.forEach(drawKey(C_COLOR.shortcutFill, C_COLOR.shortcutStroke, C_COLOR.shortcutText));
 	};
 
 	// -------------------------------------------------------------------------
@@ -10963,6 +10976,10 @@ const keyconfigKeyboardPreview = (() => {
 
 		_state.mappedSet = new Set(ctrl.map(arr => arr[0]).filter(v => v > 0));
 		_state.altSet = new Set(ctrl.flatMap(arr => arr.slice(1)).filter(v => v > 0));
+		// プレイ中ショートカット: keyRetry / keyTitleBack は g_headerObj から取得、PgDn(34) / PgUp(33) は固定
+		_state.shortcutSet = new Set(
+			[g_headerObj.keyRetry, g_headerObj.keyTitleBack, 34, 33].filter(v => v > 0)
+		);
 		if (_state.visible) drawMap();
 	};
 
@@ -10974,6 +10991,7 @@ const keyconfigKeyboardPreview = (() => {
 		_state.visible = false;
 		_state.mappedSet = new Set();
 		_state.altSet = new Set();
+		_state.shortcutSet = new Set();
 		_state.keyRects = [];
 		_state.canvasBase = null;
 		_state.canvasMap = null;

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10540,8 +10540,8 @@ const keyconfigKeyboardPreview = (() => {
 							{ kc: 32, w: 8.25 },
 						]
 					),
+					{ kc: 93 },
 					{ kc: 258 },
-					{ kc: 91 },
 					...(isJa
 						? [
 							{ kc: 257, w: 1.2 },

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10833,12 +10833,14 @@ const keyconfigKeyboardPreview = (() => {
 			ctx.strokeStyle = stroke; ctx.lineWidth = 1; ctx.stroke();
 			ctx.fillStyle = C_COLOR.legendText;
 			ctx.fillText(label, x + 14, ly);
-		};
 
-		drawLegend(8, C_COLOR.keyFill, C_COLOR.keyStroke, g_lblNameObj.unallocated);
-		drawLegend(95, C_COLOR.mappedFill, C_COLOR.mappedStroke, g_lblNameObj.allocated);
-		drawLegend(182, C_COLOR.altFill, C_COLOR.altStroke, g_lblNameObj.altAllocated);
-		drawLegend(269, C_COLOR.shortcutFill, C_COLOR.shortcutStroke, g_lblNameObj.shortcutKey);
+			return 14 + ctx.measureText(label).width + 14;
+		};
+		let lx = 8;
+		lx += drawLegend(lx, C_COLOR.keyFill, C_COLOR.keyStroke, g_lblNameObj.unallocated);
+		lx += drawLegend(lx, C_COLOR.mappedFill, C_COLOR.mappedStroke, g_lblNameObj.allocated);
+		lx += drawLegend(lx, C_COLOR.altFill, C_COLOR.altStroke, g_lblNameObj.altAllocated);
+		lx += drawLegend(lx, C_COLOR.shortcutFill, C_COLOR.shortcutStroke, g_lblNameObj.shortcutKey);
 	};
 
 	/**

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -4743,6 +4743,7 @@ const g_lang_lblNameObj = {
         unallocated: `未割当`,
         allocated: `割当済`,
         altAllocated: `代替キー`,
+        shortcutKey: `ショートカットキー`,
 
         j_ii: "(・∀・)ｲｲ!!",
         j_shakin: "(`・ω・)ｼｬｷﾝ",
@@ -4798,6 +4799,7 @@ const g_lang_lblNameObj = {
         unallocated: `Unallocated`,
         allocated: `Allocated`,
         altAllocated: `Alternate Keys`,
+        shortcutKey: `Shortcut Keys`,
 
         j_ii: ":D Perfect!!",
         j_shakin: ":) Great!",


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. キーボードマッププレビューの配置調整、ショートカットキーの表示に対応
- キー毎の幅が揃っていなかったので、レイアウトを調整しました。
- プレイ中ショートカットキーの表示に対応しました。
プレイ中ショートカットキーの変更は、Previewを開き直すことで反映します。

### 2. キーボードマッププレビュー周りのコメント見直し
- 内容と乖離している部分を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 見やすさの改善のため。また、未使用キーをわかりやすくするため。
2. 実態に沿っていないコメントがあったため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/c0268a19-f680-40e8-bcf3-816b70feeeaa" /><img width="50%" alt="image" src="https://github.com/user-attachments/assets/f7863f64-a2b4-46a0-aaa2-6f16e885f2f0" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
