### PR TITLE
improve: [1108] 背景の明暗に合わせてDisplay設定のプレビューが変わるように変更、レイアウト調整

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9311,11 +9311,14 @@ const buildPreviewUI = (_frame, _playW, _playH) => {
 	// 青いラインの右端（totalW から10pxほど外側）に数値を表示
 	multiAppend(
 		lineNormal,
-		createDivCss2Label(`previewHitPosTitle`, g_lblNameObj.HitPosition, {
-			...g_lblPosObj.previewHitPosText, x: -105, align: C_ALIGN_RIGHT,
+		createDivCss2Label(`previewHitPosTitle`, `Hit`, {
+			...g_lblPosObj.previewHitPosText, x: -100, y: -14, align: C_ALIGN_RIGHT,
+		}),
+		createDivCss2Label(`previewHitPosTitle2`, `Position`, {
+			...g_lblPosObj.previewHitPosText, x: -100, y: -2, align: C_ALIGN_RIGHT,
 		}),
 		createDivCss2Label(`previewHitPosText`, `${hitPos > 0 ? '+' : ''}${hitPos}px↑↓`, {
-			...g_lblPosObj.previewHitPosText, x: totalW + 10, align: C_ALIGN_LEFT,
+			...g_lblPosObj.previewHitPosText, x: totalW + 5, y: -8, align: C_ALIGN_LEFT,
 		}),
 	);
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9312,10 +9312,10 @@ const buildPreviewUI = (_frame, _playW, _playH) => {
 	multiAppend(
 		lineNormal,
 		createDivCss2Label(`previewHitPosTitle`, `Hit`, {
-			...g_lblPosObj.previewHitPosText, x: -100, y: -14, align: C_ALIGN_RIGHT,
+			...g_lblPosObj.previewHitPosText, x: -60, y: -14, align: C_ALIGN_RIGHT,
 		}),
 		createDivCss2Label(`previewHitPosTitle2`, `Position`, {
-			...g_lblPosObj.previewHitPosText, x: -100, y: -2, align: C_ALIGN_RIGHT,
+			...g_lblPosObj.previewHitPosText, x: -60, y: -2, align: C_ALIGN_RIGHT,
 		}),
 		createDivCss2Label(`previewHitPosText`, `${hitPos > 0 ? '+' : ''}${hitPos}px↑↓`, {
 			...g_lblPosObj.previewHitPosText, x: totalW + 5, y: -8, align: C_ALIGN_LEFT,

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9209,7 +9209,7 @@ const openDisplayPreview = () => {
 
 	const frame = createEmptySprite(overlay, `previewFrame`, {
 		x: frameX, y: frameY, w: playW, h: playH,
-		background: `#111111`,
+		background: g_headerObj.baseBrightFlg ? `#eeeeeedd` : `#111111`,
 		border: `1px solid #444444`,
 		boxSizing: `border-box`,
 		transform: `scale(${rate})`,
@@ -9372,9 +9372,9 @@ const buildPreviewUI = (_frame, _playW, _playH) => {
 		_frame.appendChild(disableBox(`LifeGauge`, g_lblPosObj.previewLifeDisabled));
 	} else {
 		multiAppend(_frame,
-			createDivCss2Label(`previewLifeBack`, ``, g_lblPosObj.previewLifeBack),
-			createDivCss2Label(`previewLifeBar`, ``, g_lblPosObj.previewLifeBar),
-			createDivCss2Label(`previewLifeNum`, `700`, g_lblPosObj.previewLifeNum),
+			createDivCss2Label(`previewLifeBack`, ``, g_lblPosObj.previewLifeBack, g_cssObj.life_Background),
+			createDivCss2Label(`previewLifeBar`, ``, g_lblPosObj.previewLifeBar, g_cssObj.life_Cleared),
+			createDivCss2Label(`previewLifeNum`, `700`, g_lblPosObj.previewLifeNum, g_cssObj.life_Cleared),
 		);
 	}
 
@@ -9389,31 +9389,31 @@ const buildPreviewUI = (_frame, _playW, _playH) => {
 		}
 	} else {
 		const scoreItems = [
-			{ color: `#66ffff`, cnt: `5` },
-			{ color: `#99ff99`, cnt: `0` },
-			{ color: `#ffcc66`, cnt: `0` },
-			{ color: `#cc99ff`, cnt: `0` },
-			{ color: `#ff9999`, cnt: `0` },
-			{ color: `#ffffff`, cnt: `5` },
+			{ name: `ii`, cnt: `5` },
+			{ name: `shakin`, cnt: `0` },
+			{ name: `matari`, cnt: `0` },
+			{ name: `shobon`, cnt: `0` },
+			{ name: `uwan`, cnt: `0` },
+			{ name: `combo`, cnt: `5` },
 			{},
-			{ color: `#ffff99`, cnt: `5` },
-			{ color: `#99ff66`, cnt: `0` },
-			{ color: `#ffffff`, cnt: `5` },
+			{ name: `kita`, cnt: `5` },
+			{ name: `iknai`, cnt: `0` },
+			{ name: `combo`, cnt: `5` },
 		];
 		const sx = _playW - 110 + g_headerObj.scAreaWidth;
 		scoreItems.forEach((item, i) => {
 			_frame.appendChild(
 				createDivCss2Label(`previewScore${i}`, item.cnt || ``, {
 					x: sx + 50, y: 20 * (i + 1), w: 50, h: 20,
-					siz: 16, color: item.color, align: `right`,
-				}),
+					siz: 16, align: `right`,
+				}, g_cssObj[`common_${item.name}`]),
 			);
 		});
 
 		// FrzReturn用ゲージ
 		if (g_stateObj.frzReturn !== C_FLG_OFF) {
 			multiAppend(_frame,
-				createDivCss2Label(`previewFrzLifeBack`, ``, g_lblPosObj.previewFrzLifeBack),
+				createDivCss2Label(`previewFrzLifeBack`, ``, g_lblPosObj.previewFrzLifeBack, g_cssObj.life_Background),
 				createDivCss2Label(`previewFrzLifeBar`, ``, g_lblPosObj.previewFrzLifeBar, g_cssObj.life_frzNormal),
 			);
 		}
@@ -9530,11 +9530,12 @@ const makeElementDraggable = (_target, _key, _playW, _playH, _bounds, _config) =
 	const handleId = _target.id ? `handle_${_target.id}` : `dragHandle_${Math.random().toString(36).slice(2, 9)}`;
 	_target.style.cursor = `grab`;
 
+	const bgColor = g_headerObj.baseBrightFlg ? `0,0,0` : `255,255,255`;
 	createEmptySprite(_target, handleId, {
 		x: 0, y: 0, w: boundsW, h: boundsH,
-		border: `1px dashed rgba(255,255,255,0.3)`,
+		border: `1px dashed rgba(${bgColor},0.3)`,
 		boxSizing: `border-box`, borderRadius: `2px`,
-		background: `rgba(255,255,255,0.04)`,
+		background: `rgba(${bgColor},0.04)`,
 	});
 
 	const keyDown = addPreviewListener(_target, `pointerdown`, _evt => {
@@ -9623,18 +9624,18 @@ const buildDraggableJudgGroup = (_parent, _groupId, _initX, _initY, _playW, _pla
 		// キャラクタ
 		createDivCss2Label(`previewChara_${_groupId}`, _opts.charaText, {
 			x: 0, y: 0, w: g_limitObj.jdgCharaWidth, h: g_limitObj.jdgCharaHeight,
-			siz: g_limitObj.jdgCharaSiz, color: _opts.charaColor, opacity,
-		}),
+			siz: g_limitObj.jdgCharaSiz, opacity,
+		}, _groupId === `arrowJdg` ? g_cssObj.common_ii : g_cssObj.common_kita),
 		// コンボ
 		createDivCss2Label(`previewCombo_${_groupId}`, _opts.comboText, {
 			x: 170, y: 0, w: g_limitObj.jdgCharaWidth, h: g_limitObj.jdgCharaHeight,
-			siz: g_limitObj.jdgCharaSiz, color: `#ffffff`, opacity,
-		}),
+			siz: g_limitObj.jdgCharaSiz, opacity,
+		}, _groupId === `arrowJdg` ? g_cssObj.common_kita : g_cssObj.common_ii),
 		// Fast/Slow
 		createDivCss2Label(`previewDiff_${_groupId}`, _opts.diffText, {
 			x: 170, y: 25, w: g_limitObj.jdgCharaWidth, h: g_limitObj.jdgCharaHeight,
 			siz: g_limitObj.mainSiz, color: `#ff9966`, opacity,
-		}),
+		}, g_cssObj.common_fast),
 	);
 
 	// ============================================================

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -569,23 +569,21 @@ const updateWindowSiz = () => {
         },
         previewLifeBack: {
             x: 5, y: 50, w: 15, h: g_headerObj.playingHeight - 100,
-            background: `#333333`, border: `1px solid #555555`,
         },
         previewLifeBar: {
             x: 5, y: 50 + (g_headerObj.playingHeight - 100) * 0.3,
-            w: 15, h: (g_headerObj.playingHeight - 100) * 0.7, background: `#006666`,
+            w: 15, h: (g_headerObj.playingHeight - 100) * 0.7,
         },
         previewLifeNum: {
             x: 0, y: 30, w: 70, h: 20,
-            siz: g_limitObj.jdgCntsSiz, color: `#ffffff`, background: `#006666`, align: C_ALIGN_CENTER,
+            siz: g_limitObj.jdgCntsSiz, align: C_ALIGN_CENTER,
         },
         previewFrzLifeBack: {
-            x: 0, y: 50, w: 5, h: g_headerObj.playingHeight - 100,
-            background: `#333333`, border: `1px solid #555555`,
+            x: 0, y: 50, w: 4, h: g_headerObj.playingHeight - 100,
         },
         previewFrzLifeBar: {
             x: 0, y: 50 + (g_headerObj.playingHeight - 100) * 0.7,
-            w: 5, h: (g_headerObj.playingHeight - 100) * 0.3,
+            w: 4, h: (g_headerObj.playingHeight - 100) * 0.3,
         },
         previewHitPosText: {
             y: -8, w: 100, h: 16, siz: 14, color: `#33aaff`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -586,7 +586,7 @@ const updateWindowSiz = () => {
             w: 4, h: (g_headerObj.playingHeight - 100) * 0.3,
         },
         previewHitPosText: {
-            w: 100, h: 16, siz: 14, color: `#33aaff`,
+            w: 60, h: 16, siz: 14, color: `#33aaff`,
             fontFamily: `monospace`, fontWeight: `bold`,
         },
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -586,7 +586,7 @@ const updateWindowSiz = () => {
             w: 4, h: (g_headerObj.playingHeight - 100) * 0.3,
         },
         previewHitPosText: {
-            y: -8, w: 100, h: 16, siz: 14, color: `#33aaff`,
+            w: 100, h: 16, siz: 14, color: `#33aaff`,
             fontFamily: `monospace`, fontWeight: `bold`,
         },
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. 背景の明暗に合わせてDisplay設定のプレビューが変わるように変更
- 背景の明暗に合わせてDisplay設定のプレビューが変わるように変更しました。

### 2. Display設定のプレビューのHitPositionのラベルを二段に分割
- プレイ幅が狭い場合に収まらないことがあるため、二段に分割しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 明背景のときに一部見づらい箇所(ゲージ設定名、ショートカットキー表示)があるため。
黒背景で統一せず、明背景時は白ベースにして実際のCSS設定を極力見るようにしました。
2. ライフゲージと重なる事象を避けるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/07ecd74d-24b8-49d1-91b7-8d43c04ed2eb" /><img width="50%" alt="image" src="https://github.com/user-attachments/assets/60390d1b-541b-4c2c-b04c-d07c302b7a39" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
