### PR TITLE
refactor: [1128] ロード部分のコード整理

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2064,10 +2064,9 @@ const makeBgCanvas = (_ctx, { w = g_sWidth, h = g_sHeight } = {}) => {
  * - divオブジェクト(ボタンなど)はdivRoot配下で管理しているため、子要素のみを全削除している。
  * - dicRoot自体を削除しないよう注意すること。
  * - 再描画時に共通で表示する箇所はここで指定している。
- * @param {boolean} [_redrawFlg=false] 画面横幅を再定義し、Canvas背景を再描画するかどうか
  * @param {string} [_customDisplayName=''] 画面名(メイン画面: 'Main', それ以外: 空)
  */
-const clearWindow = (_redrawFlg = false, _customDisplayName = ``) => {
+const clearWindow = (_customDisplayName = ``) => {
 	closeDisplayPreview();
 	resetKeyControl();
 	resetTransform();
@@ -2114,37 +2113,33 @@ const clearWindow = (_redrawFlg = false, _customDisplayName = ``) => {
 			getLayerWithClear(`layer2`);
 		}
 
-		if (_redrawFlg) {
-			// 画面背景を指定 (background-color)
-			$id(`canvas-frame`).width = wUnit(g_sWidth + diffX);
-			layer0.width = g_sWidth + diffX;
-			if (!g_headerObj[`customBack${_customDisplayName}Use`]) {
-				makeBgCanvas(l0ctx, { w: g_sWidth + diffX });
-			}
+		// 画面背景を指定 (background-color)
+		$id(`canvas-frame`).width = wUnit(g_sWidth + diffX);
+		layer0.width = g_sWidth + diffX;
+		if (!g_headerObj[`customBack${_customDisplayName}Use`]) {
+			makeBgCanvas(l0ctx, { w: g_sWidth + diffX });
 		}
 	}
 
 	// 背景を再描画
-	if (_redrawFlg) {
-		g_btnAddFunc = {};
-		g_btnDeleteFlg = {};
-		g_cxtAddFunc = {};
-		g_cxtDeleteFlg = {};
+	g_btnAddFunc = {};
+	g_btnDeleteFlg = {};
+	g_cxtAddFunc = {};
+	g_cxtDeleteFlg = {};
 
-		if (document.getElementById(`layer0`) === null ||
-			(!g_headerObj[`customBack${_customDisplayName}Use`] && !g_headerObj.defaultSkinFlg)) {
+	if (document.getElementById(`layer0`) === null ||
+		(!g_headerObj[`customBack${_customDisplayName}Use`] && !g_headerObj.defaultSkinFlg)) {
 
-			$id(`canvas-frame`).width = wUnit(g_sWidth + diffX);
-			createEmptySprite(divRoot, `divBack`, { w: g_sWidth + diffX });
-		}
-
-		// CSSスタイルの初期化
-		Object.keys(g_cssBkProperties).forEach(prop =>
-			document.documentElement.style.setProperty(prop, g_cssBkProperties[prop]));
-
-		Object.keys(g_headerObj).filter(val => val.startsWith(`--`) && hasVal(g_headerObj[val])).forEach(prop =>
-			document.documentElement.style.setProperty(prop, getCssCustomProperty(prop, g_headerObj[prop])));
+		$id(`canvas-frame`).width = wUnit(g_sWidth + diffX);
+		createEmptySprite(divRoot, `divBack`, { w: g_sWidth + diffX });
 	}
+
+	// CSSスタイルの初期化
+	Object.keys(g_cssBkProperties).forEach(prop =>
+		document.documentElement.style.setProperty(prop, g_cssBkProperties[prop]));
+
+	Object.keys(g_headerObj).filter(val => val.startsWith(`--`) && hasVal(g_headerObj[val])).forEach(prop =>
+		document.documentElement.style.setProperty(prop, getCssCustomProperty(prop, g_headerObj[prop])));
 };
 
 /**
@@ -5662,7 +5657,7 @@ const setKeyDfVal = _ptnName => {
  */
 const titleInit = (_initFlg = false) => {
 
-	clearWindow(true);
+	clearWindow();
 	g_currentPage = `title`;
 	g_stateObj.settingSummaryVisible = false;
 
@@ -6671,7 +6666,7 @@ const setWindowStyle = (_text, _bkColor, _textColor, _align = C_ALIGN_LEFT, { _x
 /*-----------------------------------------------------------*/
 
 const dataMgtInit = () => {
-	clearWindow(true);
+	clearWindow();
 	pauseBGM();
 	const prevPage = g_currentPage;
 	g_currentPage = `dataMgt`;
@@ -6909,7 +6904,7 @@ const dataMgtInit = () => {
 /*-----------------------------------------------------------*/
 
 const preconditionInit = () => {
-	clearWindow(true);
+	clearWindow();
 	pauseBGM();
 	const prevPage = g_currentPage;
 	g_currentPage = `precondition`;
@@ -7137,7 +7132,7 @@ const makePlayButton = _func => createCss2Button(`btnPlay`, g_lblNameObj.b_play,
  */
 const optionInit = () => {
 
-	clearWindow(true);
+	clearWindow();
 	pauseBGM();
 	const divRoot = document.getElementById(`divRoot`);
 	g_currentPage = `option`;
@@ -9215,7 +9210,7 @@ const resetGroupList = (_type, _keyCtrlPtn) => {
 
 const settingsDisplayInit = () => {
 
-	clearWindow(true);
+	clearWindow();
 	const divRoot = document.getElementById(`divRoot`);
 	g_currentPage = `settingsDisplay`;
 
@@ -10022,7 +10017,7 @@ const interlockingButton = (_headerObj, _name, _current, _next, _buttonFlg = fal
 /*-----------------------------------------------------------*/
 
 const exSettingInit = () => {
-	clearWindow(true);
+	clearWindow();
 	g_currentPage = `exSetting`;
 
 	multiAppend(divRoot,
@@ -10183,7 +10178,7 @@ const createGeneralSettingEx = (_spriteList, _name, { defaultList = [C_FLG_OFF],
  */
 const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 
-	clearWindow(true);
+	clearWindow();
 	const divRoot = document.getElementById(`divRoot`);
 	g_kcType = _kcType;
 	g_currentPage = `keyConfig`;
@@ -11961,7 +11956,7 @@ const changeShuffleConfigColor = (_keyCtrlPtn, _vals, _j = -1) => {
 
 const loadMusic = async () => {
 
-	clearWindow(true);
+	clearWindow();
 	pauseBGM();
 	g_currentPage = `loading`;
 
@@ -14535,7 +14530,7 @@ const setKeyCtrl = (_localStorage, _keyNum, _keyCtrlPtn) => {
  * メイン画面初期化
  */
 const mainInit = () => {
-	clearWindow(true, `Main`);
+	clearWindow(`Main`);
 	const divRoot = document.getElementById(`divRoot`);
 	document.oncontextmenu = () => false;
 	g_currentPage = `main`;
@@ -16305,7 +16300,7 @@ const executeRetry = async (_logLabel = `Retry`) => {
 	try {
 		g_audio.pause();
 		clearTimeout(g_timeoutEvtId);
-		clearWindow();
+		clearWindow(`Main`);
 		await musicAfterLoaded();
 		await loadChartFile();
 		prepareScoreData();
@@ -16929,7 +16924,7 @@ const finishViewing = () => {
  */
 const resultInit = () => {
 
-	clearWindow(true);
+	clearWindow();
 	g_currentPage = `result`;
 
 	// 結果画面用フレーム初期化

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -12032,6 +12032,7 @@ const loadAndSetupAudio = async (_url, _lblLoading) => {
 	const audioUrl = g_isFile ? _url : await fetchMusicBlobUrl(_url, _lblLoading);
 
 	// エンコードなしの場合
+	// - ファイルの場合はAudioタグで再生、オンラインの場合はWebAudioAPI(URL)で再生
 	if (!g_musicEncodedFlg) {
 		return readyToStart(() => {
 			if (g_isFile) {
@@ -12039,18 +12040,21 @@ const loadAndSetupAudio = async (_url, _lblLoading) => {
 				g_audio.src = audioUrl;
 				return musicAfterLoaded();
 			}
-			return initWebAudioAPIfromURL(audioUrl);
+			return setupWebAudio(async () => {
+				const response = await fetch(audioUrl);
+				return response.arrayBuffer();
+			}, _url);
 		});
 	}
 
-	// エンコードありの場合は、まずスクリプトを読み込む
+	// エンコードありの場合
 	await loadScript2(audioUrl);
 	if (typeof musicInit !== C_TYP_FUNCTION) {
-		makeWarningWindow(g_msgInfoObj.E_0031);
-		return musicAfterLoaded();
+		makeWarningWindow(g_msgInfoObj.E_0031, { backBtnUse: true });
+		throw new Error(`musicInit is not defined`);
 	}
 	musicInit();
-	return readyToStart(() => initWebAudioAPIfromBase64(g_musicdata, _url));
+	return readyToStart(() => setupWebAudio(() => Promise.resolve(base64ToUint8Array(g_musicdata).buffer), _url));
 };
 
 /**
@@ -12068,6 +12072,7 @@ const fetchMusicBlobUrl = (_url, _lblLoading) => new Promise((resolve, reject) =
 	const STALL_TIMEOUT_MS = 30000; // 30秒間、進捗がなければ停滞とみなす
 	let stallTimer = null;
 
+	// 停滞タイマーをリセット
 	const resetStallTimer = () => {
 		clearTimeout(stallTimer);
 		stallTimer = setTimeout(() => {
@@ -12118,16 +12123,21 @@ const fetchMusicBlobUrl = (_url, _lblLoading) => new Promise((resolve, reject) =
 	request.send();
 });
 
-// Base64から音声データに変換してWebAudioAPIで再生する準備
-const initWebAudioAPIfromBase64 = async (_base64, _cacheKey) => {
+/**
+ * WebAudioAPIによる音源再生の準備(共通処理)
+ * @param {() => Promise<ArrayBuffer>} _fetchArrayBuffer
+ * @param {string} [_cacheKey]
+ * @returns {Promise<void>}
+ */
+const setupWebAudio = async (_fetchArrayBuffer, _cacheKey) => {
 	g_audio = new AudioPlayer();
 	const loadedPromise = musicAfterLoaded(); // canplaythrough/errorの発火をここで待つ
 
 	if (_cacheKey && g_audioBufferCache.has(_cacheKey)) {
 		g_audio.setBuffer(g_audioBufferCache.get(_cacheKey)); // デコード完全スキップ
 	} else {
-		const array = base64ToUint8Array(_base64);
-		await g_audio.init(array.buffer);
+		const arrayBuffer = await _fetchArrayBuffer();
+		await g_audio.init(arrayBuffer);
 		if (_cacheKey) {
 			cacheAudioBuffer(_cacheKey, g_audio.getBuffer());
 		}
@@ -12135,19 +12145,15 @@ const initWebAudioAPIfromBase64 = async (_base64, _cacheKey) => {
 	return loadedPromise;
 };
 
-// 音声ファイルを読み込んでWebAudioAPIで再生する準備
-const initWebAudioAPIfromURL = async (_url) => {
-	g_audio = new AudioPlayer();
-	const loadedPromise = musicAfterLoaded();
-	const promise = await fetch(_url);
-	const arrayBuffer = await promise.arrayBuffer();
-	await g_audio.init(arrayBuffer);
-	return loadedPromise;
-};
-
 const g_audioBufferCache = new Map();
 const AUDIO_CACHE_MAX = 5;
 
+/**
+ * デコード済みAudioBufferのキャッシュへの登録
+ * - 直近 AUDIO_CACHE_MAX 件を保持するLRU方式。上限を超えた場合は最も古いエントリから破棄する
+ * @param {string} _key キャッシュキー(楽曲の実URL)
+ * @param {AudioBuffer} _buffer デコード済みのAudioBuffer
+ */
 const cacheAudioBuffer = (_key, _buffer) => {
 	g_audioBufferCache.set(_key, _buffer);
 	if (g_audioBufferCache.size > AUDIO_CACHE_MAX) {
@@ -12155,6 +12161,13 @@ const cacheAudioBuffer = (_key, _buffer) => {
 	}
 };
 
+/**
+ * base64文字列をUint8Arrayに変換
+ * - Uint8Array.from(atob(str), callback)によるコールバック呼び出し形式は
+ *   大容量データで変換オーバーヘッドが大きいため、forループによる直接代入で高速化している
+ * @param {string} _base64Str base64エンコードされた文字列
+ * @returns {Uint8Array} 変換後のバイト配列
+ */
 const base64ToUint8Array = (_base64Str) => {
 	const binaryStr = atob(_base64Str);
 	const len = binaryStr.length;
@@ -12165,6 +12178,13 @@ const base64ToUint8Array = (_base64Str) => {
 	return array;
 };
 
+/**
+ * 音源の再生準備完了を待つ
+ * - g_audio が Audio要素の場合は canplaythrough/error イベントの発火を待つ
+ * - g_audio が AudioPlayer の場合、readyState が既に4(デコード済み、キャッシュヒット時など)であれば即時解決する
+ * - canplaythrough/error のどちらが発火しても、もう一方のリスナーも確実に削除する(cleanup)
+ * @returns {Promise<void>} 再生準備が完了したら解決し、読込エラー時は例外を投げて拒否するPromise
+ */
 const musicAfterLoaded = () => new Promise((resolve, reject) => {
 	g_audio.load();
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -11996,22 +11996,68 @@ const loadMusic = async () => {
 };
 
 /**
- * 音源の取得とセットアップ(ローカル/オンライン双方を吸収する橋渡し役)
- * @param {string} _url
- * @param {HTMLDivElement} _lblLoading
- * @returns {Promise<void>}
+ * 音源の取得とセットアップ
+ * - エンコード形式(base64)か通常の音声ファイルかを判定し、それぞれの準備処理に振り分ける
+ * - iOSの場合はユーザー操作(ジェスチャー)を待ってから再生準備を行う(readyToStart経由)
+ * @param {string} _url 音源の取得元URL
+ * @param {HTMLDivElement} _lblLoading ローディング表示用のDiv要素
+ * @returns {Promise<void>} 再生準備(canplaythrough相当)が完了したら解決するPromise
  */
 const loadAndSetupAudio = async (_url, _lblLoading) => {
+
+	/**
+	 * iOSの場合はユーザー操作(ジェスチャー)を待ってから_funcを実行する
+	 * - AudioContextの制約上、iOSはジェスチャーを起点にしないと音声再生が許可されないため
+	 * @param {() => Promise<void>} _func 実行する音源準備処理
+	 * @returns {Promise<void>}
+	 */
+	const readyToStart = _func => {
+		if (!g_isIos) {
+			return _func(); // 通常環境はそのまま実行するだけ
+		}
+		return new Promise((resolve, reject) => {
+			g_currentPage = `loadingIos`;
+			_lblLoading.textContent = `Click to Start!`;
+			divRoot.appendChild(makePlayButton(evt => {
+				getSharedAudioContext().resume();
+				g_currentPage = `loading`;
+				resetKeyControl();
+				divRoot.removeChild(evt.target);
+				_func().then(resolve).catch(reject);
+			}));
+			setShortcutEvent(g_currentPage);
+		});
+	};
+
 	const audioUrl = g_isFile ? _url : await fetchMusicBlobUrl(_url, _lblLoading);
-	// キャッシュキーは常に変化しない元のurlを使う(Blob URLは毎回一意になるため)
-	return setAudio(audioUrl, _url);
+
+	// エンコードなしの場合
+	if (!g_musicEncodedFlg) {
+		return readyToStart(() => {
+			if (g_isFile) {
+				g_audio = new Audio();
+				g_audio.src = _url;
+				return musicAfterLoaded();
+			}
+			return initWebAudioAPIfromURL(_url);
+		});
+	}
+
+	// エンコードありの場合は、まずスクリプトを読み込む
+	await loadScript2(audioUrl);
+	if (typeof musicInit !== C_TYP_FUNCTION) {
+		makeWarningWindow(g_msgInfoObj.E_0031);
+		return musicAfterLoaded();
+	}
+	musicInit();
+	return readyToStart(() => initWebAudioAPIfromBase64(g_musicdata, _url));
 };
 
 /**
  * XHRによる音源ファイルのダウンロード(Promise化)
  * - ダウンロードして Blob URL を返す
- * @param {string} _url
- * @param {HTMLDivElement} _lblLoading
+ * @param {string} _url 音源ファイルのURL
+ * @param {HTMLDivElement} _lblLoading ローディング表示用のDiv要素
  * @returns {Promise<string>} Blob URL
  */
 const fetchMusicBlobUrl = (_url, _lblLoading) => new Promise((resolve, reject) => {
@@ -12071,72 +12117,6 @@ const fetchMusicBlobUrl = (_url, _lblLoading) => new Promise((resolve, reject) =
 	resetStallTimer(); // 初回(最初のprogressが来るまで)のタイマーも開始
 	request.send();
 });
-
-/**
- * 音源のセットアップ
- * - エンコード形式(base64)か通常の音声ファイルかを判定し、それぞれの準備処理に振り分ける
- * - iOSの場合はユーザー操作(ジェスチャー)を待ってから再生準備を行う(readyToStart経由)
- * @param {string} _url 音源の取得元URL(ローカルパス、または loadAndSetupAudio 経由のBlob URL)
- * @param {string} [_cacheKey=_url] AudioBufferキャッシュ照合用のキー(常に変化しない楽曲の実URLを渡す)
- * @returns {Promise<void>} 再生準備(canplaythrough相当)が完了したら解決するPromise
- */
-const setAudio = async (_url, _cacheKey = _url) => {
-
-	/**
-	 * iOSの場合はユーザー操作(ジェスチャー)を待ってから_funcを実行する
-	 * - AudioContextの制約上、iOSはジェスチャーを起点にしないと音声再生が許可されないため
-	 * @param {() => Promise<void>} _func 実行する音源準備処理
-	 * @returns {Promise<void>}
-	 */
-	const readyToStart = _func => {
-		if (!g_isIos) {
-			return _func(); // 通常環境はそのまま実行するだけ
-		}
-		return new Promise((resolve, reject) => {
-			g_currentPage = `loadingIos`;
-			if (document.getElementById(`lblLoading`) === null) {
-				divRoot.appendChild(getLoadingLabel());
-			}
-			lblLoading.textContent = `Click to Start!`;
-			divRoot.appendChild(makePlayButton(evt => {
-				getSharedAudioContext().resume();
-				g_currentPage = `loading`;
-				resetKeyControl();
-				divRoot.removeChild(evt.target);
-				_func().then(resolve).catch(reject);
-			}));
-			setShortcutEvent(g_currentPage);
-		});
-	};
-
-	/**
-	 * mp3等、非エンコード形式の音源準備
-	 * - ローカル実行時は Audio 要素で直接再生、オンライン時は WebAudioAPI 経由で取得・デコードする
-	 * @returns {Promise<void>}
-	 */
-	const loadMp3 = () => {
-		if (g_isFile) {
-			g_audio = new Audio();
-			g_audio.src = _url;
-			return musicAfterLoaded();
-		}
-		return initWebAudioAPIfromURL(_url);
-	};
-
-	// エンコードなしの場合
-	if (!g_musicEncodedFlg) {
-		return readyToStart(loadMp3);
-	}
-
-	// エンコードありの場合は、まずスクリプトを読み込む
-	await loadScript2(_url);
-	if (typeof musicInit !== C_TYP_FUNCTION) {
-		makeWarningWindow(g_msgInfoObj.E_0031);
-		return musicAfterLoaded();
-	}
-	musicInit();
-	return readyToStart(() => initWebAudioAPIfromBase64(g_musicdata, _cacheKey));
-};
 
 // Base64から音声データに変換してWebAudioAPIで再生する準備
 const initWebAudioAPIfromBase64 = async (_base64, _cacheKey) => {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -11999,6 +11999,8 @@ const loadMusic = async () => {
  * 音源の取得とセットアップ
  * - エンコード形式(base64)か通常の音声ファイルかを判定し、それぞれの準備処理に振り分ける
  * - iOSの場合はユーザー操作(ジェスチャー)を待ってから再生準備を行う(readyToStart経由)
+ * - キャッシュヒット時はダウンロード自体を行わないよう、取得処理はsetupWebAudioへ
+ *   コールバックとして渡し、キャッシュミス時にのみ評価されるようにしている
  * @param {string} _url 音源の取得元URL
  * @param {HTMLDivElement} _lblLoading ローディング表示用のDiv要素
  * @returns {Promise<void>} 再生準備(canplaythrough相当)が完了したら解決するPromise
@@ -12029,32 +12031,49 @@ const loadAndSetupAudio = async (_url, _lblLoading) => {
 		});
 	};
 
-	const audioUrl = g_isFile ? _url : await fetchMusicBlobUrl(_url, _lblLoading);
-
 	// エンコードなしの場合
 	// - ファイルの場合はAudioタグで再生、オンラインの場合はWebAudioAPI(URL)で再生
 	if (!g_musicEncodedFlg) {
-		return readyToStart(() => {
-			if (g_isFile) {
+		// ローカル実行時: Audio要素で直接再生(WebAudioAPIキャッシュの対象外)
+		if (g_isFile) {
+			return readyToStart(() => {
 				g_audio = new Audio();
-				g_audio.src = audioUrl;
+				g_audio.src = _url;
 				return musicAfterLoaded();
-			}
-			return setupWebAudio(async () => {
-				const response = await fetch(audioUrl);
-				return response.arrayBuffer();
-			}, _url);
-		});
+			});
+		}
+		// オンライン時: WebAudioAPI経由。ダウンロード処理はsetupWebAudioへ委譲する
+		return readyToStart(() =>
+			setupWebAudio(async () => {
+				// この関数はキャッシュミス時のみ呼ばれる
+				const blobUrl = await fetchMusicBlobUrl(_url, _lblLoading);
+				try {
+					const response = await fetch(blobUrl);
+					return await response.arrayBuffer();
+				} finally {
+					URL.revokeObjectURL(blobUrl); // 使用後は必ず解放
+				}
+			}, _url)
+		);
 	}
 
-	// エンコードありの場合
-	await loadScript2(audioUrl);
-	if (typeof musicInit !== C_TYP_FUNCTION) {
-		makeWarningWindow(g_msgInfoObj.E_0031, { backBtnUse: true });
-		throw new Error(`musicInit is not defined`);
-	}
-	musicInit();
-	return readyToStart(() => setupWebAudio(() => Promise.resolve(base64ToUint8Array(g_musicdata).buffer), _url));
+	// エンコードありの場合。スクリプト読込・musicInit実行もキャッシュミス時のみ行う
+	return readyToStart(() => setupWebAudio(async () => {
+		const scriptSrc = g_isFile ? _url : await fetchMusicBlobUrl(_url, _lblLoading);
+		try {
+			await loadScript2(scriptSrc);
+		} finally {
+			if (!g_isFile) {
+				URL.revokeObjectURL(scriptSrc); // 使用後は必ず解放
+			}
+		}
+		if (typeof musicInit !== C_TYP_FUNCTION) {
+			makeWarningWindow(g_msgInfoObj.E_0031, { backBtnUse: true });
+			throw new Error(`musicInit is not defined`);
+		}
+		musicInit();
+		return base64ToUint8Array(g_musicdata).buffer;
+	}, _url));
 };
 
 /**
@@ -12125,9 +12144,11 @@ const fetchMusicBlobUrl = (_url, _lblLoading) => new Promise((resolve, reject) =
 
 /**
  * WebAudioAPIによる音源再生の準備(共通処理)
- * @param {() => Promise<ArrayBuffer>} _fetchArrayBuffer
- * @param {string} [_cacheKey]
- * @returns {Promise<void>}
+ * - AudioPlayerを生成し、canplaythrough/errorの発火待ちを開始した上で、
+ *   ArrayBufferを取得してデコードする(キャッシュヒット時はデコードをスキップ)
+ * @param {() => Promise<ArrayBuffer>} _fetchArrayBuffer 未キャッシュの場合にArrayBufferを取得する関数
+ * @param {string} [_cacheKey] AudioBufferキャッシュ照合用のキー(省略時はキャッシュを使わない)
+ * @returns {Promise<void>} 再生準備(canplaythrough相当)が完了したら解決するPromise
  */
 const setupWebAudio = async (_fetchArrayBuffer, _cacheKey) => {
 	g_audio = new AudioPlayer();

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -12251,7 +12251,7 @@ const musicAfterLoaded = () => new Promise((resolve, reject) => {
 /**
  * 譜面データの変換処理
  * - 音源データの状態に依存しない部分のみを担う(g_audio非参照)
- * - loadMusic経由(並行フロー)、loadingScoreInit経由(曲中リトライ)の両方から呼ばれる
+ * - loadMusic経由(並行フロー)、executeRetry経由(曲中リトライ)の両方から呼ばれる
  */
 const prepareScoreData = () => {
 
@@ -12402,17 +12402,6 @@ const prepareScoreData = () => {
 
 	// ユーザカスタムイベント
 	safeExecuteCustomHooks(`g_customJsObj.loading`, g_customJsObj.loading);
-};
-
-/**
- * 読込画面初期化
- * - 曲中リトライ専用。loadMusic経由(初回起動)の並行フローとは別に、
- *   譜面再読込からmainInitまでを一括で直列実行する。
- */
-const loadingScoreInit = async () => {
-	await loadChartFile();
-	prepareScoreData();
-	mainInit();
 };
 
 /**
@@ -15011,26 +15000,16 @@ const mainInit = () => {
 
 		// 曲中リトライ、タイトルバック
 		if (setCode === g_kCdN[g_headerObj.keyRetry]) {
-			g_audio.pause();
-			clearTimeout(g_timeoutEvtId);
 
 			if (g_isMac && keyIsShift()) {
 				// Mac OS、IPad OSはDeleteキーが無いためShift+BSで代用
+				g_audio.pause();
+				clearTimeout(g_timeoutEvtId);
 				titleInit();
 
 			} else {
 				// その他の環境では単にRetryに対応するキーのみで適用
-				if (g_retryInProgress) return blockCode(setCode);
-				g_retryInProgress = true;
-				clearWindow();
-				try {
-					await musicAfterLoaded();
-					await loadingScoreInit(); // 譜面データを再読込
-				} catch (e) {
-					console.warn(`Retry audio load error: ${e}`);
-				} finally {
-					g_retryInProgress = false;
-				}
+				await executeRetry(`Retry`);
 			}
 
 		} else if (setCode === g_kCdN[g_headerObj.keyTitleBack]) {
@@ -16313,6 +16292,32 @@ const executeFrzReturn = (_seq, _idx, _axis) => {
 };
 
 /**
+ * 曲中リトライの共通処理
+ * - 手動リトライ、AutoRetryの両方から呼ばれる
+ * - g_retryInProgressによる多重実行防止、失敗時のログ出力・フラグ復帰を一括で行う
+ * @param {string} [_logLabel='Retry'] エラーログに表示するラベル(手動/自動の区別用)
+ */
+const executeRetry = async (_logLabel = `Retry`) => {
+	if (g_retryInProgress) {
+		return;
+	}
+	g_retryInProgress = true;
+	try {
+		g_audio.pause();
+		clearTimeout(g_timeoutEvtId);
+		clearWindow();
+		await musicAfterLoaded();
+		await loadChartFile();
+		prepareScoreData();
+		mainInit();
+	} catch (e) {
+		console.warn(`${_logLabel} audio load error: ${e}`);
+	} finally {
+		g_retryInProgress = false;
+	}
+};
+
+/**
  * AutoRetryの設定
  * @param {string} _retryCondition リトライ基準となるAutoRetry名
  */
@@ -16322,19 +16327,8 @@ const quickRetry = (_retryCondition) => {
 		return;
 	}
 	if (g_settings.autoRetryNum >= retryNum && !g_retryInProgress) {
-		g_retryInProgress = true;
 		setTimeout(async () => {
-			g_audio.pause();
-			clearTimeout(g_timeoutEvtId);
-			clearWindow();
-			try {
-				await musicAfterLoaded();
-				await loadingScoreInit(); // 譜面データを再読込
-			} catch (e) {
-				console.warn(`AutoRetry audio load error: ${e}`);
-			} finally {
-				g_retryInProgress = false;
-			}
+			await executeRetry(`AutoRetry`);
 		}, 16);
 	}
 };

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -12032,49 +12032,51 @@ const loadAndSetupAudio = async (_url, _lblLoading) => {
 		});
 	};
 
-	// エンコードなしの場合
-	// - ファイルの場合はAudioタグで再生、オンラインの場合はWebAudioAPI(URL)で再生
-	if (!g_musicEncodedFlg) {
-		// ローカル実行時: Audio要素で直接再生(WebAudioAPIキャッシュの対象外)
-		if (g_isFile) {
-			return readyToStart(() => {
+	// 音源準備処理そのものを、条件に応じて組み立てる
+	const setupAudioFunc = (() => {
+
+		// エンコードなし & ローカル実行: Audio要素で直接再生
+		if (!g_musicEncodedFlg && g_isFile) {
+			return () => {
 				g_audio = new Audio();
 				g_audio.src = _url;
 				return musicAfterLoaded();
-			});
+			};
 		}
-		// オンライン時: WebAudioAPI経由。ダウンロード処理はsetupWebAudioへ委譲する
-		return readyToStart(() =>
-			setupWebAudio(async () => {
-				// この関数はキャッシュミス時のみ呼ばれる
+
+		// エンコードなし & オンライン: WebAudioAPI経由(URLからfetch)
+		if (!g_musicEncodedFlg) {
+			return () => setupWebAudio(async () => {
 				const blobUrl = await fetchMusicBlobUrl(_url, _lblLoading);
 				try {
 					const response = await fetch(blobUrl);
 					return await response.arrayBuffer();
 				} finally {
-					URL.revokeObjectURL(blobUrl); // 使用後は必ず解放
+					URL.revokeObjectURL(blobUrl);
 				}
-			}, _url)
-		);
-	}
+			}, _url);
+		}
 
-	// エンコードありの場合。スクリプト読込・musicInit実行もキャッシュミス時のみ行う
-	return readyToStart(() => setupWebAudio(async () => {
-		const scriptSrc = g_isFile ? _url : await fetchMusicBlobUrl(_url, _lblLoading);
-		try {
-			await loadScript2(scriptSrc);
-		} finally {
-			if (!g_isFile) {
-				URL.revokeObjectURL(scriptSrc); // 使用後は必ず解放
+		// エンコードあり: スクリプト読込・musicInit実行を経てWebAudioAPI準備
+		return () => setupWebAudio(async () => {
+			const scriptSrc = g_isFile ? _url : await fetchMusicBlobUrl(_url, _lblLoading);
+			try {
+				await loadScript2(scriptSrc);
+			} finally {
+				if (!g_isFile) {
+					URL.revokeObjectURL(scriptSrc);
+				}
 			}
-		}
-		if (typeof musicInit !== C_TYP_FUNCTION) {
-			makeWarningWindow(g_msgInfoObj.E_0031, { backBtnUse: true });
-			throw new Error(`musicInit is not defined`);
-		}
-		musicInit();
-		return base64ToUint8Array(g_musicdata).buffer;
-	}, _url));
+			if (typeof musicInit !== C_TYP_FUNCTION) {
+				makeWarningWindow(g_msgInfoObj.E_0031, { backBtnUse: true });
+				throw new Error(`musicInit is not defined`);
+			}
+			musicInit();
+			return base64ToUint8Array(g_musicdata).buffer;
+		}, _url);
+	})();
+
+	return readyToStart(setupAudioFunc);
 };
 
 /**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -12036,10 +12036,10 @@ const loadAndSetupAudio = async (_url, _lblLoading) => {
 		return readyToStart(() => {
 			if (g_isFile) {
 				g_audio = new Audio();
-				g_audio.src = _url;
+				g_audio.src = audioUrl;
 				return musicAfterLoaded();
 			}
-			return initWebAudioAPIfromURL(_url);
+			return initWebAudioAPIfromURL(audioUrl);
 		});
 	}
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -6393,9 +6393,10 @@ const playBGM = async (_num, _currentLoopNum = g_settings.musicLoopNum) => {
 	if (encodeFlg) {
 		try {
 			closeExistingAudio();
-			if (g_audioBufferCache.has(url)) {
+			const cachedBuffer = getAudioBufferFromCache(url);
+			if (cachedBuffer !== undefined) {
 				const tmpAudio = new AudioPlayer();
-				tmpAudio.setBuffer(g_audioBufferCache.get(url)); // 新設メソッド、decode不要
+				tmpAudio.setBuffer(cachedBuffer);
 				g_audioForMS = tmpAudio;
 			} else {
 				await loadScript2(url);
@@ -12154,8 +12155,9 @@ const setupWebAudio = async (_fetchArrayBuffer, _cacheKey) => {
 	g_audio = new AudioPlayer();
 	const loadedPromise = musicAfterLoaded(); // canplaythrough/errorの発火をここで待つ
 
-	if (_cacheKey && g_audioBufferCache.has(_cacheKey)) {
-		g_audio.setBuffer(g_audioBufferCache.get(_cacheKey)); // デコード完全スキップ
+	const cachedBuffer = _cacheKey ? getAudioBufferFromCache(_cacheKey) : undefined;
+	if (cachedBuffer !== undefined) {
+		g_audio.setBuffer(cachedBuffer);
 	} else {
 		const arrayBuffer = await _fetchArrayBuffer();
 		await g_audio.init(arrayBuffer);
@@ -12168,6 +12170,23 @@ const setupWebAudio = async (_fetchArrayBuffer, _cacheKey) => {
 
 const g_audioBufferCache = new Map();
 const AUDIO_CACHE_MAX = 5;
+
+/**
+ * デコード済みAudioBufferのキャッシュからの取得
+ * - Mapは挿入順を保持するのみでアクセス順を保持しないため、
+ *   ヒット時にエントリを一度削除して再挿入し、最新として扱う(LRU方式)
+ * @param {string} _key キャッシュキー(楽曲の実URL)
+ * @returns {AudioBuffer|undefined} キャッシュされたAudioBuffer。存在しない場合はundefined
+ */
+const getAudioBufferFromCache = (_key) => {
+	if (!g_audioBufferCache.has(_key)) {
+		return undefined;
+	}
+	const buffer = g_audioBufferCache.get(_key);
+	g_audioBufferCache.delete(_key);
+	g_audioBufferCache.set(_key, buffer); // 末尾(最新)に再挿入
+	return buffer;
+};
 
 /**
  * デコード済みAudioBufferのキャッシュへの登録


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 音源セットアップ関連処理の整理
- `setAudio`を`loadAndSetupAudio`に統合して一本化しました。これにより、音源のダウンロード(`fetchMusicBlobUrl`として分離)と、音源のセットアップ(エンコード判定、iOSジェスチャー待ち、WebAudioAPI準備)の責務がより明確になりました。
- 3つの準備パターン(ローカル非エンコード、オンライン非エンコード、エンコードあり)の分岐を整理し、いずれも最終的に`readyToStart(...)`へ委譲する構成にすることで、iOSジェスチャー待ちの制御と音源準備処理本体の関心を分離しました。

### 2. WebAudioAPI準備処理の共通化とエラー処理の是正
- 内容がほぼ同一だった`initWebAudioAPIfromBase64`と`initWebAudioAPIfromURL`を、`setupWebAudio`として1つの共通関数に統合しました。
- `musicInit`が未定義の場合、従来は警告表示をしつつ処理を正常系に戻していましたが、他の読込失敗ケースと同様に例外を投げて処理を停止するよう修正しました。
- 非エンコード音源(mp3等)についても、キャッシュキー(楽曲の実URL)を渡すよう変更し、エンコード音源同様にリトライ・選曲プレビュー時のデコード省略の恩恵を受けられるようにしました。

### 3. Blob URLの解放漏れ・ダウンロード処理の遅延評価化(レビュー指摘反映)
- 音源ダウンロード処理(`fetchMusicBlobUrl`)が、キャッシュヒット判定より前に無条件で実行されており、キャッシュがある場合でも不要なダウンロードが発生していたため、ダウンロード処理自体を`setupWebAudio`へのコールバックとして遅延評価させ、キャッシュミス時にのみ実行されるよう修正しました。
- `URL.createObjectURL()`で生成したBlob URLが使用後も解放されていなかったため、`finally`で`URL.revokeObjectURL()`を確実に呼ぶよう修正しました。

### 4. AudioBufferキャッシュのLRU化(レビュー指摘反映)
- `Map`の`get()`はアクセス順を更新しないため、キャッシュヒットが続いても実質FIFO(挿入順)で破棄されてしまう問題がありました。キャッシュ取得を`getAudioBufferFromCache`として関数化し、ヒット時にエントリを削除・再挿入することで、真のLRU(最近使われたものほど残る)として機能するよう修正しました。
- 選曲画面のプレビュー再生(`playBGM`)側で`g_audioBufferCache`に直接アクセスしていた箇所も、同じく`getAudioBufferFromCache`経由に統一し、どちらの経路からアクセスしてもLRU順が正しく更新されるようにしました。

### 5. 曲中リトライ処理の共通化
- 手動リトライ(`mainInit`内の`onkeydown`)とAutoRetry(`quickRetry`)で重複していた「多重実行防止(`g_retryInProgress`)、音源読込完了待ち、譜面再読込、エラー時のログ出力とフラグ復帰」の処理を`executeRetry`として共通化しました。
- これに伴い、中間ラッパーとなっていた`loadingScoreInit`は不要になったため削除し、`loadChartFile` → `prepareScoreData` → `mainInit`を`executeRetry`内で直接呼ぶ構成にしました。

### 6. `clearWindow`の引数整理
- `clearWindow`の第一引数`_redrawFlg`は、過去の実装経緯(PR #1003)により全ての呼び出し元で`true`固定となっており、実質的に区別が不要な状態でした。曲中リトライ処理からの呼び出しのみ、この引数を渡し忘れており再描画がスキップされていたため、これを機に`_redrawFlg`引数自体を廃止し、常に再描画処理を行う一本化した実装に整理しました。これにより、曲中リトライ時にも他の画面遷移と同様に再描画が行われるようになります(従来の抜け漏れの是正)。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes

1. 音源のダウンロードとセットアップが1つの関数に混在しており、責務が不明瞭で見通しが悪かったため。関数を分割し、それぞれの役割を明確にするため。
2. ほぼ同一の処理を行う関数が重複して存在しており保守性が低かったため、共通化するため。また`musicInit`未定義時の処理が他のエラーケースと異なる中途半端な挙動になっていたため、一貫した挙動に統一するため。
3. レビュー(CodeRabbit)にて、キャッシュヒット時にも不要なダウンロードが発生する点、およびBlob URLの解放漏れによるメモリリークの懸念を指摘されたため。
4. レビュー(CodeRabbit)にて、`Map`ベースのキャッシュが実質FIFOとして動作しており、意図したLRU(直近使用したものを優先して残す)になっていない点を指摘されたため。
5. 手動リトライとAutoRetryで同じ処理が重複しており、修正時に両方への反映漏れが起きやすい状態だったため、保守性向上のため共通化するため。
6. `clearWindow`の引数が実質的に形骸化しており、曲中リトライ処理でのみ再描画が意図せず省略されていたことが判明したため、これを是正し引数自体を整理するため。

## :camera: スクリーンショット / Screenshot

(該当なし: 画面デザインの変更は含まれません)

## :pencil: その他コメント / Other Comments

- `prepareScoreData`は音源データ(`g_audio`)を一切参照しない処理であることを確認済みのため、並行実行による副作用はありません。
- `clearWindow`は内部で`resetKeyControl()`を呼んでおり、画面遷移・非同期処理待ちの間も`document.onkeydown`/`onkeyup`がDOM要素を参照しない安全なハンドラに保たれることを確認済みです(CodeRabbitからの「非同期リロード中の古いキーハンドラ」指摘については、既存の`resetKeyControl`により対応済みであることを確認しています)。
- `clearWindow`の引数整理に伴い、呼び出し元(`titleInit`, `loadMusic`, `resultInit`, `mainInit`関連, `executeRetry`)を全て更新しています。他に旧引数形式で呼び出している箇所がないか確認済みです。
- 動作確認をお願いしたい観点:
  - 通常のオンライン環境、およびローカル実行(`file://`)双方での曲読込・ゲーム開始
  - iOS/iPadOS実機での「Click to Start」ボタン表示とタップ後の動作
  - エンコード音源・非エンコード音源(mp3等)双方でのリトライ・選曲プレビュー時のキャッシュ挙動(2回目以降の読込が高速化されること)
  - キャッシュ上限を超える数の曲を選曲画面で行き来した際、直近使用した曲が優先して残ること(LRU動作の確認)
  - `musicInit`未定義など、音源設定に不備がある場合にBackボタン付きのエラー画面で正しく停止すること
  - 曲中リトライ、AutoRetry、リザルト画面からのリトライがそれぞれ従来通り機能すること
  - 曲中リトライ時に背景の再描画が正しく行われること(従来スキップされていた点の是正確認)