### PR TITLE
feat: [1145] 背景・マスクモーションで指定できるtransform指定についてid名の設定に対応

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2350,7 +2350,8 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 			// [t]始まりの場合、レイヤーに対してtransformを掛ける準備を行う
 			const transformData = tmpObj.path.slice(`[t]`.length);
 			spriteFrameData.transform = transformData || ``;
-			spriteFrameData.transPriority = tmpObj.class;
+			spriteFrameData.transformId = tmpObj.class;
+			spriteFrameData.transPriority = tmpObj.left;
 
 		} else if (tmpObj.path === ``) {
 			spriteFrameData.command = ``;
@@ -2463,7 +2464,7 @@ const drawBaseSpriteData = (_spriteData, _name, _condition = true) => {
 					}
 				} else {
 					// 明示指定のtransformを適用
-					const transformId = `${_name}${_spriteData.depth}`;
+					const transformId = _spriteData.transformId || `${_name}${_spriteData.depth}`;
 
 					if (hasVal(_spriteData.transform)) {
 						addTransform(targetId, transformId, _spriteData.transform,

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2303,10 +2303,12 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 			class: escapeHtml(tmpSpriteData[3] ?? ``),                          // CSSクラス
 			left: transformFlg
 				? setVal(tmpSpriteData[4], 1000, C_TYP_NUMBER)					// [t]のみtransformのPriority
-				: setVal(tmpSpriteData[4], `0`).includes(`{`) ?
-					`${setVal(tmpSpriteData[4], 0)}` : `{${setVal(tmpSpriteData[4], 0)}}`, // X座標
-			top: setVal(tmpSpriteData[5], `0`).includes(`{`) ?
-				`${setVal(tmpSpriteData[5], 0)}` : `{${setVal(tmpSpriteData[5], 0)}}`, // Y座標
+				: setVal(tmpSpriteData[4], `0`).includes(`{`)
+					? `${setVal(tmpSpriteData[4], 0)}`
+					: `{${setVal(tmpSpriteData[4], 0)}}`,                       // X座標
+			top: setVal(tmpSpriteData[5], `0`).includes(`{`)
+				? `${setVal(tmpSpriteData[5], 0)}`
+				: `{${setVal(tmpSpriteData[5], 0)}}`, 							// Y座標
 			width: `${setIntVal(tmpSpriteData[6])}`,                            // spanタグの場合は font-size
 			height: `${escapeHtml(tmpSpriteData[7] ?? ``)}`,                    // spanタグの場合は color(文字列可)
 			opacity: setVal(tmpSpriteData[8], 1, C_TYP_FLOAT),

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -2296,11 +2296,15 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 			maxDepth = tmpDepth;
 		}
 
+		const colorObjFlg = tmpSpriteData[2]?.startsWith(`[c]`) || false;
+		const transformFlg = tmpSpriteData[2]?.startsWith(`[t]`) || false;
 		const tmpObj = {
 			path: escapeHtml(tmpSpriteData[2] ?? ``, g_escapeStr.escapeCode),   // 画像パス or テキスト
 			class: escapeHtml(tmpSpriteData[3] ?? ``),                          // CSSクラス
-			left: setVal(tmpSpriteData[4], `0`).includes(`{`) ?
-				`${setVal(tmpSpriteData[4], 0)}` : `{${setVal(tmpSpriteData[4], 0)}}`, // X座標
+			left: transformFlg
+				? setVal(tmpSpriteData[4], 1000, C_TYP_NUMBER)					// [t]のみtransformのPriority
+				: setVal(tmpSpriteData[4], `0`).includes(`{`) ?
+					`${setVal(tmpSpriteData[4], 0)}` : `{${setVal(tmpSpriteData[4], 0)}}`, // X座標
 			top: setVal(tmpSpriteData[5], `0`).includes(`{`) ?
 				`${setVal(tmpSpriteData[5], 0)}` : `{${setVal(tmpSpriteData[5], 0)}}`, // Y座標
 			width: `${setIntVal(tmpSpriteData[6])}`,                            // spanタグの場合は font-size
@@ -2319,8 +2323,6 @@ const makeSpriteData = (_data, _calcFrame = _frame => _frame) => {
 			checkDuplicatedObjects(spriteData[tmpFrame]);
 
 		const emptyPatterns = [`[loop]`, `[jump]`];
-		const colorObjFlg = tmpSpriteData[2]?.startsWith(`[c]`) || false;
-		const transformFlg = tmpSpriteData[2]?.startsWith(`[t]`) || false;
 		const spriteFrameData = spriteData[tmpFrame][dataCnts] = {
 			depth: tmpDepth,
 		};
@@ -2467,8 +2469,7 @@ const drawBaseSpriteData = (_spriteData, _name, _condition = true) => {
 					const transformId = _spriteData.transformId || `${_name}${_spriteData.depth}`;
 
 					if (hasVal(_spriteData.transform)) {
-						addTransform(targetId, transformId, _spriteData.transform,
-							parseInt(_spriteData.transPriority || 1000));
+						addTransform(targetId, transformId, _spriteData.transform, _spriteData.transPriority);
 					} else {
 						delTransform(targetId, transformId);
 					}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. feat: 背景・マスクモーションで指定できるtransform指定についてid名の設定に対応
- PR #2195 の項番2でtransform指定を実装しましたが、transformIdが設定できるように仕様を一部変更しました。
```
|back_data=
7520,0,[t]rotate(30deg) translateX(-30px),newId,400
8500,0,[t],newId    // [t]の後にtransformIdを指定して対応するtransformを解除
|
```
|番号|論理名|設定例|内容|
|----|----|----|----|
|1|Frame|200|変更するタイミングのフレーム数を指定します。|
|2|Depth|0|背景の深度を数字で指定します。0以上の値を指定。<br>深度は大きくすることもできますが、その分背景スプライトの数が増えるので重くなる可能性があります。|
|3|**Transform**|[t]translateX(50px) translateY(50px)|`[t]transform属性` の形式で指定します。<br>transform属性を2つ以上重ねたいときは半角スペースで区切るか、別のtransformIdで指定します。|
|4|**TransformId**|back4_newId|transformId。階層ごとに独立。同じ値・同じ階層であれば上書きされる。デフォルトは`back もしくは mask + 階層の値`|
|5|Priority|20|transformの優先順設定。値が小さいほど前に配置する。既定は1000。<br>同一の場合は挿入順になる。|


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. transformIdを指定した方が自由度が上がるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
