### PR TITLE
fix: [1146] 初回プレイ時、別タブから復帰時などのケースで音源のオフセットずれが起きる問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -135,6 +135,19 @@ let g_fps = 60;
 // プレイ画面再生時の内部スケジューリング用のマージン時間(100ms)
 let g_scheduleLead = 0.1;
 
+// フレーム進行を音源クロック(AudioContext.currentTime)基準で補正するか
+// - false の場合は従来通り performance.now() 基準で動作
+let g_audioClockSync = true;
+
+// 出力遅延(AudioContext.outputLatency)をタイミング補正に含めるか
+// - true にすると出力デバイス(有線/Bluetooth等)によらず同じAdjustmentが使えるが、
+//   既存のAdjustment設定値と互換性がなくなるため既定は false
+let g_audioLatencyCompensation = false;
+
+// 次フレームまでの待機時間の上限(ms)
+// - 音源クロックが一時的に停止した際に待ち続けないようにするための保険
+let g_maxFrameWait = 50;
+
 // 譜面データの&区切りを有効にするか
 let g_enableAmpersandSplit = true;
 
@@ -2562,6 +2575,7 @@ class AudioPlayer {
 		this._gain = this._context.createGain();
 		this._gain.connect(this._context.destination);
 		this._startTime = 0;
+		this._scheduledTime = 0;
 		this._fadeinPosition = 0;
 		this._eventListeners = {};
 		this.playbackRate = 1;
@@ -2586,17 +2600,25 @@ class AudioPlayer {
 	 * - scheduleLead は安定した再生タイミングを確保するための内部マージン
 	 */
 	play(_adjustmentTime = 0) {
+		// AudioContextの時計は1回だけ読み、以降はその値を使い回す
+		// - currentTimeはレンダークォンタム単位でしか進まないため、複数回読むと
+		//   予約時刻と論理開始時刻が最大1クォンタム分ずれる
+		const ctxNow = this._context.currentTime;
+
 		this._source = this._context.createBufferSource();
 		this._source.buffer = this._buffer;
 		this._source.playbackRate.value = this.playbackRate;
 		this._source.connect(this._gain);
 
 		// 実際の予約時刻（内部スケジューリング用のマージンを含む）
-		const startAt = this._context.currentTime + g_scheduleLead + _adjustmentTime;
+		const startAt = ctxNow + g_scheduleLead + _adjustmentTime;
 		this._source.start(startAt, this._fadeinPosition);
 
 		// ゲーム側の論理的開始時刻（g_scheduleLead を含めない）
-		this._startTime = this._context.currentTime + _adjustmentTime;
+		this._startTime = ctxNow + _adjustmentTime;
+
+		// 実際に音が鳴り始めるAudioContext上の時刻（フレーム同期の基準）
+		this._scheduledTime = startAt;
 	}
 
 	pause() {
@@ -2619,6 +2641,26 @@ class AudioPlayer {
 
 	get elapsedTime() {
 		return this._context.currentTime - this._startTime + this._fadeinPosition;
+	}
+
+	/** AudioContextの現在時刻(秒) */
+	get contextTime() {
+		return this._context.currentTime;
+	}
+
+	/** 実際に音が鳴り始めるAudioContext上の時刻(秒) */
+	get scheduledTime() {
+		return this._scheduledTime;
+	}
+
+	/** 音が出力デバイスから実際に出るまでの遅延(秒) */
+	get outputLatency() {
+		return this._context.outputLatency || this._context.baseLatency || 0;
+	}
+
+	/** AudioContextの状態(running / suspended / closed) */
+	get contextState() {
+		return this._context.state;
 	}
 
 	set currentTime(_currentTime) {
@@ -2706,6 +2748,37 @@ const getSharedAudioContext = () => {
 		g_sharedAudioContext.resume();
 	}
 	return g_sharedAudioContext;
+};
+
+/**
+ * AudioContextのウォームアップ
+ * - 生成直後・resume直後のAudioContextは出力デバイスの起動待ちのため、
+ *   しばらく currentTime が進まない(環境により数十〜数百ms)
+ * - この状態で音源をスケジュールすると、起動に要した時間がそのまま
+ *   音源と譜面のずれになるため、無音を1回鳴らして時計が動き出すまで待つ
+ * @returns {Promise<void>}
+ */
+const warmUpAudioContext = async () => {
+	const ctx = getSharedAudioContext();
+	if (ctx.state !== `running`) {
+		await ctx.resume().catch(() => { });
+	}
+	if (ctx.state !== `running`) {
+		return; // ジェスチャー未取得等でresumeできない場合は何もしない
+	}
+
+	// 無音を1サンプルだけ鳴らして出力デバイスを起動させる
+	const source = ctx.createBufferSource();
+	source.buffer = ctx.createBuffer(1, 1, ctx.sampleRate);
+	source.connect(ctx.destination);
+	source.start();
+
+	// currentTimeが実際に進み始めるまで待機(最大500ms)
+	const baseTime = ctx.currentTime;
+	const limitTime = performance.now() + 500;
+	while (ctx.currentTime === baseTime && performance.now() < limitTime) {
+		await new Promise(resolve => setTimeout(resolve, 10));
+	}
 };
 
 /**
@@ -12208,6 +12281,9 @@ const loadMusic = async () => {
 	}
 
 	if (loadSucceeded) {
+		// 初回プレイ時に出力デバイスの起動待ちでずれるのを防ぐため、
+		// メイン画面へ移行する前にAudioContextを起動させておく
+		await warmUpAudioContext();
 		mainInit(); // 音源・譜面変換双方の完了後にまとめて呼ぶ
 	}
 };
@@ -14964,6 +15040,7 @@ const mainInit = () => {
 	let thisTime;
 	let buffTime;
 	let musicStartTime;
+	let musicStartCtxTime;
 	let musicStartFlg = false;
 
 	g_inputKeyBuffer = {};
@@ -16197,14 +16274,32 @@ const mainInit = () => {
 			}
 
 			// 60fpsから遅延するため、その差分を取って次回のタイミングで遅れをリカバリする
+			// - WebAudioAPI使用時は音源クロック(AudioContext.currentTime)を基準とする
+			//   performance.now()とAudioContextの時計は独立して進むため、後者を基準にしないと
+			//   再生開始時のオフセットずれやsuspend/resumeによるずれを吸収できない
 			thisTime = performance.now();
 			buffTime = 0;
-			if (g_audio instanceof AudioPlayer || currentFrame >= musicStartFrame) {
+			let holdFrame = false;
+
+			if (g_audio instanceof AudioPlayer && g_audioClockSync && musicStartCtxTime !== undefined) {
+				if (g_audio.contextState === `running`) {
+					buffTime = (g_audio.contextTime - musicStartCtxTime) * 1000
+						- (currentFrame - musicStartFrame) * 1000 / g_fps;
+				} else {
+					// AudioContext停止中は音源も止まっているため、フレーム進行も止めて復帰を待つ
+					getSharedAudioContext(); // suspended時はresumeを試行
+					holdFrame = true;
+				}
+			} else if (g_audio instanceof AudioPlayer || currentFrame >= musicStartFrame) {
 				buffTime = (thisTime - musicStartTime - (currentFrame - musicStartFrame) * 1000 / g_fps);
 			}
-			g_scoreObj.frameNum++;
-			g_scoreObj.baseFrame++;
-			g_timeoutEvtId = setTimeout(flowTimeline, 1000 / g_fps - buffTime);
+
+			if (!holdFrame) {
+				g_scoreObj.frameNum++;
+				g_scoreObj.baseFrame++;
+			}
+			g_timeoutEvtId = setTimeout(flowTimeline, holdFrame ? g_maxFrameWait :
+				Math.min(Math.max(1000 / g_fps - buffTime, 0), g_maxFrameWait));
 		}
 	};
 	safeExecuteCustomHooks(`g_skinJsObj.main`, g_skinJsObj.main);
@@ -16217,6 +16312,11 @@ const mainInit = () => {
 		const musicStartAdjustment = (g_headerObj.blankFrame - g_stateObj.decimalAdjustment + 1) / g_fps;
 		musicStartTime = performance.now() + (musicStartAdjustment + g_scheduleLead) * 1000;
 		g_audio.play(musicStartAdjustment);
+
+		// 音源クロック基準の開始時刻(フレーム進行の基準)
+		// - g_audioLatencyCompensationが有効な場合は出力遅延分だけ表示を後ろへずらす
+		musicStartCtxTime = g_audio.scheduledTime
+			+ (g_audioLatencyCompensation ? g_audio.outputLatency : 0);
 	}
 
 	g_timeoutEvtId = setTimeout(flowTimeline, 1000 / g_fps);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. fix: 初回プレイ時、別タブから復帰時などのケースで音源のオフセットずれが起きる問題を修正

- 現行ソースにおいて、以下の問題が発生していました。
  - 初回のみ大きくずれる
  - 毎回わずかにタイミングがずれる
  - 別タブで何かしてからリトライするとずれる
 - 基準とする時刻管理が`this._context.currentTime`(OS/デバイスのオーディオクロック)と`performance.now()`(システムクロック)と2系統あり、前者はAudioContext生成/resume直後は出力デバイス起動待ちやsuspendにより止まってしまうため、後者との差異が生じてオフセットずれが発生していました。
 - 両者をg_audio.scheduledTimeを基準にすること、currentTimeが動き出すまでのウォームアップ処理を挟むことで問題を解決しています。


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. Discordでの指摘より。詳細は以下のリンクが参考になります。
https://discord.com/channels/698460971231870977/944491021918683196/1539595770355912724

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- 実装当初からの不具合と想定されます。
- 以下の２変数は、将来的に変更する可能性はありますが現状からの影響を考慮して現状はそのままとします。
```javascript
// フレーム進行を音源クロック(AudioContext.currentTime)基準で補正するか
// - false の場合は従来通り performance.now() 基準で動作
let g_audioClockSync = true;

// 出力遅延(AudioContext.outputLatency)をタイミング補正に含めるか
// - true にすると出力デバイス(有線/Bluetooth等)によらず同じAdjustmentが使えるが、
//   既存のAdjustment設定値と互換性がなくなるため既定は false
let g_audioLatencyCompensation = false;

```