### PR TITLE
feat: [1129] カスタムゲージ名の別名を指定する機能を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5013,7 +5013,7 @@ const setColorList = (_data, _colorInit, _colorInitLength,
 
 /**
  * 複合カスタムゲージの定義設定
- * |customGauge=Original::F,Normal::V,Escape::V|
+ * |customGauge=_Original::F::Original,_Normal::V::Normal,Escape::V|
  * @param {object} _dosObj 
  * @param {string} [object.scoreId=0]
  * @returns {object} ※Object.assign(obj, resetCustomGauge(...))の形で呼び出しが必要
@@ -5041,6 +5041,9 @@ const resetCustomGauge = (_dosObj, { scoreId = 0 } = {}) => {
 				const customGaugeSets = customGauges[j].split(`::`);
 				obj[`custom${scoreId}`][j] = customGaugeSets[0];
 				obj[`varCustom${scoreId}`][j] = boolToSwitch(customGaugeSets[1] === `V`);
+				if (hasVal(customGaugeSets[2])) {
+					g_lblNameObj[`u_${customGaugeSets[0]}`] = customGaugeSets[2];
+				}
 			}
 			if (scoreId === 0) {
 				obj.custom = obj.custom0.concat();


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. feat: カスタムゲージ名の別名を指定する機能を追加

- 譜面ヘッダーのカスタムゲージ名について、表示用の別名を指定する機能を追加しました。
- gaugeXは元のゲージ名で設定する必要があります。（カスタムキーのkeyNameXと同じ考え方）
- 内部的には g_lblNameObj["u_ゲージ名"] = "別名"; に代入されます。
```
|customGauge=MyOriginal::F::Original,MyNormal::V::Normal|
|gaugeMyOriginal=x,20,70,30|
```

#### 補足
- 今回の別名の設定は全譜面で共通です。
- customGaugeを分けても、元の名前と別名の組合せは維持されます。
- ただ、誤解を招くので元の名前を分けてしまうか、別名の指定までセットで行っておくことを推奨します。
```
|customGauge=MyOrignal::F::Original,...|
|customGauge2=MyOriginal::F|  // 省略しても、略名のOriginalと表記される
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. ゲージ名のOriginal, Normal, Light, Easyは特殊なゲージで、カスタムゲージに組み込むと不具合の温床になるため。
オリジナルの名前を別の名前とし、表示名にOriginal, Normalなどを指定するといった使い方を想定しています。
既存でもできないことはないですが、カスタムJSの利用が必須になっていて使いにくくなっていました。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->