### PR TITLE
improve: [1102] プレイ画面にゲージ設定名を表示するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -14265,7 +14265,7 @@ const mainInit = () => {
 		}, lblInitColor),
 
 		// ゲージ種類
-		createDivCss2Label(`lblGaugeMode`, g_stateObj.gauge, { ...g_lblPosObj.lblGaugeMode }),
+		createDivCss2Label(`lblGaugeMode`, g_stateObj.gauge, { ...g_lblPosObj.lblGaugeMode, display: g_workObj.musicinfoDisp }),
 
 		// ライフ背景
 		createColorObject2(`lifeBackObj`, { ...g_lblPosObj.lifeBackObj, display: g_workObj.lifegaugeDisp }, g_cssObj.life_Background),

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -14264,6 +14264,9 @@ const mainInit = () => {
 			x: 0, y: 30, w: 70, h: 20, siz: g_limitObj.jdgCntsSiz, display: g_workObj.lifegaugeDisp,
 		}, lblInitColor),
 
+		// ゲージ種類
+		createDivCss2Label(`lblGaugeMode`, g_stateObj.gauge, { ...g_lblPosObj.lblGaugeMode }),
+
 		// ライフ背景
 		createColorObject2(`lifeBackObj`, { ...g_lblPosObj.lifeBackObj, display: g_workObj.lifegaugeDisp }, g_cssObj.life_Background),
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -640,7 +640,7 @@ const updateWindowSiz = () => {
             x: -8, y: -8, w: C_ARW_WIDTH + 16, h: C_ARW_WIDTH + 16,
         },
         lblframe: {
-            x: 0, y: 0, w: 100, h: 30, siz: 20,
+            x: 0, y: 0, w: 100, h: 30, siz: 18,
         },
         lblCredit: {
             x: 125, y: g_headerObj.playingHeight - 30, w: g_headerObj.playingWidth - 125, h: 20, align: C_ALIGN_LEFT,
@@ -653,6 +653,9 @@ const updateWindowSiz = () => {
         },
         lblTime2: {
             x: 60, y: g_headerObj.playingHeight - 30, w: 60, h: 20, siz: g_limitObj.mainSiz,
+        },
+        lblGaugeMode: {
+            x: 5, y: 18, w: 100, h: 20, siz: 11, align: C_ALIGN_LEFT,
         },
         lifeBackObj: {
             x: 5, y: 50, w: 15, h: g_headerObj.playingHeight - 100, styleName: `lifeBar`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. プレイ画面にゲージ設定名を表示するよう変更
- プレイ画面の左上にゲージ設定名を表示するようにしました。
- この表示はDisplay設定の「MusicInfo」をOFFにしたときに非表示にする設定です。
（ライフゲージというより、関連情報という扱いのため）
- この変更に伴い、プレイ画面左上のフレーム数表示を20pxから18pxに変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. Discordでの要望より。
https://discord.com/channels/698460971231870977/944491021918683196/1509904225889681429

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/a937c626-4066-4ad9-9e5b-bd4f6c9f62fa" /><img width="50%" alt="image" src="https://github.com/user-attachments/assets/b9b80a01-37ba-4b15-9053-842b40611597" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- 重なりの関係で、ゲージ数字よりは手前に表示されるようにしています。