### PR TITLE
feat: [1155] フレーム毎の後半と矢印・フリーズアロー生成の前半にカスタムフックを追加

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -16385,7 +16385,9 @@ const mainInit = () => {
 		});
 
 		// ユーザカスタムイベント(フレーム毎、タイマー直前)
-		safeExecuteCustomHooks(`g_customJsObj.mainBeforeFrameTimer`, g_customJsObj.mainBeforeFrameTimer);
+		safeExecuteCustomHooks(`g_customJsObj.mainBeforeFrameTimer`, g_customJsObj.mainBeforeFrameTimer, {
+			arrowCnts, frzCnts, dummyArrowCnts, dummyFrzCnts,
+		});
 
 		// 曲終了判定
 		if (currentFrame >= fullFrame) {

--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -15898,6 +15898,10 @@ const mainInit = () => {
 		// 矢印色の設定
 		// - 枠/塗りつぶし色: g_attrObj[arrowName].Arrow / ArrowShadow
 		g_typeLists.arrowColor.forEach(val => g_attrObj[arrowName][`Arrow${val}`] = g_workObj[`${_name}${val}Colors`][_j]);
+
+		// g_attrObj定義後のカスタムイベント
+		safeExecuteCustomHooks(`g_customJsObj.preMakeArrow`, g_customJsObj.preMakeArrow, _attrs, arrowName, _name, _arrowCnt);
+
 		arrowSprite[g_workObj.dividePos[_j]].appendChild(arrowRoot);
 		const arrowSubRoot = createEmptySprite(arrowRoot, `sub${arrowName}`, { x: 0, y: 0, w: C_ARW_WIDTH, h: C_ARW_WIDTH });
 
@@ -16038,6 +16042,10 @@ const mainInit = () => {
 				g_attrObj[frzName][`${val}All`] = g_workObj[`${_name}${val}ColorsAll`][_j];
 			}
 		});
+
+		// g_attrObj定義後のカスタムイベント
+		safeExecuteCustomHooks(`g_customJsObj.preMakeFrzArrow`, g_customJsObj.preMakeFrzArrow, _attrs, frzName, _name, _arrowCnt);
+
 		arrowSprite[g_workObj.dividePos[_j]].appendChild(frzRoot);
 		let shadowColor = _shadowColor === `Default` ? _normalColor : _shadowColor;
 		const frzSubRoot = createEmptySprite(frzRoot, `sub${frzName}`, { x: 0, y: 0, w: C_ARW_WIDTH, h: C_ARW_WIDTH + firstBarLength });
@@ -16375,6 +16383,9 @@ const mainInit = () => {
 				}
 			}
 		});
