### PR TITLE
fix: [1152] resolveKeyFamilyで先に見つかった関数値が適用パターンによらず適用されてしまう問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -8528,25 +8528,26 @@ const resolveKeyFamily = () => {
 	const allPaths = new Set(g_familyObj.families.flatMap(f => Object.keys(f.fields)));
 	allPaths.forEach(path => {
 		const spec = newFamily?.fields[path];
-		// 該当プロパティのカスタム処理があれば優先し、なければ通常のプロパティ代入を使用
-		const applier = g_familyObj.families.map(f => f.appliers[path]).find(Boolean) ?? (v => setPathVal(path, v));
 
 		if (spec !== undefined) {
 			// 【変更値の適用】現在のファミリーにそのプロパティの設定がある場合
 			// 初めて書き換えるプロパティの場合のみ、元の値をスナップショット（初期値）として退避
 			if (!g_familyObj.ownership[path]) {
 				g_familyObj.snapshot[path] = getPathVal(path);
-				g_familyObj.ownership[path] = true;
 			}
 			// 関数なら評価し、値ならそのまま適用値とする
+			g_familyObj.ownership[path] = newFamily;
+			const applier = newFamily.appliers[path] ?? (v => setPathVal(path, v));
 			applyIfChanged(path, typeof spec === `function` ? spec() : spec, applier);
+
 		} else if (g_familyObj.ownership[path]) {
 			// 【標準への復元】別のファミリーに移行し、かつ元々自分が書き換えていたプロパティの場合
 			// スナップショットから元の値（初期値）を復元し、オーナーシップを解放
+			const applier = g_familyObj.ownership[path].appliers[path] ?? (v => setPathVal(path, v));
 			applyIfChanged(path, g_familyObj.snapshot[path], applier);
-			g_familyObj.ownership[path] = false;
+			g_familyObj.ownership[path] = null;
 		}
-		// ownership[path]がfalseのままなら、標準同士の切り替えでも一切触らない
+		// ownership[path]がnullのままなら、標準同士の切り替えでも一切触らない
 	});
 };
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. fix: resolveKeyFamilyで先に見つかった関数値が適用パターンによらず適用されてしまう問題を修正
- resolveKeyFamilyにおいて、本来は現在アクティブのファミリーの関数（applier）を使って処理させる必要がありましたが登録順になっており、意図した処理になっていませんでした。
- g_familyObj.ownership[path]についてファミリーオブジェクトを保持する方法に変更しています。
（現在アクティブなファミリーを表す）

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 同じ変数に対して、複数の異なる関数を適用させようとする場合に問題となることがあるため。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- ver50.0.0で実装した機能の考慮漏れとなります。