### PR TITLE
improve: [1124] BGM再生処理の高速化(AudioContext共有・デコード結果キャッシュ)

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2514,7 +2514,7 @@ const drawTitleResultMotion = _displayName =>
 // WebAudioAPIでAudio要素風に再生するクラス
 class AudioPlayer {
 	constructor() {
-		this._context = new AudioContext();
+		this._context = getSharedAudioContext();
 		this._gain = this._context.createGain();
 		this._gain.connect(this._context.destination);
 		this._startTime = 0;
@@ -2562,11 +2562,8 @@ class AudioPlayer {
 	}
 
 	close() {
-		if (this._context) {
-			this._context.close()?.catch(() => {/* ignore double-close */ });
-			this._buffer = null;
-		}
 		if (this._source) {
+			this._source.stop(0);
 			this._source.disconnect(this._gain);
 			this._source = null;
 		}
@@ -2641,9 +2638,32 @@ class AudioPlayer {
 		this._eventListeners[_type] = this._eventListeners[_type].filter(_element => _element !== _listener);
 	}
 
+	getBuffer() {
+		return this._buffer;
+	}
+
+	setBuffer(_buffer) {
+		this._buffer = _buffer;
+		this._duration = _buffer.duration;
+		this._eventListeners[`canplaythrough`]?.forEach(_listener => _listener());
+	}
+
 	load() { }
 	dispatchEvent() { }
 }
+
+// グローバルで1つだけ保持(遅延生成)
+let g_sharedAudioContext = null;
+const getSharedAudioContext = () => {
+	if (!g_sharedAudioContext) {
+		g_sharedAudioContext = new AudioContext();
+	}
+	// タブのバックグラウンド化等でsuspendedになることがあるため念のためresume
+	if (g_sharedAudioContext.state === `suspended`) {
+		g_sharedAudioContext.resume();
+	}
+	return g_sharedAudioContext;
+};
 
 /**
  * クリップボードコピー関数
@@ -6370,23 +6390,22 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
 
 	if (encodeFlg) {
 		try {
-			// base64エンコードは読込に時間が掛かるため、曲変更時のみ読込
-			if (!hasVal(g_musicdata) || Math.abs(_num) % g_headerObj.musicIdxList.length !== 0) {
-				closeExistingAudio();
+			closeExistingAudio();
+			if (g_audioBufferCache.has(url)) {
+				const tmpAudio = new AudioPlayer();
+				tmpAudio.setBuffer(g_audioBufferCache.get(url)); // 新設メソッド、decode不要
+				g_audioForMS = tmpAudio;
+			} else {
 				await loadScript2(url);
 				musicInit();
-				if (!isTitle()) {
-					g_musicdata = ``;
-					return;
-				}
+				if (!isTitle()) { g_musicdata = ``; return; }
+
 				const tmpAudio = new AudioPlayer();
-				const array = Uint8Array.from(atob(g_musicdata), v => v.charCodeAt(0));
+				const array = base64ToUint8Array(g_musicdata);
 				await tmpAudio.init(array.buffer);
-				if (!isTitle()) {
-					g_musicdata = ``;
-					tmpAudio.close();
-					return;
-				}
+				if (!isTitle()) { g_musicdata = ``; tmpAudio.close(); return; }
+
+				cacheAudioBuffer(url, tmpAudio.getBuffer());
 				g_audioForMS = tmpAudio;
 			}
 			g_audioForMS.volume = g_stateObj.bgmVolume / 100;
@@ -11969,7 +11988,7 @@ const loadMusic = () => {
 			const blobUrl = URL.createObjectURL(request.response);
 			createEmptySprite(divRoot, `loader`, g_windowObj.loader);
 			lblLoading.textContent = g_lblNameObj.pleaseWait;
-			setAudio(blobUrl);
+			setAudio(blobUrl, url);
 		} else {
 			makeWarningWindow(`${g_msgInfoObj.E_0041.split('{0}').join(getFullPath(url))}<br>(${request.status} ${request.statusText})`, { backBtnUse: true });
 		}
@@ -12001,8 +12020,9 @@ const loadMusic = () => {
  * 音楽データの設定
  * iOSの場合はAudioタグによる再生
  * @param {string} _url 
+ * @param {string} _cacheKey 
  */
-const setAudio = async (_url) => {
+const setAudio = async (_url, _cacheKey = _url) => {
 
 	const loadMp3 = () => {
 		if (g_isFile) {
@@ -12034,7 +12054,7 @@ const setAudio = async (_url) => {
 		await loadScript2(_url);
 		if (typeof musicInit === C_TYP_FUNCTION) {
 			musicInit();
-			readyToStart(() => initWebAudioAPIfromBase64(g_musicdata));
+			readyToStart(() => initWebAudioAPIfromBase64(g_musicdata, _cacheKey));
 		} else {
 			makeWarningWindow(g_msgInfoObj.E_0031);
 			musicAfterLoaded();
@@ -12045,11 +12065,19 @@ const setAudio = async (_url) => {
 };
 
 // Base64から音声データに変換してWebAudioAPIで再生する準備
-const initWebAudioAPIfromBase64 = async (_base64) => {
+const initWebAudioAPIfromBase64 = async (_base64, _cacheKey) => {
 	g_audio = new AudioPlayer();
 	musicAfterLoaded();
-	const array = Uint8Array.from(atob(_base64), v => v.charCodeAt(0))
+
+	if (_cacheKey && g_audioBufferCache.has(_cacheKey)) {
+		g_audio.setBuffer(g_audioBufferCache.get(_cacheKey)); // デコード完全スキップ
+		return;
+	}
+	const array = base64ToUint8Array(_base64);
 	await g_audio.init(array.buffer);
+	if (_cacheKey) {
+		cacheAudioBuffer(_cacheKey, g_audio.getBuffer());
+	}
 };
 
 // 音声ファイルを読み込んでWebAudioAPIで再生する準備
@@ -12059,6 +12087,26 @@ const initWebAudioAPIfromURL = async (_url) => {
 	const promise = await fetch(_url);
 	const arrayBuffer = await promise.arrayBuffer();
 	await g_audio.init(arrayBuffer);
+};
+
+const g_audioBufferCache = new Map();
+const AUDIO_CACHE_MAX = 5;
+
+const cacheAudioBuffer = (_key, _buffer) => {
+	g_audioBufferCache.set(_key, _buffer);
+	if (g_audioBufferCache.size > AUDIO_CACHE_MAX) {
+		g_audioBufferCache.delete(g_audioBufferCache.keys().next().value); // 古い順に破棄
+	}
+};
+
+const base64ToUint8Array = (_base64Str) => {
+	const binaryStr = atob(_base64Str);
+	const len = binaryStr.length;
+	const array = new Uint8Array(len);
+	for (let i = 0; i < len; i++) {
+		array[i] = binaryStr.charCodeAt(i);
+	}
+	return array;
 };
 
 const musicAfterLoaded = () => {


### PR DESCRIPTION

## :hammer: 変更内容 / Details of Changes

### 1. BGM再生におけるAudioContextの共有化
- `AudioPlayer`クラスが選曲・楽曲切替のたびに`new AudioContext()`を生成していたのを廃止し、グローバルで1つの`AudioContext`を共有・再利用する方式(`getSharedAudioContext()`)に変更しました。
- `AudioPlayer.close()`から`this._context.close()`の呼び出しを削除し、代わりに`this._source.stop(0)`を明示的に呼ぶようにしました。

### 2. デコード済み音源(AudioBuffer)のキャッシュ機構を追加
- base64エンコードされた音源データのデコード結果(`AudioBuffer`)を、楽曲URLをキーとした`Map`(`g_audioBufferCache`)にキャッシュするようにしました。
- 選曲画面のプレビュー再生(`playBGM`)とゲーム本編再生(`initWebAudioAPIfromBase64`)の両方で同じキャッシュを参照するため、選曲画面で一度再生した曲をそのままゲーム開始した場合や、同一曲でのリトライ時に、base64デコード処理(`atob`＋`decodeAudioData`)を省略できるようになりました。
- キャッシュは直近5曲分を保持し、上限を超えた場合は最も古いエントリから破棄するLRU方式としました。
- `AudioPlayer`に`getBuffer()`/`setBuffer()`メソッドを追加し、キャッシュヒット時はデコード処理を経由せず既存の`AudioBuffer`を直接セットできるようにしました。
- 音源をXHR経由でBlobとして取得する環境(非ローカル実行時)では`URL.createObjectURL()`により毎回異なるURLが発行されるため、読み込み用URLとは別に、変化しないキャッシュキー(音源の実URL)を明示的に受け渡すよう`setAudio`/`initWebAudioAPIfromBase64`の引数を分離しました。

### 3. base64→Uint8Array変換処理の高速化
- `Uint8Array.from(atob(str), callback)`によるコールバック呼び出し形式から、`for`ループによる直接代入形式(`base64ToUint8Array`関数)に変更し、大容量の音源データ変換時のオーバーヘッドを削減しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 楽曲切替のたびに`AudioContext`を生成・破棄しており、生成コストがオーバーヘッドとなっていたため。また、`AudioBuffer`は生成元の`AudioContext`に紐付くため、後述のバッファキャッシュを機能させるための前提としても必要な変更のため。
2. 曲サイズが大きい場合、特にbase64エンコードされた音源(`encodeFlg=true`)で選曲画面の読み込みやゲーム開始までの待ち時間が長くなっていたため。同一曲を選曲画面で試聴後にそのままゲーム開始する、またはリトライを行うケースで重複してデコード処理が走っていたのを解消するため。
3. 大容量音源データのデコード時にメインスレッドのブロック時間を短縮するため。

## :camera: スクリーンショット / Screenshot



## :pencil: その他コメント / Other Comments

- 選曲画面では譜面ごとに異なる曲を割り当てられる仕様のため、キャッシュキーは曲グループ単位ではなく楽曲URL単位としています。同一曲であれば譜面が異なってもキャッシュが効き、異なる曲であれば自動的にキャッシュミスとなり従来通りデコードされるため、既存の仕様に対して追加の分岐処理は不要です。
- ローカル実行(`file://`)時とサーバー配信時(XHR/Blob経由)の両方で動作確認をお願いします。特にサーバー配信時は`URL.createObjectURL()`が毎回異なるURLを発行する関係で、キャッシュキーの受け渡し漏れがないかご確認いただけると助かります。
- 非エンコード形式(mp3等、`fetch`で直接取得する`initWebAudioAPIfromURL`)は、ブラウザのHTTPキャッシュで一定の効果が見込めるため、今回のキャッシュ対象からは除外しています。
