### PR TITLE
fix: [1136] 11keyの譜面で11L, 11ikeyモードでプレイしたときに割当先の譜面がおかしくなる問題を修正

### DIFF
--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3343,12 +3343,13 @@ const g_keyObj = {
     chara5_2: [`left`, `down`, `space`, `up`, `right`],
     chara8_2: [`sleft`, `left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
     chara9h_2: [`1x`, `ax`, `zx`, `sx`, `hx`, `yx`, `ux`, `mx`, `ix`],
-    chara11_2: [`left`, `sleft`, `sdown`, `leftdia`, `down`, `space`,
-        `up`, `sup`, `sright`, `rightdia`, `right`],
     chara11L_2: [`left`, `sleft`, `sdown`, `leftdia`, `down`, `space`,
         `up`, `sup`, `sright`, `rightdia`, `right`],
 
     chara9h_3: [`1x`, `ax`, `zx`, `sx`, `hx`, `yx`, `ux`, `mx`, `ix`],
+    chara11_3: [`left`, `sleft`, `sdown`, `leftdia`, `down`, `space`,
+        `up`, `sup`, `sright`, `rightdia`, `right`],
+
     chara9h_4: [`1x`, `ax`, `gor`, `zx`, `sx`, `hx`, `yx`, `ux`, `siyo`, `mx`, `ix`],
     chara9h_5: [`1x`, `ax`, `zx`, `sx`, `hx`, `yx`, `ux`, `mx`, `ix`],
     chara9h_6: [`1x`, `ax`, `zx`, `sx`, `hx`, `yx`, `ux`, `mx`, `ix`],


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. fix: 11keyの譜面で11L, 11ikeyモードでプレイしたときに割当先の譜面がおかしくなる問題を修正
- 11keyの譜面で11L, 11ikeyモードでプレイしたとき、割当先がおかしくなっていました。
この問題を修正しています。
- 11keyのキーパターン2をver44.1.0で増やしましたが、そのときに全体的に別キーモードのキーパターン番号が変わりました。基本的にはその対応を行っていましたが、g_keyObj.chara11_Xのみ設定が反映されていませんでした。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. Discordでの指摘より。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- v44.1.0が原因の不具合になります。