### PR TITLE
feat: [1138] デバッグモード時にレーンごとの変数名をキーコンフィグ画面上に表示する機能を追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10419,6 +10419,13 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 				}, g_cssObj.button_Default_NoColor, g_cssObj.title_base)
 			);
 		}
+		if (g_isDebug) {
+			keyconSprite.appendChild(
+				createDivCss2Label(`arrowChara${j}`, g_keyObj[`chara${keyCtrlPtn}`][j], {
+					x: keyconX, y: keyconY + 40, w: C_ARW_WIDTH, h: 10, siz: 10, align: C_ALIGN_CENTER, background: `rgba(0,0,0,0.5)`,
+				}, g_cssObj.title_base)
+			);
+		}
 
 		// 割り当て先のキー名を表示
 		for (let k = 0; k < g_keyObj[`keyCtrl${keyCtrlPtn}`][j].length; k++) {
@@ -10729,6 +10736,9 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 			$id(`color${_j}`).display = _display;
 			if (document.getElementById(`sArrow${_j}`) !== null) {
 				$id(`sArrow${_j}`).display = _display;
+			}
+			if (document.getElementById(`arrowChara${_j}`) !== null) {
+				$id(`arrowChara${_j}`).display = _display;
 			}
 			const ctrlPtn = g_keyObj[`keyCtrl${g_headerObj.keyLabels[g_stateObj.scoreId]}_${g_keyObj.currentPtn}`][_j];
 			for (let k = 0; k < ctrlPtn.length; k++) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -10422,7 +10422,8 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 		if (g_isDebug) {
 			keyconSprite.appendChild(
 				createDivCss2Label(`arrowChara${j}`, g_keyObj[`chara${keyCtrlPtn}`][j], {
-					x: keyconX, y: keyconY + 40, w: C_ARW_WIDTH, h: 10, siz: 10, align: C_ALIGN_CENTER, background: `rgba(0,0,0,0.5)`,
+					x: keyconX, y: keyconY + 40, w: C_ARW_WIDTH, h: 10, siz: 10, align: C_ALIGN_CENTER,
+					background: g_headerObj.baseBrightFlg ? `rgba(255,255,255,0.5)` : `rgba(0,0,0,0.5)`,
 				}, g_cssObj.title_base)
 			);
 		}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. feat: デバッグモード時にレーンごとの変数名をキーコンフィグ画面上に表示する機能を追加
- デバッグモード（ローカル起動含む）のときにキーコンフィグ画面上に
レーンごとの変数名を表示するようにしました。通常公開時は表示しません。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. カスタムキー定義時や別キーモード時の設定間違いを画面上で確認しやすくするため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/6bc8acd4-99f4-424d-9800-01711685a1f9" />
<img width="80%" alt="image" src="https://github.com/user-attachments/assets/7e3c1568-414d-4bed-854d-85c9e6f6cdfe" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
