### PR TITLE
feat: [1144] 背景・マスクモーションでカラーオブジェクトに対してレーン番号指定に対応、レイヤーに対してtransform指定に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2320,6 +2320,7 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 
 		const emptyPatterns = [`[loop]`, `[jump]`];
 		const colorObjFlg = tmpSpriteData[2]?.startsWith(`[c]`) || false;
+		const transformFlg = tmpSpriteData[2]?.startsWith(`[t]`) || false;
 		const spriteFrameData = spriteData[tmpFrame][dataCnts] = {
 			depth: tmpDepth,
 		};
@@ -2327,9 +2328,15 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 		if (colorObjFlg) {
 			// [c]始まりの場合、カラーオブジェクト用の作成準備を行う
 			const data = tmpObj.path.slice(`[c]`.length).split(`/`);
+			let objPart = data[0];
+			if (!isNaN(parseInt(data[0]))) {
+				const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
+				objPart = g_keyObj[`stepRtn${keyCtrlPtn}`][data[0]];
+				spriteFrameData.transform = parseInt(data[0]);
+			}
 			spriteFrameData.colorObjInfo = {
 				x: tmpObj.left, y: tmpObj.top, w: tmpObj.width, h: tmpObj.height,
-				rotate: setVal(data[0], `0`), opacity: tmpObj.opacity,
+				rotate: setVal(objPart, `0`), opacity: tmpObj.opacity,
 				background: makeColorGradation(setVal(data[1], `#ffffff`), { _defaultColorgrd: false }),
 				animationName: tmpObj.animationName,
 				animationDuration: `${tmpObj.animationDuration}s`,
@@ -2339,6 +2346,10 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 			if (tmpObj.animationFillMode !== undefined) {
 				spriteFrameData.colorObjInfo.animationFillMode = tmpObj.animationFillMode;
 			}
+		} else if (transformFlg) {
+			// [t]始まりの場合、レイヤーに対してtransformを掛ける準備を行う
+			const transformData = tmpObj.path.slice(`[t]`.length);
+			spriteFrameData.transform = transformData;
 
 		} else if (tmpObj.path === ``) {
 			spriteFrameData.command = ``;
@@ -2422,6 +2433,10 @@ const drawBaseSpriteData = (_spriteData, _name, _condition = true) => {
 		}
 	} else {
 		if (_condition) {
+			if (_spriteData.colorObjInfo === undefined && _spriteData.transform === undefined) {
+				baseSprite.innerHTML = convertStrToVal(_spriteData.htmlText);
+				return;
+			}
 			if (_spriteData.colorObjInfo !== undefined) {
 				const colorObjClass = _spriteData.colorObjClass?.split(`/`) ?? [];
 				const id = `${_name}${_spriteData.depth}${_spriteData.colorObjId}`;
@@ -2429,8 +2444,13 @@ const drawBaseSpriteData = (_spriteData, _name, _condition = true) => {
 				baseSprite.appendChild(
 					createColorObject2(id, _spriteData.colorObjInfo, ...colorObjClass)
 				);
-			} else {
-				baseSprite.innerHTML = convertStrToVal(_spriteData.htmlText);
+			}
+			if (_spriteData.transform !== undefined) {
+				if (!isNaN(parseInt(_spriteData.transform))) {
+					let mainTransform = getTransform(`mainSprite`, `playWindow`);
+					if (hasVal(mainTransform))
+						addTransform(`${_name}Sprite${_spriteData.depth}`, `main${_name}${_spriteData.depth}`, mainTransform);
+				}
 			}
 		}
 	}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2447,12 +2447,30 @@ const drawBaseSpriteData = (_spriteData, _name, _condition = true) => {
 				);
 			}
 			if (_spriteData.transform !== undefined) {
+				const targetId = `${_name}Sprite${_spriteData.depth}`;
+
 				if (!isNaN(parseInt(_spriteData.transform))) {
-					let mainTransform = getTransform(`mainSprite`, `playWindow`);
-					if (hasVal(mainTransform))
-						addTransform(`${_name}Sprite${_spriteData.depth}`, `${_name}${_spriteData.depth}`, mainTransform, g_transPriority.playWindow);
+					// PlayWindow由来のtransformを継承（別transformId）
+					const transformId = `${_name}${_spriteData.depth}PlayWindow`;
+					const transformData = getTransform(`mainSprite`, `playWindow`);
+
+					if (hasVal(transformData)) {
+						if (transformData !== getTransform(targetId, transformId)) {
+							addTransform(targetId, transformId, transformData, g_transPriority.playWindow);
+						}
+					} else {
+						delTransform(targetId, transformId);
+					}
 				} else {
-					addTransform(`${_name}Sprite${_spriteData.depth}`, `${_name}${_spriteData.depth}`, _spriteData.transform, parseInt(_spriteData.transPriority || 1000));
+					// 明示指定のtransformを適用
+					const transformId = `${_name}${_spriteData.depth}`;
+
+					if (hasVal(_spriteData.transform)) {
+						addTransform(targetId, transformId, _spriteData.transform,
+							parseInt(_spriteData.transPriority || 1000));
+					} else {
+						delTransform(targetId, transformId);
+					}
 				}
 			}
 		}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2349,7 +2349,7 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 		} else if (transformFlg) {
 			// [t]始まりの場合、レイヤーに対してtransformを掛ける準備を行う
 			const transformData = tmpObj.path.slice(`[t]`.length);
-			spriteFrameData.transform = transformData;
+			spriteFrameData.transform = transformData || ``;
 			spriteFrameData.transPriority = tmpObj.class;
 
 		} else if (tmpObj.path === ``) {
@@ -2450,9 +2450,9 @@ const drawBaseSpriteData = (_spriteData, _name, _condition = true) => {
 				if (!isNaN(parseInt(_spriteData.transform))) {
 					let mainTransform = getTransform(`mainSprite`, `playWindow`);
 					if (hasVal(mainTransform))
-						addTransform(`${_name}Sprite${_spriteData.depth}`, `main${_name}${_spriteData.depth}`, mainTransform, g_transPriority.playWindow);
+						addTransform(`${_name}Sprite${_spriteData.depth}`, `${_name}${_spriteData.depth}`, mainTransform, g_transPriority.playWindow);
 				} else {
-					addTransform(`${_name}Sprite${_spriteData.depth}`, `main${_name}${_spriteData.depth}`, _spriteData.transform, parseInt(_spriteData.transPriority || 1000));
+					addTransform(`${_name}Sprite${_spriteData.depth}`, `${_name}${_spriteData.depth}`, _spriteData.transform, parseInt(_spriteData.transPriority || 1000));
 				}
 			}
 		}

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2350,6 +2350,7 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 			// [t]始まりの場合、レイヤーに対してtransformを掛ける準備を行う
 			const transformData = tmpObj.path.slice(`[t]`.length);
 			spriteFrameData.transform = transformData;
