### PR TITLE
feat: [1139] 別キーモード時に対応するキーのキーコンフィグを読み込みできる機能を実装

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -5619,6 +5619,8 @@ const keysConvert = (_dosObj, { keyExtraList = _dosObj.keyExtraList?.split(`,`) 
 					},
 				});
 			}
+			// カスタムキーで定義されたtransKeyPtnを補完
+			completeTransKeyPtn([newKey]);
 
 			// keyRetry, keyTitleBackのキー名をキーコードに変換
 			const keyTypePatterns = Object.keys(g_keyObj).filter(val => val.startsWith(`keyRetry${newKey}`) || val.startsWith(`keyTitleBack${newKey}`));
@@ -8079,6 +8081,59 @@ const drawMinimap = (_scoreId, { _initFlg = false, _fadeinFlg = false } = {}) =>
 };
 
 /**
+ * 指定したキー名のキー別ストレージオブジェクトを取得
+ * @param {string} _keyName
+ * @returns {[Object, string]} [storageObj, addKey]
+ */
+const getKeyStorageObjByName = (_keyName) => {
+	if (g_headerObj.keyExtraList.includes(_keyName)) {
+		return [g_localStorage, _keyName];
+	}
+	return [parseStorageData(`danonicw-${_keyName}k`, {
+		reverse: C_FLG_OFF, keyCtrl: [[]], keyCtrlPtn: 0, setColor: [],
+	}), ``];
+};
+
+/**
+ * 別キーモード時、移行先キーが保持するSelf保存パターンの取得可否チェック
+ * @param {string} _keyCtrlPtn 例: "7_2"
+ * @returns {number[][]|undefined} 適用可能な場合はSelf保存済みkeyCtrl配列、不可ならundefined
+ */
+const getTransKeySelfCtrl = (_keyCtrlPtn) => {
+	const transKeyName = g_keyObj[`transKey${_keyCtrlPtn}`];
+	const transKeyPtn = g_keyObj[`transKeyPtn${_keyCtrlPtn}`];
+	if (!hasVal(transKeyName) || transKeyPtn === undefined) {
+		return undefined;
+	}
+	const [storageObj, addKey] = getKeyStorageObjByName(transKeyName);
+	const savedCtrl = storageObj[`keyCtrl${addKey}`];
+	const savedPtn = storageObj[`keyCtrlPtn${addKey}`];
+
+	if (!hasArrayList(savedCtrl?.[0], 1) || savedPtn !== transKeyPtn) {
+		return undefined;
+	}
+	return savedCtrl;
+};
+
+/**
+ * 別キーモードの移行先Selfパターンを現在のキー配置へ反映（保存はしない）
+ */
+const applyTransKeySelfPattern = () => {
+	const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
+	const savedCtrl = getTransKeySelfCtrl(keyCtrlPtn);
+	if (savedCtrl === undefined) {
+		return;
+	}
+	const baseKeyNum = g_keyObj[`${g_keyObj.defaultProp}${keyCtrlPtn}`].length;
+	for (let j = 0; j < baseKeyNum; j++) {
+		for (let k = 0; k < (savedCtrl[j]?.length ?? 0); k++) {
+			g_keyObj[`keyCtrl${keyCtrlPtn}`][j][k] = setIntVal(savedCtrl[j][k], 0);
+		}
+	}
+	keyConfigInit();
+};
+
+/**
  * 譜面初期化処理
  * - 譜面の基本設定（キー数、初期速度、リバース、ゲージ設定）をここで行う
  * - g_canLoadDifInfoFlg は譜面初期化フラグで、初期化したくない場合は対象画面にて false にしておく
@@ -8114,24 +8169,11 @@ const setDifficulty = (_initFlg) => {
 			g_keyObj.currentPtn = 0;
 			g_keycons.keySwitchNum = 0;
 		}
-		let storageObj, addKey = ``;
-
-		if (!g_stateObj.extraKeyFlg) {
-
-			// キー別のローカルストレージの初期設定 ※特殊キーは除く
-			g_localKeyStorage = parseStorageData(`danonicw-${g_keyObj.currentKey}k`, {
-				reverse: C_FLG_OFF,
-				keyCtrl: [[]],
-				keyCtrlPtn: 0,
-				setColor: [],
-			});
-			storageObj = g_localKeyStorage;
-
-		} else {
-			storageObj = g_localStorage;
-			addKey = g_keyObj.currentKey;
-		}
+		const [storageObj, addKey] = getKeyStorageObjByName(g_keyObj.currentKey);
 		if (isNotSameKey) {
+			if (!g_stateObj.extraKeyFlg) {
+				g_localKeyStorage = storageObj;
+			}
 			getKeyReverse(storageObj, addKey);
 
 			// キーコンフィグ初期値設定
@@ -11088,6 +11130,18 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 	);
 	toggleKcDesc();
 
+	// Selfパターン取込ボタン（条件成立時のみ表示）
+	const keyCtrlPtnForSelf = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
+	if (getTransKeySelfCtrl(keyCtrlPtnForSelf) !== undefined) {
+		divRoot.appendChild(
+			createCss2Button(`btnPtnSelf`, `Self`, () => applyTransKeySelfPattern(), {
+				x: g_lblPosObj.lblPattern.x + g_lblPosObj.lblPattern.w - 50,
+				y: g_lblPosObj.lblPattern.y - 14,
+				w: 50, h: 14, siz: 10, title: g_msgObj.ptnSelfImport,
+			}, g_cssObj.button_Mini)
+		);
+	}
+
 	// キーボード押下時処理
 	setShortcutEvent(g_currentPage, (kbCode) => {
 		const C_KEY_ESCAPE = 27;
@@ -11188,6 +11242,35 @@ const keyConfigInit = (_kcType = g_kcType, _initFlg = false) => {
 	safeExecuteCustomHooks(`g_skinJsObj.keyconfig`, g_skinJsObj.keyconfig);
 	document.onkeyup = evt => commonKeyUp(evt);
 	document.oncontextmenu = () => false;
+};
+
+/**
+ * transKeyPtnの自動補完処理
+ * - 明示指定(transKeyPtn)が無いパターンについて、
+ *   キー内で同一のtransKey対象へ向かうパターンを出現順(パターン番号昇順)に
+ *   0から連番で補完する
+ * @param {string[]} _keyList 対象とするキー名一覧
+ */
+const completeTransKeyPtn = (_keyList) => {
+	_keyList.forEach(keyName => {
+		const counterMap = {};
+		let ptnNum = 0;
+		while (g_keyObj[`keyCtrl${keyName}_${ptnNum}`] !== undefined) {
+			const keyPtn = `${keyName}_${ptnNum}`;
+			const targetKey = g_keyObj[`transKey${keyPtn}`];
+			if (hasVal(targetKey)) {
+				if (g_keyObj[`transKeyPtn${keyPtn}`] === undefined) {
+					counterMap[targetKey] = counterMap[targetKey] ?? 0;
+					g_keyObj[`transKeyPtn${keyPtn}`] = counterMap[targetKey];
+					counterMap[targetKey]++;
+				} else {
+					// 明示指定がある場合は以降の自動採番と重複しないよう位置を合わせる
+					counterMap[targetKey] = Math.max(counterMap[targetKey] ?? 0, g_keyObj[`transKeyPtn${keyPtn}`] + 1);
+				}
+			}
+			ptnNum++;
+		}
+	});
 };
 
 const toggleKcDesc = () => {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8109,10 +8109,17 @@ const getTransKeySelfCtrl = (_keyCtrlPtn) => {
 	const savedCtrl = storageObj[`keyCtrl${addKey}`];
 	const savedPtn = storageObj[`keyCtrlPtn${addKey}`];
 
-	if (!hasArrayList(savedCtrl?.[0], 1) || savedPtn !== transKeyPtn) {
+	if (savedPtn !== transKeyPtn) {
 		return undefined;
 	}
-	return savedCtrl;
+
+	// 現在のキー配置(基準形状)とレーン数・各レーン長が完全一致することを確認
+	const baseCtrl = g_keyObj[`keyCtrl${_keyCtrlPtn}`];
+	const isValidShape = hasArrayList(savedCtrl, baseCtrl.length) &&
+		savedCtrl.length === baseCtrl.length &&
+		baseCtrl.every((lane, j) => hasArrayList(savedCtrl[j], lane.length) && savedCtrl[j].length === lane.length);
+
+	return isValidShape ? savedCtrl : undefined;
 };
 
 /**

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -4905,7 +4905,7 @@ const g_lang_lblNameObj = {
         kcShortcutDesc: `Shortcut during play:`,
         kcShortcutDesc1: `Return to title: {0}`,
         kcShortcutDesc2: `Retry the game: {1}`,
-        transKeyDesc: `Key config, Color type, etc. are not saved in another key mode`,
+        transKeyDesc: `Key config, Color type, etc. are not saved for alternate keymode`,
         colorTypeDesc: `With the current ColorType setting, color change (Display:Color) will be automatically turned OFF.`,
         sdShortcutDesc: `When "Hidden+" or "Sudden+" select, "pageUp" cover up / "pageDown" cover down`,
         displayPreviewDesc: `If you drag the judgment character section or shortcut display, it will be adjusted to that position.`,
@@ -5185,7 +5185,7 @@ const g_lang_msgObj = {
         pickColorR: `Switches the arrow color type to be set.`,
         pickColorCopy: `Pressing this button will override the color scheme of the freeze arrow with the frame color of the arrow. \nIt also overrides the color of the freeze arrow on hit.`,
         pickColorReset: `Restore the color scheme for arrows and freeze arrows.`,
-        ptnSelfImport: `Load the key config saved in the corresponding another keymode.`,
+        ptnSelfImport: `Load the key config saved for the corresponding alternate keymode.`,
 
         customFunctionError: `An error occurred during the first execution. This process will be ignored until the error is resolved.`,
     },

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -3676,7 +3676,7 @@ const g_keyObj = {
     keyTitleBack11j_0: 27,  // 27: Escape
 
     // 別キー
-    transKey8_2: '12',
+    transKey8_2: '12u',
     transKey15A_1: '15B',   // 15A/15Bはキーパターンをコピーして生成するため、transKeyを明示的に指定
     transKey15B_0: '',      // 15A/15Bはキーパターンをコピーして生成するため、transKeyを明示的に指定
 
@@ -4136,6 +4136,9 @@ g_keycons.groups.forEach(type => {
     tmpName.forEach(property => g_keyObj[`${property.slice(0, -2)}`] = g_keyObj[property].concat());
 });
 
+// デフォルトで定義されたキーパターンのtransKeyPtnを補完する
+completeTransKeyPtn(g_keyObj.defaultKeyList);
+
 // 外部エディター用テンプレート
 // g_editorTmp: Dancing☆Onigiriエディター (CW Edition対応)
 // g_editorTmp2: ダンおに譜面作成エディタ ver3.x
@@ -4177,7 +4180,7 @@ const g_editorTmp2Template = `
 // 後でプロパティ削除に影響するため、先頭文字が全く同じ場合は長い方を先に定義する (例: divMax, div)
 const g_keyCopyLists = {
     simpleDef: [`blank`, `scale`],
-    simple: [`divMax`, `div`, `blank`, `scale`, `keyRetry`, `keyTitleBack`, `transKey`, `scrollDir`, `assistPos`, `flatMode`],
+    simple: [`divMax`, `div`, `blank`, `scale`, `keyRetry`, `keyTitleBack`, `transKeyPtn`, `transKey`, `scrollDir`, `assistPos`, `flatMode`],
     multiple: [`chara`, `color`, `stepRtn`, `pos`, `shuffle`, `keyGroupOrder`, `keyGroup`, `layerGroup`, `layerTrans`],
 };
 
@@ -5073,6 +5076,7 @@ const g_lang_msgObj = {
         pickColorR: `設定する矢印色の種類を切り替えます。`,
         pickColorCopy: `このボタンを押すと、フリーズアローの配色を矢印（枠）の色で上書きします。\nヒット時のフリーズアローの色も上書きします。`,
         pickColorReset: `矢印・フリーズアローの配色を元に戻します。`,
+        ptnSelfImport: `対応する別キーで保存されているキーコンフィグを読み込みます。`,
 
         customFunctionError: `初回の実行エラーが発生しました。修正されるまでこの処理は無視されます。`,
     },
@@ -5181,6 +5185,7 @@ const g_lang_msgObj = {
         pickColorR: `Switches the arrow color type to be set.`,
         pickColorCopy: `Pressing this button will override the color scheme of the freeze arrow with the frame color of the arrow. \nIt also overrides the color of the freeze arrow on hit.`,
         pickColorReset: `Restore the color scheme for arrows and freeze arrows.`,
+        ptnSelfImport: `Load the key config saved in the corresponding another keymode.`,
 
         customFunctionError: `An error occurred during the first execution. This process will be ignored until the error is resolved.`,
     },


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. feat: 別キーモード時に対応するキーのキーコンフィグを読み込みできる機能を実装

- 別キーモード時はこれまで、デフォルトのパターンが保存されずに表示されるのみでしたが、
対応するキーのキーコンフィグ情報があれば、読み込みできるようにしました。
- キー割り当てに関する部分のみです。色やシャッフルなどは復元しません。
- 従来通り、別キーモードのキーコンフィグ情報を上書きはしません。
- 保存したキーコンフィグと同一パターンが見つかった場合に、
「Self」というボタンがキーパターン表示の近くに表示されます。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 保存しているキーコンフィグ情報があるにもかかわらず、復元手段がないため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/80119c72-1b40-4984-8a2a-c2f4bdbcbb69" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
