### PR TITLE
fix: [1125] iPadOSかつSafariの場合のみプレイ中の音が鳴らない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -12039,6 +12039,7 @@ const setAudio = async (_url, _cacheKey = _url) => {
 			g_currentPage = `loadingIos`;
 			lblLoading.textContent = `Click to Start!`;
 			divRoot.appendChild(makePlayButton(evt => {
+				getSharedAudioContext().resume();
 				g_currentPage = `loading`;
 				resetKeyControl();
 				divRoot.removeChild(evt.target);

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -145,7 +145,8 @@ const g_localeObj = {
 };
 
 const g_userAgent = window.navigator.userAgent.toLowerCase(); // msie, edge, chrome, safari, firefox, opera
-const g_isIos = listMatching(g_userAgent, [`iphone`, `ipad`, `ipod`]);
+const g_isIos = listMatching(g_userAgent, [`iphone`, `ipad`, `ipod`]) ||
+    (navigator.maxTouchPoints > 1 && /macintosh/i.test(g_userAgent));
 const g_isMac = listMatching(g_userAgent, [`iphone`, `ipad`, `ipod`, `mac os`]);
 
 // 変数型


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. iPadOSかつSafariの場合のみプレイ中の音が鳴らない問題を修正
- iPadOSの判定条件に問題があり、Safariブラウザの場合のみプレイ中の音が鳴らない問題が発生していました。
※Chromeブラウザの場合は現状でも動作します。
- ver49.1.0の問題ではなく、それ以前から発生している問題です。
- iPadOSのSafariの場合、window.navigator.userAgentに「ipod」「iphone」「ipad」といった文字列は含まれず、
Mac（macintosh）と同じになっているため、条件をすり抜けていました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. iPadOSの条件指定が不完全のため。
当時の仕様の勘違い（iPadOS×Chromeでは動作するため）によるものです。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- 選曲画面で試したことはないですが、プレイ画面より優先度が落ちることと
こちらはボタンアクションになっているため、影響は限定的と考えています。
- 当初からの問題ですが、強いて言えばver10.1.0の修正漏れです。