### PR TITLE
fix: [1100] keyGroupOrderで指定した部分キーが空のときに無限ループが発生する問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10408,6 +10408,7 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 			}
 		}
 		if (g_keycons.cursorNumList.length === 0) {
+			makeInfoWindow(g_msgInfoObj.I_0011, ``);
 		} else {
 			changeConfigCursor(0);
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10408,7 +10408,6 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 			}
 		}
 		if (g_keycons.cursorNumList.length === 0) {
-			appearConfigSteps(0);
 		} else {
 			changeConfigCursor(0);
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -4383,6 +4383,7 @@ const g_lang_msgInfoObj = {
         I_0005: `正規のミラー譜面で無いため、ハイスコアは保存されません`,
         I_0006: `ローカルストレージ情報をクリップボードにコピーしました！`,
         I_0007: `オブジェクト情報をクリップボードにコピーしました！`,
+        I_0011: `指定した部分キーが未定義のため、画面表示できません。設定を見直してください。`,
     },
     En: {
         W_0001: `Your browser is not guaranteed to work.<br>
@@ -4432,6 +4433,7 @@ const g_lang_msgInfoObj = {
         I_0005: `Highscore is not saved because not a regular mirrored chart.`,
         I_0006: `Local storage information copied to clipboard!`,
         I_0007: `Object information copied to clipboard!`,
+        I_0011: `The specified partial key is undefined and cannot be displayed on the screen. Please review your settings.`,
     },
 };
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. keyGroupOrderで指定した部分キーが空のときに無限ループが発生する問題を修正
- keyGroupOrderで指定した部分キーが、keyGroupXに存在しないときに無限ループが発生するようになっていました。
- 修正すると共に、該当時にメッセージを表示するようにしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. Discordでの指摘より。
https://discord.com/channels/698460971231870977/944491021918683196/1508520250067652758

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/350275ed-4ee2-4e86-9aeb-fd6ce05e9529" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
PR #1612 で組み込んだ問題のようです。
過去バージョンではメッセージの追加は行わず、エラー回避のみ実施する予定です。
