### PR TITLE
improve: [1103] Display設定のプレビューにゲージ設定名とFrzReturn用ゲージの表示とカスタム関数を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9321,7 +9321,11 @@ const buildPreviewUI = (_frame, _playW, _playH) => {
 	// スコア・判定カウンタ（右端縦列）
 	// ============================================================
 	if (d.score === C_FLG_OFF) {
-		_frame.appendChild(disableBox(`Score`, { x: _playW - 80, y: 20, w: 70, h: 200 }));
+		_frame.appendChild(disableBox(`Score`, g_lblPosObj.previewScoreDisabled));
+
+		if (g_stateObj.frzReturn !== C_FLG_OFF) {
+			_frame.appendChild(disableBox(`FrzReturn`, g_lblPosObj.previewLifeFrzDisabled));
+		}
 	} else {
 		const scoreItems = [
 			{ color: `#66ffff`, cnt: `5` },
@@ -9365,6 +9369,7 @@ const buildPreviewUI = (_frame, _playW, _playH) => {
 	// ============================================================
 	if (d.musicinfo === C_FLG_OFF) {
 		_frame.appendChild(disableBox(`MusicInfo`, { x: 5, y: _playH - 50, w: _playW - 125, h: 40 }));
+		_frame.appendChild(disableBox(`GaugeName`, { x: 0, y: 10, w: 110, h: 18 }));
 	} else {
 		const creditName = `Sample Music / Artist Name`;
 		const difName = `[7key / Normal]`;
@@ -9380,14 +9385,10 @@ const buildPreviewUI = (_frame, _playW, _playH) => {
 			createDivCss2Label(`previewTime1`, `0:04 /`, {
 				...g_lblPosObj.lblTime1,
 			}),
-			createDivCss2Label(`previewTime2`, `2:54`, {
-				...g_lblPosObj.lblTime2,
-			}),
+			createDivCss2Label(`previewTime2`, `2:54`, g_lblPosObj.lblTime2),
 
 			// ゲージ設定名
-			createDivCss2Label(`previewGauge`, `Original`, {
-				...g_lblPosObj.lblGaugeMode,
-			}),
+			createDivCss2Label(`previewGauge`, `Original`, g_lblPosObj.lblGaugeMode),
 		)
 	}
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9382,6 +9382,74 @@ const buildPreviewUI = (_frame, _playW, _playH) => {
 };
 
 /**
+ * 要素をドラッグ可能にする（汎用ユーティリティ）
+ * @param {HTMLElement} _target ドラッグ対象の要素
+ * @param {number} _playW 制限範囲の幅
+ * @param {number} _playH 制限範囲の高さ
+ * @param {object} _bounds 要素自体のサイズ { w, h } (はみ出し防止用)
+ * @param {function} _onDragEnd 位置確定時に呼ばれるコールバック (_finalX, _finalY) => void
+ */
+const makeElementDraggable = (_target, _playW, _playH, _bounds, _onDragEnd) => {
+	let dragging = false;
+	let dragStartX = 0, dragStartY = 0;
+	let elemStartX = 0, elemStartY = 0;
+
+	const boundsW = _bounds?.w ?? _target.offsetWidth ?? 0;
+	const boundsH = _bounds?.h ?? _target.offsetHeight ?? 0;
+
+	const keyDown = addPreviewListener(_target, `pointerdown`, _evt => {
+		dragging = true;
+		dragStartX = _evt.clientX;
+		dragStartY = _evt.clientY;
+		elemStartX = parseInt(_target.style.left, 10) || 0;
+		elemStartY = parseInt(_target.style.top, 10) || 0;
+		_target.style.cursor = `grabbing`;
+		_target.setPointerCapture(_evt.pointerId);
+		_evt.stopPropagation();
+	});
+
+	const keyMove = addPreviewListener(_target, `pointermove`, _evt => {
+		if (!dragging) return;
+		const dx = _evt.clientX - dragStartX;
+		const dy = _evt.clientY - dragStartY;
+
+		// 境界値制限
+		const newX = Math.max(0, Math.min(_playW - boundsW, elemStartX + dx));
+		const newY = Math.max(0, Math.min(_playH - boundsH, elemStartY + dy));
+
+		_target.style.left = wUnit(newX);
+		_target.style.top = wUnit(newY);
+		_evt.stopPropagation();
+	});
+
+	const keyUp = addPreviewListener(_target, `pointerup`, _evt => {
+		if (!dragging) return;
+		dragging = false;
+		_target.style.cursor = `grab`;
+
+		const finalX = parseInt(_target.style.left, 10) || 0;
+		const finalY = parseInt(_target.style.top, 10) || 0;
+
+		// 外部の保存処理などを実行
+		if (typeof _onDragEnd === `function`) {
+			_onDragEnd(finalX, finalY);
+		}
+
+		_evt.stopPropagation();
+	});
+
+	addPreviewListener(_target, `pointercancel`, _evt => {
+		dragging = false;
+		_target.style.cursor = `grab`;
+	});
+
+	// 既存の管理用属性（必要に応じて）
+	_target.setAttribute(`lsnrkey`, keyMove);
+	_target.setAttribute(`lsnrkeyTS`, keyDown);
+	_target.setAttribute(`lsnrkeyTE`, keyUp);
+};
+
+/**
  * ドラッグ可能な判定グループを生成する
  * @param {HTMLElement} _parent    親要素
  * @param {string}      _groupId   `jdgJ` または `jdgFJ`
@@ -9392,11 +9460,14 @@ const buildPreviewUI = (_frame, _playW, _playH) => {
  * @param {object}      _opts      表示テキスト・色オプション
  */
 const buildDraggableJudgGroup = (_parent, _groupId, _initX, _initY, _playW, _playH, _opts) => {
+	const groupW = 370;
+	const groupH = 51;
 
 	const group = createEmptySprite(_parent, `previewGrp_${_groupId}`, {
-		x: _initX, y: _initY, w: 370, h: 51, cursor: `grab`, pointerEvents: C_DIS_AUTO,
+		x: _initX, y: _initY, w: groupW, h: groupH, cursor: `grab`, pointerEvents: C_DIS_AUTO,
 	});
 
+	// 内包要素の生成 (省略：元のコードの multiAppend 部分と同一)
 	multiAppend(
 		group,
 		// キャラクタ
@@ -9418,91 +9489,73 @@ const buildDraggableJudgGroup = (_parent, _groupId, _initX, _initY, _playW, _pla
 
 	// ドラッグハンドル（薄い枠）
 	createEmptySprite(group, `lblHandle_${_groupId}`, {
-		x: 0, y: 0, w: 370, h: 51, border: `1px dashed rgba(255,255,255,0.3)`,
-		boxSizing: `border-box`, borderRadius: `2px`,
-		background: `rgba(255,255,255,0.04)`,
+		x: 0, y: 0, w: groupW, h: groupH, border: `1px dashed rgba(255,255,255,0.3)`,
+		boxSizing: `border-box`, borderRadius: `2px`, background: `rgba(255,255,255,0.04)`,
 	});
 
-	// ---- ドラッグ処理 ----
-	let dragging = false;
-	let dragStartX = 0, dragStartY = 0;
-	let elemStartX = 0, elemStartY = 0;
+	// ============================================================
+	// 判定グループ固有の「座標反映ルール」を定義
+	// ============================================================
+	const configMap = {
+		jdgJ: {
+			toastTitle: g_lblNameObj.arrowJdgUpdate,
+			getStdX: (pw) => Math.round(pw / 2 - 220),
+			getStdY: (ph, syr) => Math.round((ph + syr) / 2 - 60),
+			saveCallback: (dx, dy) => {
+				g_diffObj.arrowJdgX = dx;
+				g_diffObj.arrowJdgY = dy;
+			}
+		},
+		jdgFJ: {
+			toastTitle: g_lblNameObj.frzJdgUpdate,
+			getStdX: (pw) => Math.round(pw / 2 - 120),
+			getStdY: (ph, syr) => Math.round((ph + syr) / 2 + 10),
+			saveCallback: (dx, dy) => {
+				g_diffObj.frzJdgX = dx;
+				g_diffObj.frzJdgY = dy;
+			}
+		}
+	};
 
-	const keyDown = addPreviewListener(group, `pointerdown`, _evt => {
-		dragging = true;
-		dragStartX = _evt.clientX;
-		dragStartY = _evt.clientY;
-		elemStartX = parseInt(group.style.left, 10);
-		elemStartY = parseInt(group.style.top, 10);
-		group.style.cursor = `grabbing`;
-		group.setPointerCapture(_evt.pointerId);
-		_evt.stopPropagation();
-	});
-	const keyMove = addPreviewListener(group, `pointermove`, _evt => {
-		if (!dragging) return;
-		const dx = _evt.clientX - dragStartX;
-		const dy = _evt.clientY - dragStartY;
-		const newX = Math.max(0, Math.min(_playW - 370, elemStartX + dx));
-		const newY = Math.max(0, Math.min(_playH - 50, elemStartY + dy));
-		group.style.left = wUnit(newX);
-		group.style.top = wUnit(newY);
-		_evt.stopPropagation();
-	});
-	const keyUp = addPreviewListener(group, `pointerup`, _evt => {
-		if (!dragging) return;
-		dragging = false;
-		group.style.cursor = `grab`;
-
-		const finalX = parseInt(group.style.left, 10);
-		const finalY = parseInt(group.style.top, 10);
-
-		// ---- 座標をグローバル状態とゲーム本体に反映 ----
+	// 汎用関数を呼び出し、判定位置特有の処理をコールバックとして渡す
+	makeElementDraggable(group, _playW, _playH, { w: groupW, h: groupH }, (finalX, finalY) => {
+		// グローバルなプレビュー座標を更新
 		g_previewPos[_groupId].x = finalX;
 		g_previewPos[_groupId].y = finalY;
-		applyJudgPositionToGame(_groupId, finalX, finalY);
 
-		_evt.stopPropagation();
+		// 設定マップから該当するルールを適用して保存
+		const currentConfig = configMap[_groupId];
+		if (currentConfig) {
+			applyElementPositionToGame(finalX, finalY, currentConfig);
+		}
 	});
-	// pointerup が届かないケースを拾う
-	addPreviewListener(group, `pointercancel`, _evt => {
-		dragging = false;
-		group.style.cursor = `grab`;
-	});
-	group.setAttribute(`lsnrkey`, keyMove);
-	group.setAttribute(`lsnrkeyTS`, keyDown);
-	group.setAttribute(`lsnrkeyTE`, keyUp);
 };
 
 /**
- * ドラッグ結果の座標をゲーム本体の判定位置設定に反映する
- * @param {string} _groupId  `jdgJ` または `jdgFJ`
- * @param {number} _x        frame相対X
- * @param {number} _y        frame相対Y
+ * ドラッグ結果の座標をゲーム本体の設定に汎用的に反映する
+ * @param {number} _x 確定したframe相対X
+ * @param {number} _y 確定したframe相対Y
+ * @param {object} _config 反映用の設定オブジェクト
  */
-const applyJudgPositionToGame = (_groupId, _x, _y) => {
+const applyElementPositionToGame = (_x, _y, _config) => {
+	const playW = g_headerObj.playingWidth || g_sWidth;
 	const playH = g_headerObj.playingHeight || g_sHeight;
 	const stepYR = g_posObj?.stepYR ?? 0;
 
-	// mainInit内のjdgX[0/1], jdgY[0/1]はローカル変数なため、
-	// g_diffObj経由でオフセットとして保持し、次回プレイ開始時に反映する。
-	// ここでは g_diffObj.arrowJdgY / frzJdgY をオフセット格納先として利用する。
-	//
-	// 「標準Y」= (playH + stepYR) / 2 - 60  (jdgJ の場合)
-	//           = (playH + stepYR) / 2 + 10  (jdgFJ の場合)
-	// オフセット = 実際のY - 標準Y
+	// 1. 各要素固有の「標準座標（基準点）」を計算
+	const stdX = _config.getStdX(playW);
+	const stdY = _config.getStdY(playH, stepYR);
 
-	if (_groupId === `jdgJ`) {
-		const stdX = g_headerObj.playingWidth / 2 - 220;
-		const stdY = Math.round((playH + stepYR) / 2 - 60);
-		g_diffObj.arrowJdgX = _x - stdX;
-		g_diffObj.arrowJdgY = _y - stdY;
-		showToast(`${g_lblNameObj.arrowJdgUpdate}: dX=${g_diffObj.arrowJdgX}, dY=${g_diffObj.arrowJdgY}`);
-	} else if (_groupId === `jdgFJ`) {
-		const stdX = g_headerObj.playingWidth / 2 - 120;
-		const stdY = Math.round((playH + stepYR) / 2 + 10);
-		g_diffObj.frzJdgX = _x - stdX;
-		g_diffObj.frzJdgY = _y - stdY;
-		showToast(`${g_lblNameObj.frzJdgUpdate}: dX=${g_diffObj.frzJdgX}, dY=${g_diffObj.frzJdgY}`);
+	// 2. オフセット（差分）を計算
+	const diffX = _x - stdX;
+	const diffY = _y - stdY;
+
+	// 3. 指定された保存先にオフセットを格納
+	_config.saveCallback(diffX, diffY);
+
+	// 4. トースト表示 (通知が不要な要素なら省略可能にする)
+	if (_config.toastTitle) {
+		showToast(`${_config.toastTitle}: dX=${diffX}, dY=${diffY}`);
 	}
 };
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9344,6 +9344,20 @@ const buildPreviewUI = (_frame, _playW, _playH) => {
 				}),
 			);
 		});
+
+		// FrzReturn用ゲージ
+		if (g_stateObj.frzReturn !== C_FLG_OFF) {
+			multiAppend(_frame,
+				createDivCss2Label(`previewFrzLifeBack`, ``, {
+					x: 0, y: 50, w: 5, h: _playH - 100,
+					background: `#333333`, border: `1px solid #555555`,
+				}),
+				createDivCss2Label(`previewFrzLifeBar`, ``, {
+					x: 0, y: 50 + (_playH - 100) * 0.7,
+					w: 5, h: (_playH - 100) * 0.3,
+				}, g_cssObj.life_frzNormal),
+			);
+		}
 	}
 
 	// ============================================================
@@ -9352,8 +9366,7 @@ const buildPreviewUI = (_frame, _playW, _playH) => {
 	if (d.musicinfo === C_FLG_OFF) {
 		_frame.appendChild(disableBox(`MusicInfo`, { x: 5, y: _playH - 50, w: _playW - 125, h: 40 }));
 	} else {
-		multiAppend(
-			_frame,
+		multiAppend(_frame,
 			createDivCss2Label(`previewCredit`, `Sample Music / Artist Name`, {
 				...g_lblPosObj.previewCredit, x: 100, y: _playH - 30, w: _playW - 125, h: 20,
 			}),
@@ -9366,8 +9379,16 @@ const buildPreviewUI = (_frame, _playW, _playH) => {
 			createDivCss2Label(`previewTime2`, `2:54`, {
 				...g_lblPosObj.previewCredit, x: 60, y: _playH - 30, w: 60, h: 20,
 			}),
+
+			// ゲージ設定名
+			createDivCss2Label(`previewGauge`, `Original`, {
+				...g_lblPosObj.lblGaugeMode,
+			}),
 		)
 	}
+
+	// ユーザカスタムイベント(プレビュー表示用)
+	safeExecuteCustomHooks(`g_customJsObj.displayPreview`, g_customJsObj.displayPreview, _frame, _playW, _playH);
 };
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9366,18 +9366,22 @@ const buildPreviewUI = (_frame, _playW, _playH) => {
 	if (d.musicinfo === C_FLG_OFF) {
 		_frame.appendChild(disableBox(`MusicInfo`, { x: 5, y: _playH - 50, w: _playW - 125, h: 40 }));
 	} else {
+		const creditName = `Sample Music / Artist Name`;
+		const difName = `[7key / Normal]`;
+		const checkMusicSiz = (_text, _siz) => getFontSize2(_text, g_headerObj.playingWidth - g_headerObj.customViewWidth - 125, { maxSiz: _siz });
+
 		multiAppend(_frame,
-			createDivCss2Label(`previewCredit`, `Sample Music / Artist Name`, {
-				...g_lblPosObj.previewCredit, x: 100, y: _playH - 30, w: _playW - 125, h: 20,
+			createDivCss2Label(`previewCredit`, creditName, {
+				...g_lblPosObj.lblCredit, siz: checkMusicSiz(creditName, g_limitObj.musicTitleSiz)
 			}),
-			createDivCss2Label(`previewDifName`, `[7key / Normal]`, {
-				...g_lblPosObj.previewCredit, x: 100, y: _playH - 16, w: _playW - 125, h: 16, siz: 12,
+			createDivCss2Label(`previewDifName`, difName, {
+				...g_lblPosObj.lblDifName, siz: checkMusicSiz(difName, 12)
 			}),
 			createDivCss2Label(`previewTime1`, `0:04 /`, {
-				...g_lblPosObj.previewCredit, x: 18, y: _playH - 30, w: 40, h: 20, align: C_ALIGN_RIGHT,
+				...g_lblPosObj.lblTime1,
 			}),
 			createDivCss2Label(`previewTime2`, `2:54`, {
-				...g_lblPosObj.previewCredit, x: 60, y: _playH - 30, w: 60, h: 20,
+				...g_lblPosObj.lblTime2,
 			}),
 
 			// ゲージ設定名

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9299,21 +9299,12 @@ const buildPreviewUI = (_frame, _playW, _playH) => {
 	// ライフゲージ（左縦帯）
 	// ============================================================
 	if (d.lifegauge === C_FLG_OFF) {
-		_frame.appendChild(disableBox(`LifeGauge`, { x: 5, y: 50, w: 15, h: _playH - 100 }));
+		_frame.appendChild(disableBox(`LifeGauge`, g_lblPosObj.previewLifeDisabled));
 	} else {
 		multiAppend(_frame,
-			createDivCss2Label(`previewLifeBack`, ``, {
-				x: 5, y: 50, w: 15, h: _playH - 100,
-				background: `#333333`, border: `1px solid #555555`,
-			}),
-			createDivCss2Label(`previewLifeBar`, ``, {
-				x: 5, y: 50 + (_playH - 100) * 0.3,
-				w: 15, h: (_playH - 100) * 0.7, background: `#006666`,
-			}),
-			createDivCss2Label(`previewLifeNum`, `700`, {
-				x: 0, y: 30, w: 70, h: 20,
-				size: 14, color: `#ffffff`, background: `#006666`, align: `center`,
-			}),
+			createDivCss2Label(`previewLifeBack`, ``, g_lblPosObj.previewLifeBack),
+			createDivCss2Label(`previewLifeBar`, ``, g_lblPosObj.previewLifeBar),
+			createDivCss2Label(`previewLifeNum`, `700`, g_lblPosObj.previewLifeNum),
 		);
 	}
 
@@ -9324,7 +9315,7 @@ const buildPreviewUI = (_frame, _playW, _playH) => {
 		_frame.appendChild(disableBox(`Score`, g_lblPosObj.previewScoreDisabled));
 
 		if (g_stateObj.frzReturn !== C_FLG_OFF) {
-			_frame.appendChild(disableBox(`FrzReturn`, g_lblPosObj.previewLifeFrzDisabled));
+			_frame.appendChild(disableBox(`FrzReturnBar`, g_lblPosObj.previewLifeFrzDisabled));
 		}
 	} else {
 		const scoreItems = [
@@ -9352,14 +9343,8 @@ const buildPreviewUI = (_frame, _playW, _playH) => {
 		// FrzReturn用ゲージ
 		if (g_stateObj.frzReturn !== C_FLG_OFF) {
 			multiAppend(_frame,
-				createDivCss2Label(`previewFrzLifeBack`, ``, {
-					x: 0, y: 50, w: 5, h: _playH - 100,
-					background: `#333333`, border: `1px solid #555555`,
-				}),
-				createDivCss2Label(`previewFrzLifeBar`, ``, {
-					x: 0, y: 50 + (_playH - 100) * 0.7,
-					w: 5, h: (_playH - 100) * 0.3,
-				}, g_cssObj.life_frzNormal),
+				createDivCss2Label(`previewFrzLifeBack`, ``, g_lblPosObj.previewFrzLifeBack),
+				createDivCss2Label(`previewFrzLifeBar`, ``, g_lblPosObj.previewFrzLifeBar, g_cssObj.life_frzNormal),
 			);
 		}
 	}
@@ -9368,8 +9353,8 @@ const buildPreviewUI = (_frame, _playW, _playH) => {
 	// 曲名・制作者（左下）
 	// ============================================================
 	if (d.musicinfo === C_FLG_OFF) {
-		_frame.appendChild(disableBox(`MusicInfo`, { x: 5, y: _playH - 50, w: _playW - 125, h: 40 }));
-		_frame.appendChild(disableBox(`GaugeName`, { x: 0, y: 10, w: 110, h: 18 }));
+		_frame.appendChild(disableBox(`MusicInfo`, g_lblPosObj.previewMusicInfoDisabled));
+		_frame.appendChild(disableBox(`GaugeName`, g_lblPosObj.previewGaugeNameDisabled));
 	} else {
 		const creditName = `Sample Music / Artist Name`;
 		const difName = `[7key / Normal]`;

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -546,6 +546,12 @@ const updateWindowSiz = () => {
         lblDisplayPreviewMsg: {
             x: g_btnX(), y: g_sHeight - 40, w: g_btnWidth(), h: 20, siz: 14,
         },
+        previewScoreDisabled: {
+            x: g_headerObj.playingWidth - 80, y: 20, w: 70, h: 200,
+        },
+        previewLifeFrzDisabled: {
+            x: 0, y: 50, w: 5, h: g_headerObj.playingHeight - 100,
+        },
 
         /** キーコンフィグ画面 */
         scKcMsg: {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -571,7 +571,7 @@ const updateWindowSiz = () => {
         },
         previewLifeNum: {
             x: 0, y: 30, w: 70, h: 20,
-            size: 14, color: `#ffffff`, background: `#006666`, align: C_ALIGN_CENTER,
+            siz: g_limitObj.jdgCntsSiz, color: `#ffffff`, background: `#006666`, align: C_ALIGN_CENTER,
         },
         previewFrzLifeBack: {
             x: 0, y: 50, w: 5, h: g_headerObj.playingHeight - 100,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -5112,6 +5112,7 @@ const g_customJsObj = {
     option: [],
     difficulty: [],
     settingsDisplay: [],
+    displayPreview: [],
     exSetting: [],
     settingSummary: [],
     keyconfig: [],

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -546,9 +546,6 @@ const updateWindowSiz = () => {
         lblDisplayPreviewMsg: {
             x: g_btnX(), y: g_sHeight - 40, w: g_btnWidth(), h: 20, siz: 14,
         },
-        previewCredit: {
-            siz: 13, color: `#cccccc`, align: C_ALIGN_LEFT,
-        },
 
         /** キーコンフィグ画面 */
         scKcMsg: {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -549,8 +549,37 @@ const updateWindowSiz = () => {
         previewScoreDisabled: {
             x: g_headerObj.playingWidth - 80, y: 20, w: 70, h: 200,
         },
+        previewLifeDisabled: {
+            x: 5, y: 50, w: 15, h: g_headerObj.playingHeight - 100,
+        },
         previewLifeFrzDisabled: {
+            x: 0, y: 70, w: 5, h: g_headerObj.playingHeight - 120,
+        },
+        previewMusicInfoDisabled: {
+            x: 5, y: g_headerObj.playingHeight - 50, w: g_headerObj.playingWidth - 125, h: 40,
+        },
+        previewGaugeNameDisabled: {
+            x: 0, y: 10, w: 110, h: 18,
+        },
+        previewLifeBack: {
+            x: 5, y: 50, w: 15, h: g_headerObj.playingHeight - 100,
+            background: `#333333`, border: `1px solid #555555`,
+        },
+        previewLifeBar: {
+            x: 5, y: 50 + (g_headerObj.playingHeight - 100) * 0.3,
+            w: 15, h: (g_headerObj.playingHeight - 100) * 0.7, background: `#006666`,
+        },
+        previewLifeNum: {
+            x: 0, y: 30, w: 70, h: 20,
+            size: 14, color: `#ffffff`, background: `#006666`, align: C_ALIGN_CENTER,
+        },
+        previewFrzLifeBack: {
             x: 0, y: 50, w: 5, h: g_headerObj.playingHeight - 100,
+            background: `#333333`, border: `1px solid #555555`,
+        },
+        previewFrzLifeBar: {
+            x: 0, y: 50 + (g_headerObj.playingHeight - 100) * 0.7,
+            w: 5, h: (g_headerObj.playingHeight - 100) * 0.3,
         },
 
         /** キーコンフィグ画面 */


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. Display設定のプレビューにゲージ設定名とFrzReturn用ゲージの表示を追加
- どの設定で隠せるかがわかりにくいため、追加しました。
- FrzReturn用ゲージについてはFrzReturnが有効時の場合のみ、表示します。

### 2. Display設定のプレビュー用にカスタム関数を追加
- カスタムで表示制御を行う可能性があることを考慮して、差し込み処理を実装しました。
g_customObj.displayPreviewで定義します。
引数はプレビュー上で表示する親要素、プレイ表示幅、プレイ表示の高さです。
親要素側で縮小しているため、カスタム定義上は実際の位置を指定すれば反映されるはずです。

### 3. Display設定のプレビューでの曲関連情報部分の座標をプレイ画面のものと統一
- 2.に関連して、別変数を使う必要はないため同じものを使うようにしました。
- なお、ライフゲージなど他の要素は実際と異なるサンプル設定を含むため、独自のままとしています。

### 4. Display設定のプレビューでのドラッグ処理を汎化
- 判定処理に特化されていたため、他の要素に将来的に拡張できるように汎化しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 具体的にどの設定で何を隠すかを明確にするため。
2. カスタムで隠す対象を示したい場合に有用となるため。
3. 二重定義の回避のため。
4. 将来的な拡張を見据えた変更となります。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/fa6e71f0-9275-4f47-8050-98beebf44610" />
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/1920019a-48df-4e12-a65d-fd2db08153f3" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