+
+		// ユーザカスタムイベント(フレーム毎、タイマー直前)
+		safeExecuteCustomHooks(`g_customJsObj.mainBeforeFrameTimer`, g_customJsObj.mainBeforeFrameTimer);
 
 		// 曲終了判定
 		if (currentFrame >= fullFrame) {

--- a/js/lib/danoni_constants.js
+++ b/js/lib/danoni_constants.js
@@ -5244,6 +5244,8 @@ const g_customJsObj = {
     progress: [],
     main: [],
 
+    preMakeArrow: [],
+    preMakeFrzArrow: [],
     makeArrow: [],
     makeFrzArrow: [],
 
@@ -5265,6 +5267,7 @@ const g_customJsObj = {
     judg_dummyFrzHit: [],
 
     mainEnterFrame: [],
+    mainBeforeFrameTimer: [],
     result: [],
     resultEnterFrame: [],
 };

--- a/js/template/danoni_custom.js
+++ b/js/template/danoni_custom.js
@@ -289,8 +289,12 @@ g_customJsObj.mainEnterFrame.push(() => {
 /**
  * メイン画面(フレーム毎表示、タイマー直前)
  * - 矢印生成、移動後に処理を行いたいときに記述
+ * @param {number[]} arrowCnts 矢印カウント情報
+ * @param {number[]} frzCnts フリーズアローカウント情報
+ * @param {number[]} dummyArrowCnts ダミー矢印カウント情報
+ * @param {number[]} dummyFrzCnts ダミーフリーズアローカウント情報
  */
-g_customJsObj.mainBeforeFrameTimer.push(() => {
+g_customJsObj.mainBeforeFrameTimer.push(({ arrowCnts, frzCnts, dummyArrowCnts, dummyFrzCnts }) => {
 
 });
 

--- a/js/template/danoni_custom.js
+++ b/js/template/danoni_custom.js
@@ -41,6 +41,16 @@ g_customJsObj.titleEnterFrame.push(() => {
 });
 
 /**
+ * 選曲変更時（選曲モード時のみ）
+ * - この設定は譜面ヘッダーの|packageName=パッケージ名|を指定した場合のみ利用可能です。
+ * - 曲を変更したときに呼び出されます。
+ * @param {number} _musicIdxNum 選択曲番号
+ */
+g_customJsObj.musicSelect.push((_musicIdxNum) => {
+
+});
+
+/**
  * データ管理画面 [Scene: Data Management / Pear]
  */
 g_customJsObj.dataMgt.push(() => {
@@ -55,7 +65,7 @@ g_customJsObj.precondition.push(() => {
 });
 
 /**
- * オプション画面(初期表示) [Scene: Option / Lime]
+ * Settings画面(初期表示) [Scene: Option / Lime]
  */
 g_customJsObj.option.push(() => {
 
@@ -71,16 +81,33 @@ g_customJsObj.difficulty.push((_initFlg, _canLoadDifInfoFlg) => {
 });
 
 /**
- * 表示変更(初期表示) [Scene: Settings-Display / Lemon]
+ * Display画面(初期表示) [Scene: Settings-Display / Lemon]
  */
 g_customJsObj.settingsDisplay.push(() => {
 
 });
 
 /**
- * 表示変更(初期表示) [Scene: Ex-Settings / apple]
+ * Display画面(プレビュー表示) [Scene: Settings-Display / Lemon]
+ * @param {object} _parent Display設定のプレビューの親要素
+ * @param {number} _playingWidth プレイ画面の横幅(px)
+ * @param {number} _playingHeight プレイ画面の高さ(px)
+ */
+g_customJsObj.displayPreview.push((_parent, _playingWidth, _playingHeight) => {
+
+});
+
+/**
+ * Ex-Settings画面(初期表示) [Scene: Ex-Settings / apple]
  */
 g_customJsObj.exSetting.push(() => {
+
+});
+
+/**
+ * 設定サマリー表示描画時
+ */
+g_customJsObj.settingSummary.push(() => {
 
 });
 
@@ -125,6 +152,18 @@ g_customJsObj.main.push(() => {
 });
 
 /**
+ * 矢印生成前（g_attrObj定義後）
+ * - g_attrObjの書き換えを行いたいときなどの使用を想定
+ * @param {object} _attrs 矢印属性
+ * @param {string} _arrowName 矢印名
+ * @param {string} _name 矢印識別名
+ * @param {number} _arrowCnt 矢印番号
+ */
+g_customJsObj.preMakeArrow.push((_attrs, _arrowName, _name, _arrowCnt) => {
+
+});
+
+/**
  * 矢印生成
  * @param {object} _attrs 矢印属性
  * @param {string} _arrowName 矢印名
@@ -136,11 +175,23 @@ g_customJsObj.makeArrow.push((_attrs, _arrowName, _name, _arrowCnt) => {
 });
 
 /**
+ * フリーズアロー生成前（g_attrObj定義後）
+ * - g_attrObjの書き換えを行いたいときなどの使用を想定
+ * @param {object} _attrs フリーズアロー属性
+ * @param {string} _arrowName フリーズアロー名
+ * @param {string} _name フリーズアロー識別名
+ * @param {number} _arrowCnt フリーズアロー番号
+ */
+g_customJsObj.preMakeFrzArrow.push((_attrs, _arrowName, _name, _arrowCnt) => {
+
+});
+
+/**
  * フリーズアロー生成
- * @param {object} _attrs 矢印属性
- * @param {string} _arrowName 矢印名
- * @param {string} _name 矢印識別名
- * @param {number} _arrowCnt 矢印番号
+ * @param {object} _attrs フリーズアロー属性
+ * @param {string} _arrowName フリーズアロー名
+ * @param {string} _name フリーズアロー識別名
+ * @param {number} _arrowCnt フリーズアロー番号
  */
 g_customJsObj.makeFrzArrow.push((_attrs, _arrowName, _name, _arrowCnt) => {
 
@@ -148,72 +199,98 @@ g_customJsObj.makeFrzArrow.push((_attrs, _arrowName, _name, _arrowCnt) => {
 
 /**
  * ダミー矢印判定時
+ * @param {number} _j レーン番号
  */
-g_customJsObj.dummyArrow.push(() => {
+g_customJsObj.dummyArrow.push((_j) => {
 
 });
 
 /**
  * ダミーフリーズアロー判定時
+ * @param {number} _j レーン番号
  */
-g_customJsObj.dummyFrz.push(() => {
+g_customJsObj.dummyFrz.push((_j) => {
+
+});
+
+/**
+ * Appearanceフィルター動作時
+ * @param {number} _topNum 上部のフィルターに対応するmainSpriteの番号
+ * @param {number} _bottomNum 下部のフィルターに対応するmainSpriteの番号
+ */
+g_customJsObj.appearanceFilter.push((_topNum, _bottomNum) => {
 
 });
 
 /**
  * 判定カスタム処理 (引数は共通で1つ保持)
  * @param {number} _difFrame タイミング誤差(フレーム数)
+ * @param {number} _j レーン番号
  */
 // イイ
-g_customJsObj.judg_ii.push((_difFrame) => {
+g_customJsObj.judg_ii.push((_difFrame, _j) => {
 
 });
 
 // シャキン
-g_customJsObj.judg_shakin.push((_difFrame) => {
+g_customJsObj.judg_shakin.push((_difFrame, _j) => {
 
 });
 
 // マターリ
-g_customJsObj.judg_matari.push((_difFrame) => {
+g_customJsObj.judg_matari.push((_difFrame, _j) => {
 
 });
 
 // ショボーン
-g_customJsObj.judg_shobon.push((_difFrame) => {
+g_customJsObj.judg_shobon.push((_difFrame, _j) => {
 
 });
 
 // ウワァン
-g_customJsObj.judg_uwan.push((_difFrame) => {
+g_customJsObj.judg_uwan.push((_difFrame, _j) => {
 
 });
 
 // キター
-g_customJsObj.judg_kita.push((_difFrame) => {
+g_customJsObj.judg_kita.push((_difFrame, _j) => {
 
 });
 
 // イクナイ
-g_customJsObj.judg_iknai.push((_difFrame) => {
+g_customJsObj.judg_iknai.push((_difFrame, _j) => {
+
+});
+
+// Excessive
+g_customJsObj.judg_excessive.push((_difFrame, _j) => {
 
 });
 
 // 通常フリーズアローヒット時
-g_customJsObj.judg_frzHit.push((_difFrame) => {
+g_customJsObj.judg_frzHit.push((_difFrame, _j) => {
 
 });
 
 // ダミーフリーズアローヒット時
-g_customJsObj.judg_dummyFrzHit.push((_difFrame) => {
+g_customJsObj.judg_dummyFrzHit.push((_difFrame, _j) => {
 
 });
 
 /**
  * メイン画面(フレーム毎表示) [Scene: Main / Banana]
  * - 現在のフレーム数は g_scoreObj.baseFrame で取得可能
+ * - 矢印生成、移動前に処理を行いたいときに記述
  */
 g_customJsObj.mainEnterFrame.push(() => {
+
+});
+
+/**
+ * メイン画面(フレーム毎表示、タイマー直前)
+ * - 矢印生成、移動後に処理を行いたいときに記述
+ */
+g_customJsObj.mainBeforeFrameTimer.push(() => {
 
 });
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. feat: フレーム毎の後半と矢印・フリーズアロー生成の前半にカスタムフックを追加
- 以下にカスタムフックを追加しました。

|プロパティ|内容|引数|
|---|---|---|
|mainBeforeFrameTimer|プレイ画面（フレーム毎）<br>※タイマーの直前|{arrowCnts, frzCnts. dummyArrowCnts, dummyFrzCnts}|
|preMakeArrow|矢印生成前(g_attrObj定義後)|_attrs, _arrowName, _name, _arrowCnt|
|preMakeFrzArrow|フリーズアロー生成前(g_attrObj定義後)|_attrs, _arrowName, _name, _arrowCnt|

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. Discordでの要望より。
https://discord.com/channels/698460971231870977/944491021918683196/1545807006479163452

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- プレイ画面のタイマー以後の処理はフレーム同期処理に関わるため、割込み位置はタイマー処理の前にしています。