### PR TITLE
improve: [1092] ColorTypeでカラーパレット表示時にキーコンフィグ画面に警告メッセージを表示する仕様に変更 他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9812,7 +9812,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		// ColorType警告メッセージ
 		createDivCss2Label(
 			`kcMsg2`,
-			[`Default`, `Type0`].includes(g_colorType) ? `` : g_lblNameObj.colorTypeDesc,
+			g_keycons.colorDefTypes.includes(g_colorType) ? `` : g_lblNameObj.colorTypeDesc,
 			g_lblPosObj.kcMsg2, g_cssObj.keyconfig_Defaultkey
 		),
 
@@ -9994,7 +9994,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	const setColorType = (_scrollNum = 1, _reloadFlg = true) => {
 		const nextNum = getNextNum(_scrollNum, `colorTypes`, g_colorType);
 		g_colorType = g_keycons.colorTypes[nextNum];
-		const isDefault = [`Default`, `Type0`].includes(g_colorType);
+		const isDefault = g_keycons.colorDefTypes.includes(g_colorType);
 		if (g_headerObj.colorUse) {
 			g_stateObj.d_color = boolToSwitch(g_keycons.colorDefTypes.findIndex(val => val === g_colorType) !== -1);
 		}
@@ -10027,7 +10027,7 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	};
 
 	const colorPickSprite = createEmptySprite(divRoot, `colorPickSprite`, { ...g_windowObj.colorPickSprite, title: g_msgObj.pickArrow });
