### PR TITLE
feat: [1119] キーコンフィグ画面にキー割り当てを無効にするモードを追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5602,6 +5602,7 @@ const titleInit = (_initFlg = false) => {
 	});
 
 	const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
+	g_stateObj.keyLockFlg = false;
 
 	// 譜面初期情報ロード許可フラグ
 	// (初回読み込み時はローカルストレージのロードが必要なため、
@@ -10239,11 +10240,24 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 	 * @param {number} _scrollNum 
 	 */
 	const changeTmpColor = (_j, _scrollNum = 1) => {
-		changeTmpData(`color`, g_headerObj.setColor.length, _j, _scrollNum);
-		const arrowColor = getKeyConfigColor(_j, g_keyObj[`color${keyCtrlPtn}`][_j]);
-		$id(`arrow${_j}`).background = arrowColor;
-		$id(`arrowShadow${_j}`).background = getShadowColor(g_keyObj[`color${keyCtrlPtn}`][_j], arrowColor);
+		const changeTmpOneColor = _idx => {
+			changeTmpData(`color`, g_headerObj.setColor.length, _idx, _scrollNum);
+			const arrowColor = getKeyConfigColor(_j, g_keyObj[`color${keyCtrlPtn}`][_idx]);
+			$id(`arrow${_idx}`).background = arrowColor;
+			$id(`arrowShadow${_idx}`).background = getShadowColor(g_keyObj[`color${keyCtrlPtn}`][_idx], arrowColor);
+		};
 
+		if (g_stateObj.keyLockFlg && keyIsShift()) {
+			const tmpList = [];
+			g_keyObj[`color${keyCtrlPtn}`].forEach((val, idx) => {
+				if (val === g_keyObj[`color${keyCtrlPtn}`][_j]) {
+					tmpList.push(idx);
+				}
+			});
+			tmpList.forEach(idx => changeTmpOneColor(idx));
+		} else {
+			changeTmpOneColor(_j);
+		}
 		adjustScrollPoint(parseFloat($id(`arrow${_j}`).left));
 	};
 
@@ -10253,10 +10267,23 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 	 * @param {number} _scrollNum 
 	 */
 	const changeTmpShuffleNum = (_j, _scrollNum = 1) => {
-		const tmpShuffle = changeTmpData(`shuffle`, g_keyObj[`keyCtrl${keyCtrlPtn}`].length - 1, _j, _scrollNum);
-		document.getElementById(`sArrow${_j}`).textContent = tmpShuffle + 1;
+		const changeTmpOneShuffle = _idx => {
+			const tmpShuffle = changeTmpData(`shuffle`, g_keyObj[`keyCtrl${keyCtrlPtn}`].length - 1, _idx, _scrollNum);
+			document.getElementById(`sArrow${_idx}`).textContent = tmpShuffle + 1;
+			changeShuffleConfigColor(keyCtrlPtn, g_keyObj[`shuffle${keyCtrlPtn}_${g_keycons.shuffleGroupNum}`][_idx], _idx);
+		};
 
-		changeShuffleConfigColor(keyCtrlPtn, g_keyObj[`shuffle${keyCtrlPtn}_${g_keycons.shuffleGroupNum}`][_j], _j);
+		if (g_stateObj.keyLockFlg && keyIsShift()) {
+			const tmpList = [];
+			g_keyObj[`shuffle${keyCtrlPtn}`].forEach((val, idx) => {
+				if (val === g_keyObj[`shuffle${keyCtrlPtn}`][_j]) {
+					tmpList.push(idx);
+				}
+			});
+			tmpList.forEach(idx => changeTmpOneShuffle(idx));
+		} else {
+			changeTmpOneShuffle(_j);
+		}
 		adjustScrollPoint(parseFloat($id(`arrow${_j}`).left));
 	};
 
@@ -10944,17 +10971,29 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 			}
 		}, g_lblPosObj.btnKcReset, g_cssObj.button_Reset),
 
