### PR TITLE
feat: [1094] 色変化(ncolor_data)の0フレーム時の色をキーコンフィグ画面に一部反映する仕様を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9499,16 +9499,21 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 	).filter(val => val[0] === 0);
 	const initColors = [];
 	arrowColors.forEach(val => {
-		if (val[1].startsWith('g')) {
+		const laneToken = val[1];
+		const laneStr = String(laneToken ?? ``);
+		if (laneStr.startsWith('g')) {
 			// g付きの場合は矢印グループから対象の矢印番号を検索
-			const groupVal = setIntVal(val[1].slice(1));
+			const groupVal = setIntVal(laneStr.slice(1));
 			for (let j = 0; j < tkObj.keyNum; j++) {
 				if (g_keyObj[`color${tkObj.keyCtrlPtn}`][j] === groupVal) {
 					initColors[j] = makeColorGradation(val[2]);
 				}
 			}
 		} else {
-			initColors[val[1]] = makeColorGradation(val[2]);
+			const laneIdx = setIntVal(laneToken, -1);
+			if (laneIdx >= 0 && laneIdx < tkObj.keyNum) {
+				initColors[laneIdx] = makeColorGradation(val[2]);
+			}
 		}
 	});
 	if (_initFlg) {
@@ -9535,11 +9540,19 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 	 */
 	const getKeyConfigColor = (_j, _colorPos) => {
 		let arrowColor = g_headerObj.setColor[_colorPos];
-		const baseGroupNum = g_keycons.colorGroupNum === -1 ? g_localKeyStorage.keyCtrlPtn : g_keycons.colorGroupNum;
+
+		// 色変化データの利用条件設定（Default/Type0限定）
+		const baseGroupNum = g_keycons.colorGroupNum === -1
+			? (g_localKeyStorage?.keyCtrlPtn ?? 0)
+			: g_keycons.colorGroupNum;
+		const currentColorGr = g_keyObj[`color${keyCtrlPtn}_${g_keycons.colorGroupNum}`];
+		const baseColorGr = g_baseColorGrs?.[`color${keyCtrlPtn}_${baseGroupNum}`];
 		if (hasVal(initColors[_j]) && g_keycons.colorDefTypes.includes(g_colorType)
-			&& g_keyObj[`color${keyCtrlPtn}_${g_keycons.colorGroupNum}`][_j] === g_baseColorGrs[`color${keyCtrlPtn}_${baseGroupNum}`][_j]) {
+			&& currentColorGr?.[_j] === baseColorGr?.[_j]) {
 			arrowColor = initColors[_j];
 		}
+
+		// アシスト設定時はアシストの色を優先して適用
 		if (typeof g_keyObj[`assistPos${keyCtrlPtn}`] === C_TYP_OBJECT &&
 			g_keyObj[`assistPos${keyCtrlPtn}`][g_stateObj.autoPlay] !== undefined &&
 			!g_autoPlaysBase.includes(g_stateObj.autoPlay)) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6924,7 +6924,7 @@ const commonSettingBtn = _labelName => {
 		// キーコンフィグ画面へ移動
 		createCss2Button(`btnKeyConfig`, g_lblNameObj.b_keyConfig, () => true, {
 			...g_lblPosObj.btnKeyConfig,
-			animationName: (g_initialFlg ? `` : `smallToNormalY`), resetFunc: () => keyConfigInit(`Main`),
+			animationName: (g_initialFlg ? `` : `smallToNormalY`), resetFunc: () => keyConfigInit(`Main`, true),
 		}, g_cssObj.button_Setting),
 
 		// プレイ開始
@@ -9444,8 +9444,9 @@ const createGeneralSettingEx = (_spriteList, _name, { defaultList = [C_FLG_OFF],
 /**
  * キーコンフィグ画面初期化
  * @param {string} _kcType
+ * @param {boolean} _initFlg 初期表示フラグ
  */
-const keyConfigInit = (_kcType = g_kcType) => {
+const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 
 	clearWindow(true);
 	const divRoot = document.getElementById(`divRoot`);
@@ -9491,6 +9492,31 @@ const keyConfigInit = (_kcType = g_kcType) => {
 		g_keyObj[`keyGroupOrder${keyCtrlPtn}`] ?? tkObj.keyGroupList;
 	g_keycons.colorCursorNum = 0;
 
+	// 色変化中の初期色を取得（矢印枠のみ）
+	const arrowColorTmp = g_detailObj.miniMapParams[g_stateObj.scoreId]._scoreObj.ncolorData.Arrow;
+	const arrowColors = Array.from({ length: Math.ceil(arrowColorTmp.length / 5) }, (_, i) =>
+		arrowColorTmp.slice(i * 5, i * 5 + 5)
+	).filter(val => val[0] === 0);
+	const initColors = [];
+	arrowColors.forEach(val => {
+		if (val[1].startsWith('g')) {
+			// g付きの場合は矢印グループから対象の矢印番号を検索
+			const groupVal = setIntVal(val[1].slice(1));
+			for (let j = 0; j < tkObj.keyNum; j++) {
+				if (g_keyObj[`color${tkObj.keyCtrlPtn}`][j] === groupVal) {
+					initColors[j] = makeColorGradation(val[2]);
+				}
+			}
+		} else {
+			initColors[val[1]] = makeColorGradation(val[2]);
+		}
+	});
+	if (_initFlg) {
+		g_baseColorGrs = {};
+		const colorKey = Object.keys(g_keyObj).filter(val => val.startsWith(`color${g_keyObj.currentKey}`));
+		colorKey.forEach(val => g_baseColorGrs[val] = g_keyObj[val]);
+	}
+
 	/**
 	 * keyconSpriteのスクロール位置調整
 	 * @param {number} _targetX 
@@ -9509,6 +9535,11 @@ const keyConfigInit = (_kcType = g_kcType) => {
 	 */
 	const getKeyConfigColor = (_j, _colorPos) => {
 		let arrowColor = g_headerObj.setColor[_colorPos];
+		const baseGroupNum = g_keycons.colorGroupNum === -1 ? g_localKeyStorage.keyCtrlPtn : g_keycons.colorGroupNum;
+		if (hasVal(initColors[_j]) && g_keycons.colorDefTypes.includes(g_colorType)
+			&& g_keyObj[`color${keyCtrlPtn}_${g_keycons.colorGroupNum}`][_j] === g_baseColorGrs[`color${keyCtrlPtn}_${baseGroupNum}`][_j]) {
+			arrowColor = initColors[_j];
+		}
 		if (typeof g_keyObj[`assistPos${keyCtrlPtn}`] === C_TYP_OBJECT &&
 			g_keyObj[`assistPos${keyCtrlPtn}`][g_stateObj.autoPlay] !== undefined &&
 			!g_autoPlaysBase.includes(g_stateObj.autoPlay)) {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3838,6 +3838,8 @@ Object.keys(g_keyObj)
     .filter(key => key.startsWith(g_keyObj.defaultProp) && key.endsWith(`_0`))
     .forEach(key => g_keyObj.defaultKeyList.push(key.split(`_`)[0].slice(g_keyObj.defaultProp.length)));
 
+let g_baseColorGrs = {};
+
 // キーパターンのコピーリスト
 // ・コピー先：コピー元の順に指定する
 // ・上から順に処理する


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. 色変化(ncolor_data)の0フレーム時の色をキーコンフィグ画面に一部反映する仕様を追加
- 色変化(ncolor_data)の0フレーム時の矢印枠の色をキーコンフィグ画面に優先して反映するようにしました。
- ColorType: Default/Type0のときのみ有効です。譜面ヘッダーのsetColorより優先して表示します。
- 塗りつぶし色は見ません。旧色変化仕様（color_data/acolor_data）も参照しません。
- 矢印をクリックした場合に属するカラーグループを一時的に変更できますが、
その場合はカラーグループに属する色に変わります（ncolor_dataの値を参照しません）。
⇒このため、一時的にカラーグループを変更した場合は実際の矢印色と異なる場合があります。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 譜面ヘッダーのsetColorで設定できないパターン（レーン別に色を変えている場合など）に対応して表示できるようにするため。Discordでの要望です。
https://discord.com/channels/698460971231870977/944491021918683196/1505405885944434828

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/51ab4741-1a00-4ea4-8902-e6e148401437" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- 色変化(ncolor_data)の0フレーム時の色について、
同じレーンで複数色変化を指定した場合の順序保証はありません。