### PR TITLE
improve: [1114] キー別のShapeパターンが複数無い場合のキーコンフィグ画面の表示を改善

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -9070,14 +9070,15 @@ const resetGroupList = (_type, _keyCtrlPtn) => {
 	let k = 1;
 	g_keycons[`${_type}Groups`] = [0];
 
-	if (g_keyObj.currentPtn === -1) {
-		g_keycons[`${_type}Groups`] = addValtoArray(g_keycons[`${_type}Groups`], -1);
-	}
-	g_keycons[`${_type}GroupNum`] = Math.min(g_keyObj.currentPtn, 0);
 	while (g_keyObj[`${_type}${_keyCtrlPtn}_${k}`] !== undefined) {
 		g_keycons[`${_type}Groups`].push(k);
 		k++;
 	}
+	if (g_keyObj.currentPtn === -1
+		&& (_type !== `stepRtn` || (_type === `stepRtn` && g_keycons[`${_type}Groups`].length > 1))) {
+		g_keycons[`${_type}Groups`] = addValtoArray(g_keycons[`${_type}Groups`], -1);
+	}
+	g_keycons[`${_type}GroupNum`] = Math.min(g_keyObj.currentPtn, 0);
 };
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. キー別のShapeパターンが複数無い場合のキーコンフィグ画面の表示を改善
- キー別のShapeパターンが複数無い場合、ShapeGr.の表記が不要になるため非表示にしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. キー別のShapeパターンはShuffleやColorと異なりキー個別の変更ができないため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/36d05552-e821-4603-9996-c2fb2b838d8c" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