-	if ([`Default`, `Type0`].includes(g_colorType)) {
+	if (g_keycons.colorDefTypes.includes(g_colorType)) {
 		colorPickSprite.style.display = C_DIS_NONE;
 	}
 	multiAppend(colorPickSprite,
@@ -11062,7 +11062,7 @@ const updateKeyInfo = (_header, _keyCtrlPtn) => {
  * - ここでのID管理は1譜面目も区別して設定する (setScoreIdHeaderの第三引数を使用)
  */
 const changeSetColor = () => {
-	const isDefault = [`Default`, `Type0`].includes(g_colorType);
+	const isDefault = g_keycons.colorDefTypes.includes(g_colorType);
 	const idHeader = setScoreIdHeader(g_stateObj.scoreId, false, true);
 	const defaultType = idHeader + g_colorType;
 	const currentTypes = {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9809,6 +9809,12 @@ const keyConfigInit = (_kcType = g_kcType) => {
 			hasVal(g_keyObj[`transKey${keyCtrlPtn}`]) ? g_lblNameObj.transKeyDesc : ``,
 			g_lblPosObj.kcMsg, g_cssObj.keyconfig_warning
 		),
+		// ColorType警告メッセージ
+		createDivCss2Label(
+			`kcMsg2`,
+			[`Default`, `Type0`].includes(g_colorType) ? `` : g_lblNameObj.colorTypeDesc,
+			g_lblPosObj.kcMsg2, g_cssObj.keyconfig_Defaultkey
+		),
 
 		// キーカラータイプ切替ボタン
 		makeKCButtonHeader(`lblcolorType`, `ColorType`, { x: 10 + g_btnX() }, g_cssObj.keyconfig_ColorType),
@@ -9988,14 +9994,18 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	const setColorType = (_scrollNum = 1, _reloadFlg = true) => {
 		const nextNum = getNextNum(_scrollNum, `colorTypes`, g_colorType);
 		g_colorType = g_keycons.colorTypes[nextNum];
+		const isDefault = [`Default`, `Type0`].includes(g_colorType);
 		if (g_headerObj.colorUse) {
 			g_stateObj.d_color = boolToSwitch(g_keycons.colorDefTypes.findIndex(val => val === g_colorType) !== -1);
 		}
 		changeSetColor();
 		viewGroupObj.color(`_${g_keycons.colorGroupNum}`);
 		lnkColorType.textContent = `${getStgDetailName(g_colorType)}${g_localStorage.colorType === g_colorType ? ' *' : ''}`;
+		kcMsg2.textContent = isDefault ? `` : g_lblNameObj.colorTypeDesc;
+		kcMsg2.style.top = wUnit(hasVal(g_keyObj[`transKey${keyCtrlPtn}`]) ? g_lblPosObj.kcMsg2.y : g_lblPosObj.kcMsg.y);
+		kcMsg2.style.fontSize = wUnit(getFontSize2(kcMsg2.textContent, g_btnWidth()));
 		if (_reloadFlg) {
-			colorPickSprite.style.display = ([`Default`, `Type0`].includes(g_colorType) ? C_DIS_NONE : C_DIS_INHERIT);
+			colorPickSprite.style.display = isDefault ? C_DIS_NONE : C_DIS_INHERIT;
 			g_keycons.colorCursorNum = g_keycons.colorCursorNum % Math.ceil(g_headerObj.setColor.length / g_limitObj.kcColorPickerNum);
 			changeColorPickers();
 		}

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -542,7 +542,10 @@ const updateWindowSiz = () => {
             x: g_btnX(), y: g_sHeight - 50, w: g_btnWidth(1 / 4), h: 20,
         },
         kcMsg: {
-            x: g_btnX(), y: g_sHeight - 33, w: g_btnWidth(), h: 20, siz: g_limitObj.mainSiz,
+            x: g_btnX(), y: g_sHeight - 35, w: g_btnWidth(), h: 20, siz: g_limitObj.mainSiz,
+        },
+        kcMsg2: {
+            x: g_btnX(), y: g_sHeight - 20, w: g_btnWidth(), h: 20, siz: g_limitObj.mainSiz,
         },
         kcDesc: {
             x: g_btnX() + 50, y: 68, w: g_btnWidth() - 100, h: 20,
@@ -4719,6 +4722,7 @@ const g_lang_lblNameObj = {
         kcShortcutDesc1: `タイトルバック: {0}`,
         kcShortcutDesc2: `リトライ: {1}`,
         transKeyDesc: `別キーモードではキーコンフィグ、ColorType等は保存されません`,
+        colorTypeDesc: `現在のColorTypeの設定では、色変化(Display:Color)は自動的にOFFになります`,
         sdShortcutDesc: `Hid+/Sud+時ショートカット：「pageUp」カバーを上へ / 「pageDown」下へ`,
         resultImageDesc: `画像を右クリックしてコピーできます`,
 
@@ -4775,6 +4779,7 @@ const g_lang_lblNameObj = {
         kcShortcutDesc1: `Return to title: {0}`,
         kcShortcutDesc2: `Retry the game: {1}`,
         transKeyDesc: `Key config, Color type, etc. are not saved in another key mode`,
+        colorTypeDesc: `With the current ColorType setting, color change (Display:Color) will be automatically turned OFF.`,
         sdShortcutDesc: `When "Hidden+" or "Sudden+" select, "pageUp" cover up / "pageDown" cover down`,
         resultImageDesc: `You can copy the image by right-clicking on it.`,
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. ColorTypeでカラーパレット表示時にキーコンフィグ画面に警告メッセージを表示する仕様に変更
- ColorTypeでカラーパレット表示する設定（Default/Type0以外）のときに
警告メッセージを表示するようにしました。
- 青色で表示する仕様とし別キーモード表示の下に表示しますが、
別キーモード警告が無い場合はその分上に表示します。

### 2. 関連コードの整理
- Default/Type0を識別するパターンが多いため、`g_keycons.colorDefTypes`を参照するように変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. ColorTypeでカラーパレット表示時に色変化が自動OFFされる仕様が認知されにくいため。
Discordでの指摘の派生です。
なお実際には無効ではなくOFFにするだけなので、Display設定よりColorをONにすれば、色変化は反映されます。
2. 類似コードを統一してコードを見やすくするため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/ef029b85-3c8b-4cb1-b5d0-2df0e9be1205" /><img width="50%" alt="image" src="https://github.com/user-attachments/assets/bf7672f2-8863-46e4-86f9-8b73d3855353" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- メッセージを2段にすると横スクロールが出るパターンが対応できませんが、現状そういったものはキリズマやパンパネしかなく、それらに別キーモードは存在しないためこの実装でも良いと考えています。