+			spriteFrameData.transPriority = tmpObj.class;
 
 		} else if (tmpObj.path === ``) {
 			spriteFrameData.command = ``;
@@ -2449,7 +2450,9 @@ const drawBaseSpriteData = (_spriteData, _name, _condition = true) => {
 				if (!isNaN(parseInt(_spriteData.transform))) {
 					let mainTransform = getTransform(`mainSprite`, `playWindow`);
 					if (hasVal(mainTransform))
-						addTransform(`${_name}Sprite${_spriteData.depth}`, `main${_name}${_spriteData.depth}`, mainTransform);
+						addTransform(`${_name}Sprite${_spriteData.depth}`, `main${_name}${_spriteData.depth}`, mainTransform, g_transPriority.playWindow);
+				} else {
+					addTransform(`${_name}Sprite${_spriteData.depth}`, `main${_name}${_spriteData.depth}`, _spriteData.transform, parseInt(_spriteData.transPriority || 1000));
 				}
 			}
 		}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. feat: 背景・マスクモーションでカラーオブジェクトに対してレーン番号指定に対応
- 背景・マスクモーションでカラーオブジェクト指定する対象にレーン番号を指定できるようになりました。
- レーン番号を指定すると、レーン番号に対応する矢印・おにぎりが表示されます。
- また、PlayWindow設定が有効な場合に自動で設定に応じた回転が反映されるようになります。
```
|back_data=
7520,0,[c]4/#ccccff,,{g_workObj.stepX[4]},{g_posObj.stepY + g_posObj.reverseStepY * g_workObj.dividePos[4]},50,50,1,slide1-0,20,forwards
|
```

### 2. feat: 背景・マスクモーションで階層ごとにtransform指定が行える機能を追加
- 背景・マスクモーションの階層ごとに、transform指定が行えるようになりました。
- 階層の後に`[t]`に続いてtransform属性を指定します。
その後続けてカンマで優先度を指定します。（優先度の初期値は1000）
- 実態はaddTransform関数を使っています。transformIdは`アニメーション種類 + 階層`が割り当てられます
（例. back3, mask4）
```
|back_data=
7520,0,[t]rotate(30deg) translateX(-30px),400
8500,0,[t]    // 無指定で設定されているtransformを解除
|
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 実際のステップゾーンに続けてアニメーションさせたいときがあるため。
2. 階層の位置自体を変えたい場合があるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
