### PR TITLE
fix: [1135] カスタムキー定義のlayerTransXについて、Reverseの反転に対応できていない問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -12903,8 +12903,11 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 				const arrowNum = parseFloat(tmpScrollchData[1]);
 				const scrollDir = parseFloat(tmpScrollchData[2] ?? `1`);
 				const layerGroup = parseFloat(tmpScrollchData[3] ?? `-1`);
-				const layerTrans = tmpScrollchData[4] ?? ``;
+				let layerTrans = tmpScrollchData[4] ?? ``;
 				maxLayerGroup = Math.max(maxLayerGroup, layerGroup);
+				if (g_stateObj.reverse === C_FLG_ON) {
+					layerTrans = invertSpecificTransforms(layerTrans);
+				}
 
 				scrollchData.push([frame, arrowNum, frame, scrollDir, layerGroup, layerTrans]);
 			});

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -14062,6 +14062,32 @@ const pushScrollchs = (_header, _frameArrow, _val, _frameStep, _scrollDir, _laye
 };
 
 /**
+ * ホワイトリストに登録されたCSS関数内の数値符号のみを反転する関数
+ * @param {string} cssString 
+ * @returns {string} 
+ */
+const invertSpecificTransforms = (cssString) => {
+	// 1. 反転対象にしたいCSS関数名を指定（ホワイトリスト）
+	const targetFunctions = [
+		'rotate', 'rotateX', 'rotateY', 'rotateZ', 'rotate3d',
+		'translate', 'translateX', 'translateY', 'translateZ', 'translate3d',
+		'skew', 'skewX', 'skewY'
+	];
+
+	// RegExパターンを作成: /(rotate|translate...)\(([^)]+)\)/g
+	const pattern = new RegExp(`\\b(${targetFunctions.join('|')})\\(([^)]+)\\)`, 'g');
+
+	return cssString.replace(pattern, (match, funcName, args) => {
+		// 関数の中身（引数）に含まれる数値だけを符号反転
+		const invertedArgs = args.replace(/(-?\d+(?:\.\d+)?)/g, (numStr) => {
+			return numStr.startsWith('-') ? numStr.slice(1) : '-' + numStr;
+		});
+
+		return `${funcName}(${invertedArgs})`;
+	});
+}
+
+/**
  * メイン画面前の初期化処理
  */
 const getArrowSettings = () => {
@@ -14095,6 +14121,7 @@ const getArrowSettings = () => {
 	g_workObj.diffList = [];
 	g_workObj.mainEndTime = 0;
 	g_workObj.currentLifeState = ``;
+	g_workObj.layerTrans = [];
 	g_errorCache['g_customJsObj.mainEnterFrame'] = [];
 
 	const rotateBy = (val, delta) => {
@@ -14133,6 +14160,13 @@ const getArrowSettings = () => {
 
 	g_workObj.keyGroupMaps = tkObj.keyGroupMaps;
 	g_workObj.keyGroupList = tkObj.keyGroupList;
+
+	if (g_keyObj[`layerTrans${keyCtrlPtn}`]?.[0]) {
+		g_workObj.layerTrans = structuredClone(g_keyObj[`layerTrans${keyCtrlPtn}`][0]);
+		if (g_stateObj.reverse === C_FLG_ON) {
+			g_workObj.layerTrans = g_workObj.layerTrans.map(val => invertSpecificTransforms(val));
+		}
+	}
 
 	const keyCtrlLen = g_workObj.keyCtrl.length;
 	g_workObj.keyCtrlN = [...Array(keyCtrlLen)].map(() => []);
@@ -14630,7 +14664,7 @@ const mainInit = () => {
 		// StepAreaオプションにより、レイヤーが倍化される場合があるため基準レイヤー数ごとに設定
 		const transj = j % g_stateObj.layerNumDf;
 		addTransform(`mainSprite${j}`, `mainSprite${j}`,
-			g_keyObj[`layerTrans${keyCtrlPtn}`]?.[0]?.[Math.floor(transj / 2) * 2 + (transj + Number(g_stateObj.reverse === C_FLG_ON)) % 2], g_transPriority.layer);
+			g_workObj.layerTrans[Math.floor(transj / 2) * 2 + (transj + Number(g_stateObj.reverse === C_FLG_ON)) % 2], g_transPriority.layer);
 
 		stepSprite.push(createEmptySprite(mainSpriteJ, `stepSprite${j}`, mainCommonPos));
 		arrowSprite.push(createEmptySprite(mainSpriteJ, `arrowSprite${j}`, { ...mainCommonPos, y: g_workObj.hitPosition * (j % 2 === 0 ? 1 : -1) }));

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -14070,20 +14070,20 @@ const pushScrollchs = (_header, _frameArrow, _val, _frameStep, _scrollDir, _laye
  * @returns {string} 
  */
 const invertSpecificTransforms = (cssString) => {
-	// 1. 反転対象にしたいCSS関数名を指定（ホワイトリスト）
+	// 反転対象にしたいCSS関数名を指定（ホワイトリスト）
 	const targetFunctions = [
-		'rotate', 'rotateX', 'rotateY', 'rotateZ', 'rotate3d',
-		'translate', 'translateX', 'translateY', 'translateZ', 'translate3d',
-		'skew', 'skewX', 'skewY'
+		`rotate`, `rotateX`, `rotateY`, `rotateZ`, `rotate3d`,
+		`translate`, `translateX`, `translateY`, `translateZ`, `translate3d`,
+		`skew`, `skewX`, `skewY`
 	];
 
 	// RegExパターンを作成: /(rotate|translate...)\(([^)]+)\)/g
-	const pattern = new RegExp(`\\b(${targetFunctions.join('|')})\\(([^)]+)\\)`, 'g');
+	const pattern = new RegExp(`\\b(${targetFunctions.join(`|`)})\\(([^)]+)\\)`, `g`);
 
 	return cssString.replace(pattern, (match, funcName, args) => {
 		// 関数の中身（引数）に含まれる数値だけを符号反転
 		const invertedArgs = args.replace(/(-?\d+(?:\.\d+)?)/g, (numStr) => {
-			return numStr.startsWith('-') ? numStr.slice(1) : '-' + numStr;
+			return numStr.startsWith(`-`) ? numStr.slice(1) : `-` + numStr;
 		});
 
 		return `${funcName}(${invertedArgs})`;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. fix: カスタムキー定義のlayerTransXについて、Reverseの反転に対応できていない問題を修正

- カスタムキー定義のlayerTransXでスクロール方向により別のtransitionを指定している場合、
Reverse設定を行うと想定しない方向にステップゾーンや矢印が表示される問題が発生していました。
- 今回の変更で、Reverse設定時はTranstionの設定を反転した内容を反映するように変更します。
  - 例. `rotate(30deg)` -> `rotate(-30deg)`
- なお、反転の対象は限定しています。scaleのように逆転すると困るケースがあるためです。
```javascript
	const targetFunctions = [
		'rotate', 'rotateX', 'rotateY', 'rotateZ', 'rotate3d',
		'translate', 'translateX', 'translateY', 'translateZ', 'translate3d',
		'skew', 'skewX', 'skewY'
	];
```
- スクロール反転・階層移動（scrollch_data）にも同様の処理があり、対処済みです。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. layerTransXでReverseでの動きを想定していなかったため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
