### PR TITLE
improve: [1116] 設定画面のDifficulty設定の近くに選択中の譜面のキーモードの説明リンクを追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8013,6 +8013,7 @@ const setDifficulty = (_initFlg) => {
 	}
 	// 特殊キーフラグ
 	g_stateObj.extraKeyFlg = g_headerObj.keyExtraList.includes(g_keyObj.currentKey);
+	btnKeymodeHelp.style.display = (g_keyObj.defaultKeyList.includes(g_keyObj.currentKey) ? `` : C_DIS_NONE);
 
 	// ---------------------------------------------------
 	// 2. 初期化設定
@@ -8227,6 +8228,11 @@ const createOptionWindow = _sprite => {
 	if (g_headerObj.difSelectorUse) {
 		createScText(spriteList.difficulty, `DifficultyList`, { x: 147, y: -10, targetLabel: `lnkDifficulty` });
 	}
+	multiAppend(difficultySprite,
+		createCss2Button(`btnKeymodeHelp`, `?`, () => {
+			openLink(g_lblNameObj.keymodeUrl + g_keyObj.currentKey);
+		}, g_lblPosObj.btnKeymodeHelp, g_cssObj.button_Setting),
+	)
 
 	// ---------------------------------------------------
 	// ハイスコア機能実装時に使用予定のスペース

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5447,6 +5447,9 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 			// 位置マニュアル化 (initManualX)
 			g_keyObj[`initManual${newKey}`] = setBoolVal(_dosObj[`initManual${newKey}`] ?? g_keyObj[`initManual${newKey}`], false);
 
+			// カスタムキーの説明ページ（keyHelpJaX / keyHelpEnX）
+			Object.keys(g_lang_lblNameObj).forEach(lang => g_lang_lblNameObj[lang][`keyHelp${newKey}`] = _dosObj[`keyHelp${lang}${newKey}`]);
+
 			// キーコンフィグ (keyCtrlX_Y)
 			g_keyObj.minPatterns = newKeyMultiParam(newKey, `keyCtrl`, toKeyCtrlArray, {
 				errCd: `E_0104`, baseCopyFlg: true,
@@ -8013,7 +8016,10 @@ const setDifficulty = (_initFlg) => {
 	}
 	// 特殊キーフラグ
 	g_stateObj.extraKeyFlg = g_headerObj.keyExtraList.includes(g_keyObj.currentKey);
-	btnKeymodeHelp.style.display = (g_keyObj.defaultKeyList.includes(g_keyObj.currentKey) ? `` : C_DIS_NONE);
+	btnKeymodeHelp.style.display = (
+		g_keyObj.defaultKeyList.includes(g_keyObj.currentKey) || g_lblNameObj[`keyHelp${g_keyObj.currentKey}`]
+			? `` : C_DIS_NONE
+	);
 
 	// ---------------------------------------------------
 	// 2. 初期化設定
@@ -8226,11 +8232,13 @@ const createOptionWindow = _sprite => {
 	);
 	createScText(spriteList.difficulty, `Difficulty`);
 	if (g_headerObj.difSelectorUse) {
-		createScText(spriteList.difficulty, `DifficultyList`, { x: 147, y: -10, targetLabel: `lnkDifficulty` });
+		createScText(spriteList.difficulty, `DifficultyList`, { x: 152, y: -10, targetLabel: `lnkDifficulty` });
 	}
 	multiAppend(difficultySprite,
 		createCss2Button(`btnKeymodeHelp`, `?`, () => {
-			openLink(g_lblNameObj.keymodeUrl + g_keyObj.currentKey);
+			openLink(g_keyObj.defaultKeyList.includes(g_keyObj.currentKey)
+				? g_lblNameObj.keymodeUrl + g_keyObj.currentKey
+				: g_lblNameObj[`keyHelp${g_keyObj.currentKey}`]);
 		}, g_lblPosObj.btnKeymodeHelp, g_cssObj.button_Setting),
 	)
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2763,6 +2763,10 @@ const initialControl = async () => {
 			.sort((a, b) => parseInt(a) - parseInt(b));
 	}
 
+	// ラベルテキスト、オンマウステキスト、確認メッセージ定義の上書き設定
+	Object.assign(g_lblNameObj, g_lang_lblNameObj[g_localeObj.val], g_presetObj.lblName?.[g_localeObj.val]);
+	Object.assign(g_msgObj, g_lang_msgObj[g_localeObj.val], g_presetObj.msg?.[g_localeObj.val]);
+
 	// デフォルトのカラー・シャッフルグループ設定を退避
 	g_keycons.groups.forEach(type =>
 		Object.keys(g_keyObj).filter(val => val.startsWith(type))
@@ -3932,10 +3936,6 @@ const headerConvert = _dosObj => {
 	} else {
 		g_imgObj.titleArrow = C_IMG_ARROW;
 	}
-
-	// ラベルテキスト、オンマウステキスト、確認メッセージ定義の上書き設定
-	Object.assign(g_lblNameObj, g_lang_lblNameObj[g_localeObj.val], g_presetObj.lblName?.[g_localeObj.val]);
-	Object.assign(g_msgObj, g_lang_msgObj[g_localeObj.val], g_presetObj.msg?.[g_localeObj.val]);
 
 	// 自動横幅拡張設定
 	obj.autoSpread = setBoolVal(_dosObj.autoSpread, g_presetObj.autoSpread ?? true);
@@ -5448,7 +5448,8 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 			g_keyObj[`initManual${newKey}`] = setBoolVal(_dosObj[`initManual${newKey}`] ?? g_keyObj[`initManual${newKey}`], false);
 
 			// カスタムキーの説明ページ（keyHelpJaX / keyHelpEnX）
-			Object.keys(g_lang_lblNameObj).forEach(lang => g_lang_lblNameObj[lang][`keyHelp${newKey}`] = _dosObj[`keyHelp${lang}${newKey}`]);
+			Object.keys(g_lang_lblNameObj).forEach(lang =>
+				g_lang_lblNameObj[lang][`keyHelp${newKey}`] = _dosObj[`keyHelp${lang}${newKey}`] ?? _dosObj[`keyHelp${newKey}`] ?? ``);
 
 			// キーコンフィグ (keyCtrlX_Y)
 			g_keyObj.minPatterns = newKeyMultiParam(newKey, `keyCtrl`, toKeyCtrlArray, {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -2730,6 +2730,7 @@ const g_shortcutObj = {
         ShiftRight_KeyD: { id: `lnkDifficultyL` },
         KeyD: { id: `lnkDifficultyR` },
         Slash: { id: `btnKeymodeHelp`, reset: true },
+        F1: { id: `btnKeymodeHelp`, reset: true },
 
         ShiftLeft_ArrowRight: { id: `lnkSpeedR` },
         ShiftRight_ArrowRight: { id: `lnkSpeedR` },

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -424,6 +424,10 @@ const updateWindowSiz = () => {
             x: 70, y: 65, w: g_btnWidth() - 120, h: 20, siz: 12, align: C_ALIGN_LEFT,
         },
 
+        btnKeymodeHelp: {
+            x: 150, y: -10, w: 15, h: 30, siz: 16, title: g_msgObj.keymodeHelp,
+            border: `solid 1px #666666`, borderRadius: 5,
+        },
         lblMusicInfo: {
             x: g_btnX(1 / 4), y: 0, w: g_btnWidth(3 / 4), h: 20, align: C_ALIGN_RIGHT
         },
@@ -2725,6 +2729,7 @@ const g_shortcutObj = {
         ShiftLeft_KeyD: { id: `lnkDifficultyL` },
         ShiftRight_KeyD: { id: `lnkDifficultyL` },
         KeyD: { id: `lnkDifficultyR` },
+        Slash: { id: `btnKeymodeHelp`, reset: true },
 
         ShiftLeft_ArrowRight: { id: `lnkSpeedR` },
         ShiftRight_ArrowRight: { id: `lnkSpeedR` },
@@ -4868,6 +4873,7 @@ const g_lang_lblNameObj = {
 
         helpUrl: `https://github.com/cwtickle/danoniplus/wiki/AboutGameSystem`,
         securityUrl: `https://github.com/cwtickle/danoniplus/security/policy`,
+        keymodeUrl: `https://github.com/cwtickle/danoniplus/wiki/Keys-`,
     },
     En: {
         dataDeleteOFFDesc: `Select the type of data you wish to delete and press "Reset".`,
@@ -4930,6 +4936,7 @@ const g_lang_lblNameObj = {
 
         helpUrl: `https://github.com/cwtickle/danoniplus-docs/wiki/AboutGameSystem`,
         securityUrl: `https://github.com/cwtickle/danoniplus-docs/wiki/SecurityPolicy`,
+        keymodeUrl: `https://github.com/cwtickle/danoniplus-docs/wiki/Keys-`,
     },
 };
 
@@ -4979,6 +4986,8 @@ const g_lang_msgObj = {
         adjustment: `曲とのタイミングにズレを感じる場合、\n数値を変えることでフレーム単位のズレを直すことができます。\n外側のボタンは5f刻み、真ん中は1f刻み、内側は0.5f刻みで調整できます。`,
         fadein: `譜面を途中から再生します。\n途中から開始した場合はハイスコアを保存しません。`,
         volume: `ゲーム内の音量を設定します。`,
+
+        keymodeHelp: `現在選択中の譜面のキータイプの説明ページへリンクします（GitHub Wiki）`,
 
         graph: `譜面密度や速度変化状況、\n譜面の難易度などの情報を表示します。`,
         dataSave: `ハイスコア、リバース設定、\nキーコンフィグの保存の有無を設定します。`,
@@ -5085,6 +5094,8 @@ const g_lang_msgObj = {
         adjustment: `If you feel that the timing is out of sync with the music, \nyou can correct the shift in frame units by changing the value.\nThe outer button can be adjusted in 5 frame increments, the middle in 1 frame increments, \nand the inner button in 0.5 frame increments.`,
         fadein: `Plays the chart from the middle.\nIf you start in the middle, the high score will not be saved.`,
         volume: `Set the in-game volume.`,
+
+        keymodeHelp: `Go to the explanation page for the key type of the currently selected chart (GitHub Wiki).`,
 
         graph: `Displays detailed information about the chart, such as chart's density status, sequences' velocity changes, and chart's difficulty.`,
         dataSave: `Set whether to save the high score, reverse setting, and key config.`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -4988,7 +4988,7 @@ const g_lang_msgObj = {
         fadein: `譜面を途中から再生します。\n途中から開始した場合はハイスコアを保存しません。`,
         volume: `ゲーム内の音量を設定します。`,
 
-        keymodeHelp: `現在選択中の譜面のキータイプの説明ページへリンクします（GitHub Wiki）`,
+        keymodeHelp: `現在選択中の譜面のキータイプの説明ページへリンクします（外部リンク）`,
 
         graph: `譜面密度や速度変化状況、\n譜面の難易度などの情報を表示します。`,
         dataSave: `ハイスコア、リバース設定、\nキーコンフィグの保存の有無を設定します。`,
@@ -5096,7 +5096,7 @@ const g_lang_msgObj = {
         fadein: `Plays the chart from the middle.\nIf you start in the middle, the high score will not be saved.`,
         volume: `Set the in-game volume.`,
 
-        keymodeHelp: `Go to the explanation page for the key type of the currently selected chart (GitHub Wiki).`,
+        keymodeHelp: `Go to the explanation page for the key type of the currently selected chart (External Link).`,
 
         graph: `Displays detailed information about the chart, such as chart's density status, sequences' velocity changes, and chart's difficulty.`,
         dataSave: `Set whether to save the high score, reverse setting, and key config.`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. 設定画面のDifficulty設定の近くに選択中の譜面のキーモードの説明リンクを追加
- 設定画面のDifficulty設定のラベル横（左回りボタンのやや右）に、選択中の譜面のキーモードの説明リンクを追加しました。現状、標準搭載キーしか該当するリンクが無いため、このリンクが表示されるのは標準搭載キーに限ります。
- ショートカットとして「?」キー/「F1」キーに対応しています。
- カスタムキーの場合、keyHelpJaXもしくはkeyHelpEnXの指定があれば表示対象になります。

### 2. 言語別のラベル、メッセージ適用箇所の変更
- 1.の変更に伴い、カスタムキー定義後に適用する必要があるため、
適用箇所をカスタムキー定義適用後に変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 選択中のキーの説明文が画面上のどこにも存在しないため。
2. 1.を利用するために必要なため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/07ecd279-02fc-45d6-a875-e4e2e0dc21d8" /><img width="50%" alt="image" src="https://github.com/user-attachments/assets/6e669307-e7c9-40ad-bf9e-d5ae21d1f03e" />

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/decd0869-8252-4ee1-8fd8-6ccf064fadc0" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
