### PR TITLE
improve: [1118] 8key（パターン2）の仕様変更、15A/15Bkeyを分離 他

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8998,6 +8998,9 @@ const setExcessive = (_btn, _val) => {
 const getKeyCtrl = (_localStorage, _extraKeyName = ``) => {
 	g_keyObj.storagePtn = _localStorage[`keyCtrlPtn${_extraKeyName}`];
 	const basePtn = `${g_keyObj.currentKey}_${g_keyObj.storagePtn}`;
+	if (g_keyObj[`keyCtrl${basePtn}`] === undefined || hasVal(g_keyObj[`transKey${basePtn}`])) {
+		return;
+	}
 	const baseKeyNum = g_keyObj[`${g_keyObj.defaultProp}${basePtn}`].length;
 
 	if (_localStorage[`keyCtrl${_extraKeyName}`]?.[0].length > 0) {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3597,7 +3597,7 @@ const g_keyObj = {
     // - _0 の数字部分をカウントアップすることで実現できる。
     keyCtrl5_1: [[`Space`], [`Left`], [`Down`], [`Up`], [`Right`]],
     keyCtrl7_1: [[`S`], [`E`], [`F`], [`Space`, `G`, `H`], [`J`], [`I`], [`L`]],
-    keyCtrl8_1: [[`Enter`], [`S`], [`D`], [`F`], [`Space`], [`J`], [`K`], [`L`]],
+    keyCtrl8_1: [[`Tab`], [`S`], [`D`], [`F`], [`Space`], [`J`], [`K`], [`L`]],
     keyCtrl9A_1: [[`S`], [`D`], [`E`, `R`], [`F`], [`Space`], [`Left`], [`Down`], [`Up`], [`Right`]],
     keyCtrl9i_1: [[`A`], [`S`], [`D`], [`F`], [`Space`], [`Left`], [`Down`], [`Up`], [`Right`]],
     keyCtrl11_1: [[`S`], [`D`], [`F`], [`Space`], [`J`], [`K`], [`L`], [`Left`], [`Down`], [`Up`], [`Right`]],
@@ -3658,7 +3658,7 @@ const g_keyObj = {
     // ショートカットキーコード
     keyRetry: 8,            // 8: Backspace
     keyRetry8_0: 9,         // 9: Tab
-    keyRetry8_1: 9,
+    keyRetry8_1: 8,         // 8: Backspace
     keyRetry11j_0: 123,     // 123: F12
 
     keyTitleBack: 46,       // 46: Delete

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3666,9 +3666,8 @@ const g_keyObj = {
 
     // 別キー
     transKey8_2: '12',
-    transKey15A_1: '',
-    transKey15B_0: '',
-    transKey15B_1: '',
+    transKey15A_1: '15B',   // 15A/15Bはキーパターンをコピーして生成するため、transKeyを明示的に指定
+    transKey15B_0: '',      // 15A/15Bはキーパターンをコピーして生成するため、transKeyを明示的に指定
 
     // キー置換用(ParaFla版との互換)
     keyTransPattern: {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. 8key（Pattern: 2）のEnterキーをTabキーに変更
- 8key（Pattern: 2）について、EnterキーをTabキーにデフォルトを変更しました。
- また、リトライキーのデフォルトをBackSpaceキーに変更しています。

### 2. 15Akey, 15Bkeyを明示的に分離
- 15Akeyと15Bkeyは例外的に相互のキーコンフィグを選択しても別キーモードにしていませんでしたが、
別キーモードとして扱うように変更しました。

### 3. 保存したキーパターンが存在しない、もしくは別キーモードになっているときに保存したキーコンフィグを読み込まないように変更
- キーパターンの改変があった場合にデータ不整合を起こす可能性があったため、処理を見直しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 実際のキー配置に対して反対側にあり、直感的でないため。
また、11jkeyとの関連を考えた時に従来の8keyに対する逆版があったほうがよさそうなため。
2. 他のキーとの整合のため。
3. 2.に関連して、想定しないエラーが出ることを防ぐため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/bf9b4c97-dfb0-4b92-80bd-834c37f6c825" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
