### PR TITLE
feat: [1106] ショートカット表示をDisplay設定のプレビューで調整できる機能を実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4361,6 +4361,14 @@ const headerConvert = _dosObj => {
 	// 矢印・フリーズアロー判定位置補正
 	g_diffObj.arrowJdgY = (isNaN(parseFloat(_dosObj.arrowJdgY)) ? 0 : parseFloat(_dosObj.arrowJdgY));
 	g_diffObj.frzJdgY = (isNaN(parseFloat(_dosObj.frzJdgY)) ? 0 : parseFloat(_dosObj.frzJdgY));
+	g_diffInitObj.arrowJdgY = g_diffObj.arrowJdgY;
+	g_diffInitObj.frzJdgY = g_diffObj.frzJdgY;
+
+	// ショートカット表示位置補正
+	g_diffObj.shortcutX = (isNaN(parseFloat(_dosObj.shortcutX)) ? 0 : parseFloat(_dosObj.shortcutX));
+	g_diffObj.shortcutY = (isNaN(parseFloat(_dosObj.shortcutY)) ? 0 : parseFloat(_dosObj.shortcutY));
+	g_diffInitObj.shortcutX = g_diffObj.shortcutX;
+	g_diffInitObj.shortcutY = g_diffObj.shortcutY;
 
 	// musicフォルダ設定
 	obj.musicFolder = _dosObj.musicFolder ?? (g_remoteFlg ? `${C_MRK_CURRENT_DIRECTORY}../music` : `music`);
@@ -9112,7 +9120,8 @@ let g_previewLsnrKeys = new Set();
 /** プレビュー内の各UIオブジェクトの現在座標 */
 const g_previewPos = {
 	arrowJdg: { x: null, y: null },   // 通常判定キャラクタ・コンボ
-	frzJdg: { x: null, y: null },   // フリーズ判定キャラクタ・コンボ
+	frzJdg: { x: null, y: null },     // フリーズ判定キャラクタ・コンボ
+	shortcut: { x: null, y: null },
 };
 
 /**
@@ -9161,8 +9170,20 @@ const openDisplayPreview = () => {
 		createCss2Button(`btnDisplayPreview2`, `↑ Preview`, _evt => {
 			toggleDisplayPreview();
 		}, g_lblPosObj.btnDisplayPreview, g_cssObj.button_Setting),
+		createCss2Button(`btnDisplayReset`, `Reset`, _evt => {
+			if (window.confirm(g_msgObj.displayPreviewResetConfirm)) {
+				Object.assign(g_diffObj, g_diffInitObj);
+				Object.keys(g_previewPos).forEach(key => g_previewPos[key] = { x: null, y: null });
+				closeDisplayPreview();
+				openDisplayPreview();
+			}
+		}, g_lblPosObj.btnDisplayReset, g_cssObj.button_Reset),
 		createDescDiv(`lblDisplayPreviewMsg`, g_lblNameObj.displayPreviewDesc),
 	);
+	if (g_headerObj.scAreaWidth > 0) {
+		overlay.appendChild(createDescDiv(`lblDisplayPreviewMsg2`, g_lblNameObj.displayPreviewDesc2));
+	}
+	createScText(btnDisplayReset, `DisplayPreviewReset`, { displayName: `displayPreview`, targetLabel: `btnDisplayReset`, x: -15 });
 
 	// ============================================================
 	// プレイ画面フレーム（白枠）
@@ -9177,7 +9198,6 @@ const openDisplayPreview = () => {
 		x: frameX, y: frameY, w: playW, h: playH,
 		background: `#111111`,
 		border: `1px solid #444444`,
-		overflow: `hidden`,
 		boxSizing: `border-box`,
 		transform: `scale(${rate})`,
 	});
@@ -9377,6 +9397,28 @@ const buildPreviewUI = (_frame, _playW, _playH) => {
 		)
 	}
 
+	// ============================================================
+	// ショートカット表示
+	// ============================================================
+	const scGroup = createEmptySprite(_frame, `previewScGroup`, {
+		x: g_sWidth + g_headerObj.scAreaWidth - 85 + g_diffObj.shortcutX,
+		y: _playH - 65 + g_diffObj.shortcutY, w: 80, h: 65, pointerEvents: C_DIS_AUTO,
+	});
+	multiAppend(scGroup,
+		createDivCss2Label(`lblRetry`, `[${g_lblNameObj.l_retry}]`, { ...g_lblPosObj.lblMainScHeader, x: 0, y: 0 }),
+		createDivCss2Label(`lblRetrySc`, g_kCd[g_headerObj.keyRetry],
+			{ ...g_lblPosObj.lblMainScKey, x: 0, y: 15, fontWeight: g_headerObj.keyRetry === C_KEY_RETRY ? `normal` : `bold` }),
+		createDivCss2Label(`lblTitleBack`, `[${g_lblNameObj.l_titleBack}]`, { ...g_lblPosObj.lblMainScHeader, x: 0, y: 35 }),
+		createDivCss2Label(`lblTitleBackSc`, g_isMac ? `Shift+${g_kCd[g_headerObj.keyRetry]}` : g_kCd[g_headerObj.keyTitleBack],
+			{ ...g_lblPosObj.lblMainScKey, x: 0, y: 50, fontWeight: g_headerObj.keyTitleBack === C_KEY_TITLEBACK ? `normal` : `bold` }),
+	);
+	const scConfig = {
+		toastTitle: g_lblNameObj.shortcutUpdate,
+		getStdX: (pw) => g_sWidth + g_headerObj.scAreaWidth - 85,
+		getStdY: (ph, syr) => _playH - 65,
+	};
+	makeElementDraggable(scGroup, `shortcut`, _playW, _playH, { w: 80, h: 65 }, scConfig);
+
 	// ユーザカスタムイベント(プレビュー表示用)
 	safeExecuteCustomHooks(`g_customJsObj.displayPreview`, g_customJsObj.displayPreview, _frame, _playW, _playH);
 };
@@ -9426,7 +9468,8 @@ const makeElementDraggable = (_target, _key, _playW, _playH, _bounds, _config) =
 		const dy = _evt.clientY - dragStartY;
 
 		// 境界値制限
-		const newX = Math.max(0, Math.min(_playW - boundsW, elemStartX + dx));
+		const minX = g_headerObj.playingLayout ? -g_headerObj.scAreaWidth : 0;
+		const newX = Math.max(minX, Math.min(_playW + g_headerObj.scAreaWidth - boundsW, elemStartX + dx));
 		const newY = Math.max(0, Math.min(_playH - boundsH, elemStartY + dy));
 
 		_target.style.left = wUnit(newX);
@@ -9509,13 +9552,11 @@ const buildDraggableJudgGroup = (_parent, _groupId, _initX, _initY, _playW, _pla
 			toastTitle: g_lblNameObj.arrowJdgUpdate,
 			getStdX: (pw) => Math.round(pw / 2 - 220),
 			getStdY: (ph, syr) => Math.round((ph + syr) / 2 - 60),
-			targetKeys: { x: `arrowJdgX`, y: `arrowJdgY` },
 		},
 		frzJdg: {
 			toastTitle: g_lblNameObj.frzJdgUpdate,
 			getStdX: (pw) => Math.round(pw / 2 - 120),
 			getStdY: (ph, syr) => Math.round((ph + syr) / 2 + 10),
-			targetKeys: { x: `frzJdgX`, y: `frzJdgY` },
 		}
 	};
 
@@ -13891,6 +13932,9 @@ const getArrowSettings = () => {
 	if (g_headerObj.scAreaWidth === 0 && (g_headerObj.keyRetry !== g_headerObj.keyRetryDef2 || g_headerObj.keyTitleBack !== g_headerObj.keyTitleBackDef2)) {
 		g_workObj.nonDefaultSc = false;
 	}
+	if (g_diffObj.shortcutX !== 0 || g_diffObj.shortcutY !== 0) {
+		g_workObj.nonDefaultSc = true;
+	}
 
 	g_workObj.backX = (g_workObj.nonDefaultSc && g_headerObj.playingLayout ? g_headerObj.scAreaWidth : 0);
 	g_workObj.playingX = g_headerObj.playingX + g_workObj.backX;
@@ -14366,12 +14410,28 @@ const mainInit = () => {
 
 	if (g_workObj.nonDefaultSc) {
 		multiAppend(infoSprite,
-			createDivCss2Label(`lblRetry`, `[${g_lblNameObj.l_retry}]`, { ...g_lblPosObj.lblMainScHeader, y: g_headerObj.playingHeight - 65 }),
-			createDivCss2Label(`lblRetrySc`, g_kCd[g_headerObj.keyRetry],
-				{ ...g_lblPosObj.lblMainScKey, y: g_headerObj.playingHeight - 50, fontWeight: g_headerObj.keyRetry === C_KEY_RETRY ? `normal` : `bold` }),
-			createDivCss2Label(`lblTitleBack`, `[${g_lblNameObj.l_titleBack}]`, { ...g_lblPosObj.lblMainScHeader, y: g_headerObj.playingHeight - 35 }),
-			createDivCss2Label(`lblTitleBackSc`, g_isMac ? `Shift+${g_kCd[g_headerObj.keyRetry]}` : g_kCd[g_headerObj.keyTitleBack],
-				{ ...g_lblPosObj.lblMainScKey, y: g_headerObj.playingHeight - 20, fontWeight: g_headerObj.keyTitleBack === C_KEY_TITLEBACK ? `normal` : `bold` }),
+			createDivCss2Label(`lblRetry`, `[${g_lblNameObj.l_retry}]`, {
+				...g_lblPosObj.lblMainScHeader,
+				x: g_sWidth + g_headerObj.scAreaWidth - 85 + g_diffObj.shortcutX,
+				y: g_headerObj.playingHeight - 65 + g_diffObj.shortcutY,
+			}),
+			createDivCss2Label(`lblRetrySc`, g_kCd[g_headerObj.keyRetry], {
+				...g_lblPosObj.lblMainScKey,
+				x: g_sWidth + g_headerObj.scAreaWidth - 85 + g_diffObj.shortcutX,
+				y: g_headerObj.playingHeight - 50 + g_diffObj.shortcutY,
+				fontWeight: g_headerObj.keyRetry === C_KEY_RETRY ? `normal` : `bold`,
+			}),
+			createDivCss2Label(`lblTitleBack`, `[${g_lblNameObj.l_titleBack}]`, {
+				...g_lblPosObj.lblMainScHeader,
+				x: g_sWidth + g_headerObj.scAreaWidth - 85 + g_diffObj.shortcutX,
+				y: g_headerObj.playingHeight - 35 + g_diffObj.shortcutY,
+			}),
+			createDivCss2Label(`lblTitleBackSc`, g_isMac ? `Shift+${g_kCd[g_headerObj.keyRetry]}` : g_kCd[g_headerObj.keyTitleBack], {
+				...g_lblPosObj.lblMainScKey,
+				x: g_sWidth + g_headerObj.scAreaWidth - 85 + g_diffObj.shortcutX,
+				y: g_headerObj.playingHeight - 20 + g_diffObj.shortcutY,
+				fontWeight: g_headerObj.keyTitleBack === C_KEY_TITLEBACK ? `normal` : `bold`,
+			}),
 		);
 	}
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9442,7 +9442,7 @@ const buildPreviewUI = (_frame, _playW, _playH) => {
  * @param {string} _key 座標保存用のキー（g_previewPosオブジェクトのプロパティ名）
  * @param {number} _playW 制限範囲の幅
  * @param {number} _playH 制限範囲の高さ
- * @param {object} _bounds 要素自体のサイズ { w, h } (はみ出し防止用)
+ * @param {object} _bounds 要素自体のサイズ { w, h, scale } (はみ出し防止用)
  * @param {object} _config 座標反映ルールオブジェクト
  */
 const makeElementDraggable = (_target, _key, _playW, _playH, _bounds, _config) => {
@@ -9452,6 +9452,7 @@ const makeElementDraggable = (_target, _key, _playW, _playH, _bounds, _config) =
 
 	const boundsW = _bounds?.w ?? _target.offsetWidth ?? 0;
 	const boundsH = _bounds?.h ?? _target.offsetHeight ?? 0;
+	const scale = _bounds?.scale ?? 0.8;
 
 	// ドラッグハンドル（薄い枠）を作成
 	const handleId = _target.id ? `handle_${_target.id}` : `dragHandle_${Math.random().toString(36).slice(2, 9)}`;
@@ -9477,10 +9478,16 @@ const makeElementDraggable = (_target, _key, _playW, _playH, _bounds, _config) =
 
 	const keyMove = addPreviewListener(_target, `pointermove`, _evt => {
 		if (!dragging) return;
-		const dx = _evt.clientX - dragStartX;
-		const dy = _evt.clientY - dragStartY;
 
-		// 境界値制限
+		// 1. マウスの実際の移動量を計算
+		const mouseDx = _evt.clientX - dragStartX;
+		const mouseDy = _evt.clientY - dragStartY;
+
+		// 2. 【最重要】スケール逆算して、縮小空間内の移動量に変換
+		const dx = mouseDx / scale;
+		const dy = mouseDy / scale;
+
+		// 3. 境界値制限
 		const minX = g_headerObj.playingLayout ? -g_headerObj.scAreaWidth : 0;
 		const newX = Math.max(minX, Math.min(_playW + g_headerObj.scAreaWidth - boundsW, elemStartX + dx));
 		const newY = Math.max(0, Math.min(_playH - boundsH, elemStartY + dy));

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4370,6 +4370,12 @@ const headerConvert = _dosObj => {
 	g_diffInitObj.shortcutX = g_diffObj.shortcutX;
 	g_diffInitObj.shortcutY = g_diffObj.shortcutY;
 
+	if (Object.keys(g_diffObj).some(key => g_localStorage[key] !== undefined)) {
+		Object.keys(g_diffObj).forEach(key =>
+			g_diffObj[key] = setIntVal(g_localStorage[key], g_diffObj[key])
+		);
+	}
+
 	// musicフォルダ設定
 	obj.musicFolder = _dosObj.musicFolder ?? (g_remoteFlg ? `${C_MRK_CURRENT_DIRECTORY}../music` : `music`);
 
@@ -9587,6 +9593,8 @@ const applyElementPositionToGame = (_x, _y, _config, _key) => {
 	// 3. 指定された保存先にオフセットを格納
 	g_diffObj[`${_key}X`] = diffX;
 	g_diffObj[`${_key}Y`] = diffY;
+	g_localStorage[`${_key}X`] = diffX;
+	g_localStorage[`${_key}Y`] = diffY;
 
 	// 4. トースト表示 (通知が不要な要素なら省略可能にする)
 	if (_config.toastTitle) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9363,7 +9363,7 @@ const buildPreviewUI = (_frame, _playW, _playH) => {
 			{ color: `#99ff66`, cnt: `0` },
 			{ color: `#ffffff`, cnt: `5` },
 		];
-		const sx = _playW - 110;
+		const sx = _playW - 110 + g_headerObj.scAreaWidth;
 		scoreItems.forEach((item, i) => {
 			_frame.appendChild(
 				createDivCss2Label(`previewScore${i}`, item.cnt || ``, {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -4359,9 +4359,13 @@ const headerConvert = _dosObj => {
 	obj.baseSpeed = 1 + ((g_posObj.distY - (g_posObj.stepY - C_STEP_Y) * 2) / (500 - C_STEP_Y) - 1) * 0.85;
 
 	// 矢印・フリーズアロー判定位置補正
+	g_diffObj.arrowJdgX = (isNaN(parseFloat(_dosObj.arrowJdgX)) ? 0 : parseFloat(_dosObj.arrowJdgX));
 	g_diffObj.arrowJdgY = (isNaN(parseFloat(_dosObj.arrowJdgY)) ? 0 : parseFloat(_dosObj.arrowJdgY));
+	g_diffObj.frzJdgX = (isNaN(parseFloat(_dosObj.frzJdgX)) ? 0 : parseFloat(_dosObj.frzJdgX));
 	g_diffObj.frzJdgY = (isNaN(parseFloat(_dosObj.frzJdgY)) ? 0 : parseFloat(_dosObj.frzJdgY));
+	g_diffInitObj.arrowJdgX = g_diffObj.arrowJdgX;
 	g_diffInitObj.arrowJdgY = g_diffObj.arrowJdgY;
+	g_diffInitObj.frzJdgX = g_diffObj.frzJdgX;
 	g_diffInitObj.frzJdgY = g_diffObj.frzJdgY;
 
 	// ショートカット表示位置補正
@@ -9179,6 +9183,9 @@ const openDisplayPreview = () => {
 		createCss2Button(`btnDisplayReset`, `Reset`, _evt => {
 			if (window.confirm(g_msgObj.displayPreviewResetConfirm)) {
 				Object.assign(g_diffObj, g_diffInitObj);
+				Object.keys(g_diffInitObj).forEach(key => {
+					g_localStorage[key] = g_diffInitObj[key];
+				});
 				Object.keys(g_previewPos).forEach(key => g_previewPos[key] = { x: null, y: null });
 				closeDisplayPreview();
 				openDisplayPreview();

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -543,8 +543,14 @@ const updateWindowSiz = () => {
             x: g_btnX() + Math.floor((g_btnWidth() - 80) / 2), y: 3, w: 80, h: 18, siz: 11,
             title: g_msgObj.displayPreview,
         },
+        btnDisplayReset: {
+            x: g_btnX() + g_btnWidth() - 80, y: 3, w: 80, h: 18, siz: 11,
+        },
         lblDisplayPreviewMsg: {
             x: g_btnX(), y: g_sHeight - 40, w: g_btnWidth(), h: 20, siz: 14,
+        },
+        lblDisplayPreviewMsg2: {
+            x: g_btnX(), y: g_sHeight - 25, w: g_btnWidth(), h: 20, siz: 14,
         },
         previewScoreDisabled: {
             x: g_headerObj.playingWidth - 80, y: 20, w: 70, h: 200,
@@ -2331,6 +2337,17 @@ const g_diffObj = {
     frzJdgX: 0,
     arrowJdgY: 0,
     frzJdgY: 0,
+    shortcutX: 0,
+    shortcutY: 0,
+};
+
+const g_diffInitObj = {
+    arrowJdgX: 0,
+    frzJdgX: 0,
+    arrowJdgY: 0,
+    frzJdgY: 0,
+    shortcutX: 0,
+    shortcutY: 0,
 };
 
 // キーコンフィグカーソル
@@ -2982,6 +2999,7 @@ const g_shortcutObj = {
     },
     displayPreview: {
         KeyP: { id: `btnDisplayPreview2` },
+        KeyR: { id: `btnDisplayReset` },
         Escape: { id: `btnBack` },
         Space: { id: `btnKeyConfig` },
         Enter: { id: `btnPlay` },
@@ -4785,9 +4803,11 @@ const g_lang_lblNameObj = {
         transKeyDesc: `別キーモードではキーコンフィグ、ColorType等は保存されません`,
         colorTypeDesc: `現在のColorTypeの設定では、色変化(Display:Color)は自動的にOFFになります`,
         sdShortcutDesc: `Hid+/Sud+時ショートカット：「pageUp」カバーを上へ / 「pageDown」下へ`,
-        displayPreviewDesc: `判定キャラクタ部分をドラッグで移動するとその位置に補正されます`,
+        displayPreviewDesc: `判定キャラクタ部分、ショートカット表示はドラッグで移動するとその位置に補正されます`,
+        displayPreviewDesc2: `枠外への移動はショートカットがデフォルトと異なるか、位置が通常と異なる場合のみ有効です`,
         arrowJdgUpdate: `矢印判定の座標を更新`,
         frzJdgUpdate: `フリーズアロー判定の座標を更新`,
+        shortcutUpdate: `ショートカット表示の座標を更新`,
         resultImageDesc: `画像を右クリックしてコピーできます`,
 
         s_level: `Level`,
@@ -4845,9 +4865,11 @@ const g_lang_lblNameObj = {
         transKeyDesc: `Key config, Color type, etc. are not saved in another key mode`,
         colorTypeDesc: `With the current ColorType setting, color change (Display:Color) will be automatically turned OFF.`,
         sdShortcutDesc: `When "Hidden+" or "Sudden+" select, "pageUp" cover up / "pageDown" cover down`,
-        displayPreviewDesc: `If you drag the judgment character section, it will be adjusted to that position.`,
+        displayPreviewDesc: `If you drag the judgment character section or shortcut display, it will be adjusted to that position.`,
+        displayPreviewDesc2: `Moving outside the frame is only effective when the shortcut display position differs from the default.`,
         arrowJdgUpdate: `Update the coordinates (arrow)`,
         frzJdgUpdate: `Update the coordinates (freeze)`,
+        shortcutUpdate: `Update the coordinates (shortcut)`,
         resultImageDesc: `You can copy the image by right-clicking on it.`,
 
         s_level: `Level`,
@@ -4993,6 +5015,7 @@ const g_lang_msgObj = {
         opacity: `判定キャラクタ、コンボ数、Fast/Slowの透明度を設定します。`,
         hitPosition: `判定位置にズレを感じる場合、\n数値を変えることで判定の中央位置を1px単位(プラス:手前, マイナス:奥側)で調整することができます。\n早押し・遅押し傾向にある場合に使用します。`,
         displayPreview: `プレイ画面上のオブジェクトの表示状態をプレビューします。\n判定キャラクタ部分をドラッグで移動するとその位置に補正されます。`,
+        displayPreviewResetConfirm: `プレイ画面上のオブジェクトの位置を初期状態に戻します。よろしいですか？`,
 
         colorType: `矢印・フリーズアローの配色セットをあらかじめ定義されたリストから選択できます。\nType1～4選択時は色変化が自動でOFFになり、カラーピッカーから好きな色に変更できます。\n[Type0] グラデーション切替, [Type1～4] デフォルトパターン`,
         imgType: `矢印・フリーズアローなどのオブジェクトの見た目を変更します。`,
@@ -5097,6 +5120,7 @@ const g_lang_msgObj = {
         opacity: `Set the transparency of some objects such as judgment, combo counts, fast and slow`,
         hitPosition: `If you feel a discrepancy in the judgment position, \nyou can adjust the center position of the judgment in 1px increments \n (plus: in front, minus: at the back) by changing the numerical value. \nUse this function when there is a tendency to push too fast or too slow.`,
         displayPreview: `Preview the display status of objects on the play screen.\nDragging the judgment character section will adjust it to that position.`,
+        displayPreviewResetConfirm: `Reset the position of objects on the play screen to the initial state. Is it OK?`,
 
         colorType: `Change the color scheme set for arrows and freeze-arrows from the predefined set.\nWhen Type1 to 4 is selected, color change is automatically turned off and can be changed to any color from the color picker.\n[Type0] Switch the sequences color gradations, [Type1～4] default color scheme`,
         imgType: `Change the appearance of sequences.`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -5040,7 +5040,7 @@ const g_lang_msgObj = {
         github: `Go to the GitHub page of Dancing Onigiri "CW Edition".`,
         security: `Go to the support information page for Dancing Onigiri "CW Edition".`,
 
-        environment: `Initialize ${g_settings.environments.map(v => toCapitalize(v)).join(`, `)} settings.`,
+        environment: `Initialize ${g_settings.environments.join(`, `)} settings.`,
         highscores: `Initializes the high score of all charts. \nIf you want to initialize each chart individually, \nplease do so from the Highscore view in the Settings screen.`,
         customKey: `Delete stored data related to all custom keymodes. \nUse this option when you cannot delete individual KeyData from the following KeyData.`,
         others: `Delete non-standard stored data.`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1334,7 +1334,8 @@ const g_settings = {
         customKey: 0,
         others: 0,
     },
-    environments: [`adjustment`, `volume`, `colorType`, `appearance`, `opacity`, `hitPosition`],
+    environments: [`adjustment`, `volume`, `colorType`, `appearance`, `opacity`, `hitPosition`,
+        `arrowJdgX`, `arrowJdgY`, `frzJdgX`, `frzJdgY`, `shortcutX`, `shortcutY`],
     keyStorages: [`reverse`, `keyCtrl`, `keyCtrlPtn`, `shuffle`, `color`, `stepRtn`],
     colorStorages: [`setColor`, `setShadowColor`, `frzColor`, `frzShadowColor`],
 
@@ -4933,7 +4934,7 @@ const g_lang_msgObj = {
         github: `Dancing☆Onigiri (CW Edition)のGitHubページへ移動します。`,
         security: `Dancing☆Onigiri (CW Edition)のサポート情報ページへ移動します。`,
 
-        environment: `${g_settings.environments.map(v => toCapitalize(v)).join(`, `)}の設定を初期化します。`,
+        environment: `${g_settings.environments.join(`, `)}の設定を初期化します。`,
         highscores: `全譜面のハイスコアを初期化します。\n個別に初期化したい場合はSettings画面より行ってください。`,
         customKey: `カスタムキーに関する全ての保存データを消去します。\n下記のKeyDataから個別に消去可能できないときに使用してください。`,
         others: `標準以外に関する保存データを消去します。`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -4934,7 +4934,7 @@ const g_lang_msgObj = {
         github: `Dancing☆Onigiri (CW Edition)のGitHubページへ移動します。`,
         security: `Dancing☆Onigiri (CW Edition)のサポート情報ページへ移動します。`,
 
-        environment: `${g_settings.environments.join(`, `)}の設定を初期化します。`,
+        environment: `以下の設定を初期化します。\n  - Adjustment, Volume, ColorType, Appearance, Opacity, HitPosition, 判定キャラクタ位置, ショートカット表示位置`,
         highscores: `全譜面のハイスコアを初期化します。\n個別に初期化したい場合はSettings画面より行ってください。`,
         customKey: `カスタムキーに関する全ての保存データを消去します。\n下記のKeyDataから個別に消去可能できないときに使用してください。`,
         others: `標準以外に関する保存データを消去します。`,
@@ -5040,7 +5040,7 @@ const g_lang_msgObj = {
         github: `Go to the GitHub page of Dancing Onigiri "CW Edition".`,
         security: `Go to the support information page for Dancing Onigiri "CW Edition".`,
 
-        environment: `Initialize ${g_settings.environments.join(`, `)} settings.`,
+        environment: `Initialize settings below:\n  - Adjustment, Volume, ColorType, Appearance, Opacity, HitPosition, judgment character positions and shortcut display position.`,
         highscores: `Initializes the high score of all charts. \nIf you want to initialize each chart individually, \nplease do so from the Highscore view in the Settings screen.`,
         customKey: `Delete stored data related to all custom keymodes. \nUse this option when you cannot delete individual KeyData from the following KeyData.`,
         others: `Delete non-standard stored data.`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. ショートカット表示をDisplay設定のプレビューで調整できる機能を実装
- ショートカット表示について、判定キャラクタと同じようにDisplay設定のプレビューで調整できるようにしました。
- 通常、ショートカット表示は非表示ですが、ここで調整した場合に限り強制表示されるようになります。
- 元に戻したい場合は、右上の「Reset」ボタンより初期位置に戻すことができます。ショートカットは「R」です。
ただし、判定キャラクタも含めて初期位置に戻るためご注意ください。
なお、譜面ヘッダーで外部制御した初期位置は維持される仕様です。

### 2. ショートカット表示の初期位置及び判定キャラクタのX座標を制御する譜面ヘッダーを追加
- 1. に関連して、ショートカット表示の初期位置及び判定キャラクタのX座標を決める
譜面ヘッダー「shortcutX」「shortcutY」「arrowJdgX」「frzJdgX」を追加しました。
- 使い方はarrowJdgY, frzJdgYと同じで、デフォルトからの差分位置をpx単位で指定します。（絶対位置ではない）
- Display設定のプレビューにて差分位置が表示されるので、それを参考に設定することを想定しています。

### 3. ローカルストレージにDisplay設定のプレビューで調整した座標を追加
- 1, 2に関連して、判定キャラクタとショートカット表示の座標についてローカルストレージの保存対象としました。
- 「Reset」ボタンを押すと、本来の初期位置（ローカルストレージ保存前）に戻りますが
リロードしても位置が保存されるようになります。
- これに伴い、データ管理画面で追加した項目を「Environments」から削除できるようにしました。

### 4. Display設定のプレビューでのドラッグ時にカーソルの位置が完全に追従しない問題を修正
- Display設定のプレビューでのドラッグ時、親要素が縮小されている関係でドラッグ位置が縮小に対応できていませんでした。これを修正しています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. ショートカット位置について個別に調整したい場合があるため。
2. 1.に関連して、作品ごとに位置制御したい場合があるため。
3. 1.のResetボタン実装に伴うものです。
4. 既存不具合です。ver48.0.0以降で発生します。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/a67bd97e-ed1e-409e-89ea-d607f5d944bf" />

### 補足1: ショートカットエリアが有効 (scArea > 0) のとき
- スコア表示部分はショートカットエリアが有効なときの表示に変更されます。

<img width="60%" alt="image" src="https://github.com/user-attachments/assets/a98ffa3f-126b-485a-9e8d-354e123a91cd" />

### 補足2: データ管理画面のメッセージ変更

<img width="60%" alt="image" src="https://github.com/user-attachments/assets/0d603832-9e37-4716-8136-64d5eb5a59fe" />


## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->