### PR TITLE
fix: [1095] キーコンフィグ画面の初期矢印色が想定通りにならない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9544,7 +9544,7 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 		// 色変化データの利用条件設定（Default/Type0限定）
 		const storageObj = g_stateObj.extraKeyFlg ? g_localStorage : g_localKeyStorage;
 		const baseGroupNum = g_keycons.colorGroupNum === -1
-			? (storageObj?.[`keyCtrlPtn${g_keyObj.currentKey}`] || storageObj?.keyCtrlPtn || 0)
+			? (storageObj?.[`keyCtrlPtn${g_keyObj.currentKey}`] ?? storageObj?.keyCtrlPtn ?? 0)
 			: g_keycons.colorGroupNum;
 		const currentColorGr = g_keyObj[`color${keyCtrlPtn}_${g_keycons.colorGroupNum}`];
 		const baseColorGr = g_baseColorGrs?.[`color${keyCtrlPtn}_${baseGroupNum}`];

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9542,8 +9542,9 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 		let arrowColor = g_headerObj.setColor[_colorPos];
 
 		// 色変化データの利用条件設定（Default/Type0限定）
+		const storageObj = g_stateObj.extraKeyFlg ? g_localStorage : g_localKeyStorage;
 		const baseGroupNum = g_keycons.colorGroupNum === -1
-			? (g_localKeyStorage?.keyCtrlPtn ?? 0)
+			? (storageObj?.[`keyCtrlPtn${g_keyObj.currentKey}`] || storageObj?.keyCtrlPtn || 0)
 			: g_keycons.colorGroupNum;
 		const currentColorGr = g_keyObj[`color${keyCtrlPtn}_${g_keycons.colorGroupNum}`];
 		const baseColorGr = g_baseColorGrs?.[`color${keyCtrlPtn}_${baseGroupNum}`];


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. キーコンフィグ画面の初期矢印色が想定通りにならない問題を修正
- カスタムキーで保存されたキーパターンが正しく取得できず、キーコンフィグ画面の初期矢印色が想定通りにならない問題を修正しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. カスタムキーの場合、保存されているキーパターンの変数が通常と異なるため。
PR #2117 の考慮漏れです。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
