### PR TITLE
fix: [1089] 状況によりキーボードマッププレビューがセンタリングされない問題を修正 他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10417,8 +10417,7 @@ const keyconfigKeyboardPreview = (() => {
 	// キーレイアウト定義
 	//
 	// 各行: { offsetX, keys }
-	//   offsetX : 行左端の水平オフセット（単位: BASE_KEY_W）。全行 0 で統一し、
-	//             L)Shift の幅で行頭位置を調整する。
+	//   offsetX : 行左端の水平オフセット（単位: BASE_KEY_W）。未指定時は0
 	//   keys    : キー定義の配列
 	//
 	// 各キー: { kc, w?, h?, label? }
@@ -10442,7 +10441,6 @@ const keyconfigKeyboardPreview = (() => {
 		return [
 			// Row0: Fn キー行（JIS/US 共通）
 			{
-				offsetX: 0,
 				keys: [
 					{ kc: 27 },                    // Esc
 					{ kc: -1, w: 0.5 },            // スペーサー
@@ -10457,7 +10455,6 @@ const keyconfigKeyboardPreview = (() => {
 			// JIS: ..., 220(intlYen), BS
 			// US : ...,               BS
 			{
-				offsetX: 0,
 				keys: [
 					{ kc: 229 },
 					{ kc: 49 }, { kc: 50 }, { kc: 51 },
@@ -10474,7 +10471,6 @@ const keyconfigKeyboardPreview = (() => {
 			// JIS: ..., [, Enter(13)
 			// US : ..., [, ]
 			{
-				offsetX: 0,
 				keys: [
 					{ kc: 9, w: 1.5 },
 					{ kc: 81 }, { kc: 87 }, { kc: 69 },
@@ -10491,7 +10487,6 @@ const keyconfigKeyboardPreview = (() => {
 			// JIS: ..., L, ;, ', ¥(221)
 			// US : ..., L, ;, ', Enter(13)
 			{
-				offsetX: 0,
 				keys: [
 					{ kc: 20, w: 1.75, label: `CapsLk` },
 					{ kc: 65 }, { kc: 83 }, { kc: 68 },
@@ -10509,7 +10504,6 @@ const keyconfigKeyboardPreview = (() => {
 			// JIS: L)Shift, ..., intlRo(226), R)Shift
 			// US : L)Shift, ...,              R)Shift
 			{
-				offsetX: 0,
 				keys: [
 					{ kc: 16, w: 2.25 },
 					{ kc: 90 }, { kc: 88 }, { kc: 67 },
@@ -10526,7 +10520,6 @@ const keyconfigKeyboardPreview = (() => {
 			// JIS: ..., NoConv(29), Space, Conv(28), カタカナひらがな(242), ...
 			// US : ..., Space, ...
 			{
-				offsetX: 0,
 				keys: [
 					{ kc: 17, w: 1.25 },
 					{ kc: 91 },
@@ -10555,12 +10548,12 @@ const keyconfigKeyboardPreview = (() => {
 	// 編集キークラスター（PrintSc/ScrollLk/Pause/Insert/Delete/Home/End/PgUp/PgDn + 矢印キー）
 	// MAIN_ROWS と行インデックスを揃えて配置する。空行はスキップされる。
 	const NAV_ROWS = [
-		{ offsetX: 0, keys: [{ kc: 44, label: `PrintSc` }, { kc: 145, label: `ScrollLk` }, { kc: 19 }] },  // PrintSc ScrollLk Pause
-		{ offsetX: 0, keys: [{ kc: 45 }, { kc: 36 }, { kc: 33 }] },  // Insert Home PgUp
-		{ offsetX: 0, keys: [{ kc: 46 }, { kc: 35 }, { kc: 34 }] },  // Delete End  PgDn
-		{ offsetX: 0, keys: [] },                                    // ASDF行：空
-		{ offsetX: 0, keys: [{ kc: -1 }, { kc: 38 }, { kc: -1 }] },  // ↑
-		{ offsetX: 0, keys: [{ kc: 37 }, { kc: 40 }, { kc: 39 }] },  // ← ↓ →
+		{ keys: [{ kc: 44, label: `PrintSc` }, { kc: 145, label: `ScrollLk` }, { kc: 19 }] },  // PrintSc ScrollLk Pause
+		{ keys: [{ kc: 45 }, { kc: 36 }, { kc: 33 }] },  // Insert Home PgUp
+		{ keys: [{ kc: 46 }, { kc: 35 }, { kc: 34 }] },  // Delete End  PgDn
+		{ keys: [] },                                    // ASDF行：空
+		{ keys: [{ kc: -1 }, { kc: 38 }, { kc: -1 }] },  // ↑
+		{ keys: [{ kc: 37 }, { kc: 40 }, { kc: 39 }] },  // ← ↓ →
 	];
 
 	// テンキー（MAIN_ROWS と行インデックスを揃えて配置。1行目は空行で Fn行に揃える）
@@ -10572,12 +10565,12 @@ const keyconfigKeyboardPreview = (() => {
 	//   [T1][T2][T3] [TEnter]
 	//   [  T0  ][T.] [TEnter]  ← T0 は横2u、TEnter は縦2u
 	const NUM_ROWS = [
-		{ offsetX: 0, keys: [] },
-		{ offsetX: 0, keys: [{ kc: 144 }, { kc: 111 }, { kc: 106 }, { kc: 109 }] },        // NumLk T/ T* T-
-		{ offsetX: 0, keys: [{ kc: 103 }, { kc: 104 }, { kc: 105 }, { kc: 107, h: 2 }] },  // T7 T8 T9 T+(縦2u)
-		{ offsetX: 0, keys: [{ kc: 100 }, { kc: 101 }, { kc: 102 }] },                     // T4 T5 T6
-		{ offsetX: 0, keys: [{ kc: 97 }, { kc: 98 }, { kc: 99 }, { kc: 108, h: 2 }] },     // T1 T2 T3 TEnter(縦2u)
-		{ offsetX: 0, keys: [{ kc: 96, w: 2 }, { kc: 110 }] },                             // T0(横2u) T.
+		{ keys: [] },
+		{ keys: [{ kc: 144 }, { kc: 111 }, { kc: 106 }, { kc: 109 }] },        // NumLk T/ T* T-
+		{ keys: [{ kc: 103 }, { kc: 104 }, { kc: 105 }, { kc: 107, h: 2 }] },  // T7 T8 T9 T+(縦2u)
+		{ keys: [{ kc: 100 }, { kc: 101 }, { kc: 102 }] },                     // T4 T5 T6
+		{ keys: [{ kc: 97 }, { kc: 98 }, { kc: 99 }, { kc: 108, h: 2 }] },     // T1 T2 T3 TEnter(縦2u)
+		{ keys: [{ kc: 96, w: 2 }, { kc: 110 }] },                             // T0(横2u) T.
 	];
 
 	// -------------------------------------------------------------------------
@@ -10755,7 +10748,7 @@ const keyconfigKeyboardPreview = (() => {
 			if (rowDef.keys.length === 0) return;
 
 			const rowY = originY + rowIdx * (baseKeyH + gap);
-			const startX = originX + Math.floor(rowDef.offsetX * BASE_KEY_W * _state.scale);
+			const startX = originX + Math.floor((rowDef.offsetX || 0) * BASE_KEY_W * _state.scale);
 			let curX = startX;
 
 			rowDef.keys.forEach(keyDef => {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10457,13 +10457,11 @@ const keyconfigKeyboardPreview = (() => {
 			{
 				keys: [
 					{ kc: 229 },
-					{ kc: 49 }, { kc: 50 }, { kc: 51 },
-					{ kc: 52 }, { kc: 53 }, { kc: 54 },
-					{ kc: 55 }, { kc: 56 }, { kc: 57 },
-					{ kc: 48 }, { kc: 189 }, { kc: 222 },
+					{ kc: 49 }, { kc: 50 }, { kc: 51 }, { kc: 52 }, { kc: 53 }, { kc: 54 },
+					{ kc: 55 }, { kc: 56 }, { kc: 57 }, { kc: 48 }, { kc: 189 }, { kc: 222 },
 					...(isJa
 						? [{ kc: 220, w: 0.75 }, { kc: 8, label: `Back\nSpace` }]  // JIS: intlYen + BS
-						: [{ kc: 8, w: 1.7 }]                 // US : BS のみ（広い）
+						: [{ kc: 8, w: 1.7 }]                                      // US : BS のみ（広い）
 					),
 				],
 			},
@@ -10473,10 +10471,8 @@ const keyconfigKeyboardPreview = (() => {
 			{
 				keys: [
 					{ kc: 9, w: 1.5 },
-					{ kc: 81 }, { kc: 87 }, { kc: 69 },
-					{ kc: 82 }, { kc: 84 }, { kc: 89 },
-					{ kc: 85 }, { kc: 73 }, { kc: 79 },
-					{ kc: 80 }, { kc: 192 },
+					{ kc: 81 }, { kc: 87 }, { kc: 69 }, { kc: 82 }, { kc: 84 }, { kc: 89 },
+					{ kc: 85 }, { kc: 73 }, { kc: 79 }, { kc: 80 }, { kc: 192 },
 					...(isJa
 						? [{ kc: 219 }, { kc: 13, w: 1.25, h: 2 }]  // JIS: [, Enter縦長
 						: [{ kc: 219 }, { kc: 221, w: 1.2 }]        // US : [, ]
@@ -10488,7 +10484,7 @@ const keyconfigKeyboardPreview = (() => {
 			// US : ..., L, ;, ', Enter(13)
 			{
 				keys: [
-					{ kc: 20, w: 1.75, label: `CapsLk` },
+					{ kc: 20, w: 1.75, label: `Caps\nLock` },
 					{ kc: 65 }, { kc: 83 }, { kc: 68 },
 					{ kc: 70 }, { kc: 71 }, { kc: 72 },
 					{ kc: 74 }, { kc: 75 }, { kc: 76 },
@@ -10522,21 +10518,12 @@ const keyconfigKeyboardPreview = (() => {
 			{
 				keys: [
 					{ kc: 17, w: 1.25 },
-					{ kc: 91 },
-					{ kc: 18 },
+					{ kc: 91 }, { kc: 18 },
 					...(isJa
-						? [
-							{ kc: 29 },
-							{ kc: 32, w: 5.25 },
-							{ kc: 28 },
-							{ kc: 242 },
-						]
-						: [
-							{ kc: 32, w: 8.25 },
-						]
+						? [{ kc: 29 }, { kc: 32, w: 5.25 }, { kc: 28 }, { kc: 242 }] // JIS: NoConv + Space + Conv + カタカナひらがな
+						: [{ kc: 32, w: 8.25 }]										 // US : Space のみ（広い）
 					),
-					{ kc: 258 },
-					{ kc: 93 },
+					{ kc: 258 }, { kc: 93 },
 					...(isJa
 						? [{ kc: 257, w: 1.2 }]
 						: [{ kc: 257, w: 1.05 }]
@@ -10548,7 +10535,7 @@ const keyconfigKeyboardPreview = (() => {
 	// 編集キークラスター（PrintSc/ScrollLk/Pause/Insert/Delete/Home/End/PgUp/PgDn + 矢印キー）
 	// MAIN_ROWS と行インデックスを揃えて配置する。空行はスキップされる。
 	const NAV_ROWS = [
-		{ keys: [{ kc: 44, label: `PrintSc` }, { kc: 145, label: `ScrollLk` }, { kc: 19 }] },  // PrintSc ScrollLk Pause
+		{ keys: [{ kc: 44, label: `Print\nScreen` }, { kc: 145, label: `Scroll\nLock` }, { kc: 19 }] },  // PrintSc ScrollLk Pause
 		{ keys: [{ kc: 45 }, { kc: 36 }, { kc: 33 }] },  // Insert Home PgUp
 		{ keys: [{ kc: 46 }, { kc: 35 }, { kc: 34 }] },  // Delete End  PgDn
 		{ keys: [] },                                    // ASDF行：空
@@ -10566,7 +10553,7 @@ const keyconfigKeyboardPreview = (() => {
 	//   [  T0  ][T.] [TEnter]  ← T0 は横2u、TEnter は縦2u
 	const NUM_ROWS = [
 		{ keys: [] },
-		{ keys: [{ kc: 144 }, { kc: 111 }, { kc: 106 }, { kc: 109 }] },        // NumLk T/ T* T-
+		{ keys: [{ kc: 144, label: `Num\nLock` }, { kc: 111 }, { kc: 106 }, { kc: 109 }] },        // NumLk T/ T* T-
 		{ keys: [{ kc: 103 }, { kc: 104 }, { kc: 105 }, { kc: 107, h: 2 }] },  // T7 T8 T9 T+(縦2u)
 		{ keys: [{ kc: 100 }, { kc: 101 }, { kc: 102 }] },                     // T4 T5 T6
 		{ keys: [{ kc: 97 }, { kc: 98 }, { kc: 99 }, { kc: 108, h: 2 }] },     // T1 T2 T3 TEnter(縦2u)

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10536,8 +10536,8 @@ const keyconfigKeyboardPreview = (() => {
 	// MAIN_ROWS と行インデックスを揃えて配置する。空行はスキップされる。
 	const NAV_ROWS = [
 		{ keys: [{ kc: 44, label: `Print\nScreen` }, { kc: 145, label: `Scroll\nLock` }, { kc: 19 }] },  // PrintSc ScrollLk Pause
-		{ keys: [{ kc: 45 }, { kc: 36 }, { kc: 33 }] },  // Insert Home PgUp
-		{ keys: [{ kc: 46 }, { kc: 35 }, { kc: 34 }] },  // Delete End  PgDn
+		{ keys: [{ kc: 45 }, { kc: 36 }, { kc: 33, label: `Page\nUp` }] },    // Insert Home PgUp
+		{ keys: [{ kc: 46 }, { kc: 35 }, { kc: 34, label: `Page\nDown` }] },  // Delete End  PgDn
 		{ keys: [] },                                    // ASDF行：空
 		{ keys: [{ kc: -1 }, { kc: 38 }, { kc: -1 }] },  // ↑
 		{ keys: [{ kc: 37 }, { kc: 40 }, { kc: 39 }] },  // ← ↓ →

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10917,10 +10917,9 @@ const keyconfigKeyboardPreview = (() => {
 			togglePreview();
 			btn.textContent = _state.visible ? `↑ Preview` : `↓ Preview`;
 		}, {
-			x: btnX, y: BTN_Y, w: btnW, h: BTN_H,
+			x: btnX, y: BTN_Y, w: btnW, h: BTN_H, siz: BTN_FS,
 			title: g_msgObj.kcPreview,
 		}, g_cssObj.button_Setting);
-		btn.style.fontSize = `${BTN_FS}px`;
 		divRoot.appendChild(btn);
 
 		// プレビューエリア: 水平・垂直センタリング
@@ -10929,21 +10928,16 @@ const keyconfigKeyboardPreview = (() => {
 
 		const areaDiv = createEmptySprite(divRoot, C_PREVIEW_ID, {
 			x: areaX, y: areaY - 60, w: _state.cvsW, h: _state.cvsH + 80,
-			pointerEvents: C_DIS_AUTO, background: `#00000080`,
+			pointerEvents: C_DIS_AUTO, background: `#00000080`, display: C_DIS_NONE, overflow: `hidden`,
 		});
-		areaDiv.style.display = `none`;
-		areaDiv.style.position = `absolute`;
-		areaDiv.style.overflow = `hidden`;
 
 		const canvasBase = document.createElement(`canvas`);
 		canvasBase.id = C_CANVAS_BASE_ID;
-		canvasBase.style.cssText = `position:absolute;left:0;top:0;`;
 		areaDiv.appendChild(canvasBase);
 		_state.canvasBase = canvasBase;
 
 		const canvasMap = document.createElement(`canvas`);
 		canvasMap.id = C_CANVAS_MAP_ID;
-		canvasMap.style.cssText = `position:absolute;left:0;top:0;`;
 		areaDiv.appendChild(canvasMap);
 		_state.canvasMap = canvasMap;
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10910,7 +10910,7 @@ const keyconfigKeyboardPreview = (() => {
 
 		// ボタン: キャンバス横幅中央に配置、小さいサイズ
 		const btnW = 80;
-		const btnX = Math.floor((g_btnWidth() - btnW) / 2);
+		const btnX = g_btnX() + Math.floor((g_btnWidth() - btnW) / 2);
 
 		// "↓ Preview" → 展開、"↑ Preview" → 閉じる のトグルボタン
 		const btn = createCss2Button(C_BTN_ID, `↓ Preview`, () => {
@@ -10924,7 +10924,7 @@ const keyconfigKeyboardPreview = (() => {
 		divRoot.appendChild(btn);
 
 		// プレビューエリア: 水平・垂直センタリング
-		const areaX = Math.floor((g_btnWidth() - _state.cvsW) / 2);
+		const areaX = g_btnX() + Math.floor((g_btnWidth() - _state.cvsW) / 2);
 		const areaY = 130;
 
 		const areaDiv = createEmptySprite(divRoot, C_PREVIEW_ID, {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10485,10 +10485,8 @@ const keyconfigKeyboardPreview = (() => {
 			{
 				keys: [
 					{ kc: 20, w: 1.75, label: `Caps\nLock` },
-					{ kc: 65 }, { kc: 83 }, { kc: 68 },
-					{ kc: 70 }, { kc: 71 }, { kc: 72 },
-					{ kc: 74 }, { kc: 75 }, { kc: 76 },
-					{ kc: 187 }, { kc: 186 },
+					{ kc: 65 }, { kc: 83 }, { kc: 68 }, { kc: 70 }, { kc: 71 }, { kc: 72 },
+					{ kc: 74 }, { kc: 75 }, { kc: 76 }, { kc: 187 }, { kc: 186 },
 					...(isJa
 						? [{ kc: 221 }]           // JIS: ¥
 						: [{ kc: 13, w: 1.9 }]    // US : Enter横長
@@ -10502,13 +10500,11 @@ const keyconfigKeyboardPreview = (() => {
 			{
 				keys: [
 					{ kc: 16, w: 2.25 },
-					{ kc: 90 }, { kc: 88 }, { kc: 67 },
-					{ kc: 86 }, { kc: 66 }, { kc: 78 },
-					{ kc: 77 }, { kc: 188 }, { kc: 190 },
-					{ kc: 191 },
+					{ kc: 90 }, { kc: 88 }, { kc: 67 }, { kc: 86 }, { kc: 66 }, { kc: 78 },
+					{ kc: 77 }, { kc: 188 }, { kc: 190 }, { kc: 191 },
 					...(isJa
 						? [{ kc: 226 }, { kc: 256, w: 1.5 }]  // JIS: intlRo + R)Shift
-						: [{ kc: 256, w: 2.4 }]                // US : R)Shift のみ（広い）
+						: [{ kc: 256, w: 2.4 }]               // US : R)Shift のみ（広い）
 					),
 				],
 			},
@@ -10517,11 +10513,12 @@ const keyconfigKeyboardPreview = (() => {
 			// US : ..., Space, ...
 			{
 				keys: [
-					{ kc: 17, w: 1.25 },
-					{ kc: 91 }, { kc: 18 },
+					{ kc: 17, w: 1.25 }, { kc: 91 }, { kc: 18 },
 					...(isJa
-						? [{ kc: 29 }, { kc: 32, w: 5.25 }, { kc: 28 }, { kc: 242 }] // JIS: NoConv + Space + Conv + カタカナひらがな
-						: [{ kc: 32, w: 8.25 }]										 // US : Space のみ（広い）
+						// JIS: NoConv + Space + Conv + カタカナひらがな
+						? [{ kc: 29 }, { kc: 32, w: 5.25 }, { kc: 28 }, { kc: 242 }]
+						// US : Space のみ（広い）
+						: [{ kc: 32, w: 8.25 }]
 					),
 					{ kc: 258 }, { kc: 93 },
 					...(isJa
@@ -10535,7 +10532,7 @@ const keyconfigKeyboardPreview = (() => {
 	// 編集キークラスター（PrintSc/ScrollLk/Pause/Insert/Delete/Home/End/PgUp/PgDn + 矢印キー）
 	// MAIN_ROWS と行インデックスを揃えて配置する。空行はスキップされる。
 	const NAV_ROWS = [
-		{ keys: [{ kc: 44, label: `Print\nScreen` }, { kc: 145, label: `Scroll\nLock` }, { kc: 19 }] },  // PrintSc ScrollLk Pause
+		{ keys: [{ kc: 44, label: `Print\nScreen` }, { kc: 145, label: `Scroll\nLock` }, { kc: 19 }] },
 		{ keys: [{ kc: 45 }, { kc: 36 }, { kc: 33, label: `Page\nUp` }] },    // Insert Home PgUp
 		{ keys: [{ kc: 46 }, { kc: 35 }, { kc: 34, label: `Page\nDown` }] },  // Delete End  PgDn
 		{ keys: [] },                                    // ASDF行：空
@@ -10553,7 +10550,7 @@ const keyconfigKeyboardPreview = (() => {
 	//   [  T0  ][T.] [TEnter]  ← T0 は横2u、TEnter は縦2u
 	const NUM_ROWS = [
 		{ keys: [] },
-		{ keys: [{ kc: 144, label: `Num\nLock` }, { kc: 111 }, { kc: 106 }, { kc: 109 }] },        // NumLk T/ T* T-
+		{ keys: [{ kc: 144, label: `Num\nLock` }, { kc: 111 }, { kc: 106 }, { kc: 109 }] }, // NumLk T/ T* T-
 		{ keys: [{ kc: 103 }, { kc: 104 }, { kc: 105 }, { kc: 107, h: 2 }] },  // T7 T8 T9 T+(縦2u)
 		{ keys: [{ kc: 100 }, { kc: 101 }, { kc: 102 }] },                     // T4 T5 T6
 		{ keys: [{ kc: 97 }, { kc: 98 }, { kc: 99 }, { kc: 108, h: 2 }] },     // T1 T2 T3 TEnter(縦2u)


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. 状況によりキーボードマッププレビューがセンタリングされない問題を修正
- 横幅がボタン描画エリアの最大値よりも大きいときに、キーボードマッププレビューがセンタリングされないようになっていました。

### 2. キーボードマッププレビューのキー名を一部正式名に変更
- 二段表記に対応したため、幅が問題ないキーについて正式名に変更しました。

### 3. 不要なコードの修正
- CSSスタイル直指定している箇所について、関数内でまとめられたり不要なため見直しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. ボタンの左端を指定する関数である`g_btnX()`の指定忘れです。
2. わかりやすさのため。
3. 他のコードとの整合のため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="80%" alt="image" src="https://github.com/user-attachments/assets/61f47cfb-a7c3-41fa-917f-9471cdcf0179" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
