### PR TITLE
improve: [1117] 別キーモード選択中は選択中の別キーをヘルプに表示するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8017,8 +8017,12 @@ const setDifficulty = (_initFlg) => {
 	}
 	// 特殊キーフラグ
 	g_stateObj.extraKeyFlg = g_headerObj.keyExtraList.includes(g_keyObj.currentKey);
+
+	// 選択中のキーのヘルプ表示
+	const targetKeymode = hasVal(g_keyObj[`transKey${g_keyObj.currentKey}_${g_keyObj.currentPtn}`])
+		? g_keyObj[`transKey${g_keyObj.currentKey}_${g_keyObj.currentPtn}`] : g_keyObj.currentKey;
 	btnKeymodeHelp.style.display = (
-		g_keyObj.defaultKeyList.includes(g_keyObj.currentKey) || g_lblNameObj[`keyHelp${g_keyObj.currentKey}`]
+		g_keyObj.defaultKeyList.includes(targetKeymode) || g_lblNameObj[`keyHelp${targetKeymode}`]
 			? `` : C_DIS_NONE
 	);
 
@@ -8237,9 +8241,12 @@ const createOptionWindow = _sprite => {
 	}
 	multiAppend(difficultySprite,
 		createCss2Button(`btnKeymodeHelp`, `?`, () => {
-			openLink(g_keyObj.defaultKeyList.includes(g_keyObj.currentKey)
-				? g_lblNameObj.keymodeUrl + g_keyObj.currentKey
-				: g_lblNameObj[`keyHelp${g_keyObj.currentKey}`]);
+			const targetKeymode = hasVal(g_keyObj[`transKey${g_keyObj.currentKey}_${g_keyObj.currentPtn}`])
+				? g_keyObj[`transKey${g_keyObj.currentKey}_${g_keyObj.currentPtn}`] : g_keyObj.currentKey;
+			openLink(
+				g_keyObj.defaultKeyList.includes(targetKeymode)
+					? g_lblNameObj.keymodeUrl + targetKeymode
+					: g_lblNameObj[`keyHelp${targetKeymode}`]);
 		}, g_lblPosObj.btnKeymodeHelp, g_cssObj.button_Setting),
 	)
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8018,14 +8018,6 @@ const setDifficulty = (_initFlg) => {
 	// 特殊キーフラグ
 	g_stateObj.extraKeyFlg = g_headerObj.keyExtraList.includes(g_keyObj.currentKey);
 
-	// 選択中のキーのヘルプ表示
-	const targetKeymode = hasVal(g_keyObj[`transKey${g_keyObj.currentKey}_${g_keyObj.currentPtn}`])
-		? g_keyObj[`transKey${g_keyObj.currentKey}_${g_keyObj.currentPtn}`] : g_keyObj.currentKey;
-	btnKeymodeHelp.style.display = (
-		g_keyObj.defaultKeyList.includes(targetKeymode) || g_lblNameObj[`keyHelp${targetKeymode}`]
-			? `` : C_DIS_NONE
-	);
-
 	// ---------------------------------------------------
 	// 2. 初期化設定
 
@@ -8122,6 +8114,20 @@ const setDifficulty = (_initFlg) => {
 	}
 	g_settings.scrollNum = getCurrentNo(g_settings.scrolls, g_stateObj.scroll);
 	g_settings.autoPlayNum = getCurrentNo(g_settings.autoPlays, g_stateObj.autoPlay);
+
+
+	// 選択中のキーのヘルプ表示
+	const targetKeymode = hasVal(g_keyObj[`transKey${g_keyObj.currentKey}_${g_keyObj.currentPtn}`])
+		? g_keyObj[`transKey${g_keyObj.currentKey}_${g_keyObj.currentPtn}`] : g_keyObj.currentKey;
+	btnKeymodeHelp.classList.remove(g_cssObj.button_Setting, g_cssObj.button_Tweet);
+	btnKeymodeHelp.classList.add(
+		g_cssObj[`button_${targetKeymode !== g_keyObj.currentKey
+			&& (g_keyObj.defaultKeyList.includes(targetKeymode) || g_lblNameObj[`keyHelp${targetKeymode}`]) ? `Tweet` : `Setting`}`]
+	);
+	btnKeymodeHelp.style.display = (
+		g_keyObj.defaultKeyList.includes(targetKeymode) || g_lblNameObj[`keyHelp${targetKeymode}`]
+			? `` : C_DIS_NONE
+	);
 
 	// ---------------------------------------------------
 	// 3. 名称の設定


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. 別キーモード選択中は選択中の別キーをヘルプに表示するよう変更
- PR #2149 にてヘルプへのリンクを追加しましたが、別キーモード選択中は文字通り別のキー種に変わるため、ヘルプもそのキー種になるように変更しました。
変更先のキーのヘルプが存在しない場合（標準搭載キーもしくはカスタムキー定義での指定なし）
は非表示になります。
- 別キーのときはヘルプボタンの色が水色になります。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 別キーの補足が必要なときがあるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/9f7f4f6d-a8bb-4b21-a063-e67b819c4a76" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
