### PR TITLE
improve: [1096] 譜面明細子画面、FrzReturn用ゲージのCSSカスタムプロパティを分離

### DIFF
--- a/css/danoni_main.css
+++ b/css/danoni_main.css
@@ -839,6 +839,14 @@ input[type="color"] {
 	color: var(--life-color-border-x, #cccccc);
 }
 
+.life_frzNormal {
+	background: var(--life-frz-normal, var(--main-stepShobon, #ccccff));
+}
+
+.life_frzActive {
+	background: var(--life-frz-active, var(--main-stepMatari, #ff9966));
+}
+
 /* 結果画面：項目、設定値 */
 .result_lbl {
 	color: var(--result-lbl-x, #999999);
@@ -907,6 +915,22 @@ input[type="color"] {
 
 .common_excessive {
 	color: var(--common-excessive, var(--common-kita));
+}
+
+.common_auto {
+	color: var(--common-auto, var(--common-kita, #ffff99));
+}
+
+.common_shuffle {
+	color: var(--settings-shuffle-x, var(--common-iknai, #99ff66));
+}
+
+.common_assist {
+	color: var(--settings-assist-x, var(--common-kita, #ffff99));
+}
+
+.common_another {
+	color: var(--settings-another-x, var(--common-ii, #66ffff));
 }
 
 /* 結果画面：枠 */

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -7006,7 +7006,7 @@ const updateSettingSummary = () => {
 	const estimatedHighscoreCondition = g_stateObj.dataSaveFlg && (g_stateObj.autoPlay !== C_FLG_ALL && g_headerObj.playbackRate === 1 && g_stateObj.fadein < 10 &&
 		(g_stateObj.shuffle === C_FLG_OFF || (g_stateObj.shuffle.endsWith(`Mirror`) && orgShuffleFlg)));
 
-	document.getElementById(`lblSummaryDifInfo`).innerHTML = settingData.difData + `${estimatedHighscoreCondition ? '' : ` | <span class="common_kita common_bold">No Records</span>`}`;
+	document.getElementById(`lblSummaryDifInfo`).innerHTML = settingData.difData + `${estimatedHighscoreCondition ? '' : ` | <span class="common_auto common_bold">No Records</span>`}`;
 	document.getElementById(`lblSummaryPlaystyleInfo`).textContent = settingData.playStyleData + `${g_stateObj.excessive === C_FLG_ON ? ' | Excessive' : ''}`;
 	document.getElementById(`lblSummaryDisplayInfo`).textContent = settingData.displayData;
 	document.getElementById(`lblSummaryDisplay2Info`).textContent = settingData.display2Data;
@@ -7784,9 +7784,9 @@ const makeHighScore = _scoreId => {
 			`${g_localStorage.highscores?.[scoreName]?.allPerfect ?? '' ? '<span class="result_AllPerfect">◆</span>' : ''}`, { xPos: 1, dx: 20, yPos: 12, w: 100, align: C_ALIGN_CENTER }),
 		createScoreLabel(`lblHClearLamps`, `Cleared: ` + (g_localStorage.highscores?.[scoreName]?.clearLamps?.join(', ') ?? C_FLG_HYPHEN), { yPos: 13, overflow: C_DIS_AUTO, w: g_sWidth / 2 + 40, h: 37 }),
 
-		createScoreLabel(`lblHShuffle`, g_stateObj.shuffle.indexOf(`Mirror`) < 0 ? `` : `Shuffle: <span class="common_iknai">${g_stateObj.shuffle}</span>`, { yPos: 11.5, dx: -130 }),
-		createScoreLabel(`lblHAssist`, g_autoPlaysBase.includes(g_stateObj.autoPlay) ? `` : `Assist: <span class="common_kita">${g_stateObj.autoPlay}</span>`, { yPos: 12.5, dx: -130 }),
-		createScoreLabel(`lblHAnother`, !hasVal(g_keyObj[`transKey${keyCtrlPtn}`]) ? `` : `A.Keymode: <span class="common_ii">${g_keyObj[`transKey${keyCtrlPtn}`]}</span>`, { yPos: 13.5, dx: -130 }),
+		createScoreLabel(`lblHShuffle`, g_stateObj.shuffle.indexOf(`Mirror`) < 0 ? `` : `Shuffle: <span class="common_shuffle">${g_stateObj.shuffle}</span>`, { yPos: 11.5, dx: -130 }),
+		createScoreLabel(`lblHAssist`, g_autoPlaysBase.includes(g_stateObj.autoPlay) ? `` : `Assist: <span class="common_assist">${g_stateObj.autoPlay}</span>`, { yPos: 12.5, dx: -130 }),
+		createScoreLabel(`lblHAnother`, !hasVal(g_keyObj[`transKey${keyCtrlPtn}`]) ? `` : `A.Keymode: <span class="common_another">${g_keyObj[`transKey${keyCtrlPtn}`]}</span>`, { yPos: 13.5, dx: -130 }),
 	);
 
 	// 結果をクリップボードへコピー (ハイスコア保存分)
@@ -13874,7 +13874,7 @@ const mainInit = () => {
 		multiAppend(infoSprite,
 			// FrzReturnゲージ
 			createColorObject2(`lifeBackFrzObj`, { ...g_lblPosObj.lifeBackFrzObj, display: g_workObj.scoreDisp }, g_cssObj.life_Background),
-			createColorObject2(`lifeBarFrz`, { ...g_lblPosObj.lifeBarFrz, display: g_workObj.scoreDisp }, g_cssObj.main_stepShobon),
+			createColorObject2(`lifeBarFrz`, { ...g_lblPosObj.lifeBarFrz, display: g_workObj.scoreDisp }, g_cssObj.life_frzNormal),
 		)
 	}
 
@@ -15259,8 +15259,8 @@ const startFrzReturn = () => {
 			clearTimeout(g_workObj.frzReturnTimerId);
 			g_workObj.frzReturnTimerId = null;
 		}
-		lifeBarFrz.classList.remove(g_cssObj.main_stepShobon, g_cssObj.main_stepMatari);
-		lifeBarFrz.classList.add(g_cssObj.main_stepMatari);
+		lifeBarFrz.classList.remove(g_cssObj.life_frzNormal, g_cssObj.life_frzActive);
+		lifeBarFrz.classList.add(g_cssObj.life_frzActive);
 		const seqLen = g_workObj.frzReturnSeq.length;
 		executeFrzReturn(
 			g_workObj.frzReturnSeq[seqLen > 1 ? Math.floor(Math.random() * seqLen) : 0], 0,
@@ -15291,8 +15291,8 @@ const executeFrzReturn = (_seq, _idx, _axis) => {
 		g_workObj.frzReturnFlg = false;
 		g_workObj.frzReturnTimerId = null;
 		const frzReturnGauge = document.getElementById(`lifeBarFrz`);
-		frzReturnGauge.classList.remove(g_cssObj.main_stepShobon, g_cssObj.main_stepMatari);
-		frzReturnGauge.classList.add(g_cssObj.main_stepShobon);
+		frzReturnGauge.classList.remove(g_cssObj.life_frzNormal, g_cssObj.life_frzActive);
+		frzReturnGauge.classList.add(g_cssObj.life_frzNormal);
 		return;
 	}
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3100,6 +3100,8 @@ const g_cssObj = {
     life_Background: `life_Background`,
     life_Border: `life_Border`,
     life_BorderColor: `life_BorderColor`,
+    life_frzNormal: `life_frzNormal`,
+    life_frzActive: `life_frzActive`,
 
     result_lbl: `result_lbl`,
     result_style: `result_style`,
@@ -3120,6 +3122,11 @@ const g_cssObj = {
     common_diffFast: `common_diffFast`,
     common_excessive: `common_excessive`,
     common_estAdj: `common_estAdj`,
+
+    common_auto: `common_auto`,
+    common_shuffle: `common_shuffle`,
+    common_assist: `common_assist`,
+    common_another: `common_another`,
 
     result_score: `result_score`,
     result_scoreHiBlanket: `result_scoreHiBlanket`,

--- a/skin/danoni_skin_default.css
+++ b/skin/danoni_skin_default.css
@@ -70,6 +70,10 @@
 	--settings-slice-gaugeTable-x: 1;
 	--settings-border-gaugeTable-x: 1px;
 
+	/* 譜面明細子画面: ハイスコア表示 */
+	/*--settings-assist-x: var(--common-kita); */
+	/*--settings-another-x: var(--common-ii); */
+
 	/* キーコンフィグ関連 */
 	--keyconfig-warning-x: #ffff99;
 	--keyconfig-imgType-x: #99ddff;
@@ -96,6 +100,7 @@
 	/* --common-diffSlow: var(--common-shobon); */
 	/* --common-estAdj: var(--common-shakin); */
 	/* --common-excessive: var(--common-kita); */
+	/* --common-auto: var(--common-kita); */
 
 	/* ステップゾーン */
 	--main-stepKeyDown: #66ffff;
@@ -114,6 +119,10 @@
 	--life-max: #444400;
 	--life-cleared: #004444;
 	--life-failed: #444444;
+
+	/* ライフゲージ: FrzReturn用 */
+	/*--life-frz-normal: var(--main-stepShobon); */
+	/*--life-frz-active: var(--main-stepMatari); */
 
 	/* ライフゲージ本体 */
 	--life-background: #222222;

--- a/skin/danoni_skin_default.css
+++ b/skin/danoni_skin_default.css
@@ -71,8 +71,8 @@
 	--settings-border-gaugeTable-x: 1px;
 
 	/* 譜面明細子画面: ハイスコア表示 */
-	/*--settings-assist-x: var(--common-kita); */
-	/*--settings-another-x: var(--common-ii); */
+	/* --settings-assist-x: var(--common-kita); */
+	/* --settings-another-x: var(--common-ii); */
 
 	/* キーコンフィグ関連 */
 	--keyconfig-warning-x: #ffff99;
@@ -121,8 +121,8 @@
 	--life-failed: #444444;
 
 	/* ライフゲージ: FrzReturn用 */
-	/*--life-frz-normal: var(--main-stepShobon); */
-	/*--life-frz-active: var(--main-stepMatari); */
+	/* --life-frz-normal: var(--main-stepShobon); */
+	/* --life-frz-active: var(--main-stepMatari); */
 
 	/* ライフゲージ本体 */
 	--life-background: #222222;

--- a/skin/danoni_skin_light.css
+++ b/skin/danoni_skin_light.css
@@ -70,6 +70,10 @@
 	--settings-slice-gaugeTable-x: 1;
 	--settings-border-gaugeTable-x: 1px;
 
+	/* 譜面明細子画面: ハイスコア表示 */
+	/*--settings-assist-x: var(--common-kita); */
+	/*--settings-another-x: var(--common-ii); */
+
 	/* キーコンフィグ関連 */
 	--keyconfig-warning-x: #999900;
 	--keyconfig-imgType-x: #003377;
@@ -96,6 +100,7 @@
 	/* --common-diffSlow: var(--common-shobon); */
 	/* --common-estAdj: var(--common-shakin); */
 	/* --common-excessive: var(--common-kita); */
+	/* --common-auto: var(--common-kita); */
 
 	/* ステップゾーン */
 	--main-stepKeyDown: #009999;
@@ -114,6 +119,10 @@
 	--life-max: #cccc66;
 	--life-cleared: #66cccc;
 	--life-failed: #999999;
+
+	/* ライフゲージ: FrzReturn用 */
+	/*--life-frz-normal: var(--main-stepShobon); */
+	/*--life-frz-active: var(--main-stepMatari); */
 
 	/* ライフゲージ本体 */
 	--life-background: #cccccc;

--- a/skin/danoni_skin_light.css
+++ b/skin/danoni_skin_light.css
@@ -71,8 +71,8 @@
 	--settings-border-gaugeTable-x: 1px;
 
 	/* 譜面明細子画面: ハイスコア表示 */
-	/*--settings-assist-x: var(--common-kita); */
-	/*--settings-another-x: var(--common-ii); */
+	/* --settings-assist-x: var(--common-kita); */
+	/* --settings-another-x: var(--common-ii); */
 
 	/* キーコンフィグ関連 */
 	--keyconfig-warning-x: #999900;
@@ -121,8 +121,8 @@
 	--life-failed: #999999;
 
 	/* ライフゲージ: FrzReturn用 */
-	/*--life-frz-normal: var(--main-stepShobon); */
-	/*--life-frz-active: var(--main-stepMatari); */
+	/* --life-frz-normal: var(--main-stepShobon); */
+	/* --life-frz-active: var(--main-stepMatari); */
 
 	/* ライフゲージ本体 */
 	--life-background: #cccccc;

--- a/skin/danoni_skin_skyblue.css
+++ b/skin/danoni_skin_skyblue.css
@@ -70,6 +70,10 @@
 	--settings-slice-gaugeTable-x: 1;
 	--settings-border-gaugeTable-x: 1px;
 
+	/* 譜面明細子画面: ハイスコア表示 */
+	/*--settings-assist-x: var(--common-kita); */
+	/*--settings-another-x: var(--common-ii); */
+
 	/* キーコンフィグ関連 */
 	--keyconfig-warning-x: #999900;
 	--keyconfig-imgType-x: #003377;
@@ -96,6 +100,7 @@
 	/* --common-diffSlow: var(--common-shobon); */
 	/* --common-estAdj: var(--common-shakin); */
 	/* --common-excessive: var(--common-kita); */
+	/* --common-auto: var(--common-kita); */
 
 	/* ステップゾーン */
 	--main-stepKeyDown: #009999;
@@ -114,6 +119,10 @@
 	--life-max: #cccc66;
 	--life-cleared: #66cccc;
 	--life-failed: #999999;
+
+	/* ライフゲージ: FrzReturn用 */
+	/*--life-frz-normal: var(--main-stepShobon); */
+	/*--life-frz-active: var(--main-stepMatari); */
 
 	/* ライフゲージ本体 */
 	--life-background: #cccccc;

--- a/skin/danoni_skin_skyblue.css
+++ b/skin/danoni_skin_skyblue.css
@@ -71,8 +71,8 @@
 	--settings-border-gaugeTable-x: 1px;
 
 	/* 譜面明細子画面: ハイスコア表示 */
-	/*--settings-assist-x: var(--common-kita); */
-	/*--settings-another-x: var(--common-ii); */
+	/* --settings-assist-x: var(--common-kita); */
+	/* --settings-another-x: var(--common-ii); */
 
 	/* キーコンフィグ関連 */
 	--keyconfig-warning-x: #999900;
@@ -121,8 +121,8 @@
 	--life-failed: #999999;
 
 	/* ライフゲージ: FrzReturn用 */
-	/*--life-frz-normal: var(--main-stepShobon); */
-	/*--life-frz-active: var(--main-stepMatari); */
+	/* --life-frz-normal: var(--main-stepShobon); */
+	/* --life-frz-active: var(--main-stepMatari); */
 
 	/* ライフゲージ本体 */
 	--life-background: #cccccc;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. 譜面明細子画面、FrzReturn用ゲージのCSSカスタムプロパティを分離
- 譜面明細子画面、FrzReturn用ゲージのCSSカスタムプロパティを新たに作成し、分離しました。
- 従来のカスタムプロパティを参照しているため、skin用のcssはフォーマットの変更のみで
入れ替えは必須ではありません。
- 追加したクラスと、対応するカスタムプロパティは次の通りです。
```css
.life_frzNormal {
	background: var(--life-frz-normal, var(--main-stepShobon, #ccccff));
}
.life_frzActive {
	background: var(--life-frz-active, var(--main-stepMatari, #ff9966));
}
.common_auto {
	color: var(--common-auto, var(--common-kita, #ffff99));
}
.common_shuffle {
	color: var(--settings-shuffle-x, var(--common-iknai, #99ff66));
}
.common_assist {
	color: var(--settings-assist-x, var(--common-kita, #ffff99));
}
.common_another {
	color: var(--settings-another-x, var(--common-ii, #66ffff));
}
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 今後、色を分離するときに便利であるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
