### PR TITLE
feat: [1091] 判定系のカスタム関数の引数にレーン番号を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -14186,7 +14186,7 @@ const mainInit = () => {
 			if (_cnt === 0) {
 				const stepDivHit = document.getElementById(`stepHit${_j}`);
 
-				judgeIi(_cnt);
+				judgeIi(_cnt, _j);
 				stepDivHit.style.opacity = 1;
 				stepDivHit.setAttribute(`cnt`, C_FRM_HITMOTION);
 				judgeObjDelete.arrow(_j, _arrowName);
@@ -14214,7 +14214,7 @@ const mainInit = () => {
 
 		// フリーズアロー(成功時)
 		frzOK: (_j, _k, _frzName, _cnt) => {
-			judgeKita(_cnt);
+			judgeKita(_cnt, _j);
 			$id(`frzHit${_j}`).opacity = 0;
 			g_attrObj[_frzName].judgEndFlg = true;
 			judgeObjDelete.frz(_j, _frzName);
@@ -14231,12 +14231,12 @@ const mainInit = () => {
 		// フリーズアロー(枠外判定)
 		frzNG: (_j, _k, _frzName, _cnt) => {
 			if (_cnt < (-1) * g_judgObj.frzJ[g_judgPosObj.iknai]) {
-				judgeIknai(_cnt);
+				judgeIknai(_cnt, _j);
 				g_attrObj[_frzName].judgEndFlg = true;
 
 				changeFailedFrz(_j, _k);
 				if (g_headerObj.frzStartjdgUse) {
-					judgeUwan(_cnt);
+					judgeUwan(_cnt, _j);
 				}
 			}
 		},
@@ -14247,7 +14247,7 @@ const mainInit = () => {
 		// フリーズアロー(キーを離したときの処理)
 		frzKeyUp: (_j, _k, _frzName, _cnt) => {
 			if (g_attrObj[_frzName].keyUpFrame > g_headerObj.frzAttempt) {
-				judgeIknai(_cnt);
+				judgeIknai(_cnt, _j);
 				g_attrObj[_frzName].judgEndFlg = true;
 				changeFailedFrz(_j, _k);
 			}
@@ -14289,7 +14289,7 @@ const mainInit = () => {
 
 					// 自身より前の矢印が未判定の場合、強制的に枠外判定を行い矢印を削除
 					if (prevArrow.cnt >= (-1) * g_judgObj.arrowJ[g_judgPosObj.uwan]) {
-						judgeUwan(prevArrow.cnt);
+						judgeUwan(prevArrow.cnt, _j);
 						judgeObjDelete.arrow(_j, prevArrowName);
 					}
 				}
@@ -14316,9 +14316,9 @@ const mainInit = () => {
 
 					// 自身より前のフリーズアローが未判定の場合、強制的に枠外判定を行う
 					if (prevFrz.cnt >= (-1) * g_judgObj.frzJ[g_judgPosObj.iknai] && !prevFrz.judgEndFlg) {
-						judgeIknai(prevFrz.cnt);
+						judgeIknai(prevFrz.cnt, _j);
 						if (g_headerObj.frzStartjdgUse) {
-							judgeUwan(prevFrz.cnt);
+							judgeUwan(prevFrz.cnt, _j);
 						}
 					}
 					// 自身より前のフリーズアローを削除して判定対象を自身に変更 (g_workObj.judgFrzCnt[_j]をカウントアップ)
@@ -14332,7 +14332,7 @@ const mainInit = () => {
 			if (_cnt === 0) {
 				changeHitFrz(_j, _k, `frz`);
 				if (g_headerObj.frzStartjdgUse) {
-					judgeIi(_cnt);
+					judgeIi(_cnt, _j);
 				}
 			}
 		},
@@ -15544,7 +15544,7 @@ const judgeArrow = _j => {
 		} else if (_difCnt <= g_judgObj.arrowJ[g_judgPosObj.shobon]) {
 			// 通常判定
 			const [resultFunc, resultJdg] = checkJudgment(_difCnt);
-			resultFunc(_difFrame);
+			resultFunc(_difFrame, _j);
 			displayDiff(_difFrame);
 			stepHitTargetArrow(resultJdg);
 			document.getElementById(arrowName).remove();
@@ -15572,7 +15572,7 @@ const judgeArrow = _j => {
 			} else {
 				changeFailedFrz(_j, fcurrentNo);
 				if (g_headerObj.frzStartjdgUse) {
-					judgeIknai(_difFrame);
+					judgeIknai(_difFrame, _j);
 					currentFrz.judgEndFlg = true;
 				}
 			}
@@ -15708,8 +15708,9 @@ const updateCombo = () => {
  * 回復判定の共通処理
  * @param {string} _name 
  * @param {number} _difFrame 
+ * @param {number} _j
  */
-const judgeRecovery = (_name, _difFrame) => {
+const judgeRecovery = (_name, _difFrame, _j) => {
 	changeJudgeCharacter(_name, g_lblNameObj[`j_${_name}`]);
 	updateCombo();
 	lifeRecovery();
@@ -15727,65 +15728,72 @@ const judgeRecovery = (_name, _difFrame) => {
 	if (_name === `shakin`) {
 		quickRetry(`Shakin(Great)`);
 	}
-	safeExecuteCustomHooks(`g_customJsObj.judg_${_name}`, g_customJsObj[`judg_${_name}`], _difFrame);
+	safeExecuteCustomHooks(`g_customJsObj.judg_${_name}`, g_customJsObj[`judg_${_name}`], _difFrame, _j);
 };
 
 /**
  * ダメージ系共通処理
  * @param {string} _name 
  * @param {number} _difFrame 
+ * @param {number} _j
  */
-const judgeDamage = (_name, _difFrame) => {
+const judgeDamage = (_name, _difFrame, _j) => {
 	changeJudgeCharacter(_name, g_lblNameObj[`j_${_name}`]);
 	g_resultObj.combo = 0;
 	comboJ.textContent = ``;
 	diffJ.textContent = ``;
 	lifeDamage();
-	safeExecuteCustomHooks(`g_customJsObj.judg_${_name}`, g_customJsObj[`judg_${_name}`], _difFrame);
+	safeExecuteCustomHooks(`g_customJsObj.judg_${_name}`, g_customJsObj[`judg_${_name}`], _difFrame, _j);
 };
 
 /**
  * 判定処理：イイ
  * @param {number} _difFrame 
+ * @param {number} _j
  */
-const judgeIi = _difFrame => judgeRecovery(`ii`, _difFrame);
+const judgeIi = (_difFrame, _j) => judgeRecovery(`ii`, _difFrame, _j);
 
 /**
  * 判定処理：シャキン
  * @param {number} _difFrame 
+ * @param {number} _j
  */
-const judgeShakin = _difFrame => judgeRecovery(`shakin`, _difFrame);
+const judgeShakin = (_difFrame, _j) => judgeRecovery(`shakin`, _difFrame, _j);
 
 /**
  * 判定処理：マターリ
  * @param {number} _difFrame 
+ * @param {number} _j
  */
-const judgeMatari = _difFrame => {
+const judgeMatari = (_difFrame, _j) => {
 	changeJudgeCharacter(`matari`, g_lblNameObj.j_matari);
 	comboJ.textContent = ``;
 	finishViewing();
 	quickRetry(`Matari(Good)`);
 
-	safeExecuteCustomHooks(`g_customJsObj.judg_matari`, g_customJsObj.judg_matari, _difFrame);
+	safeExecuteCustomHooks(`g_customJsObj.judg_matari`, g_customJsObj.judg_matari, _difFrame, _j);
 };
 
 /**
  * 判定処理：ショボーン
  * @param {number} _difFrame 
+ * @param {number} _j
  */
-const judgeShobon = _difFrame => judgeDamage(`shobon`, _difFrame);
+const judgeShobon = (_difFrame, _j) => judgeDamage(`shobon`, _difFrame, _j);
 
 /**
  * 判定処理：ウワァン
  * @param {number} _difFrame 
+ * @param {number} _j
  */
-const judgeUwan = _difFrame => judgeDamage(`uwan`, _difFrame);
+const judgeUwan = (_difFrame, _j) => judgeDamage(`uwan`, _difFrame, _j);
 
 /**
  * 判定処理：キター
  * @param {number} _difFrame 
+ * @param {number} _j
  */
-const judgeKita = _difFrame => {
+const judgeKita = (_difFrame, _j) => {
 	changeJudgeCharacter(`kita`, g_lblNameObj.j_kita, `F`);
 
 	if (++g_resultObj.fCombo > g_resultObj.fmaxCombo) {
@@ -15797,21 +15805,22 @@ const judgeKita = _difFrame => {
 	lifeRecovery();
 	finishViewing();
 
-	safeExecuteCustomHooks(`g_customJsObj.judg_kita`, g_customJsObj.judg_kita, _difFrame);
+	safeExecuteCustomHooks(`g_customJsObj.judg_kita`, g_customJsObj.judg_kita, _difFrame, _j);
 };
 
 /**
  * 判定処理：イクナイ
  * @param {number} _difFrame 
+ * @param {number} _j
  */
-const judgeIknai = _difFrame => {
+const judgeIknai = (_difFrame, _j) => {
 	changeJudgeCharacter(`iknai`, g_lblNameObj.j_iknai, `F`);
 	comboFJ.textContent = ``;
 	g_resultObj.fCombo = 0;
 
 	lifeDamage();
 
-	safeExecuteCustomHooks(`g_customJsObj.judg_iknai`, g_customJsObj.judg_iknai, _difFrame);
+	safeExecuteCustomHooks(`g_customJsObj.judg_iknai`, g_customJsObj.judg_iknai, _difFrame, _j);
 };
 
 const jdgList = [`ii`, `shakin`, `matari`, `shobon`].map(jdg => toCapitalize(jdg));

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -14176,7 +14176,7 @@ const mainInit = () => {
 		// 矢印(枠外判定、AutoPlay: OFF)
 		arrowOFF: (_j, _arrowName, _cnt) => {
 			if (_cnt < (-1) * g_judgObj.arrowJ[g_judgPosObj.shobon]) {
-				judgeUwan(_cnt);
+				judgeUwan(_cnt, _j);
 				judgeObjDelete.arrow(_j, _arrowName);
 			}
 		},
@@ -14198,7 +14198,7 @@ const mainInit = () => {
 			if (_cnt === 0) {
 				const stepDivHit = document.getElementById(`stepHit${_j}`);
 
-				safeExecuteCustomHooks(`g_customJsObj.dummyArrow`, g_customJsObj.dummyArrow);
+				safeExecuteCustomHooks(`g_customJsObj.dummyArrow`, g_customJsObj.dummyArrow, _j);
 				stepDivHit.style.top = wUnit(-15);
 				stepDivHit.style.opacity = 1;
 				stepDivHit.classList.value = ``;
@@ -14222,7 +14222,7 @@ const mainInit = () => {
 
 		// ダミーフリーズアロー(成功時)
 		dummyFrzOK: (_j, _k, _frzName, _cnt) => {
-			safeExecuteCustomHooks(`g_customJsObj.dummyFrz`, g_customJsObj.dummyFrz);
+			safeExecuteCustomHooks(`g_customJsObj.dummyFrz`, g_customJsObj.dummyFrz, _j);
 			$id(`frzHit${_j}`).opacity = 0;
 			g_attrObj[_frzName].judgEndFlg = true;
 			judgeObjDelete.dummyFrz(_j, _frzName);
@@ -15470,7 +15470,7 @@ const changeHitFrz = (_j, _k, _name, _difFrame = 0) => {
 	if (g_stateObj.frzReturn !== C_FLG_OFF) {
 		startFrzReturn();
 	}
-	safeExecuteCustomHooks(`g_customJsObj.judg_${_name}Hit`, g_customJsObj[`judg_${_name}Hit`], _difFrame);
+	safeExecuteCustomHooks(`g_customJsObj.judg_${_name}Hit`, g_customJsObj[`judg_${_name}Hit`], _difFrame, _j);
 };
 
 /**
@@ -15561,7 +15561,7 @@ const judgeArrow = _j => {
 
 			if (g_headerObj.frzStartjdgUse) {
 				const [resultFunc] = checkJudgment(_difCnt);
-				resultFunc(_difFrame);
+				resultFunc(_difFrame, _j);
 				displayDiff(_difFrame);
 			} else {
 				displayDiff(_difFrame, `F`);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. 判定系のカスタム関数の引数にレーン番号を追加
- 判定系のカスタム関数（g_customJsObj.judg_XXX）の引数にレーン番号（_j）を追加しました。
- 差分フレーム数、レーン番号の順に引数を受けると、取得できるようになります。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. Discordでの要望より。
https://discord.com/channels/698460971231870977/944491021918683196/1505190030132383835

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- 従来通りの引数でも動作すると思いますが、アップグレードガイドへ追記する予定です。