### PR TITLE
improve: [1101] データ管理画面で何も選択していない場合に別のメッセージを出すように変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6734,6 +6734,11 @@ const dataMgtInit = () => {
 				.filter(key => key.startsWith('dm_') && g_stateObj[key] === C_FLG_ON)
 				.map(key => key.slice(`dm_`.length));
 
+			if (selectedData.length === 0) {
+				window.alert(g_msgObj.noDataSelected);
+				return;
+			}
+
 			if (window.confirm(g_msgObj.dataResetConfirm +
 				`\n\n${selectedData.map(val => `- ${g_msgObj[val] || g_msgObj.keyTypes.split('{0}').join(val)}`).join(`\n`)}`)) {
 				selectedData.forEach(key => {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -4883,6 +4883,7 @@ const g_lang_msgObj = {
         keyTypes: `Key: {0} の保存データ（個別の色設定を除く）を消去します。`,
 
         dataResetConfirm: `選択したローカル設定をクリアします。よろしいですか？`,
+        noDataSelected: `消去するデータが選択されていません。`,
         dataRestoreConfirm: `ローカル設定を前回の状態に戻します（１回限り）。よろしいですか？\n消去した設定によっては今の設定が上書きされることがあります。`,
         safeModeONConfirm: `セーフモードを解除して、ローカルストレージ情報を利用します。\nよろしいですか？`,
         safeModeOFFConfirm: `セーフモードを設定して、ローカルストレージを使わずにリロードします。\nよろしいですか？`,
@@ -4987,6 +4988,7 @@ const g_lang_msgObj = {
         keyTypes: `Deletes the stored data (except color settings) for Key: {0}.`,
 
         dataResetConfirm: `Delete the selected local settings. Is it OK?`,
+        noDataSelected: `No data selected to delete.`,
         dataRestoreConfirm: `Restore local settings to previous state (one time only). Is it OK?\nSome deleted settings may overwrite the current settings.`,
         safeModeONConfirm: `Exit safe mode and use local storage information. Is it OK?`,
         safeModeOFFConfirm: `Set safe mode and reload without local storage. Is it OK?`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. データ管理画面で何も選択していない場合に別のメッセージを出すように変更
- データ管理画面で何も選択していない場合に選択を促すメッセージを出すように変更しました。


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. データを消すようなメッセージになっているため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/ae49894a-8080-4dc1-90fe-03e3c31923f1" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
