### PR TITLE
fix: [1140] カスタムキー定義のlayerTransX適用時、符号の変換処理が一部間違っている問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -13007,7 +13007,10 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 				let layerTrans = tmpScrollchData[4] ?? ``;
 				maxLayerGroup = Math.max(maxLayerGroup, layerGroup);
 				if (g_stateObj.reverse === C_FLG_ON) {
-					layerTrans = invertSpecificTransforms(layerTrans);
+					layerTrans = layerTrans.map(val => invertSpecificTransforms(val, [`translateX`]));
+				}
+				if (g_stateObj.swapping === `Mirror+`) {
+					layerTrans = layerTrans.map(val => invertSpecificTransforms(val, [`translateY`]));
 				}
 
 				scrollchData.push([frame, arrowNum, frame, scrollDir, layerGroup, layerTrans]);
@@ -14168,15 +14171,17 @@ const pushScrollchs = (_header, _frameArrow, _val, _frameStep, _scrollDir, _laye
 /**
  * ホワイトリストに登録されたCSS関数内の数値符号のみを反転する関数
  * @param {string} cssString 
+ * @param {string[]} exceptList 反転対象から除外するCSS関数名のリスト
  * @returns {string} 
  */
-const invertSpecificTransforms = (cssString) => {
+const invertSpecificTransforms = (cssString, exceptList = []) => {
 	// 反転対象にしたいCSS関数名を指定（ホワイトリスト）
-	const targetFunctions = [
+	const baseTargetFunctions = [
 		`rotate`, `rotateX`, `rotateY`, `rotateZ`, `rotate3d`,
 		`translate`, `translateX`, `translateY`, `translateZ`, `translate3d`,
 		`skew`, `skewX`, `skewY`
 	];
+	const targetFunctions = baseTargetFunctions.filter(pattern => !exceptList.includes(pattern));
 
 	// RegExパターンを作成: /(rotate|translate...)\(([^)]+)\)/g
 	const pattern = new RegExp(`\\b(${targetFunctions.join(`|`)})\\(([^)]+)\\)`, `g`);
@@ -14268,7 +14273,12 @@ const getArrowSettings = () => {
 	if (g_keyObj[`layerTrans${keyCtrlPtn}`]?.[0]) {
 		g_workObj.layerTrans = structuredClone(g_keyObj[`layerTrans${keyCtrlPtn}`][0]);
 		if (g_stateObj.reverse === C_FLG_ON) {
-			g_workObj.layerTrans = g_workObj.layerTrans.map(val => invertSpecificTransforms(val));
+			// Reverse時はX軸反転のため、X軸の座標変換では符号を変換しない
+			g_workObj.layerTrans = g_workObj.layerTrans.map(val => invertSpecificTransforms(val, [`translateX`]));
+		}
+		if (g_stateObj.swapping === `Mirror+`) {
+			// Swapping: Mirror+ はY軸反転のため、Y軸の座標変換では符号を変換しない
+			g_workObj.layerTrans = g_workObj.layerTrans.map(val => invertSpecificTransforms(val, [`translateY`]));
 		}
 	}
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -13007,10 +13007,10 @@ const scoreConvert = (_dosObj, _scoreId, _preblankFrame, _dummyNo = ``,
 				let layerTrans = tmpScrollchData[4] ?? ``;
 				maxLayerGroup = Math.max(maxLayerGroup, layerGroup);
 				if (g_stateObj.reverse === C_FLG_ON) {
-					layerTrans = layerTrans.map(val => invertSpecificTransforms(val, [`translateX`]));
+					layerTrans = invertSpecificTransforms(layerTrans, [`translateX`]);
 				}
 				if (g_stateObj.swapping === `Mirror+`) {
-					layerTrans = layerTrans.map(val => invertSpecificTransforms(val, [`translateY`]));
+					layerTrans = invertSpecificTransforms(layerTrans, [`translateY`]);
 				}
 
 				scrollchData.push([frame, arrowNum, frame, scrollDir, layerGroup, layerTrans]);
@@ -14182,6 +14182,9 @@ const invertSpecificTransforms = (cssString, exceptList = []) => {
 		`skew`, `skewX`, `skewY`
 	];
 	const targetFunctions = baseTargetFunctions.filter(pattern => !exceptList.includes(pattern));
+	if (targetFunctions.length === 0) {
+		return cssString; // 反転対象がない場合は元の文字列を返す
+	}
 
 	// RegExパターンを作成: /(rotate|translate...)\(([^)]+)\)/g
 	const pattern = new RegExp(`\\b(${targetFunctions.join(`|`)})\\(([^)]+)\\)`, `g`);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. fix: カスタムキー定義のlayerTransX適用時、符号の変換処理が一部間違っている問題を修正
- カスタムキー定義のlayerTransX適用時、PR #2178 にてReverseによる符号の変換処理を導入しましたが、それでは不十分なパターンがあり、対応しました。
  - Reverse適用時はX軸を中心とした回転のため、translateXは符号変換から除外して残りは符号変換
  - Swapping: Mirror+適用時はY軸を中心とした回転のため、translateYは符号変換から除外して残りは符号変換

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 上記の理由のため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- ver39.1.0から発生している問題となります。
- なお、translate(X, Y)やtranslate3d(X, Y, Z)でも問題が起こりますが、対応が特殊なため見送ります。