+		createCss2Button(`btnKeyLock`, getKeyLockName(), () => {
+			g_stateObj.keyLockFlg = !g_stateObj.keyLockFlg;
+			makeInfoWindow(g_msgInfoObj.I_0012.split(`{0}`).join(boolToSwitch(!g_stateObj.keyLockFlg)), `leftToRightFade`);
+			btnKeyLock.innerHTML = getKeyLockName();
+		}, g_lblPosObj.btnKcKeyLock, g_cssObj.button_Mini),
+
 		// プレイ開始
 		makePlayButton(() => loadMusic())
 	);
 
 	// キーボード押下時処理
 	setShortcutEvent(g_currentPage, (kbCode) => {
+		const C_KEY_ESCAPE = 27;
+		const C_KEY_IME = 229;
 		const keyCdObj = document.getElementById(`keycon${g_currentj}_${g_currentk}`);
 		let setKey = g_kCdN.findIndex(kCd => kCd === kbCode);
 
-		const C_KEY_ESCAPE = 27;
-		const C_KEY_IME = 229;
+		if (g_stateObj.keyLockFlg) {
+			if (setKey === C_KEY_ESCAPE) {
+				btnBack.click();
+			}
+			return;
+		}
 
 		// 全角切替、BackSpace、Deleteキー、Escキーは割り当て禁止
 		// また、直前と同じキーを押した場合(BackSpaceを除く)はキー操作を無効にする
@@ -11039,6 +11078,10 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 	document.onkeyup = evt => commonKeyUp(evt);
 	document.oncontextmenu = () => false;
 };
+
+const getKeyLockName = () =>
+	`${g_lblNameObj.b_keyLock}${g_stateObj.keyLockFlg ? g_emojiObj.locked : g_emojiObj.unlocked}`;
+
 
 /**
  * キーボードレイアウトプレビュー（Canvas版）
@@ -11615,6 +11658,8 @@ const keyconfigKeyboardPreview = (() => {
 
 		_state.visible = !_state.visible;
 		area.style.display = _state.visible ? `block` : `none`;
+		g_stateObj.keyLockFlg = _state.visible;
+		btnKeyLock.innerHTML = getKeyLockName();
 
 		if (_state.visible) refresh();
 	};

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10109,8 +10109,7 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 			`<div class="settings_Title">${g_lblNameObj.key}</div><div class="settings_Title2">${g_lblNameObj.config}</div>`
 				.replace(/[\t\n]/g, ``), 0, 15, g_cssObj.flex_centering),
 
-		createDescDiv(`kcDesc`, g_lblNameObj.kcDesc.split(`{0}`).join(g_kCd[C_KEY_RETRY])
-			.split(`{1}:`).join(g_isMac ? `` : `Delete:`)),
+		createDescDiv(`kcDesc`, getKcDescMsg()),
 
 		createDescDiv(`kcShuffleDesc`,
 			g_headerObj.shuffleUse && g_settings.shuffles.filter(val => val.endsWith(`+`)).length > 0
@@ -10974,12 +10973,13 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 		createCss2Button(`btnKeyLock`, getKeyLockName(), () => {
 			g_stateObj.keyLockFlg = !g_stateObj.keyLockFlg;
 			makeInfoWindow(g_msgInfoObj.I_0012.split(`{0}`).join(boolToSwitch(!g_stateObj.keyLockFlg)), `leftToRightFade`);
-			btnKeyLock.innerHTML = getKeyLockName();
+			toggleKcDesc();
 		}, g_lblPosObj.btnKcKeyLock, g_cssObj.button_Mini),
 
 		// プレイ開始
 		makePlayButton(() => loadMusic())
 	);
+	toggleKcDesc();
 
 	// キーボード押下時処理
 	setShortcutEvent(g_currentPage, (kbCode) => {
@@ -11079,9 +11079,23 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 	document.oncontextmenu = () => false;
 };
 
+const toggleKcDesc = () => {
+	if (document.getElementById(`kcDesc`) !== null) {
+		kcDesc.textContent = getKcDescMsg();
+		kcDesc.style.fontSize = wUnit(getFontSize2(kcDesc.textContent, g_lblPosObj.kcDesc.w, { maxSiz: g_limitObj.mainSiz }));
+		kcDesc.classList.remove(g_cssObj.title_base, g_cssObj.keyconfig_Defaultkey);
+		kcDesc.classList.add(g_stateObj.keyLockFlg ? g_cssObj.keyconfig_Defaultkey : g_cssObj.title_base);
+		btnKeyLock.innerHTML = getKeyLockName();
+	}
+};
+
+const getKcDescMsg = () =>
+	g_stateObj.keyLockFlg
+		? g_lblNameObj.kcNonDesc
+		: g_lblNameObj.kcDesc.split(`{0}`).join(g_kCd[C_KEY_RETRY]).split(`{1}:`).join(g_isMac ? `` : `Delete:`);
+
 const getKeyLockName = () =>
 	`${g_lblNameObj.b_keyLock}${g_stateObj.keyLockFlg ? g_emojiObj.locked : g_emojiObj.unlocked}`;
-
 
 /**
  * キーボードレイアウトプレビュー（Canvas版）
@@ -11659,8 +11673,7 @@ const keyconfigKeyboardPreview = (() => {
 		_state.visible = !_state.visible;
 		area.style.display = _state.visible ? `block` : `none`;
 		g_stateObj.keyLockFlg = _state.visible;
-		btnKeyLock.innerHTML = getKeyLockName();
-
+		toggleKcDesc();
 		if (_state.visible) refresh();
 	};
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10242,7 +10242,7 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 	const changeTmpColor = (_j, _scrollNum = 1) => {
 		const changeTmpOneColor = _idx => {
 			changeTmpData(`color`, g_headerObj.setColor.length, _idx, _scrollNum);
-			const arrowColor = getKeyConfigColor(_j, g_keyObj[`color${keyCtrlPtn}`][_idx]);
+			const arrowColor = getKeyConfigColor(_idx, g_keyObj[`color${keyCtrlPtn}`][_idx]);
 			$id(`arrow${_idx}`).background = arrowColor;
 			$id(`arrowShadow${_idx}`).background = getShadowColor(g_keyObj[`color${keyCtrlPtn}`][_idx], arrowColor);
 		};

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -640,6 +640,9 @@ const updateWindowSiz = () => {
             x: g_btnX() + Math.floor((g_btnWidth() - 80) / 2), y: 3, w: 80, h: 18, siz: 11,
             title: g_msgObj.displayPreview,
         },
+        btnKcKeyLock: {
+            x: g_btnX() + Math.floor((g_btnWidth() - 80) / 2) + 100, y: 3, w: 80, h: 18, siz: 11,
+        },
 
         btnKcBack: {
             x: g_btnX(1 / 3), y: g_sHeight - 75,
@@ -1062,6 +1065,8 @@ const g_emojiObj = {
     memo: `&#x1f4dd;`,        // メモ (memo)
     musical: `&#x1f3b5;`,     // 音符 (musical note)
     camera: `&#x1f4f7;`,      // カメラ (camera)
+    locked: `&#x1f512;`,      // 鍵 (locked)
+    unlocked: `&#x1f513;`,    // 鍵開 (unlocked)
 };
 
 /** 設定・オプション画面用共通 */
@@ -1283,6 +1288,8 @@ const g_stateObj = {
 
     rotateEnabled: true,
     flatStepHeight: C_ARW_WIDTH,
+
+    keyLockFlg: false,
 
     dm_environment: C_FLG_OFF,
     dm_highscores: C_FLG_OFF,
@@ -4460,6 +4467,7 @@ const g_lang_msgInfoObj = {
         I_0006: `ローカルストレージ情報をクリップボードにコピーしました！`,
         I_0007: `オブジェクト情報をクリップボードにコピーしました！`,
         I_0011: `指定した部分キーが未定義のため、画面表示できません。設定を見直してください。`,
+        I_0012: `キー割り当てモードを{0}に変更しました。`,
     },
     En: {
         W_0001: `Your browser is not guaranteed to work.<br>
@@ -4510,6 +4518,7 @@ const g_lang_msgInfoObj = {
         I_0006: `Local storage information copied to clipboard!`,
         I_0007: `Object information copied to clipboard!`,
         I_0011: `The specified partial key is undefined and cannot be displayed on the screen. Please review your settings.`,
+        I_0012: `Key assignment mode changed to {0}.`,
     },
 };
 
@@ -4565,6 +4574,7 @@ const g_lblNameObj = {
     b_close: `Close`,
     b_cReset: `Reset`,
     b_precond: `Precondition`,
+    b_keyLock: `KeyLock`,
 
     Difficulty: `Difficulty`,
     Speed: `Speed`,

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -4827,6 +4827,7 @@ const g_lang_lblNameObj = {
         dataDeleteONDesc: `セーフモード適用中はデータ消去は行えません。変更するにはセーフモードを解除してください`,
 
         kcDesc: `[{0}:スキップ / {1}:(代替キーのみ)キー無効化]`,
+        kcNonDesc: `キー割り当て無効化中です。解除するには「KeyLock」を押してください`,
         kcShuffleDesc: `番号をクリックでシャッフルグループ、矢印をクリックでカラーグループを変更`,
         kcNoShuffleDesc: `矢印をクリックでカラーグループを変更`,
         sdDesc: `[クリックでON/OFFを切替、灰色でOFF]`,
@@ -4890,6 +4891,7 @@ const g_lang_lblNameObj = {
         dataDeleteONDesc: `Data erasure cannot be performed while safe mode is applied. <br>Please deactivate the safe mode to change the data.`,
 
         kcDesc: `[{0}:Skip / {1}:Key invalidation (Alternate keys only)]`,
+        kcNonDesc: `Key assignments are currently disabled. Press "KeyLock" to disable this setting.`,
         kcShuffleDesc: `Click the number to change the shuffle group, and click the arrow to change the color.`,
         kcNoShuffleDesc: `Click the arrow to change the color group.`,
         sdDesc: `[Click to switch, gray to OFF]`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. キーコンフィグ画面にキー割り当てを無効にするモードを追加
- キーコンフィグ画面にキー割り当てを無効にするモードを追加しました。
「KeyLock」ボタンから切り替えます。
- キー割り当て無効中はキー割り当てはできませんが、以下の機能が使えるようになります。
  - シフトを押しながら矢印をクリック： 同じ色グループに属する矢印をまとめて次の色グループへ切替
  - シフトを押しながら数字をクリック： 同じシャッフルグループに属する矢印をまとめて次のグループへ切替
- また、キーボードプレビュー表示中は自動でキー割り当てが無効になります。非表示にすると有効に戻ります。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 意図しないキー割り当てを防ぐため。
またキー割り当てを防ぐことで、ショートカットキーを使った別の操作をしやすくするため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/a708c4ea-6d0e-4ec1-a0c4-c4a59035b57e" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
