### PR TITLE
improve: [1123] キーコンフィグ画面のキーボードプレビューについて、キーパターンやImgTypeが変わっても表示を維持するよう変更

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5657,7 +5657,6 @@ const titleInit = (_initFlg = false) => {
 	});
 
 	const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
-	g_stateObj.keyLockFlg = false;
 
 	// 譜面初期情報ロード許可フラグ
 	// (初回読み込み時はローカルストレージのロードが必要なため、
@@ -10171,6 +10170,11 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 	// 譜面初期情報ロード許可フラグ
 	g_canLoadDifInfoFlg = false;
 
+	if (_initFlg) {
+		g_stateObj.keyLockFlg = false;
+		g_stateObj.kbPreviewFlg = false;
+	}
+
 	multiAppend(divRoot,
 
 		// キーコンフィグ画面タイトル
@@ -11143,6 +11147,10 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 		})
 	);
 
+	if (g_stateObj.kbPreviewFlg) {
+		btnKbPreview.click();
+	}
+
 	safeExecuteCustomHooks(`g_skinJsObj.keyconfig`, g_skinJsObj.keyconfig);
 	document.onkeyup = evt => commonKeyUp(evt);
 	document.oncontextmenu = () => false;
@@ -11741,6 +11749,7 @@ const keyconfigKeyboardPreview = (() => {
 
 		_state.visible = !_state.visible;
 		area.style.display = _state.visible ? `block` : `none`;
+		g_stateObj.kbPreviewFlg = _state.visible;
 		g_stateObj.keyLockFlg = _state.visible;
 		toggleKcDesc();
 		if (_state.visible) refresh();

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -1291,6 +1291,7 @@ const g_stateObj = {
     flatStepHeight: C_ARW_WIDTH,
 
     keyLockFlg: false,
+    kbPreviewFlg: false,
 
     dm_environment: C_FLG_OFF,
     dm_highscores: C_FLG_OFF,


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. キーコンフィグ画面のキーボードプレビューについて、キーパターンやImgTypeが変わっても表示を維持するよう変更
- キーコンフィグ画面のキーボードプレビューについて、キーパターンやImgTypeを切り替えると非表示になっていましたが、キーコンフィグ画面を離脱するまでは表示を継続するよう処理を見直しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. キーパターンの比較に使えるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
