### PR TITLE
fix: [1133] Ex-Setting画面で設定名が長いとき、拡張ボタンがある前提でフォントサイズが変更される問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10115,7 +10115,7 @@ const createGeneralSettingEx = (_spriteList, _name, { defaultList = [C_FLG_OFF],
 			$id(`lnk${camelH}`).left = wUnit(g_limitObj.setLblLeftShort);
 			$id(`lnk${camelH}`).width = wUnit(g_limitObj.setLblWidthShort);
 		}
-		$id(`lnk${camelH}`).fontSize = wUnit(getFontSize2(getStgDetailName(g_stateObj[_name]), g_limitObj.setLblWidthShort, { maxSiz: g_limitObj.setLblSiz }));
+		$id(`lnk${camelH}`).fontSize = wUnit(getFontSize2(getStgDetailName(g_stateObj[_name]), g_limitObj.setLblWidthShort - 10, { maxSiz: g_limitObj.setLblSiz }));
 	};
 
 	/**

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10106,7 +10106,8 @@ const createGeneralSettingEx = (_spriteList, _name, { defaultList = [C_FLG_OFF],
 	 */
 	const setExpandedBtnSiz = () => {
 		const camelH = toCapitalize(_name);
-		if (defaultList.includes(g_stateObj[_name])) {
+		const isDefault = defaultList.includes(g_stateObj[_name]);
+		if (isDefault) {
 			$id(`lnk${camelH}Type`).display = C_DIS_NONE;
 			$id(`lnk${camelH}`).left = wUnit(g_limitObj.setLblLeft);
 			$id(`lnk${camelH}`).width = wUnit(g_limitObj.setLblWidth);
@@ -10115,7 +10116,8 @@ const createGeneralSettingEx = (_spriteList, _name, { defaultList = [C_FLG_OFF],
 			$id(`lnk${camelH}`).left = wUnit(g_limitObj.setLblLeftShort);
 			$id(`lnk${camelH}`).width = wUnit(g_limitObj.setLblWidthShort);
 		}
-		$id(`lnk${camelH}`).fontSize = wUnit(getFontSize2(getStgDetailName(g_stateObj[_name]), g_limitObj.setLblWidthShort - 10, { maxSiz: g_limitObj.setLblSiz }));
+		const labelWidth = isDefault ? g_limitObj.setLblWidth : g_limitObj.setLblWidthShort - 10;
+		$id(`lnk${camelH}`).fontSize = wUnit(getFontSize2(getStgDetailName(g_stateObj[_name]), labelWidth, { maxSiz: g_limitObj.setLblSiz }));
 	};
 
 	/**


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. fix: Ex-Setting画面で設定名が長いとき、拡張ボタンがある前提でフォントサイズが変更される問題を修正
- 拡張設定ボタンの有無を含む設定では、拡張ボタンの有無によってフォントサイズが変わるべきですが、そうなっていませんでした。その問題を修正しています。

### 2. fix: 設定画面で拡張設定ボタンがあるときに、設定名が長いと通常ボタン側の名称が収まらない問題を修正
- 具体的にはEx-Settings画面でのCamoufrage設定の「Color+Step+Arrow」で起こります。
- 以前は問題ありませんでしたが、ブラウザの仕様変更でborderが従来よりやや大きくなったため対処が必要になりました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 想定より短い設定名でフォントサイズが小さくなることがあるため。
2. ブラウザの仕様変更への対応のため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/682dbd29-3bd3-4316-8d58-c2873902c743" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- 1, 2双方、ver46.0.0 ( PR #2011 ) で対応した内容の考慮漏れです。