### PR TITLE
fix: [1150] Pause設定時にFrzReturnの設定が動いてしまう問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -16479,6 +16479,23 @@ const mainInit = () => {
 			// `paused` が false の場合だけ、再開時に play() を呼ぶ
 			nativeAudioWasPlaying = !g_audio.paused;
 		}
+		if (g_workObj.frzReturnTimerId) {
+			// FrzReturn演出はflowTimelineと独立したタイマーで動いているため、
+			// 一時停止時点で早期終了させる(位置復元はせず、通常終了時と同じ後片付けを行う)
+			clearTimeout(g_workObj.frzReturnTimerId);
+			g_workObj.frzReturnTimerId = null;
+			g_workObj.frzReturnFlg = false;
+			delTransform(`mainSprite`, `frzReturn`);
+			const mainSprite = document.getElementById(`mainSprite`);
+			if (mainSprite) {
+				mainSprite.style.opacity = 1;
+			}
+			const frzReturnGauge = document.getElementById(`lifeBarFrz`);
+			if (frzReturnGauge) {
+				frzReturnGauge.classList.remove(g_cssObj.life_frzNormal, g_cssObj.life_frzActive);
+				frzReturnGauge.classList.add(g_cssObj.life_frzNormal);
+			}
+		}
 		clearTimeout(g_timeoutEvtId);
 		g_audio.pause();
 

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -16482,19 +16482,7 @@ const mainInit = () => {
 		if (g_workObj.frzReturnTimerId) {
 			// FrzReturn演出はflowTimelineと独立したタイマーで動いているため、
 			// 一時停止時点で早期終了させる(位置復元はせず、通常終了時と同じ後片付けを行う)
-			clearTimeout(g_workObj.frzReturnTimerId);
-			g_workObj.frzReturnTimerId = null;
-			g_workObj.frzReturnFlg = false;
-			delTransform(`mainSprite`, `frzReturn`);
-			const mainSprite = document.getElementById(`mainSprite`);
-			if (mainSprite) {
-				mainSprite.style.opacity = 1;
-			}
-			const frzReturnGauge = document.getElementById(`lifeBarFrz`);
-			if (frzReturnGauge) {
-				frzReturnGauge.classList.remove(g_cssObj.life_frzNormal, g_cssObj.life_frzActive);
-				frzReturnGauge.classList.add(g_cssObj.life_frzNormal);
-			}
+			resetFrzReturn();
 		}
 		clearTimeout(g_timeoutEvtId);
 		g_audio.pause();
@@ -16883,6 +16871,27 @@ const startFrzReturn = () => {
 };
 
 /**
+ * FrzReturnの停止・後片付け(通常終了時／一時停止による中断時で共通)
+ */
+const resetFrzReturn = () => {
+	if (g_workObj.frzReturnTimerId) {
+		clearTimeout(g_workObj.frzReturnTimerId);
+	}
+	g_workObj.frzReturnTimerId = null;
+	g_workObj.frzReturnFlg = false;
+	delTransform(`mainSprite`, `frzReturn`);
+	const mainSprite = document.getElementById(`mainSprite`);
+	if (mainSprite) {
+		mainSprite.style.opacity = 1;
+	}
+	const frzReturnGauge = document.getElementById(`lifeBarFrz`);
+	if (frzReturnGauge) {
+		frzReturnGauge.classList.remove(g_cssObj.life_frzNormal, g_cssObj.life_frzActive);
+		frzReturnGauge.classList.add(g_cssObj.life_frzNormal);
+	}
+};
+
+/**
  * FrzReturnの実行
  * @param {number[]} _seq FrzReturnの移動配列
  * @param {number} _idx FrzReturnの移動配列のインディクス（transformの決定に利用）
@@ -16900,12 +16909,7 @@ const executeFrzReturn = (_seq, _idx, _axis) => {
 
 	if (!_seq || _idx >= _seq.length) {
 		// 移動終了時
-		delTransform(`mainSprite`, `frzReturn`);
-		g_workObj.frzReturnFlg = false;
-		g_workObj.frzReturnTimerId = null;
-		const frzReturnGauge = document.getElementById(`lifeBarFrz`);
-		frzReturnGauge.classList.remove(g_cssObj.life_frzNormal, g_cssObj.life_frzActive);
-		frzReturnGauge.classList.add(g_cssObj.life_frzNormal);
+		resetFrzReturn();
 		return;
 	}
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. Pause設定時にFrzReturnの設定が動いてしまう問題を修正
- FrzReturn設定は通常のフレーム動作とは別処理になっているため、Pause状態でも動いてしまう問題がありました。
- 位置再現するのではなく、FrzReturnの挙動をリセットするように変更しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. Pauseせずに挙動が残ったままになってしまっているため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- ver50.1.0 ( PR #2205 ) の考慮漏れです。