### PR TITLE
fix: [1157] フリーズアローヒット中にポーズして復帰したときに判定が失敗してしまう問題を修正

### DIFF
--- a/js/danoni_main.js
+++ b/js/danoni_main.js
@@ -15537,10 +15537,11 @@ const mainInit = () => {
 			isPaused ? resumeTimeline(true) : pauseTimeline(true);
 			return blockCode(setCode);
 		}
+		// ポーズ中でも押下状態バッファ自体は常に最新化しておく
+		g_inputKeyBuffer[setCode] = true;
 		if (isPaused) {
 			return blockCode(setCode);
 		}
-		g_inputKeyBuffer[setCode] = true;
 		mainKeyDownActFunc[g_stateObj.autoAll](setCode);
 
 		// 曲中リトライ、タイトルバック
@@ -16577,12 +16578,12 @@ const mainInit = () => {
 		g_timerHandler.clearTimeout(g_timeoutEvtId);
 		g_audio.pause();
 
-		// フォーカスを失うとkeyupが届かなくなり、押しっぱなし判定・表示が残り得るため、
-		// ここで強制的に全キー「離した」状態に戻す
-		g_inputKeyBuffer = {};
-		g_workObj.keyHitFlg.forEach(lane => lane.fill(false));
-		mainKeyUpActFunc[g_stateObj.autoAll]();
-		divRoot.classList.add(`gamePaused`);
+		// 自動ポーズ(タブ非表示等)の場合のみ強制的に全キー「離した」状態に戻す
+		if (!_manual) {
+			g_inputKeyBuffer = {};
+			g_workObj.keyHitFlg.forEach(lane => lane.fill(false));
+			mainKeyUpActFunc[g_stateObj.autoAll]();
+		}
 	};
 
 	const resumeTimeline = (_manual = false) => {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
<!-- 
    変更内容をできるだけ簡潔に書いてください
    A clear and concise description of what the changes is.
-->
### 1. fix: フリーズアローヒット中にポーズして復帰したときに判定が失敗してしまう問題を修正
- フリーズアローヒット中にポーズして復帰したときに、
少しのラグの後イクナイ（失敗）になる問題が発生していました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 
    今回の変更毎に変更理由を書いてください。関連Issueがある場合は "Resolves #1234" のように番号を入れてください
    Please write the reason for each change in this issue. If there is a related Issue, please include the number, e.g. "Resolves #1234".
-->
1. 本来想定した動きになっていないため。ver50.1.0のポーズ実装時の考慮漏れです。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- ver50.1.0以降で発生します。