### PR TITLE
improve: [1130] キーコンフィグ画面でキーボードマッププレビュー表示時でもkeySwitchできるよう改善

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -11463,7 +11463,7 @@ const keyconfigKeyboardPreview = (() => {
 		const configKeyGroupList = g_headerObj.keyGroupOrder[g_stateObj.scoreId] ??
 			g_keyObj[`keyGroupOrder${keyCtrlPtn}`] ?? tkObj.keyGroupList;
 
-		const availW = g_btnWidth() + (configKeyGroupList.length > 1 ? -60 : 0);
+		const availW = g_btnWidth() + (configKeyGroupList.length > 1 ? -g_lblPosObj.lnkKeySwitch.w - 10 : 0);
 		const availH = g_sHeight - 200 - LEGEND_H;  // 下部 UI ぶんを除いた高さ
 
 		// 縦幅基準: MAIN/NAV 高さ と テンキー高さ（余白込み）の大きい方
@@ -11473,7 +11473,7 @@ const keyconfigKeyboardPreview = (() => {
 		const scaleH = availH / totalH;
 		_state.scale = Math.min(scaleW, scaleH, 1.5);  // 最大 1.5 倍まで拡大可
 
-		_state.cvsX = configKeyGroupList.length > 1 ? -30 : 0;
+		_state.cvsX = configKeyGroupList.length > 1 ? (-g_lblPosObj.lnkKeySwitch.w - 10) / 2 : 0;
 		_state.cvsW = Math.floor(totalW * _state.scale);
 		_state.cvsH = Math.floor(totalH * _state.scale) + LEGEND_H;
 	};

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10757,6 +10757,7 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 				document.getElementById(`key${_num}`).classList.replace(g_cssObj.button_Mini, g_cssObj.button_Next);
 			}
 		}
+		keyconfigKeyboardPreview.refresh();
 	};
 
 	/**
@@ -11415,6 +11416,7 @@ const keyconfigKeyboardPreview = (() => {
 		canvasMap: null,
 		keyDataList: [],          // { code, x, y, w, h, label } — drawMap で照合するキャッシュ
 		scale: 1,                 // BASE_KEY_W/H に掛けるスケール係数
+		cvsX: 0,                  // Canvas の左上 X 座標（divRoot 内の相対座標）
 		cvsW: 500,                // 実際の Canvas 幅（スケール計算後）
 		cvsH: 240,                // 実際の Canvas 高さ（スケール計算後）
 	};
@@ -11456,7 +11458,12 @@ const keyconfigKeyboardPreview = (() => {
 		const totalW = baseMainW + BASE_KEY_GAP * 2 + BASE_NAV_W + BASE_KEY_GAP * 2
 			+ BASE_KEY_GAP * 3 + BASE_NUM_W;
 
-		const availW = g_btnWidth();
+		const tkObj = getKeyInfo();
+		const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
+		const configKeyGroupList = g_headerObj.keyGroupOrder[g_stateObj.scoreId] ??
+			g_keyObj[`keyGroupOrder${keyCtrlPtn}`] ?? tkObj.keyGroupList;
+
+		const availW = g_btnWidth() + (configKeyGroupList.length > 1 ? -60 : 0);
 		const availH = g_sHeight - 200 - LEGEND_H;  // 下部 UI ぶんを除いた高さ
 
 		// 縦幅基準: MAIN/NAV 高さ と テンキー高さ（余白込み）の大きい方
@@ -11466,6 +11473,7 @@ const keyconfigKeyboardPreview = (() => {
 		const scaleH = availH / totalH;
 		_state.scale = Math.min(scaleW, scaleH, 1.5);  // 最大 1.5 倍まで拡大可
 
+		_state.cvsX = configKeyGroupList.length > 1 ? -30 : 0;
 		_state.cvsW = Math.floor(totalW * _state.scale);
 		_state.cvsH = Math.floor(totalH * _state.scale) + LEGEND_H;
 	};
@@ -11738,7 +11746,7 @@ const keyconfigKeyboardPreview = (() => {
 		divRoot.appendChild(btn);
 
 		// プレビューエリア: 水平・垂直センタリング
-		const areaX = g_btnX() + Math.floor((g_btnWidth() - _state.cvsW) / 2);
+		const areaX = g_btnX() + Math.floor((g_btnWidth() - _state.cvsW) / 2) + _state.cvsX;
 		const areaY = 130;
 
 		const areaDiv = createEmptySprite(divRoot, C_PREVIEW_ID, {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. improve: キーコンフィグ画面でキーボードマッププレビュー表示時でもkeySwitchできるよう改善
- キーコンフィグ画面でキーボードマッププレビュー表示時、keySwitchできる場合にはボタンが隠れてしまい、
切替できない状態でしたが、ボタン分だけ幅を狭めるように変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. keySwitchしないといけないキーモードでは、キーボードマップを表示したまま切り替えたい場面が想定されるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/099004fa-a0f8-4953-b5f1-3bce9f620365" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
