### PR TITLE
improve: [1120] キーコンフィグ画面のKeyLockボタンの説明文を追加、KeyLockボタンの位置調整

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -641,7 +641,7 @@ const updateWindowSiz = () => {
             title: g_msgObj.displayPreview,
         },
         btnKcKeyLock: {
-            x: g_btnX() + Math.floor((g_btnWidth() - 80) / 2) + 100, y: 3, w: 80, h: 18, siz: 11,
+            x: g_btnX() + Math.floor((g_btnWidth() - 80) / 2) + 90, y: 3, w: 80, h: 18, siz: 11,
             title: g_msgObj.keyLock,
         },
 

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -642,6 +642,7 @@ const updateWindowSiz = () => {
         },
         btnKcKeyLock: {
             x: g_btnX() + Math.floor((g_btnWidth() - 80) / 2) + 100, y: 3, w: 80, h: 18, siz: 11,
+            title: g_msgObj.keyLock,
         },
 
         btnKcBack: {
@@ -5063,6 +5064,7 @@ const g_lang_msgObj = {
         stepRtnGroup: `矢印などノーツの種類、回転に関するパターンを切り替えます。\nあらかじめ設定されている場合のみ変更可能です。`,
         kcReset: `対応するキーの割り当てを元に戻します。`,
         kcPreview: `キーボードレイアウトのプレビューを表示/非表示します。`,
+        keyLock: `キー割り当ての有効/無効を切り替えます。\n無効化時はシフトキー+番号/矢印クリックで同一グループの矢印群をまとめてグループ変更できます。`,
 
         pickArrow: `色番号ごとの矢印色（枠、塗りつぶし）、通常時のフリーズアロー色（枠、帯）を\nカラーピッカーから選んで変更できます。`,
         pickColorR: `設定する矢印色の種類を切り替えます。`,
@@ -5170,6 +5172,7 @@ const g_lang_msgObj = {
         stepRtnGroup: `Switches the type of notes, such as arrows, and the pattern regarding rotation.\nThis can only be changed if it has been set in advance.`,
         kcReset: `Restores the corresponding key assignments.`,
         kcPreview: `Show/hide the preview of the keyboard layout.`,
+        keyLock: `Toggles key assignments on or off. \nWhen disabled, you can use the Shift key plus a number or arrow key \nto change the group of all arrows in the same group at once.`,
 
         pickArrow: `Change the frame or fill of arrow color and the frame or bar of normal freeze-arrow color\nfor each color number from the color picker.`,
         pickColorR: `Switches the arrow color type to be set.`,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. キーコンフィグ画面のKeyLockボタンの説明文を追加
- PR #2155 において新たに追加したボタンの説明文が無かったため、追加しました。

### 2. キーコンフィグ画面のKeyLockボタンの位置調整
- 横幅が狭い場合にカラーグループボタンと重なる可能性があったため、位置調整しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 変更内容を画面から確認できるようにするため。
2. レイアウト上の問題が発生する可能性があるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="70%" alt="image" src="https://github.com/user-attachments/assets/6f78ea7d-4a6f-4632-b8e6-22c7ca83f639" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
