### PR TITLE
improve: [1126] 楽曲読込処理と譜面データ読込処理の並列化

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -177,6 +177,9 @@ let g_maxScore = 1000000;
 let g_gameOverFlg = false;
 let g_finishFlg = true;
 
+// リトライ中フラグ
+let g_retryInProgress = false;
+
 /** 共通オブジェクト */
 const g_loadObj = {};
 const g_rootObj = {};
@@ -3254,7 +3257,6 @@ const loadChartFile = async (_scoreId = g_stateObj.scoreId) => {
 
 		await loadScript2(`${filename}?${Date.now()}`, false, charset);
 		if (typeof externalDosInit === C_TYP_FUNCTION) {
-			deleteDiv(divRoot, `lblLoading`);
 
 			// 外部データを読込（ファイルが見つからなかった場合は譜面追記をスキップ）
 			externalDosInit();
@@ -11956,7 +11958,7 @@ const changeShuffleConfigColor = (_keyCtrlPtn, _vals, _j = -1) => {
 /* Scene : LOADING [strawberry] */
 /*-----------------------------------------------------------*/
 
-const loadMusic = () => {
+const loadMusic = async () => {
 
 	clearWindow(true);
 	pauseBGM();
@@ -11971,15 +11973,37 @@ const loadMusic = () => {
 	const lblLoading = getLoadingLabel();
 	divRoot.appendChild(lblLoading);
 
-	// ローカル動作時
-	if (g_isFile) {
-		setAudio(url);
+	// 音源準備Promise(ローカル/オンライン双方を吸収)
+	const audioReadyPromise = g_isFile
+		? setAudio(url)
+		: loadMusicViaXhr(url, lblLoading);
+
+	// 譜面データ準備Promise(DOM削除処理は含まない)
+	const chartReadyPromise = loadChartFile();
+
+	// 両方の完了を待つ
+	try {
+		await Promise.all([audioReadyPromise, chartReadyPromise]);
+	} catch (e) {
+		console.warn(`Loading error: ${e}`);
 		return;
 	}
 
-	// XHRで読み込み
+	// ローディング表示の削除は、ここで一元的に実施
+	deleteDiv(divRoot, `lblLoading`);
+
+	loadingScoreInit();
+};
+
+/**
+ * XHRによる音源読み込み(Promise化)
+ * @param {string} _url
+ * @param {HTMLDivElement} _lblLoading
+ * @returns {Promise<void>}
+ */
+const loadMusicViaXhr = (_url, _lblLoading) => new Promise((resolve, reject) => {
 	const request = new XMLHttpRequest();
-	request.open(`GET`, url, true);
+	request.open(`GET`, _url, true);
 	request.responseType = `blob`;
 
 	// 読み込み完了時
@@ -11987,34 +12011,42 @@ const loadMusic = () => {
 		if (request.status >= 200 && request.status < 300) {
 			const blobUrl = URL.createObjectURL(request.response);
 			createEmptySprite(divRoot, `loader`, g_windowObj.loader);
-			lblLoading.textContent = g_lblNameObj.pleaseWait;
-			setAudio(blobUrl, url);
+			_lblLoading.textContent = g_lblNameObj.pleaseWait;
+			// 読込用はblobUrl、キャッシュキーは変化しない元のurlを渡す
+			setAudio(blobUrl, _url).then(resolve).catch(reject);
 		} else {
-			makeWarningWindow(`${g_msgInfoObj.E_0041.split('{0}').join(getFullPath(url))}<br>(${request.status} ${request.statusText})`, { backBtnUse: true });
+			makeWarningWindow(`${g_msgInfoObj.E_0041.split('{0}').join(getFullPath(_url))}<br>(${request.status} ${request.statusText})`, { backBtnUse: true });
+			reject(new Error(`HTTP ${request.status}`));
 		}
 	});
 
 	// 進捗時
 	request.addEventListener(`progress`, _event => {
-		const lblLoading = document.getElementById(`lblLoading`);
+		const lblLoadingElem = document.getElementById(`lblLoading`);
+		if (lblLoadingElem === null) return; // 並列処理で先に削除されている場合の防御
 
 		if (_event.lengthComputable) {
 			const rate = _event.loaded / _event.total;
 			createEmptySprite(divRoot, `loader`, { y: g_sHeight - 10, h: 10, w: g_sWidth * rate, backgroundColor: `#eeeeee` });
-			lblLoading.textContent = `${g_lblNameObj.nowLoading} ${Math.floor(rate * 100)}%`;
+			lblLoadingElem.textContent = `${g_lblNameObj.nowLoading} ${Math.floor(rate * 100)}%`;
 		} else {
-			lblLoading.textContent = `${g_lblNameObj.nowLoading} ${_event.loaded}Bytes`;
+			lblLoadingElem.textContent = `${g_lblNameObj.nowLoading} ${_event.loaded}Bytes`;
 		}
 		// ユーザカスタムイベント
 		safeExecuteCustomHooks(`g_customJsObj.progress`, g_customJsObj.progress, _event);
 	});
 
-	// エラー処理
-	request.addEventListener(`timeout`, () => makeWarningWindow(g_msgInfoObj.E_0033, { backBtnUse: true }));
-	request.addEventListener(`error`, () => makeWarningWindow(g_msgInfoObj.E_0034, { backBtnUse: true }));
+	request.addEventListener(`timeout`, () => {
+		makeWarningWindow(g_msgInfoObj.E_0033, { backBtnUse: true });
+		reject(new Error(`timeout`));
+	});
+	request.addEventListener(`error`, () => {
+		makeWarningWindow(g_msgInfoObj.E_0034, { backBtnUse: true });
+		reject(new Error(`network error`));
+	});
 
 	request.send();
-};
+});
 
 /**
  * 音楽データの設定
@@ -12028,13 +12060,13 @@ const setAudio = async (_url, _cacheKey = _url) => {
 		if (g_isFile) {
 			g_audio = new Audio();
 			g_audio.src = _url;
-			musicAfterLoaded();
+			return musicAfterLoaded();
 		} else {
-			initWebAudioAPIfromURL(_url);
+			return initWebAudioAPIfromURL(_url);
 		}
 	};
 
-	const readyToStart = _func => {
+	const readyToStart = _func => new Promise((resolve, reject) => {
 		if (g_isIos) {
 			g_currentPage = `loadingIos`;
 			lblLoading.textContent = `Click to Start!`;
@@ -12043,51 +12075,53 @@ const setAudio = async (_url, _cacheKey = _url) => {
 				g_currentPage = `loading`;
 				resetKeyControl();
 				divRoot.removeChild(evt.target);
-				_func();
+				_func().then(resolve).catch(reject);
 			}));
 			setShortcutEvent(g_currentPage);
 		} else {
-			_func();
+			_func().then(resolve).catch(reject);
 		}
-	};
+	});
 
 	if (g_musicEncodedFlg) {
 		await loadScript2(_url);
 		if (typeof musicInit === C_TYP_FUNCTION) {
 			musicInit();
-			readyToStart(() => initWebAudioAPIfromBase64(g_musicdata, _cacheKey));
+			return readyToStart(() => initWebAudioAPIfromBase64(g_musicdata, _cacheKey));
 		} else {
 			makeWarningWindow(g_msgInfoObj.E_0031);
-			musicAfterLoaded();
+			return musicAfterLoaded();
 		}
 	} else {
-		readyToStart(() => loadMp3());
+		return readyToStart(() => loadMp3());
 	}
 };
 
 // Base64から音声データに変換してWebAudioAPIで再生する準備
 const initWebAudioAPIfromBase64 = async (_base64, _cacheKey) => {
 	g_audio = new AudioPlayer();
-	musicAfterLoaded();
+	const loadedPromise = musicAfterLoaded(); // canplaythrough/errorの発火をここで待つ
 
 	if (_cacheKey && g_audioBufferCache.has(_cacheKey)) {
 		g_audio.setBuffer(g_audioBufferCache.get(_cacheKey)); // デコード完全スキップ
-		return;
+	} else {
+		const array = base64ToUint8Array(_base64);
+		await g_audio.init(array.buffer);
+		if (_cacheKey) {
+			cacheAudioBuffer(_cacheKey, g_audio.getBuffer());
+		}
 	}
-	const array = base64ToUint8Array(_base64);
-	await g_audio.init(array.buffer);
-	if (_cacheKey) {
-		cacheAudioBuffer(_cacheKey, g_audio.getBuffer());
-	}
+	return loadedPromise;
 };
 
 // 音声ファイルを読み込んでWebAudioAPIで再生する準備
 const initWebAudioAPIfromURL = async (_url) => {
 	g_audio = new AudioPlayer();
-	musicAfterLoaded();
+	const loadedPromise = musicAfterLoaded();
 	const promise = await fetch(_url);
 	const arrayBuffer = await promise.arrayBuffer();
 	await g_audio.init(arrayBuffer);
+	return loadedPromise;
 };
 
 const g_audioBufferCache = new Map();
@@ -12110,26 +12144,26 @@ const base64ToUint8Array = (_base64Str) => {
 	return array;
 };
 
-const musicAfterLoaded = () => {
+const musicAfterLoaded = () => new Promise((resolve, reject) => {
 	g_audio.load();
 
 	if (g_audio.readyState === 4) {
-		// audioの読み込みが終わった後の処理
-		loadingScoreInit();
+		resolve();
 	} else {
 		// 読込中の状態
 		g_audio.addEventListener(`canplaythrough`, (() => function f() {
 			g_audio.removeEventListener(`canplaythrough`, f, false);
-			loadingScoreInit();
+			resolve();
 		})(), false);
 
 		// エラー時
 		g_audio.addEventListener(`error`, (() => function f() {
 			g_audio.removeEventListener(`error`, f, false);
 			makeWarningWindow(g_msgInfoObj.E_0041.split(`{0}`).join(g_audio.src), { backBtnUse: true });
+			reject(new Error(`audio load error`));
 		})(), false);
 	}
-};
+});
 
 /**
  * 読込画面初期化
@@ -14876,7 +14910,7 @@ const mainInit = () => {
 	};
 
 	// キー操作イベント
-	document.onkeydown = evt => {
+	document.onkeydown = async evt => {
 		evt.preventDefault();
 		const setCode = transCode(evt);
 
@@ -14897,8 +14931,17 @@ const mainInit = () => {
 
 			} else {
 				// その他の環境では単にRetryに対応するキーのみで適用
+				if (g_retryInProgress) return blockCode(setCode);
+				g_retryInProgress = true;
 				clearWindow();
-				musicAfterLoaded();
+				try {
+					await musicAfterLoaded();
+					loadingScoreInit();
+				} catch (e) {
+					console.warn(`Retry audio load error: ${e}`);
+				} finally {
+					g_retryInProgress = false;
+				}
 			}
 
 		} else if (setCode === g_kCdN[g_headerObj.keyTitleBack]) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -177,7 +177,8 @@ let g_maxScore = 1000000;
 let g_gameOverFlg = false;
 let g_finishFlg = true;
 
-// リトライ中フラグ
+// 音源のAudioContext管理、リトライ中フラグ
+let g_sharedAudioContext = null;
 let g_retryInProgress = false;
 
 /** 共通オブジェクト */
@@ -2656,7 +2657,6 @@ class AudioPlayer {
 }
 
 // グローバルで1つだけ保持(遅延生成)
-let g_sharedAudioContext = null;
 const getSharedAudioContext = () => {
 	if (!g_sharedAudioContext) {
 		g_sharedAudioContext = new AudioContext();

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -11982,17 +11982,19 @@ const loadMusic = async () => {
 	const chartReadyPromise = loadChartFile();
 
 	// 両方の完了を待つ
+	let loadSucceeded = true;
 	try {
 		await Promise.all([audioReadyPromise, chartReadyPromise]);
 	} catch (e) {
 		console.warn(`Loading error: ${e}`);
-		return;
+		loadSucceeded = false;
+	} finally {
+		deleteDiv(divRoot, `lblLoading`);
 	}
 
-	// ローディング表示の削除は、ここで一元的に実施
-	deleteDiv(divRoot, `lblLoading`);
-
-	loadingScoreInit();
+	if (loadSucceeded) {
+		loadingScoreInit();
+	}
 };
 
 /**
@@ -12006,8 +12008,21 @@ const loadMusicViaXhr = (_url, _lblLoading) => new Promise((resolve, reject) => 
 	request.open(`GET`, _url, true);
 	request.responseType = `blob`;
 
+	const STALL_TIMEOUT_MS = 30000; // 30秒間、進捗がなければ停滞とみなす
+	let stallTimer = null;
+
+	const resetStallTimer = () => {
+		clearTimeout(stallTimer);
+		stallTimer = setTimeout(() => {
+			request.abort();
+			makeWarningWindow(g_msgInfoObj.E_0033, { backBtnUse: true });
+			reject(new Error(`stalled`));
+		}, STALL_TIMEOUT_MS);
+	};
+
 	// 読み込み完了時
 	request.addEventListener(`load`, () => {
+		clearTimeout(stallTimer);
 		if (request.status >= 200 && request.status < 300) {
 			const blobUrl = URL.createObjectURL(request.response);
 			createEmptySprite(divRoot, `loader`, g_windowObj.loader);
@@ -12022,6 +12037,7 @@ const loadMusicViaXhr = (_url, _lblLoading) => new Promise((resolve, reject) => 
 
 	// 進捗時
 	request.addEventListener(`progress`, _event => {
+		resetStallTimer(); // 進捗があるたびにタイマーをリセット
 		const lblLoadingElem = document.getElementById(`lblLoading`);
 		if (lblLoadingElem === null) return; // 並列処理で先に削除されている場合の防御
 
@@ -12036,15 +12052,13 @@ const loadMusicViaXhr = (_url, _lblLoading) => new Promise((resolve, reject) => 
 		safeExecuteCustomHooks(`g_customJsObj.progress`, g_customJsObj.progress, _event);
 	});
 
-	request.addEventListener(`timeout`, () => {
-		makeWarningWindow(g_msgInfoObj.E_0033, { backBtnUse: true });
-		reject(new Error(`timeout`));
-	});
 	request.addEventListener(`error`, () => {
+		clearTimeout(stallTimer);
 		makeWarningWindow(g_msgInfoObj.E_0034, { backBtnUse: true });
 		reject(new Error(`network error`));
 	});
 
+	resetStallTimer(); // 初回(最初のprogressが来るまで)のタイマーも開始
 	request.send();
 });
 
@@ -12150,18 +12164,18 @@ const musicAfterLoaded = () => new Promise((resolve, reject) => {
 	if (g_audio.readyState === 4) {
 		resolve();
 	} else {
-		// 読込中の状態
-		g_audio.addEventListener(`canplaythrough`, (() => function f() {
-			g_audio.removeEventListener(`canplaythrough`, f, false);
-			resolve();
-		})(), false);
-
-		// エラー時
-		g_audio.addEventListener(`error`, (() => function f() {
-			g_audio.removeEventListener(`error`, f, false);
+		const onCanPlay = () => { cleanup(); resolve(); };
+		const onError = () => {
+			cleanup();
 			makeWarningWindow(g_msgInfoObj.E_0041.split(`{0}`).join(g_audio.src), { backBtnUse: true });
 			reject(new Error(`audio load error`));
-		})(), false);
+		};
+		const cleanup = () => {
+			g_audio.removeEventListener(`canplaythrough`, onCanPlay, false);
+			g_audio.removeEventListener(`error`, onError, false);
+		};
+		g_audio.addEventListener(`canplaythrough`, onCanPlay, false);
+		g_audio.addEventListener(`error`, onError, false);
 	}
 });
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
### 1. 楽曲読込処理と譜面データ読込処理の並列化
- ゲーム開始時、音源データの読込・デコード処理と、譜面データ(dos)の読込・変換処理が直列に実行されていたのを、`Promise.all`を用いて並行実行するよう変更しました。
- `loadChartFile`関数からローディング表示(`lblLoading`)のDOM削除処理を除去し、呼び出し元(`loadMusic`)で両方の処理完了後にまとめて削除するよう一元化しました。
- XHRによる音源読込処理を`loadMusicViaXhr`関数として分離し、Promiseで完了を通知できるようにしました。
- `setAudio`, `initWebAudioAPIfromBase64`, `initWebAudioAPIfromURL`, `musicAfterLoaded`の各関数をPromiseベースに変更し、呼び出し元で完了を`await`できるようにしました。
- 音源読込に失敗した場合でもローディング表示が消えるよう、`lblLoading`の削除処理を`finally`で行うようにし、失敗時は`loadingScoreInit()`を呼ばないようフラグでガードしました。
- 音源データが大容量(数十分規模の曲など)になるケースを考慮し、固定時間によるXHRタイムアウトではなく、`progress`イベントの発火間隔を監視して一定時間（30秒）データが流れてこない場合に中断する方式(stall検知)を採用しました。
- `musicAfterLoaded`内の`canplaythrough`/`error`イベントについて、どちらか一方が発火した際にもう一方のリスナーも確実に削除するよう修正し、読込成功後に遅れて発火したイベントが誤って警告表示を出さないようにしました。

### 2. リトライ時の音源読込完了待ち処理の修正
- 上記のPromise化に伴い、`musicAfterLoaded`が内部で`loadingScoreInit()`を直接呼ぶ実装から、Promiseの`resolve`/`reject`のみを行う実装に変更したため、曲中リトライ時に`loadingScoreInit()`が呼ばれず画面が停止する不具合が発生していました。これに対応し、リトライ処理側で`musicAfterLoaded()`の完了を`await`した上で`loadingScoreInit()`を呼ぶよう修正しました。
- リトライキーの連続入力(短時間での複数回押下)による多重実行を防ぐため、`g_retryInProgress`フラグを追加しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 音源データの読込・デコードには時間がかかる場合があり、特に譜面ファイルが外部読込形式の場合、音源と譜面それぞれの読込処理が直列に実行されることで、ゲーム開始までの待ち時間が両者の合計になっていたため。並行実行にすることで、待ち時間を両者のうち長い方まで短縮するため。
2. 上記の並列化に伴う内部処理の変更(Promise化)により、リトライ時の処理呼び出し漏れが発生していたため。これを修正するとともに、リトライキーの連打によって同一処理が多重に走ることを防ぐため。

## :camera: スクリーンショット / Screenshot

## :pencil: その他コメント / Other Comments
- 音源処理と譜面処理は参照するグローバル状態が独立しているため、並行実行による相互の副作用はないことを確認済みです。
- `mainInit`が`g_audio.duration`を参照する関係上、`Promise.all`の完了(=音源のデコード完了)を待ってから`mainInit`を呼ぶ必要があるため、両処理の完了を待ってから初めて後続処理に進む設計としています。
- 進捗表示中のDOM要素(`lblLoading`)について、並行処理により先に削除されるタイミングが生じ得るため、進捗イベント側で要素の存在チェックを追加しています。
- レビュー(CodeRabbit)で指摘のあった以下3点について対応済みです。
  - 音源読込失敗時に`lblLoading`が残り続ける問題 → `finally`でのクリーンアップに変更
  - XHRの`timeout`未設定により機能していなかったタイムアウト処理 → 進捗停滞(stall)検知方式に変更
  - `canplaythrough`/`error`双方のリスナー解除漏れ → 相互クリーンアップに修正
- 動作確認をお願いしたい観点:
  - 通常のオンライン環境(XHR経由)、およびローカル実行(`file://`)双方での曲読込・ゲーム開始
  - 外部譜面ファイル使用時、音源ダウンロードと譜面ダウンロードが並行して進むこと
  - 曲中リトライの連続操作時、画面が正常に切り替わること
  - iOS/iPadOS実機での「Click to Start」ボタン表示とタップ後の動作(既存の挙動に変化がないこと)
  - 音源読込に失敗した場合、ローディング表示が正しく消えてエラー画面に切り替わること
  - 大容量の音源ファイルや低速回線を想定した環境での、stall検知が過剰に反応しないこと