### PR TITLE
improve: [1113] キーコンフィグのキーボードマッププレビューにおいて内部配列のキーをkeyCodeからcodeに変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -11236,9 +11236,9 @@ const keyconfigKeyboardPreview = (() => {
 	 * _state に書き込む。init 時に呼ぶ。
 	 *
 	 * 基準サイズ（フルキーボード = メイン + ナビクラスター）:
-	 * 横: MAIN最大行幅 + ナビ幅(3キー) + 余白
-	 * 縦: 6行 × (BASE_KEY_H + BASE_KEY_GAP) - BASE_KEY_GAP
-	 * BASE_KEY_W = BASE_KEY_H = 28px、BASE_KEY_GAP = 3px を基準とする。
+	 *   横: MAIN最大行幅 + ナビ幅(3キー) + 余白
+	 *   縦: 6行 × (BASE_KEY_H + BASE_KEY_GAP) - BASE_KEY_GAP
+	 *   BASE_KEY_W = BASE_KEY_H = 28px、BASE_KEY_GAP = 3px を基準とする。
 	 */
 	const BASE_KEY_W = 28;
 	const BASE_KEY_H = 28;
@@ -11308,6 +11308,8 @@ const keyconfigKeyboardPreview = (() => {
 	// -------------------------------------------------------------------------
 	// Canvas ヘルパー
 	// -------------------------------------------------------------------------
+
+	// スケール済みの各寸法を返すヘルパー
 	const kw = w => Math.floor(w * BASE_KEY_W * _state.scale + (w - 1) * BASE_KEY_GAP * _state.scale);
 	const kh = h => Math.floor(h * BASE_KEY_H * _state.scale + (h - 1) * BASE_KEY_GAP * _state.scale);
 	const kg = () => Math.max(1, Math.round(BASE_KEY_GAP * _state.scale));
@@ -11584,8 +11586,8 @@ const keyconfigKeyboardPreview = (() => {
 	 * プレビューが表示中なら即時再描画する。
 	 *
 	 * g_keyObj[`keyCtrl${keyCtrlPtn}`] は二次元配列:
-	 * [ [矢印0のメインkeyCode, 代替keyCode, ...], [矢印1のメインkeyCode, ...], ... ]
-	 * 各サブ配列 of index 0 がメインキー、index 1 以降が代替キー。
+	 *   [ [矢印0のメインkeyCode, 代替keyCode, ...], [矢印1のメインkeyCode, ...], ... ]
+	 * 各サブ配列の index 0 がメインキー、index 1 以降が代替キー。
 	 */
 	const refresh = () => {
 		const tkObj = getKeyInfo();

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -11067,10 +11067,6 @@ const keyconfigKeyboardPreview = (() => {
 		legendText: `#cccccc`,    // 凡例テキスト
 	};
 
-	// プレビューエリア
-	// X: canvas を divRoot 内で水平センタリング（init で動的計算）
-	// Y: g_sHeight に対して垂直センタリング（init で動的計算）
-
 	// 凡例エリアの高さ
 	const LEGEND_H = 25;
 
@@ -11081,15 +11077,12 @@ const keyconfigKeyboardPreview = (() => {
 	//   offsetX : 行左端の水平オフセット（単位: BASE_KEY_W）。未指定時は0
 	//   keys    : キー定義の配列
 	//
-	// 各キー: { kc, w?, h?, label? }
-	//   kc    : keyCode（数値）。-1 はスペーサー（描画・キャッシュなし）。
-	//   w     : 幅倍率（BASE_KEY_W 基準。省略時 1）
-	//   h     : 高さ倍率（BASE_KEY_H 基準。省略時 1）
-	//   label : 省略時は g_kCd[kc] を参照。g_kCd が空文字のキーや
-	//           左右を区別したいキーに指定する。
-	//
-	// 右Shift/Ctrl/Alt は danoniplus 独自コード 256〜258 を使用。
-	// Appli キーは 93 を使用（g_kCd[93] = `Appli`）。
+	// 各キー: { code, w?, h?, label? }
+	//   code   : KeyboardEvent.code（文字列）。空文字 "" はスペーサー（描画・キャッシュなし）。
+	//   w      : 幅倍率（BASE_KEY_W 基準。省略時 1）
+	//   h      : 高さ倍率（BASE_KEY_H 基準。省略時 1）
+	//   label  : 省略時は g_kCd[keyCode] を参照。g_kCd が空文字のキーや
+	//            左右を区別したいキーに指定する。
 	// -------------------------------------------------------------------------
 	/**
 	 * g_localeObj.val に応じた MAIN_ROWS を生成して返す。
@@ -11103,106 +11096,106 @@ const keyconfigKeyboardPreview = (() => {
 			// Row0: Fn キー行（JIS/US 共通）
 			{
 				keys: [
-					{ kc: 27 },                    // Esc
-					{ kc: -1, w: 0.5 },            // スペーサー
-					{ kc: 112 }, { kc: 113 }, { kc: 114 }, { kc: 115 },
-					{ kc: -1, w: 0.25 },           // スペーサー
-					{ kc: 116 }, { kc: 117 }, { kc: 118 }, { kc: 119 },
-					{ kc: -1, w: 0.25 },           // スペーサー
-					{ kc: 120 }, { kc: 121 }, { kc: 122 }, { kc: 123 },
+					{ code: `Escape` },
+					{ code: ``, w: 0.5 },            // スペーサー
+					{ code: `F1` }, { code: `F2` }, { code: `F3` }, { code: `F4` },
+					{ code: ``, w: 0.25 },           // スペーサー
+					{ code: `F5` }, { code: `F6` }, { code: `F7` }, { code: `F8` },
+					{ code: ``, w: 0.25 },           // スペーサー
+					{ code: `F9` }, { code: `F10` }, { code: `F11` }, { code: `F12` },
 				],
 			},
 			// Row1: 数字行
-			// JIS: ..., 220(intlYen), BS
-			// US : ...,               BS
+			// JIS: ..., Minus, Equal, IntlYen, BS
+			// US : ..., Minus, Equal,          BS
 			{
 				keys: [
-					{ kc: 229 },
-					{ kc: 49 }, { kc: 50 }, { kc: 51 }, { kc: 52 }, { kc: 53 }, { kc: 54 },
-					{ kc: 55 }, { kc: 56 }, { kc: 57 }, { kc: 48 }, { kc: 189 }, { kc: 222 },
+					{ code: `Backquote` },
+					{ code: `Digit1` }, { code: `Digit2` }, { code: `Digit3` }, { code: `Digit4` }, { code: `Digit5` }, { code: `Digit6` },
+					{ code: `Digit7` }, { code: `Digit8` }, { code: `Digit9` }, { code: `Digit0` }, { code: `Minus` }, { code: `Equal` },
 					...(isJa
-						? [{ kc: 220, w: 0.75 }, { kc: 8, label: `Back\nSpace` }]  // JIS: intlYen + BS
-						: [{ kc: 8, w: 1.7 }]                                      // US : BS のみ（広い）
+						? [{ code: `IntlYen`, w: 0.75 }, { code: `Backspace`, label: `Back\nSpace` }]  // JIS: IntlYen + BS
+						: [{ code: `Backspace`, w: 1.7 }]                                             // US : BS のみ（広い）
 					),
 				],
 			},
 			// Row2: QWERTY
-			// JIS: ..., [, Enter(13)
-			// US : ..., [, ]
+			// JIS: ..., BracketLeft, BracketRight, Enter(縦長)
+			// US : ..., BracketLeft, BracketRight, Backslash
 			{
 				keys: [
-					{ kc: 9, w: 1.5 },
-					{ kc: 81 }, { kc: 87 }, { kc: 69 }, { kc: 82 }, { kc: 84 }, { kc: 89 },
-					{ kc: 85 }, { kc: 73 }, { kc: 79 }, { kc: 80 }, { kc: 192 },
+					{ code: `Tab`, w: 1.5 },
+					{ code: `KeyQ` }, { code: `KeyW` }, { code: `KeyE` }, { code: `KeyR` }, { code: `KeyT` }, { code: `KeyY` },
+					{ code: `KeyU` }, { code: `KeyI` }, { code: `KeyO` }, { code: `KeyP` }, { code: `BracketLeft` },
 					...(isJa
-						? [{ kc: 219 }, { kc: 13, w: 1.25, h: 2 }]  // JIS: [, Enter縦長
-						: [{ kc: 219 }, { kc: 221, w: 1.2 }]        // US : [, ]
+						? [{ code: `BracketRight` }, { code: `Enter`, w: 1.25, h: 2 }]  // JIS: BracketRight + Enter縦長
+						: [{ code: `BracketRight` }, { code: `Backslash`, w: 1.2 }]     // US : BracketRight + Backslash
 					),
 				],
 			},
 			// Row3: ASDF
-			// JIS: ..., L, ;, ', ¥(221)
-			// US : ..., L, ;, ', Enter(13)
+			// JIS: ..., KeyL, Semicolon, Quote, Backslash
+			// US : ..., KeyL, Semicolon, Quote, Enter(横長)
 			{
 				keys: [
-					{ kc: 20, w: 1.75, label: `Caps\nLock` },
-					{ kc: 65 }, { kc: 83 }, { kc: 68 }, { kc: 70 }, { kc: 71 }, { kc: 72 },
-					{ kc: 74 }, { kc: 75 }, { kc: 76 }, { kc: 187 }, { kc: 186 },
+					{ code: `CapsLock`, w: 1.75, label: `Caps\nLock` },
+					{ code: `KeyA` }, { code: `KeyS` }, { code: `KeyD` }, { code: `KeyF` }, { code: `KeyG` }, { code: `KeyH` },
+					{ code: `KeyJ` }, { code: `KeyK` }, { code: `KeyL` }, { code: `Semicolon` }, { code: `Quote` },
 					...(isJa
-						? [{ kc: 221 }]           // JIS: ¥
-						: [{ kc: 13, w: 1.9 }]    // US : Enter横長
+						? [{ code: `Backslash` }]           // JIS: Backslash(¥)
+						: [{ code: `Enter`, w: 1.9 }]       // US : Enter横長
 					),
 				],
 			},
 			// Row4: ZXCV
 			// L)Shift の幅で行頭位置を揃える
-			// JIS: L)Shift, ..., intlRo(226), R)Shift
-			// US : L)Shift, ...,              R)Shift
+			// JIS: L)Shift, ..., IntlRo, R)Shift
+			// US : L)Shift, ...,         R)Shift
 			{
 				keys: [
-					{ kc: 16, w: 2.25 },
-					{ kc: 90 }, { kc: 88 }, { kc: 67 }, { kc: 86 }, { kc: 66 }, { kc: 78 },
-					{ kc: 77 }, { kc: 188 }, { kc: 190 }, { kc: 191 },
+					{ code: `ShiftLeft`, w: 2.25 },
+					{ code: `KeyZ` }, { code: `KeyX` }, { code: `KeyC` }, { code: `KeyV` }, { code: `KeyB` }, { code: `KeyN` },
+					{ code: `KeyM` }, { code: `Comma` }, { code: `Period` }, { code: `Slash` },
 					...(isJa
-						? [{ kc: 226 }, { kc: 256, w: 1.5 }]  // JIS: intlRo + R)Shift
-						: [{ kc: 256, w: 2.4 }]               // US : R)Shift のみ（広い）
+						? [{ code: `IntlRo` }, { code: `ShiftRight`, w: 1.5 }]  // JIS: IntlRo + R)Shift
+						: [{ code: `ShiftRight`, w: 2.4 }]                      // US : R)Shift のみ（広い）
 					),
 				],
 			},
 			// Row5: スペースバー行
-			// JIS: ..., NoConv(29), Space, Conv(28), カタカナひらがな(242), ...
+			// JIS: ..., NonConvert, Space, Convert, KanaMode, ...
 			// US : ..., Space, ...
 			{
 				keys: [
-					{ kc: 17, w: 1.25 }, { kc: 91 }, { kc: 18 },
+					{ code: `ControlLeft`, w: 1.25 }, { code: `MetaLeft` }, { code: `AltLeft` },
 					...(isJa
-						// JIS: NoConv + Space + Conv + カタカナひらがな
-						? [{ kc: 29 }, { kc: 32, w: 5.25 }, { kc: 28 }, { kc: 242 }]
+						// JIS: NonConvert + Space + Convert + KanaMode
+						? [{ code: `NonConvert` }, { code: `Space`, w: 5.25 }, { code: `Convert` }, { code: `KanaMode` }]
 						// US : Space のみ（広い）
-						: [{ kc: 32, w: 8.25 }]
+						: [{ code: `Space`, w: 8.25 }]
 					),
-					{ kc: 258 }, { kc: 93 },
+					{ code: `AltRight` }, { code: `ContextMenu` },
 					...(isJa
-						? [{ kc: 257, w: 1.2 }]
-						: [{ kc: 257, w: 1.05 }]
+						? [{ code: `ControlRight`, w: 1.2 }]
+						: [{ code: `ControlRight`, w: 1.05 }]
 					),
 				],
 			},
 		];
 	};
+
 	// 編集キークラスター（PrintSc/ScrollLk/Pause/Insert/Delete/Home/End/PgUp/PgDn + 矢印キー）
 	// MAIN_ROWS と行インデックスを揃えて配置する。空行はスキップされる。
 	const NAV_ROWS = [
-		{ keys: [{ kc: 44, label: `Print\nScreen` }, { kc: 145, label: `Scroll\nLock` }, { kc: 19 }] },
-		{ keys: [{ kc: 45 }, { kc: 36 }, { kc: 33, label: `Page\nUp` }] },    // Insert Home PgUp
-		{ keys: [{ kc: 46 }, { kc: 35 }, { kc: 34, label: `Page\nDown` }] },  // Delete End  PgDn
-		{ keys: [] },                                    // ASDF行：空
-		{ keys: [{ kc: -1 }, { kc: 38 }, { kc: -1 }] },  // ↑
-		{ keys: [{ kc: 37 }, { kc: 40 }, { kc: 39 }] },  // ← ↓ →
+		{ keys: [{ code: `PrintScreen`, label: `Print\nScreen` }, { code: `ScrollLock`, label: `Scroll\nLock` }, { code: `Pause` }] },
+		{ keys: [{ code: `Insert` }, { code: `Home` }, { code: `PageUp`, label: `Page\nUp` }] },    // Insert Home PgUp
+		{ keys: [{ code: `Delete` }, { code: `End` }, { code: `PageDown`, label: `Page\nDown` }] },  // Delete End  PgDn
+		{ keys: [] },                                                                               // ASDF行：空
+		{ keys: [{ code: `` }, { code: `ArrowUp` }, { code: `` }] },                                // ↑
+		{ keys: [{ code: `ArrowLeft` }, { code: `ArrowDown` }, { code: `ArrowRight` }] },           // ← ↓ →
 	];
 
 	// テンキー（MAIN_ROWS と行インデックスを揃えて配置。1行目は空行で Fn行に揃える）
-	// kc は g_kCd 定義に従う: 96〜111=テンキー各種, 144=NumLk
 	// 標準テンキーレイアウト（2行目から）:
 	//   [NumLk] [T/] [T*] [T-]
 	//   [T7][T8][T9] [T+]
@@ -11211,11 +11204,11 @@ const keyconfigKeyboardPreview = (() => {
 	//   [  T0  ][T.] [TEnter]  ← T0 は横2u、TEnter は縦2u
 	const NUM_ROWS = [
 		{ keys: [] },
-		{ keys: [{ kc: 144, label: `Num\nLock` }, { kc: 111 }, { kc: 106 }, { kc: 109 }] }, // NumLk T/ T* T-
-		{ keys: [{ kc: 103 }, { kc: 104 }, { kc: 105 }, { kc: 107, h: 2 }] },  // T7 T8 T9 T+(縦2u)
-		{ keys: [{ kc: 100 }, { kc: 101 }, { kc: 102 }] },                     // T4 T5 T6
-		{ keys: [{ kc: 97 }, { kc: 98 }, { kc: 99 }, { kc: 108, h: 2 }] },     // T1 T2 T3 TEnter(縦2u)
-		{ keys: [{ kc: 96, w: 2 }, { kc: 110 }] },                             // T0(横2u) T.
+		{ keys: [{ code: `NumLock`, label: `Num\nLock` }, { code: `NumpadDivide` }, { code: `NumpadMultiply` }, { code: `NumpadSubtract` }] }, // NumLk T/ T* T-
+		{ keys: [{ code: `Numpad7` }, { code: `Numpad8` }, { code: `Numpad9` }, { code: `NumpadAdd`, h: 2 }] },                               // T7 T8 T9 T+(縦2u)
+		{ keys: [{ code: `Numpad4` }, { code: `Numpad5` }, { code: `Numpad6` }] },                                                             // T4 T5 T6
+		{ keys: [{ code: `Numpad1` }, { code: `Numpad2` }, { code: `Numpad3` }, { code: `NumpadEnter`, h: 2 }] },                             // T1 T2 T3 TEnter(縦2u)
+		{ keys: [{ code: `Numpad0`, w: 2 }, { code: `NumpadDecimal` }] },                                                                     // T0(横2u) T.
 	];
 
 	// -------------------------------------------------------------------------
@@ -11223,12 +11216,12 @@ const keyconfigKeyboardPreview = (() => {
 	// -------------------------------------------------------------------------
 	const _state = {
 		visible: false,
-		mappedSet: new Set(),     // メインキー（各矢印の index 0）
-		altSet: new Set(),        // 代替キー（各矢印の index 1 以降）
-		shortcutSet: new Set(),   // プレイ中ショートカット（keyRetry / keyTitleBack / PgDn / PgUp）
+		mappedSet: new Set(),     // メインキー（code文字列）
+		altSet: new Set(),        // 代替キー（code文字列）
+		shortcutSet: new Set(),   // ショートカットキー（code文字列）
 		canvasBase: null,
 		canvasMap: null,
-		keyDataList: [],          // { kc, x, y, w, h, label } — drawMap で照合するキャッシュ
+		keyDataList: [],          // { code, x, y, w, h, label } — drawMap で照合するキャッシュ
 		scale: 1,                 // BASE_KEY_W/H に掛けるスケール係数
 		cvsW: 500,                // 実際の Canvas 幅（スケール計算後）
 		cvsH: 240,                // 実際の Canvas 高さ（スケール計算後）
@@ -11243,9 +11236,9 @@ const keyconfigKeyboardPreview = (() => {
 	 * _state に書き込む。init 時に呼ぶ。
 	 *
 	 * 基準サイズ（フルキーボード = メイン + ナビクラスター）:
-	 *   横: MAIN最大行幅 + ナビ幅(3キー) + 余白
-	 *   縦: 6行 × (BASE_KEY_H + BASE_KEY_GAP) - BASE_KEY_GAP
-	 *   BASE_KEY_W = BASE_KEY_H = 28px、BASE_KEY_GAP = 3px を基準とする。
+	 * 横: MAIN最大行幅 + ナビ幅(3キー) + 余白
+	 * 縦: 6行 × (BASE_KEY_H + BASE_KEY_GAP) - BASE_KEY_GAP
+	 * BASE_KEY_W = BASE_KEY_H = 28px、BASE_KEY_GAP = 3px を基準とする。
 	 */
 	const BASE_KEY_W = 28;
 	const BASE_KEY_H = 28;
@@ -11290,22 +11283,24 @@ const keyconfigKeyboardPreview = (() => {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * keyCode に対応する [primaryLabel, subLabel] を返す。
-	 * kc が -1（スペーサー）の場合は [``, ``] を返す。
-	 * g_kCd の値は `"primary"` または `"primary sub"` 形式の文字列。
+	 * code に対応する [primaryLabel, subLabel] を返す。
 	 *
-	 * @param {number}           kc
+	 * @param {string}           code
 	 * @param {string|undefined} forcedLabel - ROWS の label 指定がある場合に優先
 	 * @returns {string[]} [primary, sub]
 	 */
-	const getKeyLabels = (kc, forcedLabel) => {
-		if (kc < 0) return [``, ``];
+	const getKeyLabels = (code, forcedLabel) => {
+		if (!code) return [``, ``];
 		if (forcedLabel !== undefined) return [forcedLabel, ``];
 
-		const raw = g_kCd[kc];
-		if (raw && raw !== g_kCd[0] && raw !== g_kCd[1]) {
-			const parts = raw.split(` `);
-			return [parts[0] || ``, parts[1] || ``];
+		// code 文字列から従来の keyCode を逆引きして g_kCd から取得
+		const kc = g_kCdN.indexOf(code);
+		if (kc >= 0) {
+			const raw = g_kCd[kc];
+			if (raw && raw !== g_kCd[0] && raw !== g_kCd[1]) {
+				const parts = raw.split(` `);
+				return [parts[0] || ``, parts[1] || ``];
+			}
 		}
 		return [`?`, ``];
 	};
@@ -11313,15 +11308,13 @@ const keyconfigKeyboardPreview = (() => {
 	// -------------------------------------------------------------------------
 	// Canvas ヘルパー
 	// -------------------------------------------------------------------------
-
-	// スケール済みの各寸法を返すヘルパー
 	const kw = w => Math.floor(w * BASE_KEY_W * _state.scale + (w - 1) * BASE_KEY_GAP * _state.scale);
 	const kh = h => Math.floor(h * BASE_KEY_H * _state.scale + (h - 1) * BASE_KEY_GAP * _state.scale);
 	const kg = () => Math.max(1, Math.round(BASE_KEY_GAP * _state.scale));
 	const kr = () => Math.max(2, Math.round(4 * _state.scale));
 
 	/**
-	 * Canvasの共通初期化処理（サイズ設定、高解像度化、Context取得の冗長性を解消）
+	 * Canvasの共通初期化処理
 	 */
 	const setupCanvasContext = (canvas) => {
 		if (!canvas) return null;
@@ -11358,7 +11351,7 @@ const keyconfigKeyboardPreview = (() => {
 	 * @param {number} lw      - 枠線の太さ(lineWidth)
 	 */
 	const drawOneKey = (ctx, { keyData, style, lw = 1 }) => {
-		const { x, y, w: keyW, h: keyH, kc, label } = keyData;
+		const { x, y, w: keyW, h: keyH, code, label } = keyData;
 
 		// 1. キーの枠線・背景を描画
 		roundRect(ctx, x + 0.5, y + 0.5, keyW - 1, keyH - 1, kr());
@@ -11369,7 +11362,7 @@ const keyconfigKeyboardPreview = (() => {
 		ctx.stroke();
 
 		// 2. キー内部のテキスト（メイン・サブ）を描画
-		const [primary, sub] = getKeyLabels(kc, label);
+		const [primary, sub] = getKeyLabels(code, label);
 
 		const fs = (_textLen) => _textLen >= 5 * keyW / BASE_KEY_W
 			? Math.max(6, Math.floor(9 * _state.scale))
@@ -11430,9 +11423,9 @@ const keyconfigKeyboardPreview = (() => {
 				const keyW = kw(keyDef.w || 1);
 				const keyH = kh(keyDef.h || 1);
 
-				if (keyDef.kc >= 0) {
+				if (keyDef.code !== ``) {
 					const keyData = {
-						kc: keyDef.kc,
+						code: keyDef.code,
 						x: curX,
 						y: rowY,
 						w: keyW,
@@ -11482,13 +11475,10 @@ const keyconfigKeyboardPreview = (() => {
 
 		// 凡例
 		const ly = _state.cvsH - 10;
-		const fnt = `${Math.max(9, Math.floor(12 * _state.scale))}px ${getBasicFont()}`;
-		ctx.font = fnt;
+		ctx.font = `${Math.max(9, Math.floor(12 * _state.scale))}px ${getBasicFont()}`;
 		ctx.textAlign = `left`;
 		ctx.textBaseline = `middle`;
 
-		// 凡例定義データの配列化により、同一処理の繰り返しをループに統合
-		// 構造化した C_COLOR からオブジェクトをそのままセットするように変更
 		const legends = [
 			{ style: C_COLOR.normal, label: g_lblNameObj.unallocated },
 			{ style: C_COLOR.mapped, label: g_lblNameObj.allocated },
@@ -11519,17 +11509,15 @@ const keyconfigKeyboardPreview = (() => {
 		ctx.clearRect(0, 0, _state.cvsW, _state.cvsH);
 
 		// キー状態に応じた色取得ロジック（優先度: ショートカット > メイン > 代替）
-		// 構造化した C_COLOR オブジェクトをそのまま返却するスッキリした形に改善
-		const getKeyStyle = (kc) => {
-			if (_state.shortcutSet.has(kc)) return C_COLOR.shortcut;
-			if (_state.mappedSet.has(kc)) return C_COLOR.mapped;
-			if (_state.altSet.has(kc)) return C_COLOR.alt;
+		const getKeyStyle = (code) => {
+			if (_state.shortcutSet.has(code)) return C_COLOR.shortcut;
+			if (_state.mappedSet.has(code)) return C_COLOR.mapped;
+			if (_state.altSet.has(code)) return C_COLOR.alt;
 			return null;
 		};
 
-		// 配列のフィルタ・多重ループ連鎖を解消し、1回のループで優先度順に正しく描画
 		_state.keyDataList.forEach(keyData => {
-			const style = getKeyStyle(keyData.kc);
+			const style = getKeyStyle(keyData.code);
 			if (style) {
 				drawOneKey(ctx, { keyData, style, lw: 1.5 });
 			}
@@ -11596,8 +11584,8 @@ const keyconfigKeyboardPreview = (() => {
 	 * プレビューが表示中なら即時再描画する。
 	 *
 	 * g_keyObj[`keyCtrl${keyCtrlPtn}`] は二次元配列:
-	 *   [ [矢印0のメインkeyCode, 代替keyCode, ...], [矢印1のメインkeyCode, ...], ... ]
-	 * 各サブ配列の index 0 がメインキー、index 1 以降が代替キー。
+	 * [ [矢印0のメインkeyCode, 代替keyCode, ...], [矢印1のメインkeyCode, ...], ... ]
+	 * 各サブ配列 of index 0 がメインキー、index 1 以降が代替キー。
 	 */
 	const refresh = () => {
 		const tkObj = getKeyInfo();
@@ -11606,12 +11594,17 @@ const keyconfigKeyboardPreview = (() => {
 		const ctrl = g_keyObj[`keyCtrl${tkObj.keyCtrlPtn}`]
 			.filter((val, idx) => tkObj.keyGroupMaps[idx].includes(configKeyGroupList[g_keycons.keySwitchNum]));
 
-		_state.mappedSet = new Set(ctrl.map(arr => arr[0]).filter(v => v > 0));
-		_state.altSet = new Set(ctrl.flatMap(arr => arr.slice(1)).filter(v => v > 0));
+		// 数値から code 文字列へ安全に変換するヘルパー
+		const toCodeStr = (num) => g_kCdN[num] || ``;
+
+		_state.mappedSet = new Set(ctrl.map(arr => toCodeStr(arr[0])).filter(v => v !== ``));
+		_state.altSet = new Set(ctrl.flatMap(arr => arr.slice(1)).map(toCodeStr).filter(v => v !== ``));
+
 		// プレイ中ショートカット: keyRetry / keyTitleBack は g_headerObj から取得、PgDn(34) / PgUp(33) は固定
 		_state.shortcutSet = new Set(
-			[g_headerObj.keyRetry, g_headerObj.keyTitleBack, 34, 33].filter(v => v > 0)
+			[g_headerObj.keyRetry, g_headerObj.keyTitleBack, 34, 33].map(toCodeStr).filter(v => v !== ``)
 		);
+
 		if (_state.visible) drawMap();
 	};
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. キーコンフィグのキーボードマッププレビューにおいて内部配列のキーをkeyCodeからcodeに変更
- キーコンフィグのキーボードプレビューにおいてキーボード配列を表すコードを
keyCode互換からKeyboardEvent.codeに変更しました。


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. メンテナンスが必要なときに読み替えが発生するため。
内部的な変更のため、機能的な変更はありません。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
